### PR TITLE
Use gofumnt for formatting in golangci-lint 🧹

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,3 +17,7 @@ linters:
   - misspell
   - deadcode
   - gomnd
+  - gosec
+  - gosimple
+  - govet
+  - ifshort

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,3 +28,5 @@ linters:
   - revive
   - staticcheck
   - stylecheck
+  - unused
+  - unparam

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,3 +21,8 @@ linters:
   - gosimple
   - govet
   - ifshort
+  - importas
+  - makezero
+  - nakedret
+  - predeclared
+  - revive

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,10 +9,11 @@ linters-settings:
 linters:
   enable:
   - errcheck
-  - gofmt
+  - gofumpt
   - goimports
   - gosec
   - gocritic
   - golint
   - misspell
   - deadcode
+  - gomnd

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,12 +20,12 @@ linters:
   - gosec
   - gosimple
   - govet
-  - ifshort
-  - importas
-  - makezero
+  #- ifshort
+  #- importas
+  #- makezero
   - nakedret
-  - predeclared
-  - revive
+  # - predeclared
+  # - revive
   - staticcheck
   - stylecheck
   - unused

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,3 +26,5 @@ linters:
   - nakedret
   - predeclared
   - revive
+  - staticcheck
+  - stylecheck

--- a/pkg/cli/params.go
+++ b/pkg/cli/params.go
@@ -46,7 +46,6 @@ func (p *PacParams) dynamicClient(config *rest.Config) (dynamic.Interface, error
 	dynamicClient, err := dynamic.NewForConfig(config)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create dynamic client from config")
-
 	}
 	return dynamicClient, err
 }
@@ -104,14 +103,12 @@ func (p *PacParams) githubClient(config *rest.Config) (webvcs.GithubVCS, error) 
 
 // Only returns kube client, not tekton client
 func (p *PacParams) KubeClient() (k8s.Interface, error) {
-
 	config, err := p.config()
 	if err != nil {
 		return nil, err
 	}
 
 	kube, err := p.kubeClient(config)
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cli/params.go
+++ b/pkg/cli/params.go
@@ -92,13 +92,13 @@ func (p *PacParams) pacClient(config *rest.Config) (pacversioned.Interface, erro
 	return cs, nil
 }
 
-func (p *PacParams) hubClient(config *rest.Config) hub.Client {
+func (p *PacParams) hubClient() hub.Client {
 	cs := hub.NewClient()
 	return cs
 }
 
-func (p *PacParams) githubClient(config *rest.Config) (webvcs.GithubVCS, error) {
-	return webvcs.NewGithubVCS(p.githubToken), nil
+func (p *PacParams) githubClient() webvcs.GithubVCS {
+	return webvcs.NewGithubVCS(p.githubToken)
 }
 
 // Only returns kube client, not tekton client
@@ -146,12 +146,9 @@ func (p *PacParams) Clients() (*Clients, error) {
 		return nil, err
 	}
 
-	hub := p.hubClient(config)
+	hub := p.hubClient()
 
-	ghClient, err := p.githubClient(config)
-	if err != nil {
-		return nil, err
-	}
+	ghClient := p.githubClient()
 
 	dynamic, err := p.dynamicClient(config)
 	if err != nil {

--- a/pkg/cmd/pipelineascode/pipelineascode.go
+++ b/pkg/cmd/pipelineascode/pipelineascode.go
@@ -20,7 +20,7 @@ const (
 
 func Command(p cli.Params) *cobra.Command {
 	opts := &pacpkg.Options{}
-	var cmd = &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "run",
 		Short: "Run pipelines as code",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/pipelineascode/pipelineascode.go
+++ b/pkg/cmd/pipelineascode/pipelineascode.go
@@ -63,7 +63,7 @@ func getRunInfoFromArgsOrPayload(cs *cli.Clients, payload string, runinfo *webvc
 	if err := runinfo.Check(); err != nil {
 		return runinfo, err
 	} else if payload == "" {
-		return &webvcs.RunInfo{}, fmt.Errorf("No payload or not enough params set properly")
+		return &webvcs.RunInfo{}, fmt.Errorf("no payload or not enough params set properly")
 	}
 
 	payloadinfo, err := cs.GithubClient.ParsePayload(cs.Log, payload)
@@ -72,7 +72,7 @@ func getRunInfoFromArgsOrPayload(cs *cli.Clients, payload string, runinfo *webvc
 	}
 
 	if err := payloadinfo.Check(); err != nil {
-		return &webvcs.RunInfo{}, fmt.Errorf("Invalid Payload, missing some values : %+v", runinfo)
+		return &webvcs.RunInfo{}, fmt.Errorf("invalid Payload, missing some values : %+v", runinfo)
 	}
 
 	return payloadinfo, nil

--- a/pkg/cmd/pipelineascode/pipelineascode.go
+++ b/pkg/cmd/pipelineascode/pipelineascode.go
@@ -60,7 +60,7 @@ func Command(p cli.Params) *cobra.Command {
 }
 
 func getRunInfoFromArgsOrPayload(cs *cli.Clients, payload string, runinfo *webvcs.RunInfo) (*webvcs.RunInfo, error) {
-	if err := runinfo.Check(); err != nil {
+	if err := runinfo.Check(); err == nil {
 		return runinfo, err
 	} else if payload == "" {
 		return &webvcs.RunInfo{}, fmt.Errorf("no payload or not enough params set properly")

--- a/pkg/cmd/pipelineascode/pipelineascode.go
+++ b/pkg/cmd/pipelineascode/pipelineascode.go
@@ -60,8 +60,7 @@ func Command(p cli.Params) *cobra.Command {
 }
 
 func getRunInfoFromArgsOrPayload(cs *cli.Clients, payload string, runinfo *webvcs.RunInfo) (*webvcs.RunInfo, error) {
-	err := runinfo.Check()
-	if err == nil {
+	if err := runinfo.Check(); err != nil {
 		return runinfo, err
 	} else if payload == "" {
 		return &webvcs.RunInfo{}, fmt.Errorf("No payload or not enough params set properly")

--- a/pkg/cmd/pipelineascode/pipelineascode_test.go
+++ b/pkg/cmd/pipelineascode/pipelineascode_test.go
@@ -70,13 +70,13 @@ func TestGetInfo(t *testing.T) {
 			desc:    "Good json but bad payload",
 			runinfo: webvcs.RunInfo{},
 			payload: "{}",
-			errmsg:  "Cannot parse payload",
+			errmsg:  "cannot parse payload",
 		},
 		{
 			desc:    "No payload no runcheck",
 			runinfo: webvcs.RunInfo{},
 			payload: "",
-			errmsg:  "No payload or not enough params",
+			errmsg:  "no payload or not enough params",
 		},
 		{
 			desc: "Bad runinfo with missing infos",
@@ -84,7 +84,7 @@ func TestGetInfo(t *testing.T) {
 				Owner: "foo",
 			},
 			payload: "",
-			errmsg:  "No payload or not enough params",
+			errmsg:  "no payload or not enough params",
 		},
 		{
 			desc:    "Missing values payload",

--- a/pkg/cmd/resolve/resolve.go
+++ b/pkg/cmd/resolve/resolve.go
@@ -14,7 +14,7 @@ import (
 )
 
 func Command(p cli.Params) *cobra.Command {
-	var cmd = &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "resolve",
 		Short: "Resolve a bunch of yaml file in a single PipelineRun",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -23,7 +23,7 @@ import (
 )
 
 func Root(p cli.Params) *cobra.Command {
-	var cmd = &cobra.Command{
+	cmd := &cobra.Command{
 		Short:        "Pipeline as Code entrypoint",
 		Long:         ``,
 		SilenceUsage: true,

--- a/pkg/consoleui/consoleui.go
+++ b/pkg/consoleui/consoleui.go
@@ -23,7 +23,6 @@ const (
 func getOpenshiftConsole(cs *cli.Clients, ns, pr string) (string, error) {
 	gvr := schema.GroupVersionResource{Group: openShiftRouteGroup, Version: openShiftRouteVersion, Resource: openShiftRouteResource}
 	route, err := cs.Dynamic.Resource(gvr).Namespace(openShiftConsoleNS).Get(context.Background(), openShiftConsoleRouteName, metav1.GetOptions{})
-
 	if err != nil {
 		return "", err
 	}

--- a/pkg/kubeinteraction/kubeinteraction.go
+++ b/pkg/kubeinteraction/kubeinteraction.go
@@ -18,8 +18,7 @@ func (k Interaction) GetConsoleUI(ns, pr string) (string, error) {
 
 func NewKubernetesInteraction(c *cli.Clients) (*Interaction, error) {
 	cliparams := &cliinterface.TektonParams{}
-	_, err := cliparams.Clients()
-	if err != nil {
+	if _, err := cliparams.Clients(); err != nil {
 		return nil, err
 	}
 	cliparams.SetNoColour(true)

--- a/pkg/kubeinteraction/tektoncli.go
+++ b/pkg/kubeinteraction/tektoncli.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/jonboulle/clockwork"
 	cliinterface "github.com/tektoncd/cli/pkg/cli"
-	"github.com/tektoncd/cli/pkg/log"
 	clilog "github.com/tektoncd/cli/pkg/log"
 	cliprdesc "github.com/tektoncd/cli/pkg/pipelinerun/description"
 	k8s "k8s.io/client-go/kubernetes"
@@ -75,7 +74,7 @@ func (k Interaction) TektonCliFollowLogs(namespace, prName string) (string, erro
 		Err: mwr,
 	}
 
-	log.NewWriter(log.LogTypePipeline).Write(k.TektonCliLogsOptions.Stream, logC, errC)
+	clilog.NewWriter(clilog.LogTypePipeline).Write(k.TektonCliLogsOptions.Stream, logC, errC)
 	return outputBuffer.String(), nil
 }
 

--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -30,7 +30,6 @@ func getRepoByCR(cs *cli.Clients, url, branch, eventType, forceNamespace string)
 
 	repositories, err := cs.PipelineAsCode.PipelinesascodeV1alpha1().Repositories("").List(
 		context.Background(), metav1.ListOptions{})
-
 	if err != nil {
 		return repository, err
 	}
@@ -60,7 +59,7 @@ func Run(cs *cli.Clients, k8int cli.KubeInteractionIntf, runinfo *webvcs.RunInfo
 	var err error
 	var maintekton TektonYamlConfig
 
-	var ctx = context.Background()
+	ctx := context.Background()
 	checkRun, err := cs.GithubClient.CreateCheckRun("in_progress", runinfo)
 	if err != nil {
 		return err
@@ -108,7 +107,7 @@ func Run(cs *cli.Clients, k8int cli.KubeInteractionIntf, runinfo *webvcs.RunInfo
 		return err
 	}
 
-	var yamlConfig = TektonYamlConfig{}
+	yamlConfig := TektonYamlConfig{}
 	for _, file := range objects {
 		if file.GetName() == tektonConfigurationFile {
 			data, err := cs.GithubClient.GetObject(file.GetSHA(), runinfo)

--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -10,7 +10,6 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/resolve"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/webvcs"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -37,14 +36,14 @@ func getRepoByCR(cs *cli.Clients, url, branch, eventType, forceNamespace string)
 		if value.Spec.URL == url && value.Spec.Branch == branch && value.Spec.EventType == eventType {
 			if forceNamespace != "" && value.Namespace != forceNamespace {
 				return repository, fmt.Errorf(
-					"Repo CR matches but should be installed in \"%s\" as configured from tekton.yaml on the main branch",
+					"repo CR matches but should be installed in \"%s\" as configured from tekton.yaml on the main branch",
 					forceNamespace)
 			}
 
 			// Disallow attempts for hijacks. If the installed CR is not configured on the
 			// Namespace the Spec is targeting then disallow it.
 			if value.Namespace != value.Spec.Namespace {
-				return repository, fmt.Errorf("Repo CR %s matches but belongs to \"%s\" while it should be in \"%s\"",
+				return repository, fmt.Errorf("repo CR %s matches but belongs to \"%s\" while it should be in \"%s\"",
 					value.Name,
 					value.Namespace,
 					value.Spec.Namespace)
@@ -141,7 +140,7 @@ func Run(cs *cli.Clients, k8int cli.KubeInteractionIntf, runinfo *webvcs.RunInfo
 	if err != nil {
 		return err
 	}
-	pr, err := cs.Tekton.TektonV1beta1().PipelineRuns(repo.Spec.Namespace).Create(ctx, prun[0], v1.CreateOptions{})
+	pr, err := cs.Tekton.TektonV1beta1().PipelineRuns(repo.Spec.Namespace).Create(ctx, prun[0], metav1.CreateOptions{})
 	if err != nil {
 		return err
 	}
@@ -180,7 +179,7 @@ func Run(cs *cli.Clients, k8int cli.KubeInteractionIntf, runinfo *webvcs.RunInfo
 
 	// TODO: Get another time the repo in case it was updated, there may be a
 	// locking problem we should solve here but we are talking miliseconds race.
-	lastrepo, err := cs.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(repo.Spec.Namespace).Get(ctx, repo.Name, v1.GetOptions{})
+	lastrepo, err := cs.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(repo.Spec.Namespace).Get(ctx, repo.Name, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -192,7 +191,7 @@ func Run(cs *cli.Clients, k8int cli.KubeInteractionIntf, runinfo *webvcs.RunInfo
 	}
 	lastrepo.Status = append(lastrepo.Status, repoStatus)
 	nrepo, err := cs.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(lastrepo.Namespace).Update(
-		ctx, lastrepo, v1.UpdateOptions{})
+		ctx, lastrepo, metav1.UpdateOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/pipelineascode/pipelineascode_test.go
+++ b/pkg/pipelineascode/pipelineascode_test.go
@@ -95,7 +95,7 @@ func TestFilterByGood(t *testing.T) {
 			newRepo("test-good", url, branch, eventType, targetNamespace, targetNamespace),
 		},
 	}
-	cs, _ := test.SeedTestData(t, ctx, d)
+	cs, _ := test.SeedTestData(ctx, t, d)
 	client := &cli.Clients{PipelineAsCode: cs.PipelineAsCode}
 	repo, err := getRepoByCR(client, url, branch, eventType, "")
 	assert.NilError(t, err)
@@ -116,7 +116,7 @@ func TestFilterByNotMatch(t *testing.T) {
 			newRepo("test-notmatch", url, branch, eventType, targetNamespace, targetNamespace),
 		},
 	}
-	cs, _ := test.SeedTestData(t, ctx, d)
+	cs, _ := test.SeedTestData(ctx, t, d)
 	client := &cli.Clients{PipelineAsCode: cs.PipelineAsCode}
 	repo, err := getRepoByCR(client, otherurl, branch, eventType, "")
 	assert.NilError(t, err)
@@ -137,7 +137,7 @@ func TestFilterByNotInItsNamespace(t *testing.T) {
 			newRepo(testname, url, branch, eventType, installNamespace, targetNamespace),
 		},
 	}
-	cs, _ := test.SeedTestData(t, ctx, d)
+	cs, _ := test.SeedTestData(ctx, t, d)
 	client := &cli.Clients{PipelineAsCode: cs.PipelineAsCode}
 	repo, err := getRepoByCR(client, url, branch, eventType, "")
 	assert.ErrorContains(t, err, fmt.Sprintf("Repo CR %s matches but belongs to", testname))
@@ -159,7 +159,7 @@ func TestFilterForceNamespace(t *testing.T) {
 			newRepo(testname, url, branch, eventType, targetNamespace, targetNamespace),
 		},
 	}
-	cs, _ := test.SeedTestData(t, ctx, d)
+	cs, _ := test.SeedTestData(ctx, t, d)
 	client := &cli.Clients{PipelineAsCode: cs.PipelineAsCode}
 	_, err := getRepoByCR(client, url, branch, eventType, forcedNamespace)
 	assert.ErrorContains(t, err, "as configured from tekton.yaml on the main branch")
@@ -208,7 +208,7 @@ func TestRunDeniedFromForcedNamespace(t *testing.T) {
 			newRepo("repo", runinfo.URL, runinfo.Branch, "pull_request", installedNamespace, installedNamespace),
 		},
 	}
-	stdata, _ := test.SeedTestData(t, ctx, datas)
+	stdata, _ := test.SeedTestData(ctx, t, datas)
 	cs := &cli.Clients{
 		GithubClient:   gcvs,
 		PipelineAsCode: stdata.PipelineAsCode,
@@ -336,7 +336,7 @@ func TestRun(t *testing.T) {
 				"namespace"),
 		},
 	}
-	stdata, _ := test.SeedTestData(t, ctx, repo)
+	stdata, _ := test.SeedTestData(ctx, t, repo)
 
 	observer, log := zapobserver.New(zap.InfoLevel)
 	logger := zap.New(observer).Sugar()

--- a/pkg/pipelineascode/pipelineascode_test.go
+++ b/pkg/pipelineascode/pipelineascode_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/test"
 	testhelper "github.com/openshift-pipelines/pipelines-as-code/pkg/test"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/webvcs"
 	"go.uber.org/zap"
@@ -90,12 +89,12 @@ func TestFilterByGood(t *testing.T) {
 	branch := "mainone"
 	targetNamespace := "namespace"
 	url := "https://psg.fr"
-	d := test.Data{
+	d := testhelper.Data{
 		Repositories: []*v1alpha1.Repository{
 			newRepo("test-good", url, branch, eventType, targetNamespace, targetNamespace),
 		},
 	}
-	cs, _ := test.SeedTestData(ctx, t, d)
+	cs, _ := testhelper.SeedTestData(ctx, t, d)
 	client := &cli.Clients{PipelineAsCode: cs.PipelineAsCode}
 	repo, err := getRepoByCR(client, url, branch, eventType, "")
 	assert.NilError(t, err)
@@ -111,12 +110,12 @@ func TestFilterByNotMatch(t *testing.T) {
 	targetNamespace := "namespace"
 	url := "https://psg.com"
 	otherurl := "https://marseille.com"
-	d := test.Data{
+	d := testhelper.Data{
 		Repositories: []*v1alpha1.Repository{
 			newRepo("test-notmatch", url, branch, eventType, targetNamespace, targetNamespace),
 		},
 	}
-	cs, _ := test.SeedTestData(ctx, t, d)
+	cs, _ := testhelper.SeedTestData(ctx, t, d)
 	client := &cli.Clients{PipelineAsCode: cs.PipelineAsCode}
 	repo, err := getRepoByCR(client, otherurl, branch, eventType, "")
 	assert.NilError(t, err)
@@ -132,12 +131,12 @@ func TestFilterByNotInItsNamespace(t *testing.T) {
 	targetNamespace := "namespace"
 	installNamespace := "olympiquelyon"
 	url := "https://psg.fr"
-	d := test.Data{
+	d := testhelper.Data{
 		Repositories: []*v1alpha1.Repository{
 			newRepo(testname, url, branch, eventType, installNamespace, targetNamespace),
 		},
 	}
-	cs, _ := test.SeedTestData(ctx, t, d)
+	cs, _ := testhelper.SeedTestData(ctx, t, d)
 	client := &cli.Clients{PipelineAsCode: cs.PipelineAsCode}
 	repo, err := getRepoByCR(client, url, branch, eventType, "")
 	assert.ErrorContains(t, err, fmt.Sprintf("Repo CR %s matches but belongs to", testname))
@@ -154,12 +153,12 @@ func TestFilterForceNamespace(t *testing.T) {
 	forcedNamespace := "asmonaco"
 
 	url := "https://psg.fr"
-	d := test.Data{
+	d := testhelper.Data{
 		Repositories: []*v1alpha1.Repository{
 			newRepo(testname, url, branch, eventType, targetNamespace, targetNamespace),
 		},
 	}
-	cs, _ := test.SeedTestData(ctx, t, d)
+	cs, _ := testhelper.SeedTestData(ctx, t, d)
 	client := &cli.Clients{PipelineAsCode: cs.PipelineAsCode}
 	_, err := getRepoByCR(client, url, branch, eventType, forcedNamespace)
 	assert.ErrorContains(t, err, "as configured from tekton.yaml on the main branch")
@@ -203,17 +202,17 @@ func TestRunDeniedFromForcedNamespace(t *testing.T) {
 		Client:  fakeclient,
 		Context: ctx,
 	}
-	datas := test.Data{
+	datas := testhelper.Data{
 		Repositories: []*v1alpha1.Repository{
 			newRepo("repo", runinfo.URL, runinfo.Branch, "pull_request", installedNamespace, installedNamespace),
 		},
 	}
-	stdata, _ := test.SeedTestData(ctx, t, datas)
+	stdata, _ := testhelper.SeedTestData(ctx, t, datas)
 	cs := &cli.Clients{
 		GithubClient:   gcvs,
 		PipelineAsCode: stdata.PipelineAsCode,
 	}
-	k8int := test.KinterfaceTest{}
+	k8int := testhelper.KinterfaceTest{}
 
 	err := Run(cs, &k8int, runinfo)
 
@@ -318,7 +317,7 @@ func TestRun(t *testing.T) {
 		Context: ctx,
 	}
 
-	repo := test.Data{
+	repo := testhelper.Data{
 		Namespaces: []*corev1.Namespace{
 			{
 				ObjectMeta: metav1.ObjectMeta{
@@ -336,7 +335,7 @@ func TestRun(t *testing.T) {
 				"namespace"),
 		},
 	}
-	stdata, _ := test.SeedTestData(ctx, t, repo)
+	stdata, _ := testhelper.SeedTestData(ctx, t, repo)
 
 	observer, log := zapobserver.New(zap.InfoLevel)
 	logger := zap.New(observer).Sugar()
@@ -353,7 +352,7 @@ func TestRun(t *testing.T) {
 		Dynamic:        dc,
 	}
 
-	k8int := test.KinterfaceTest{
+	k8int := testhelper.KinterfaceTest{
 		ConsoleURL: "https://console.url",
 	}
 

--- a/pkg/pipelineascode/pipelineascode_test.go
+++ b/pkg/pipelineascode/pipelineascode_test.go
@@ -169,10 +169,10 @@ func TestRunDeniedFromForcedNamespace(t *testing.T) {
 	ctx, _ := rtesting.SetupFakeContext(t)
 	fakeclient, mux, _, teardown := testhelper.SetupGH()
 	defer teardown()
-	var defaultBranch = "default"
-	var forcedNamespace = "laotronamspace"
-	var installedNamespace = "nomespace"
-	var runinfo = &webvcs.RunInfo{
+	defaultBranch := "default"
+	forcedNamespace := "laotronamspace"
+	installedNamespace := "nomespace"
+	runinfo := &webvcs.RunInfo{
 		SHA:           "principale",
 		Owner:         "chmouel",
 		Repository:    "repo",
@@ -326,13 +326,14 @@ func TestRun(t *testing.T) {
 				},
 			},
 		},
-		Repositories: []*v1alpha1.Repository{newRepo(
-			"test-run",
-			runinfo.URL,
-			runinfo.Branch,
-			"pull_request",
-			"namespace",
-			"namespace"),
+		Repositories: []*v1alpha1.Repository{
+			newRepo(
+				"test-run",
+				runinfo.URL,
+				runinfo.Branch,
+				"pull_request",
+				"namespace",
+				"namespace"),
 		},
 	}
 	stdata, _ := test.SeedTestData(t, ctx, repo)

--- a/pkg/pipelineascode/processconfig.go
+++ b/pkg/pipelineascode/processconfig.go
@@ -62,7 +62,7 @@ func processTektonYaml(cs *cli.Clients, runinfo *webvcs.RunInfo, data string) (T
 			tyConfig.RemoteTasks += addTaskYamlDocuments(string(data))
 		default:
 			var version string
-			var taskName = task
+			taskName := task
 			if strings.Contains(task, ":") {
 				split := strings.Split(task, ":")
 				version = split[len(split)-1]

--- a/pkg/pipelineascode/processconfig_test.go
+++ b/pkg/pipelineascode/processconfig_test.go
@@ -88,5 +88,4 @@ func TestProcessTektonYamlRefInternal(t *testing.T) {
 	if d := cmp.Diff(ret.RemoteTasks, "\n---\n"+expected+"\n"); d != "" {
 		t.Fatalf("-got, +want: %v", d)
 	}
-
 }

--- a/pkg/pipelineascode/status.go
+++ b/pkg/pipelineascode/status.go
@@ -112,7 +112,7 @@ func statusOfAllTaskListForCheckRun(pr *tektonv1beta1.PipelineRun) (string, erro
 		"formatCondition": ConditionEmoji,
 	}
 
-	var data = struct {
+	data := struct {
 		TaskrunList taskrunList
 	}{
 		TaskrunList: trl,
@@ -128,7 +128,7 @@ func statusOfAllTaskListForCheckRun(pr *tektonv1beta1.PipelineRun) (string, erro
 }
 
 func postFinalStatus(ctx context.Context, cs *cli.Clients, k8int cli.KubeInteractionIntf, runinfo *webvcs.RunInfo, prName, namespace string) (*tektonv1beta1.PipelineRun, error) {
-	var pr = &tektonv1beta1.PipelineRun{}
+	pr := &tektonv1beta1.PipelineRun{}
 	var outputBuffer bytes.Buffer
 
 	tknDescribeOutput, err := k8int.TektonCliPRDescribe(prName, namespace)

--- a/pkg/pipelineascode/status_test.go
+++ b/pkg/pipelineascode/status_test.go
@@ -7,13 +7,11 @@ import (
 	"time"
 
 	"github.com/jonboulle/clockwork"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"gotest.tools/v3/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
-	knative1 "knative.dev/pkg/apis/duck/v1beta1"
 )
 
 func TestPipelineRunStatus(t *testing.T) {
@@ -29,7 +27,7 @@ func TestPipelineRunStatus(t *testing.T) {
 						Conditions: duckv1beta1.Conditions{
 							{
 								Status:  corev1.ConditionTrue,
-								Reason:  v1beta1.PipelineRunReasonSuccessful.String(),
+								Reason:  tektonv1beta1.PipelineRunReasonSuccessful.String(),
 								Message: "Completed",
 							},
 						},
@@ -45,7 +43,7 @@ func TestPipelineRunStatus(t *testing.T) {
 						Conditions: duckv1beta1.Conditions{
 							{
 								Status:  corev1.ConditionFalse,
-								Reason:  v1beta1.PipelineRunReasonSuccessful.String(),
+								Reason:  tektonv1beta1.PipelineRunReasonSuccessful.String(),
 								Message: "Completed",
 							},
 						},
@@ -127,7 +125,7 @@ func TestTaskRunListMapSort(t *testing.T) {
 func TestConditionEmoji(t *testing.T) {
 	tests := []struct {
 		name      string
-		condition knative1.Conditions
+		condition duckv1beta1.Conditions
 		substr    string
 	}{
 		{

--- a/pkg/resolve/resolve.go
+++ b/pkg/resolve/resolve.go
@@ -17,7 +17,7 @@ type Types struct {
 	Tasks        []*tektonv1beta1.Task
 }
 
-func readTypes(cs *cli.Clients, data []byte) (Types, error) {
+func readTypes(cs *cli.Clients, data []byte) Types {
 	types := Types{}
 	decoder := k8scheme.Codecs.UniversalDeserializer()
 
@@ -43,7 +43,7 @@ func readTypes(cs *cli.Clients, data []byte) (Types, error) {
 		}
 	}
 
-	return types, nil
+	return types
 }
 
 func getTaskByName(name string, tasks []*tektonv1beta1.Task) (*tektonv1beta1.Task, error) {
@@ -65,10 +65,7 @@ func getPipelineByName(name string, tasks []*tektonv1beta1.Pipeline) (*tektonv1b
 }
 
 func resolve(cs *cli.Clients, data []byte, generateName bool) ([]*tektonv1beta1.PipelineRun, error) {
-	types, err := readTypes(cs, data)
-	if err != nil {
-		return []*tektonv1beta1.PipelineRun{}, err
-	}
+	types := readTypes(cs, data)
 	if len(types.PipelineRuns) == 0 {
 		return []*tektonv1beta1.PipelineRun{}, errors.New("we need at least one pipelinerun to start with")
 	}

--- a/pkg/resolve/resolve.go
+++ b/pkg/resolve/resolve.go
@@ -6,22 +6,20 @@ import (
 	"strings"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	"k8s.io/client-go/kubernetes/scheme"
 	k8scheme "k8s.io/client-go/kubernetes/scheme"
 )
 
 type Types struct {
-	PipelineRuns []*v1beta1.PipelineRun
-	Pipelines    []*v1beta1.Pipeline
-	TaskRuns     []*v1beta1.TaskRun
-	Tasks        []*v1beta1.Task
+	PipelineRuns []*tektonv1beta1.PipelineRun
+	Pipelines    []*tektonv1beta1.Pipeline
+	TaskRuns     []*tektonv1beta1.TaskRun
+	Tasks        []*tektonv1beta1.Task
 }
 
 func readTypes(cs *cli.Clients, data []byte) (Types, error) {
 	types := Types{}
-	decoder := scheme.Codecs.UniversalDeserializer()
+	decoder := k8scheme.Codecs.UniversalDeserializer()
 
 	for _, doc := range strings.Split(strings.Trim(string(data), "-"), "---") {
 		if strings.TrimSpace(doc) == "" {
@@ -34,11 +32,11 @@ func readTypes(cs *cli.Clients, data []byte) (Types, error) {
 			continue
 		}
 		switch o := obj.(type) {
-		case *v1beta1.Pipeline:
+		case *tektonv1beta1.Pipeline:
 			types.Pipelines = append(types.Pipelines, o)
-		case *v1beta1.PipelineRun:
+		case *tektonv1beta1.PipelineRun:
 			types.PipelineRuns = append(types.PipelineRuns, o)
-		case *v1beta1.Task:
+		case *tektonv1beta1.Task:
 			types.Tasks = append(types.Tasks, o)
 		default:
 			cs.Log.Info("Skipping document not looking like a tekton resource we can Resolve.")
@@ -48,44 +46,44 @@ func readTypes(cs *cli.Clients, data []byte) (Types, error) {
 	return types, nil
 }
 
-func getTaskByName(name string, tasks []*v1beta1.Task) (*v1beta1.Task, error) {
+func getTaskByName(name string, tasks []*tektonv1beta1.Task) (*tektonv1beta1.Task, error) {
 	for _, value := range tasks {
 		if value.Name == name {
 			return value, nil
 		}
 	}
-	return &v1beta1.Task{}, fmt.Errorf("Cannot find task %s in input", name)
+	return &tektonv1beta1.Task{}, fmt.Errorf("cannot find task %s in input", name)
 }
 
-func getPipelineByName(name string, tasks []*v1beta1.Pipeline) (*v1beta1.Pipeline, error) {
+func getPipelineByName(name string, tasks []*tektonv1beta1.Pipeline) (*tektonv1beta1.Pipeline, error) {
 	for _, value := range tasks {
 		if value.Name == name {
 			return value, nil
 		}
 	}
-	return &v1beta1.Pipeline{}, fmt.Errorf("Cannot find pipeline %s in input", name)
+	return &tektonv1beta1.Pipeline{}, fmt.Errorf("cannot find pipeline %s in input", name)
 }
 
-func resolve(cs *cli.Clients, data []byte, generateName bool) ([]*v1beta1.PipelineRun, error) {
+func resolve(cs *cli.Clients, data []byte, generateName bool) ([]*tektonv1beta1.PipelineRun, error) {
 	types, err := readTypes(cs, data)
 	if err != nil {
-		return []*v1beta1.PipelineRun{}, err
+		return []*tektonv1beta1.PipelineRun{}, err
 	}
 	if len(types.PipelineRuns) == 0 {
-		return []*v1beta1.PipelineRun{}, errors.New("We need at least one pipelinerun to start with")
+		return []*tektonv1beta1.PipelineRun{}, errors.New("we need at least one pipelinerun to start with")
 	}
 
 	// Resolve TaskRef inside Pipeline
 	for _, pipeline := range types.Pipelines {
-		pipelineTasks := []v1beta1.PipelineTask{}
+		pipelineTasks := []tektonv1beta1.PipelineTask{}
 		for _, task := range pipeline.Spec.Tasks {
 			if task.TaskRef != nil {
 				taskResolved, err := getTaskByName(task.TaskRef.Name, types.Tasks)
 				if err != nil {
-					return []*v1beta1.PipelineRun{}, err
+					return []*tektonv1beta1.PipelineRun{}, err
 				}
 				task.TaskRef = nil
-				task.TaskSpec = &v1beta1.EmbeddedTask{TaskSpec: taskResolved.Spec}
+				task.TaskSpec = &tektonv1beta1.EmbeddedTask{TaskSpec: taskResolved.Spec}
 			}
 			pipelineTasks = append(pipelineTasks, task)
 		}
@@ -95,15 +93,15 @@ func resolve(cs *cli.Clients, data []byte, generateName bool) ([]*v1beta1.Pipeli
 	for _, pipelinerun := range types.PipelineRuns {
 		// Resolve taskRef inside PipelineSpec inside PipelineRun
 		if pipelinerun.Spec.PipelineSpec != nil {
-			pipelineTasksResolve := []v1beta1.PipelineTask{}
+			pipelineTasksResolve := []tektonv1beta1.PipelineTask{}
 			for _, task := range pipelinerun.Spec.PipelineSpec.Tasks {
 				if task.TaskRef != nil {
 					taskResolved, err := getTaskByName(task.TaskRef.Name, types.Tasks)
 					if err != nil {
-						return []*v1beta1.PipelineRun{}, err
+						return []*tektonv1beta1.PipelineRun{}, err
 					}
 					task.TaskRef = nil
-					task.TaskSpec = &v1beta1.EmbeddedTask{TaskSpec: taskResolved.Spec}
+					task.TaskSpec = &tektonv1beta1.EmbeddedTask{TaskSpec: taskResolved.Spec}
 				}
 				pipelineTasksResolve = append(pipelineTasksResolve, task)
 			}
@@ -114,7 +112,7 @@ func resolve(cs *cli.Clients, data []byte, generateName bool) ([]*v1beta1.Pipeli
 		if pipelinerun.Spec.PipelineRef != nil {
 			pipelineResolved, err := getPipelineByName(pipelinerun.Spec.PipelineRef.Name, types.Pipelines)
 			if err != nil {
-				return []*v1beta1.PipelineRun{}, err
+				return []*tektonv1beta1.PipelineRun{}, err
 			}
 			pipelinerun.Spec.PipelineRef = nil
 			pipelinerun.Spec.PipelineSpec = &pipelineResolved.Spec
@@ -133,10 +131,10 @@ func resolve(cs *cli.Clients, data []byte, generateName bool) ([]*v1beta1.Pipeli
 // Pipeline/PipelineRuns/Tasks and resolve them inline as a single PipelineRun
 // generateName can be set as True to set the name as a generateName + "-" for
 // unique pipelinerun
-func Resolve(cs *cli.Clients, allTemplates string, generateName bool) ([]*v1beta1.PipelineRun, error) {
+func Resolve(cs *cli.Clients, allTemplates string, generateName bool) ([]*tektonv1beta1.PipelineRun, error) {
 	s := k8scheme.Scheme
 	if err := tektonv1beta1.AddToScheme(s); err != nil {
-		return []*v1beta1.PipelineRun{}, err
+		return []*tektonv1beta1.PipelineRun{}, err
 	}
 	return resolve(cs, []byte(allTemplates), generateName)
 }

--- a/pkg/resolve/resolve.go
+++ b/pkg/resolve/resolve.go
@@ -20,7 +20,7 @@ type Types struct {
 }
 
 func readTypes(cs *cli.Clients, data []byte) (Types, error) {
-	var types = Types{}
+	types := Types{}
 	decoder := scheme.Codecs.UniversalDeserializer()
 
 	for _, doc := range strings.Split(strings.Trim(string(data), "-"), "---") {

--- a/pkg/resolve/resolve_test.go
+++ b/pkg/resolve/resolve_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"go.uber.org/zap"
 	zapobserver "go.uber.org/zap/zaptest/observer"
@@ -30,10 +29,10 @@ func setup() {
 }
 
 // Not sure how to get testParams fixtures working
-func readTDfile(testname string, generateName bool) (*v1beta1.PipelineRun, *zapobserver.ObservedLogs, error) {
+func readTDfile(testname string, generateName bool) (*tektonv1beta1.PipelineRun, *zapobserver.ObservedLogs, error) {
 	data, err := ioutil.ReadFile("testdata/" + testname + ".yaml")
 	if err != nil {
-		return &v1beta1.PipelineRun{}, nil, err
+		return &tektonv1beta1.PipelineRun{}, nil, err
 	}
 	observer, log := zapobserver.New(zap.InfoLevel)
 	logger := zap.New(observer).Sugar()
@@ -42,7 +41,7 @@ func readTDfile(testname string, generateName bool) (*v1beta1.PipelineRun, *zapo
 	}
 	resolved, err := resolve(cs, data, generateName)
 	if err != nil {
-		return &v1beta1.PipelineRun{}, nil, err
+		return &tektonv1beta1.PipelineRun{}, nil, err
 	}
 	return resolved[0], log, nil
 }

--- a/pkg/resolve/resolve_test.go
+++ b/pkg/resolve/resolve_test.go
@@ -98,17 +98,17 @@ func TestNotKubernetesDocumentIgnore(t *testing.T) {
 
 func TestNoPipelineRuns(t *testing.T) {
 	_, _, err := readTDfile("no-pipelinerun", false)
-	assert.Error(t, err, "We need at least one pipelinerun to start with")
+	assert.Error(t, err, "we need at least one pipelinerun to start with")
 }
 
 func TestReferencedTaskNotInRepo(t *testing.T) {
 	_, _, err := readTDfile("referenced-task-not-in-repo", false)
-	assert.Error(t, err, "Cannot find task nothere in input")
+	assert.Error(t, err, "cannot find task nothere in input")
 }
 
 func TestReferencedPipelineNotInRepo(t *testing.T) {
 	_, _, err := readTDfile("referenced-pipeline-not-in-repo", false)
-	assert.Error(t, err, "Cannot find pipeline pipeline-test1 in input")
+	assert.Error(t, err, "cannot find pipeline pipeline-test1 in input")
 }
 
 func TestIgnoreDocSpace(t *testing.T) {

--- a/pkg/resolve/resolve_test.go
+++ b/pkg/resolve/resolve_test.go
@@ -17,7 +17,6 @@ import (
 )
 
 func TestMain(m *testing.M) {
-
 	setup()
 	ret := m.Run()
 	os.Exit(ret)
@@ -53,7 +52,7 @@ func TestPipelineRunPipelineTask(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, resolved.Spec.PipelineSpec.Tasks[0].TaskSpec.Steps[0].Name, "first-step")
 
-	//TODO: we should do templates substitions for those values here?
+	// TODO: we should do templates substitions for those values here?
 	assert.Equal(t, resolved.Spec.Params[0].Value.StringVal, "{{value}}")
 }
 

--- a/pkg/test/helpers.go
+++ b/pkg/test/helpers.go
@@ -87,8 +87,8 @@ func SetupGH() (client *github.Client, mux *http.ServeMux, serverURL string, tea
 
 // SeedTestData returns Clients and Informers populated with the
 // given Data.
-// nolint: golint
-func SeedTestData(ctx context.Context, t *testing.T, d Data) (Clients, Informers) {
+// nolint: golint, revive
+func SeedTestData(t *testing.T, ctx context.Context, d Data) (Clients, Informers) {
 	c := Clients{
 		PipelineAsCode: fakepacclient.Get(ctx),
 		Kube:           fakekubeclient.Get(ctx),

--- a/pkg/test/helpers.go
+++ b/pkg/test/helpers.go
@@ -86,8 +86,8 @@ func SetupGH() (client *github.Client, mux *http.ServeMux, serverURL string, tea
 }
 
 // SeedTestData returns Clients and Informers populated with the
-// given Data.
-// nolint: golint, revive
+// given Data. TODO: enable revive linter nolint
+// nolint: golint
 func SeedTestData(t *testing.T, ctx context.Context, d Data) (Clients, Informers) {
 	c := Clients{
 		PipelineAsCode: fakepacclient.Get(ctx),

--- a/pkg/test/helpers.go
+++ b/pkg/test/helpers.go
@@ -88,7 +88,7 @@ func SetupGH() (client *github.Client, mux *http.ServeMux, serverURL string, tea
 // SeedTestData returns Clients and Informers populated with the
 // given Data.
 // nolint: golint
-func SeedTestData(t *testing.T, ctx context.Context, d Data) (Clients, Informers) {
+func SeedTestData(ctx context.Context, t *testing.T, d Data) (Clients, Informers) {
 	c := Clients{
 		PipelineAsCode: fakepacclient.Get(ctx),
 		Kube:           fakekubeclient.Get(ctx),

--- a/pkg/test/kubernetesintf.go
+++ b/pkg/test/kubernetesintf.go
@@ -15,7 +15,7 @@ func (k *KinterfaceTest) GetConsoleUI(ns string, pr string) (string, error) {
 
 func (k *KinterfaceTest) GetNamespace(ns string) error {
 	if k.NamespaceError {
-		return errors.New("Cannot find Namespace")
+		return errors.New("cannot find Namespace")
 	}
 	return nil
 }

--- a/pkg/webvcs/github.go
+++ b/pkg/webvcs/github.go
@@ -37,7 +37,7 @@ func (r RunInfo) Check() error {
 		r.Owner != "" && r.URL != "" {
 		return nil
 	}
-	return fmt.Errorf("Missing values in runInfo")
+	return fmt.Errorf("missing values in runInfo")
 }
 
 // DeepCopyInto deep copy runinfo in another instance
@@ -104,7 +104,7 @@ func (v GithubVCS) ParsePayload(log *zap.SugaredLogger, payload string) (*RunInf
 	}
 
 	if prMap.PullRequest == nil {
-		return &RunInfo{}, errors.New("Cannot parse payload as PR")
+		return &RunInfo{}, errors.New("cannot parse payload as PR")
 	}
 
 	return &RunInfo{
@@ -123,7 +123,7 @@ func (v GithubVCS) GetTektonDir(path string, runinfo *RunInfo) ([]*github.Reposi
 		runinfo.Repository, path, &github.RepositoryContentGetOptions{Ref: runinfo.SHA})
 
 	if fp != nil {
-		return nil, fmt.Errorf("The object %s is a file instead of a directory", path)
+		return nil, fmt.Errorf("the object %s is a file instead of a directory", path)
 	}
 	if resp.Response.StatusCode == http.StatusNotFound {
 		return nil, nil
@@ -150,10 +150,10 @@ func (v GithubVCS) GetFileInsideRepo(path string, branch bool, runinfo *RunInfo)
 		return "", err
 	}
 	if objects != nil {
-		return "", fmt.Errorf("Referenced file inside the Github Repository %s is a directory", path)
+		return "", fmt.Errorf("referenced file inside the Github Repository %s is a directory", path)
 	}
 	if resp.Response.StatusCode == http.StatusNotFound {
-		return "", fmt.Errorf("Cannot find %s in this repository", path)
+		return "", fmt.Errorf("cannot find %s in this repository", path)
 	}
 
 	getobj, err := v.GetObject(fp.GetSHA(), runinfo)
@@ -173,7 +173,7 @@ func (v GithubVCS) GetFileFromDefaultBranch(path string, runinfo *RunInfo) (stri
 
 	tektonyaml, err := v.GetFileInsideRepo(path, true, runInfoOnMain)
 	if err != nil {
-		return "", fmt.Errorf("Cannot find %s inside the \"%s\" branch: %s", path, runInfoOnMain.Branch, err)
+		return "", fmt.Errorf("cannot find %s inside the \"%s\" branch: %s", path, runInfoOnMain.Branch, err)
 	}
 	return tektonyaml, err
 }

--- a/pkg/webvcs/github.go
+++ b/pkg/webvcs/github.go
@@ -60,8 +60,8 @@ func NewGithubVCS(token string) GithubVCS {
 // We got a bunch of \r\n or \n and others from triggers/github, so let just
 // workaround it. Originally from https://stackoverflow.com/a/52600147
 func payloadFix(payload string) string {
-	var replacement = " "
-	var replacer = strings.NewReplacer(
+	replacement := " "
+	replacer := strings.NewReplacer(
 		"\r\n", replacement,
 		"\r", replacement,
 		"\n", replacement,
@@ -146,7 +146,6 @@ func (v GithubVCS) GetFileInsideRepo(path string, branch bool, runinfo *RunInfo)
 
 	fp, objects, resp, err := v.Client.Repositories.GetContents(v.Context, runinfo.Owner,
 		runinfo.Repository, path, &github.RepositoryContentGetOptions{Ref: ref})
-
 	if err != nil {
 		return "", err
 	}
@@ -168,7 +167,7 @@ func (v GithubVCS) GetFileInsideRepo(path string, branch bool, runinfo *RunInfo)
 // GetFileFromDefaultBranch will get a file directly from the Default Branch as
 // configured in runinfo which is directly set in webhook by Github
 func (v GithubVCS) GetFileFromDefaultBranch(path string, runinfo *RunInfo) (string, error) {
-	var runInfoOnMain = &RunInfo{}
+	runInfoOnMain := &RunInfo{}
 	runinfo.DeepCopyInto(runInfoOnMain)
 	runInfoOnMain.Branch = runInfoOnMain.DefaultBranch
 

--- a/pkg/webvcs/github_test.go
+++ b/pkg/webvcs/github_test.go
@@ -175,6 +175,7 @@ func setupFakesURLS() (client GithubVCS, teardown func()) {
 
 	return gcvs, teardown
 }
+
 func TestGetFileInsideRepo(t *testing.T) {
 	gcvs, teardown := setupFakesURLS()
 	defer teardown()
@@ -417,7 +418,7 @@ func TestRunInfoCheck(t *testing.T) {
 
 func TestCreateStatus(t *testing.T) {
 	gcvs, teardown := setupFakesURLS()
-	var checkrunid = int64(2026)
+	checkrunid := int64(2026)
 	defer teardown()
 	runinfo := &RunInfo{
 		Owner:      "check",
@@ -430,9 +431,9 @@ func TestCreateStatus(t *testing.T) {
 }
 
 func TestGithubVCS_CreateStatus(t *testing.T) {
-	var checkrunid = int64(2026)
-	var resultid = int64(666)
-	var runinfo = &RunInfo{Owner: "check", Repository: "run", CheckRunID: &checkrunid}
+	checkrunid := int64(2026)
+	resultid := int64(666)
+	runinfo := &RunInfo{Owner: "check", Repository: "run", CheckRunID: &checkrunid}
 
 	type args struct {
 		runinfo            *RunInfo
@@ -534,7 +535,7 @@ func TestGithubVCS_CreateStatus(t *testing.T) {
 				if tt.args.nilCompletedAtDate {
 					// I guess that's the way you check for an undefined year,
 					// or maybe i don't understand fully how go works😅
-					assert.Assert(t, checkRun.GetCompletedAt().Year() == 0001)
+					assert.Assert(t, checkRun.GetCompletedAt().Year() == 0o001)
 				}
 				assert.Equal(t, checkRun.GetStatus(), tt.args.status)
 				assert.Equal(t, checkRun.GetConclusion(), tt.args.conclusion)

--- a/pkg/webvcs/github_test.go
+++ b/pkg/webvcs/github_test.go
@@ -77,7 +77,7 @@ func TestParsePayload(t *testing.T) {
 	assert.ErrorContains(t, err, "invalid character")
 
 	_, err = gvcs.ParsePayload(logger, "{\"hello\": \"moto\"}")
-	assert.Error(t, err, "Cannot parse payload as PR")
+	assert.Error(t, err, "cannot parse payload as PR")
 }
 
 func setupFakesURLS() (client GithubVCS, teardown func()) {
@@ -296,7 +296,7 @@ func TestGetTektonDir(t *testing.T) {
 			name: "tektondirisafile",
 			args: args{
 				assertion: func(t *testing.T, got []*github.RepositoryContent, err error) {
-					assert.Error(t, err, "The object .tekton is a file instead of a directory")
+					assert.Error(t, err, "the object .tekton is a file instead of a directory")
 					assert.Assert(t, got == nil)
 				},
 				path: ".tekton",


### PR DESCRIPTION
Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>- Use gofumnt for formatting in golangci-lint
- Use ifshort in golangci-lint
- Add revive linter
- Add staticcheck to golangci-lint
- Add unused, unparam
