### PR TITLE
Reverse sort the list of tasks in status

### DIFF
--- a/pkg/pipelineascode/status.go
+++ b/pkg/pipelineascode/status.go
@@ -110,7 +110,7 @@ func statusOfAllTaskListForCheckRun(pr *tektonv1beta1.PipelineRun) (string, erro
 
 	if len(pr.Status.TaskRuns) != 0 {
 		trl = newTaskrunListFromMap(pr.Status.TaskRuns)
-		sort.Sort(trl)
+		sort.Sort(sort.Reverse(trl))
 	}
 
 	funcMap := template.FuncMap{


### PR DESCRIPTION
Reverse the list of the status to be chronological instead of reverse
chrono.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
