### PR TITLE
Set webconsole url properly 🔗 

### DIFF
--- a/pkg/cmd/pipelineascode/pipelineascode.go
+++ b/pkg/cmd/pipelineascode/pipelineascode.go
@@ -90,11 +90,14 @@ func runWrap(p cli.Params, opts *pacpkg.Options) error {
 		return err
 	}
 
+	// Get webconsole url as soon as possible to have a link to click there
+	runinfo.WebConsoleURL = kinteract.GetConsoleUI("", "")
+
 	err = pacpkg.Run(cs, kinteract, runinfo)
 	if err != nil && !strings.Contains(err.Error(), "403 Resource not accessible by integration") {
 		_, _ = cs.GithubClient.CreateStatus(runinfo, "completed", "failure",
 			fmt.Sprintf("There was an issue validating the commit: %q", err),
-			"https://tenor.com/search/sad-cat-gifs")
+			runinfo.WebConsoleURL)
 	}
 	return err
 }

--- a/pkg/consoleui/consoleui.go
+++ b/pkg/consoleui/consoleui.go
@@ -30,16 +30,21 @@ func getOpenshiftConsole(cs *cli.Clients, ns, pr string) (string, error) {
 	spec, ok := route.Object["spec"].(map[string]interface{})
 	if !ok {
 		// this condition is satisfied if there's no metadata at all in the provided CR
-		return "", fmt.Errorf("couldn't find \"spec\" in the OpenShift Console route")
+		return "", fmt.Errorf("couldn't find spec in the OpenShift Console route")
 	}
 
 	host, ok := spec["host"].(string)
 	if !ok {
 		// this condition is satisfied if there's no metadata at all in the provided CR
-		return "", fmt.Errorf("couldn't find \"spec.host\" in the OpenShift Console route")
+		return "", fmt.Errorf("couldn't find spec.host in the OpenShift Console route")
 	}
 
-	return fmt.Sprintf(openShiftPipelineViewURL, host, ns, pr), err
+	// If we don't have a target ns/pr just print it.
+	if ns == "" && pr == "" {
+		return fmt.Sprintf("https://%s", host), nil
+	}
+
+	return fmt.Sprintf(openShiftPipelineViewURL, host, ns, pr), nil
 }
 
 // GetConsoleURL Get a Console URL, OpenShift Console or Tekton Dashboard.

--- a/pkg/kubeinteraction/tektoncli.go
+++ b/pkg/kubeinteraction/tektoncli.go
@@ -54,7 +54,7 @@ func (s SidestepTektonCliParams) Time() clockwork.Clock {
 	return nil
 }
 
-func (k Interaction) TektonCliFollowLogs(prName, namespace string) (string, error) {
+func (k Interaction) TektonCliFollowLogs(namespace, prName string) (string, error) {
 	var outputBuffer bytes.Buffer
 
 	k.TektonCliLogsOptions.Params.SetNamespace(namespace)

--- a/pkg/pipelineascode/pipelineascode_test.go
+++ b/pkg/pipelineascode/pipelineascode_test.go
@@ -305,7 +305,12 @@ func TestRun(t *testing.T) {
 			created := github.CreateCheckRunOptions{}
 			err := json.Unmarshal(body, &created)
 			assert.NilError(t, err)
-			assert.Equal(t, created.GetConclusion(), "neutral")
+
+			// We created multiple status but the last one should be completed.
+			// TODO: we could maybe refine this test
+			if created.GetStatus() == "completed" {
+				assert.Equal(t, created.GetConclusion(), "neutral")
+			}
 		})
 
 	gcvs := webvcs.GithubVCS{
@@ -357,8 +362,5 @@ func TestRun(t *testing.T) {
 	got, err := stdata.PipelineAsCode.PipelinesascodeV1alpha1().Repositories("namespace").Get(
 		ctx, "test-run", metav1.GetOptions{})
 	assert.NilError(t, err)
-	// TODO: we could not fake creation, so it's empty
-	// but we can test that the last one doesn't match to what we had
-	// set at first so it got properly updated
 	assert.Assert(t, got.Status[len(got.Status)-1].PipelineRunName != "pipelinerun1")
 }

--- a/pkg/test/kubernetesintf.go
+++ b/pkg/test/kubernetesintf.go
@@ -20,7 +20,7 @@ func (k *KinterfaceTest) GetNamespace(ns string) error {
 	return nil
 }
 
-func (k *KinterfaceTest) TektonCliPRDescribe(prName, namespace string) (string, error) {
+func (k *KinterfaceTest) TektonCliPRDescribe(namespace, prName string) (string, error) {
 	return k.prDescribe, nil
 }
 

--- a/pkg/webvcs/github.go
+++ b/pkg/webvcs/github.go
@@ -27,6 +27,7 @@ type RunInfo struct {
 	URL           string
 	Branch        string
 	CheckRunID    *int64
+	WebConsoleURL string
 }
 
 func (r RunInfo) Check() error {
@@ -191,18 +192,18 @@ func (v GithubVCS) GetObject(sha string, runinfo *RunInfo) ([]byte, error) {
 func (v GithubVCS) CreateCheckRun(status string, runinfo *RunInfo) (*github.CheckRun, error) {
 	now := github.Timestamp{Time: time.Now()}
 	checkrunoption := github.CreateCheckRunOptions{
-		Name:    "Tekton Pipeline as Code CI",
-		HeadSHA: runinfo.SHA,
-		Status:  &status,
-		// DetailsURL: "http://todo", // TODO: OpenShift or Tekton Dashboard Target
-		StartedAt: &now,
+		Name:       "Tekton Pipeline as Code CI",
+		HeadSHA:    runinfo.SHA,
+		Status:     &status,
+		DetailsURL: &runinfo.WebConsoleURL,
+		StartedAt:  &now,
 	}
 
 	checkRun, _, err := v.Client.Checks.CreateCheckRun(v.Context, runinfo.Owner, runinfo.Repository, checkrunoption)
 	return checkRun, err
 }
 
-func (v GithubVCS) CreateStatus(runinfo *RunInfo, status, conclusion, text, detailURL string) (*github.CheckRun, error) {
+func (v GithubVCS) CreateStatus(runinfo *RunInfo, status, conclusion, text, detailsURL string) (*github.CheckRun, error) {
 	now := github.Timestamp{Time: time.Now()}
 
 	var summary, title string
@@ -236,8 +237,8 @@ func (v GithubVCS) CreateStatus(runinfo *RunInfo, status, conclusion, text, deta
 		Output:      checkRunOutput,
 	}
 
-	if detailURL != "" {
-		opts.DetailsURL = &detailURL
+	if detailsURL != "" {
+		opts.DetailsURL = &detailsURL
 	}
 
 	checkRun, _, err := v.Client.Checks.UpdateCheckRun(v.Context, runinfo.Owner, runinfo.Repository, *runinfo.CheckRunID, opts)


### PR DESCRIPTION
We set as soon as possible the webconsole url, even if it's not to the
ns/pr.

We create two other github status before creating the pipeline and before we are
starting pipeline with the proper webconsole url to follow the logs live.

Fixes #7 

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>