### PR TITLE
Use git clone task from hub

### DIFF
--- a/.tekton/tekton.yaml
+++ b/.tekton/tekton.yaml
@@ -1,2 +1,2 @@
 tasks:
-  - https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.3/git-clone.yaml
+  - git-clone


### PR DESCRIPTION
That was buggy before, so let's use it properly now.
