### PR TITLE
Add event_type in created pod

### DIFF
--- a/config/400-triggers.yaml
+++ b/config/400-triggers.yaml
@@ -79,6 +79,7 @@ spec:
   params:
     - name: installation_id
     - name: payload
+    - name: event_type
   resourcetemplates:
     - apiVersion: tekton.dev/v1beta1
       kind: PipelineRun
@@ -93,11 +94,13 @@ spec:
             value: $(tt.params.installation_id)
           - name: payload
             value: $(tt.params.payload)
-
+          - name: event_type
+            value: $(tt.params.event_type)
         pipelineSpec:
           params:
             - name: installation_id
             - name: payload
+            - name: event_type
           workspaces:
             - name: secrets
           tasks:
@@ -116,6 +119,8 @@ spec:
                 params:
                   - name: payload
                     type: string
+                  - name: event_type
+                    type: string
                   - name: token
                     type: string
                 steps:
@@ -127,6 +132,8 @@ spec:
                             fieldPath: metadata.labels['tekton.dev/pipelineRun']
                       - name: PAC_PAYLOAD
                         value: "$(params.payload)"
+                      - name: PAC_EVENT_TYPE
+                        value: "$(params.event_type)"
                       - name: PAC_TOKEN
                         value: "$(params.token)"
                     image: "ko://github.com/openshift-pipelines/pipelines-as-code/cmd/pipelines-as-code"
@@ -135,6 +142,8 @@ spec:
                   value: "$(tasks.get-token.results.token)"
                 - name: payload
                   value: "$(params.payload)"
+                - name: event_type
+                  value: "$(params.event_type)"
         workspaces:
           - name: secrets
             secret:
@@ -152,5 +161,7 @@ spec:
   params:
     - name: payload
       value: $(body)
+    - name: event_type
+      value: $(header.X-GitHub-Event)
     - name: installation_id
       value: $(body.installation.id)

--- a/hack/replay-gh-events.py
+++ b/hack/replay-gh-events.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Author: Chmouel Boudjnah <chmouel@chmouel.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+"""Will replay a json file in Eventlistenner, it automatically detects the
+EventListenner, the webhook secret from github-app-secret secret name
+require requests library"""
+import argparse
+import base64
+import hashlib
+import hmac
+import json
+import subprocess
+
+import requests
+
+NAMESPACE = "pipelines-ascode"
+SECRET_NAME = "github-app-secret"
+ELNAME = "openshift-pipelines-ascode"
+
+
+def get_el_route():
+    elroute = subprocess.run(
+        f"oc get route -n {NAMESPACE} -l eventlistener={ELNAME}-interceptor -o json",
+        shell=True,
+        check=True,
+        capture_output=True)
+    return "https://" + \
+        json.loads(elroute.stdout)["items"][0]["status"]["ingress"][0]["host"]
+
+
+def get_installation_id_and_webhook_secret():
+    secret = subprocess.run(
+        f"kubectl get secret {SECRET_NAME} -n{NAMESPACE} -o json",
+        shell=True,
+        check=True,
+        capture_output=True)
+    jeez = json.loads(secret.stdout)
+    return (jeez["data"]["application_id"],
+            base64.b64decode(jeez["data"]["webhook.secret"]).decode())
+
+
+def main(args):
+    application_id, secret = get_installation_id_and_webhook_secret()
+    el = get_el_route()
+    text = open(args.json_file).read()
+    jeez = json.loads(text)
+    esha256 = hmac.new(secret.encode("utf-8"),
+                       msg=text.encode("utf-8"),
+                       digestmod=hashlib.sha256).hexdigest()
+    esha1 = hmac.new(secret.encode("utf-8"),
+                     msg=text.encode("utf-8"),
+                     digestmod=hashlib.sha1).hexdigest()
+
+    print("Replay event for repo " + jeez["repository"]["full_name"])
+    if jeez["action"] in ("opened", "synchronize") and "pull_request" in jeez:
+        event_type = "pull_request"
+    elif jeez["action"] in ("rerequested") and "check_run" in jeez:
+        event_type = "check_run"
+    else:
+        raise Exception("Unknown event_type")
+
+    headers = {
+        "content-type": "application/json",
+        "X-GitHub-Event": event_type,
+        "X-GitHub-Hook-Installation-Target-ID": application_id,
+        "X-GitHub-Hook-Installation-Target-Type": "integration",
+        "X-Hub-Signature": "sha1=" + esha1,
+        "X-Hub-Signature-256": "sha256=" + esha256,
+    }
+    r = requests.request("POST",
+                         el,
+                         data=text.encode("utf-8"),
+                         headers=headers)
+    print(r.content.decode())
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Replay a webhook')
+    parser.add_argument("json_file", help="json file name")
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    main(parse_args())

--- a/pkg/cmd/pipelineascode/pipelineascode.go
+++ b/pkg/cmd/pipelineascode/pipelineascode.go
@@ -62,9 +62,10 @@ func Command(p cli.Params) *cobra.Command {
 	cmd.Flags().StringVarP(&opts.RunInfo.Branch, "webhook-target-branch", "", os.Getenv("PAC_BRANCH"), "Target branch of the repository to test")
 	cmd.Flags().StringVarP(&opts.RunInfo.Sender, "webhook-sender", "", os.Getenv("PAC_Sender"), "Sender for the commit/pr")
 	cmd.Flags().StringVarP(&opts.RunInfo.URL, "webhook-url", "", os.Getenv("PAC_URL"), "URL of the repository to test")
+	cmd.Flags().StringVarP(&opts.RunInfo.EventType, "webhook-type", "", os.Getenv("PAC_EVENT_TYPE"), "Payload event type as set from Github")
 
-	cmd.Flags().StringVarP(&opts.Payload, "payload", "", os.Getenv("PAC_PAYLOAD"), "The payload from webhook")
-	cmd.Flags().StringVarP(&opts.PayloadFile, "payload-file", "", os.Getenv("PAC_PAYLOAD_FILE"), "A file which contains the webhook payload")
+	cmd.Flags().StringVarP(&opts.Payload, "payload", "", os.Getenv("PAC_PAYLOAD"), "The payload from webhook as string")
+	cmd.Flags().StringVarP(&opts.PayloadFile, "payload-file", "", os.Getenv("PAC_PAYLOAD_FILE"), "A file containing the webhook payload")
 	return cmd
 }
 
@@ -75,7 +76,7 @@ func getRunInfoFromArgsOrPayload(cs *cli.Clients, payload string, runinfo *webvc
 		return &webvcs.RunInfo{}, fmt.Errorf("no payload or not enough params set properly")
 	}
 
-	payloadinfo, err := cs.GithubClient.ParsePayload(cs.Log, payload)
+	payloadinfo, err := cs.GithubClient.ParsePayload(cs.Log, runinfo.EventType, payload)
 	if err != nil {
 		return &webvcs.RunInfo{}, err
 	}

--- a/pkg/cmd/pipelineascode/pipelineascode_test.go
+++ b/pkg/cmd/pipelineascode/pipelineascode_test.go
@@ -42,7 +42,11 @@ func TestRunWrapOld(t *testing.T) {
 		ConsoleURL: "https://console.url",
 	}
 
-	options := &pacpkg.Options{}
+	options := &pacpkg.Options{
+		RunInfo: webvcs.RunInfo{
+			EventType: "pull_request",
+		},
+	}
 	err := runWrap(options, cs, k8int)
 	assert.ErrorContains(t, err, "no payload")
 
@@ -71,6 +75,7 @@ func TestGetInfo(t *testing.T) {
 		URL:           "http://chmouel.com",
 		Branch:        "goodRuninfoBranch",
 		Sender:        "ElSender",
+		EventType:     "pull_request",
 	}
 
 	b, err := ioutil.ReadFile("testdata/pull_request.json")
@@ -103,15 +108,9 @@ func TestGetInfo(t *testing.T) {
 	}{
 		{
 			desc:    "Error on bad payload",
-			runinfo: webvcs.RunInfo{},
+			runinfo: webvcs.RunInfo{EventType: "pull_request"},
 			payload: "foo bar",
 			errmsg:  "invalid character",
-		},
-		{
-			desc:    "Good json but bad payload",
-			runinfo: webvcs.RunInfo{},
-			payload: "{}",
-			errmsg:  "cannot parse payload",
 		},
 		{
 			desc:    "No payload no runcheck",
@@ -122,14 +121,15 @@ func TestGetInfo(t *testing.T) {
 		{
 			desc: "Bad runinfo with missing infos",
 			runinfo: webvcs.RunInfo{
-				Owner: "foo",
+				Owner:     "foo",
+				EventType: "pull_request",
 			},
 			payload: "",
 			errmsg:  "no payload or not enough params",
 		},
 		{
 			desc:    "Missing values payload",
-			runinfo: webvcs.RunInfo{},
+			runinfo: webvcs.RunInfo{EventType: "pull_request"},
 			payload: missingValuesPayload,
 			errmsg:  "missing some values",
 		},
@@ -142,7 +142,7 @@ func TestGetInfo(t *testing.T) {
 		},
 		{
 			desc:           "Good payload",
-			runinfo:        webvcs.RunInfo{},
+			runinfo:        webvcs.RunInfo{EventType: "pull_request"},
 			payload:        goodPayload,
 			errmsg:         "",
 			branchShouldBe: "goodInfoBranch",
@@ -193,6 +193,7 @@ func TestRunWrap(t *testing.T) {
 		{
 			name: "good",
 			opts: &pacpkg.Options{
+				RunInfo:     webvcs.RunInfo{EventType: "pull_request"},
 				PayloadFile: "testdata/pull_request.json",
 			},
 		},


### PR DESCRIPTION
* Refactor code to use github.ParsePayload to parse the event type. This is the premice works to get proper separation of all event type.
    
* We address a minor hijack probability where a rogued user would be able to use the recheck event to DDOS a CI.
    
* Triggers is stil buggy with a full payload, we probably will need to change the
technique of passing information in there unless we start to redo everything as
a Webhook interceptor and just not deal with triggers anymore :\

* Add a python script to help test and replay json payloads 