### PR TITLE
config fixes: rights to get route and check_run event_type

### DIFF
--- a/config/200-role.yaml
+++ b/config/200-role.yaml
@@ -95,6 +95,9 @@ rules:
   - apiGroups: ["tekton.dev"]
     resources: ["taskruns"]
     verbs: ["get"]
+  - apiGroups: ["route.openshift.io"]
+    resources: ["routes"]
+    verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/config/400-triggers.yaml
+++ b/config/400-triggers.yaml
@@ -21,6 +21,7 @@ spec:
             eventTypes:
               - pull_request
               - issue_comment
+              - check_run
         - cel:
             filter: "body.action in ['created', 'rerequested', 'opened', 'synchronize'] && 'installation' in body"
       template:


### PR DESCRIPTION
* Add right to retrieve route on cluster for SA, so we know where the
console is.

* Add check_run eventtype to accept so we can get rereun working properly.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
