### PR TITLE
Only run a PR if the sender is part of the org or repo owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Pipelines as code leverage on this technologies :
   - Use GitHUB blobs and objects API to get configuration files directly.
     (instead of checking the repo locally)
 
-## Usage
+## User usage
 
 ### GitHub apps Configuration
 
@@ -104,7 +104,9 @@ into the same namespace are where we want to execute them.
   the same namespace without risk of conflicts.
 
 - Everything that runs your pipeline should be self contained inside the
-  `.tekton/` directory including the tasks. Optionally it supports a file called
+  `.tekton/` directory including the tasks. If pipelines as code cannot resolve the referenced tasks in the `Pipeline` or `PipelineSpec` it will fails.
+
+- Optionally `Pipelines as Code` supports a configuration file called
   `tekton.yaml` which allows you to integrate *remote* tasks directly on your
   pipeline. For example if you have this :
 
@@ -128,10 +130,13 @@ into the same namespace are where we want to execute them.
 
 ### Running the Pipeline
 
-You simply send your Pull Request and Pipelines as Run will apply your pipeline
-and run it.
+User create a Pull Request.
 
-You can follow the execution of your pipeline with the
+If the user sending the Pull Request is not the owner of the repository or not a public member of the organization where the repository belong to, `Pipeline as Code` will not run.
+
+If the user is allowed, `Pipelines as Code` will start creating the `PipelineRun` in the target user namespace.
+
+The user can follow the execution of your pipeline with the
 [tkn](https://github.com/tektoncd/cli) cli :
 
 ```bash

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,6 @@
-# Pipelines as Code - TODO List
+# Pipelines as Code 
+
+See GitHub issue for more details
 
 ## Installation
 

--- a/pkg/cmd/pipelineascode/pipelineascode.go
+++ b/pkg/cmd/pipelineascode/pipelineascode.go
@@ -52,6 +52,7 @@ func Command(p cli.Params) *cobra.Command {
 	cmd.Flags().StringVarP(&opts.RunInfo.Repository, "webhook-repository", "", os.Getenv("PAC_REPOSITORY_NAME"), "Repository Name of the repository to test")
 	cmd.Flags().StringVarP(&opts.RunInfo.DefaultBranch, "webhook-defaultbranch", "", os.Getenv("PAC_DEFAULTBRANCH"), "DefaultBranch of the repository to test")
 	cmd.Flags().StringVarP(&opts.RunInfo.Branch, "webhook-target-branch", "", os.Getenv("PAC_BRANCH"), "Target branch of the repository to test")
+	cmd.Flags().StringVarP(&opts.RunInfo.Sender, "webhook-sender", "", os.Getenv("PAC_Sender"), "Sender for the commit/pr")
 	cmd.Flags().StringVarP(&opts.RunInfo.URL, "webhook-url", "", os.Getenv("PAC_URL"), "URL of the repository to test")
 
 	cmd.Flags().StringVarP(&opts.Payload, "payload", "", os.Getenv("PAC_PAYLOAD"), "The payload from webhook")

--- a/pkg/cmd/pipelineascode/pipelineascode_test.go
+++ b/pkg/cmd/pipelineascode/pipelineascode_test.go
@@ -30,6 +30,7 @@ func TestGetInfo(t *testing.T) {
 		SHA:           "d0d0",
 		URL:           "http://chmouel.com",
 		Branch:        "goodRuninfoBranch",
+		Sender:        "ElSender",
 	}
 
 	b, err := ioutil.ReadFile("testdata/pull_request.json")

--- a/pkg/pipelineascode/acl.go
+++ b/pkg/pipelineascode/acl.go
@@ -1,0 +1,29 @@
+package pipelineascode
+
+import (
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/webvcs"
+)
+
+// aclCheck check if we are allowed to run pipeline
+func aclCheck(cs *cli.Clients, runinfo *webvcs.RunInfo) (bool, error) {
+	// If the user who submitted the PR is the same as the Owner of the repo
+	// then allow it.
+	if runinfo.Owner == runinfo.Sender {
+		return true, nil
+	}
+
+	// If the user who has submitted the pr is a owner on the repo then allows
+	// the CI to be run.
+	isUserMemberRepo, err := cs.GithubClient.CheckSenderOrgMembership(runinfo)
+	if err != nil {
+		return false, err
+	}
+
+	if isUserMemberRepo {
+		return true, nil
+	}
+
+	// TODO: there is going to be more stuff in there
+	return false, err
+}

--- a/pkg/pipelineascode/acl_test.go
+++ b/pkg/pipelineascode/acl_test.go
@@ -1,0 +1,97 @@
+package pipelineascode
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
+	testhelper "github.com/openshift-pipelines/pipelines-as-code/pkg/test"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/webvcs"
+)
+
+func TestAclCheck(t *testing.T) {
+	fakeclient, mux, _, teardown := testhelper.SetupGH()
+	defer teardown()
+
+	orgallowed := "allowed"
+	orgdenied := "denied"
+	errit := "err"
+
+	mux.HandleFunc("/orgs/"+orgallowed+"/public_members", func(rw http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(rw, `[{"login": "login_%s"}]`, orgallowed)
+	})
+
+	mux.HandleFunc("/orgs/"+orgdenied+"/public_members", func(rw http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(rw, `[]`)
+	})
+	mux.HandleFunc("/orgs/"+errit+"/public_members", func(rw http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(rw, `x1x`)
+	})
+
+	gvcs := webvcs.GithubVCS{
+		Client:  fakeclient,
+		Context: context.Background(),
+	}
+
+	tests := []struct {
+		name    string
+		runinfo *webvcs.RunInfo
+		allowed bool
+		wantErr bool
+	}{
+		{
+			name: "sender allowed in org",
+			runinfo: &webvcs.RunInfo{
+				Owner:  orgallowed,
+				Sender: "login_allowed",
+			},
+			allowed: true,
+			wantErr: false,
+		},
+		{
+			name: "owner is sender is allowed",
+			runinfo: &webvcs.RunInfo{
+				Owner:  orgallowed,
+				Sender: "allowed",
+			},
+			allowed: true,
+			wantErr: false,
+		},
+		{
+			name: "sender not allowed in org",
+			runinfo: &webvcs.RunInfo{
+				Owner:  orgdenied,
+				Sender: "notallowed",
+			},
+			allowed: false,
+			wantErr: false,
+		},
+		{
+			name: "err it",
+			runinfo: &webvcs.RunInfo{
+				Owner:  errit,
+				Sender: "error",
+			},
+			allowed: false,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cs := cli.Clients{
+				GithubClient: gvcs,
+			}
+
+			got, err := aclCheck(&cs, tt.runinfo)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("aclCheck() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.allowed {
+				t.Errorf("aclCheck() = %v, want %v", got, tt.allowed)
+			}
+		})
+	}
+}

--- a/pkg/pipelineascode/pipelineascode_test.go
+++ b/pkg/pipelineascode/pipelineascode_test.go
@@ -168,11 +168,12 @@ func TestRunDeniedFromForcedNamespace(t *testing.T) {
 	installedNamespace := "nomespace"
 	runinfo := &webvcs.RunInfo{
 		SHA:           "principale",
-		Owner:         "chmouel",
+		Owner:         "organizatione",
 		Repository:    "repo",
 		URL:           "https://service/documentation",
 		Branch:        "press",
 		DefaultBranch: defaultBranch,
+		Sender:        "carlos_valderama",
 	}
 	replyString(mux,
 		fmt.Sprintf("/repos/%s/%s/check-runs", runinfo.Owner, runinfo.Repository),
@@ -192,6 +193,10 @@ func TestRunDeniedFromForcedNamespace(t *testing.T) {
 		func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprintf(w, `{"content": "%s"}`, forcedNamespaceContent)
 		})
+
+	mux.HandleFunc("/orgs/"+runinfo.Owner+"/public_members", func(rw http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(rw, `[{"login": "%s"}]`, runinfo.Sender)
+	})
 
 	gcvs := webvcs.GithubVCS{
 		Client:  fakeclient,
@@ -222,10 +227,11 @@ func TestRun(t *testing.T) {
 	defer teardown()
 	runinfo := &webvcs.RunInfo{
 		SHA:        "principale",
-		Owner:      "gaston",
+		Owner:      "organizationes",
 		Repository: "lagaffe",
 		URL:        "https://service/documentation",
 		Branch:     "press",
+		Sender:     "fantasio",
 	}
 
 	replyString(mux,
@@ -256,6 +262,10 @@ func TestRun(t *testing.T) {
 	replyString(mux,
 		fmt.Sprintf("/repos/%s/%s/contents/internal/task", runinfo.Owner, runinfo.Repository),
 		`{"sha": "internaltasksha"}`)
+
+	mux.HandleFunc("/orgs/"+runinfo.Owner+"/public_members", func(rw http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(rw, `[{"login": "%s"}]`, runinfo.Sender)
+	})
 
 	// Internal task referenced in tekton.yaml
 	taskB, err := ioutil.ReadFile("testdata/task.yaml")


### PR DESCRIPTION
If PR sender is a public member (because we can't otherwise with github
app to have that info) on the organization where the pr has been sent.

If user that submitted the PR is owner of the repo then allow it too.

There is going to be a bit more logic here for OWNERS but let not go too
ahead of ourselves.

partial addressing #39

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
