### PR TITLE
Support OWNERS file at root repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,14 @@ User create a Pull Request.
 
 If the user sending the Pull Request is not the owner of the repository or not a public member of the organization where the repository belong to, `Pipeline as Code` will not run.
 
+If the user sending the Pull Request is inside an OWNER file located in the repository root in the main branch (the main branch as defined in the Github configuration for the repo) in the `approvers` or `reviewers` section like this :  
+
+```yaml
+approvers:
+  - approved
+```
+then the user `approved` will be allowed.
+
 If the user is allowed, `Pipelines as Code` will start creating the `PipelineRun` in the target user namespace.
 
 The user can follow the execution of your pipeline with the

--- a/pkg/cmd/pipelineascode/pipelineascode_test.go
+++ b/pkg/cmd/pipelineascode/pipelineascode_test.go
@@ -4,10 +4,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
 	pacpkg "github.com/openshift-pipelines/pipelines-as-code/pkg/pipelineascode"
 	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
@@ -29,13 +27,6 @@ func TestRunWrapOld(t *testing.T) {
 	checkid := 1234
 	defer teardown()
 
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(os.Stderr, `
-		============================================
-		%s
-		============================================
-		`, spew.Sdump(r.URL))
-	})
 	mux.HandleFunc("/repos/chmouel/scratchmyback/check-runs", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, `{"id": %d}`, checkid)
 	})

--- a/pkg/pipelineascode/acl.go
+++ b/pkg/pipelineascode/acl.go
@@ -1,9 +1,18 @@
 package pipelineascode
 
 import (
+	"strings"
+
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/webvcs"
+	"sigs.k8s.io/yaml"
 )
+
+// OwnersConfig prow owner, only supporting approvers or reviewers in yaml
+type OwnersConfig struct {
+	Approvers []string `json:"approvers,omitempty"`
+	Reviewers []string `json:"reviewers,omitempty"`
+}
 
 // aclCheck check if we are allowed to run pipeline
 func aclCheck(cs *cli.Clients, runinfo *webvcs.RunInfo) (bool, error) {
@@ -24,6 +33,25 @@ func aclCheck(cs *cli.Clients, runinfo *webvcs.RunInfo) (bool, error) {
 		return true, nil
 	}
 
-	// TODO: there is going to be more stuff in there
-	return false, err
+	// If we have a prow OWNERS file in the defaultBranch (ie: master) then
+	// parse it in approvers and reviewers field and check if sender is in there.
+	ownerFile, err := cs.GithubClient.GetFileFromDefaultBranch("OWNERS", runinfo)
+
+	// Don't error out if the OWNERS file cannot be found
+	if err != nil && !strings.Contains(err.Error(), "cannot find") {
+		return false, err
+	} else if ownerFile != "" {
+		var ownerConfig OwnersConfig
+		err := yaml.Unmarshal([]byte(ownerFile), &ownerConfig)
+		if err != nil {
+			return false, err
+		}
+		for _, owner := range append(ownerConfig.Approvers, ownerConfig.Reviewers...) {
+			if owner == runinfo.Sender {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
 }


### PR DESCRIPTION
If we find a OWNERS file at the repository root in the main
branch we parse it in prow syntax and allow the PR to be tested if the
owners is in there.
    
Doesn't handle OWNERS_ALIAS (yet or not yet)
    
Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
