### PR TITLE
Match pipelinerun by annotation

### DIFF
--- a/.tekton/run.yaml
+++ b/.tekton/run.yaml
@@ -3,20 +3,22 @@ apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
   name: pipelines-as-code-test-run
+  pipelinesascode.tekton.dev/on-target-branch: "[main]"
+  pipelinesascode.tekton.dev/on-event: "[pull_request]"
 spec:
   pipelineRef:
     name: pipelines-as-code-test
   params:
     - name: repo_url
-      value: {{repo_url}}
+      value: "{{repo_url}}"
     - name: revision
-      value: {{revision}}
+      value: "{{revision}}"
   workspaces:
-  - name: source
-    volumeClaimTemplate:
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: 1Gi
+    - name: source
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi

--- a/pkg/config/annotation_matcher_test.go
+++ b/pkg/config/annotation_matcher_test.go
@@ -1,0 +1,177 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/webvcs"
+	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"go.uber.org/zap"
+	zapobserver "go.uber.org/zap/zaptest/observer"
+	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestMatchPipelinerunByAnnotation(t *testing.T) {
+	pipelineGood := &tektonv1beta1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pipeline-good",
+			Annotations: map[string]string{
+				pipelinesascode.GroupName + "/" + onEventAnnotation:        "[pull_request]",
+				pipelinesascode.GroupName + "/" + onTargetBranchAnnotation: "[main]",
+			},
+		},
+	}
+
+	pipelineOther := &tektonv1beta1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pipeline-other",
+			Annotations: map[string]string{
+				pipelinesascode.GroupName + "/" + onEventAnnotation:        "[pull_request]",
+				pipelinesascode.GroupName + "/" + onTargetBranchAnnotation: "[main]",
+			},
+		},
+	}
+
+	observer, log := zapobserver.New(zap.InfoLevel)
+	logger := zap.New(observer).Sugar()
+	cs := &cli.Clients{
+		Log: logger,
+	}
+
+	type args struct {
+		pruns   []*tektonv1beta1.PipelineRun
+		runinfo *webvcs.RunInfo
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantErr    bool
+		wantPrName string
+		wantLog    string
+	}{
+		{
+			name: "good-match-with-only-one",
+			args: args{
+				pruns:   []*tektonv1beta1.PipelineRun{pipelineGood},
+				runinfo: &webvcs.RunInfo{EventType: "pull_request", BaseBranch: "main"},
+			},
+			wantErr:    false,
+			wantPrName: "pipeline-good",
+		},
+		{
+			name: "first-one-match-with-two-good-ones",
+			args: args{
+				pruns:   []*tektonv1beta1.PipelineRun{pipelineGood, pipelineOther},
+				runinfo: &webvcs.RunInfo{EventType: "pull_request", BaseBranch: "main"},
+			},
+			wantErr:    false,
+			wantPrName: "pipeline-good",
+		},
+		{
+			name: "no-match-on-event",
+			args: args{
+				pruns:   []*tektonv1beta1.PipelineRun{pipelineGood, pipelineOther},
+				runinfo: &webvcs.RunInfo{EventType: "push", BaseBranch: "main"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "no-match-on-target-branch",
+			args: args{
+				pruns:   []*tektonv1beta1.PipelineRun{pipelineGood, pipelineOther},
+				runinfo: &webvcs.RunInfo{EventType: "pull_request", BaseBranch: "other"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "no-annotation",
+			args: args{
+				pruns: []*tektonv1beta1.PipelineRun{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pipeline-other",
+						},
+					},
+				},
+				runinfo: &webvcs.RunInfo{EventType: "push", BaseBranch: "main"},
+			},
+			wantErr: true,
+			wantLog: "does not have any annotations",
+		},
+		{
+			name: "bad-event-annotation",
+			args: args{
+				runinfo: &webvcs.RunInfo{EventType: "pull_request", BaseBranch: "main"},
+				pruns: []*tektonv1beta1.PipelineRun{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "bad-event-annotation",
+							Annotations: map[string]string{
+								pipelinesascode.GroupName + "/" + onEventAnnotation:        "pull_request",
+								pipelinesascode.GroupName + "/" + onTargetBranchAnnotation: "[main]",
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "bad-target-branch-annotation",
+			args: args{
+				runinfo: &webvcs.RunInfo{EventType: "pull_request", BaseBranch: "main"},
+				pruns: []*tektonv1beta1.PipelineRun{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "bad-target-branch-annotation",
+							Annotations: map[string]string{
+								pipelinesascode.GroupName + "/" + onEventAnnotation:        "[pull_request]",
+								pipelinesascode.GroupName + "/" + onTargetBranchAnnotation: "main",
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty-annotation",
+			args: args{
+				runinfo: &webvcs.RunInfo{EventType: "pull_request", BaseBranch: "main"},
+				pruns: []*tektonv1beta1.PipelineRun{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "bad-target-branch-annotation",
+							Annotations: map[string]string{
+								pipelinesascode.GroupName + "/" + onEventAnnotation:        "[]",
+								pipelinesascode.GroupName + "/" + onTargetBranchAnnotation: "[]",
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := MatchPipelinerunByAnnotation(tt.args.pruns, cs, tt.args.runinfo)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("MatchPipelinerunByAnnotation() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantPrName != "" {
+				assert.Assert(t, got.GetName() == tt.wantPrName, "Pipelinerun hasn't been matched: "+got.GetName()+"!="+tt.wantPrName)
+			}
+			if tt.wantLog != "" {
+				logmsg := log.TakeAll()
+				assert.Assert(t, len(logmsg) > 0)
+				assert.Assert(t, strings.Contains(logmsg[0].Message, tt.wantLog))
+			}
+		})
+	}
+}

--- a/pkg/pipelineascode/pipelineascode_test.go
+++ b/pkg/pipelineascode/pipelineascode_test.go
@@ -191,7 +191,7 @@ func TestRunDeniedFromForcedNamespace(t *testing.T) {
 			}
 		})
 
-	forcedNamespaceContent := base64.RawStdEncoding.EncodeToString([]byte("namespace: "+forcedNamespace+"\n")) + "="
+	forcedNamespaceContent := base64.StdEncoding.EncodeToString([]byte("namespace: " + forcedNamespace + "\n"))
 	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/git/blobs/shaofmaintektonyaml", runinfo.Owner, runinfo.Repository),
 		func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprintf(w, `{"content": "%s"}`, forcedNamespaceContent)
@@ -235,6 +235,7 @@ func TestRun(t *testing.T) {
 		HeadBranch: "press",
 		BaseBranch: "main",
 		Sender:     "fantasio",
+		EventType:  "pull_request",
 	}
 
 	replyString(mux,
@@ -275,16 +276,16 @@ func TestRun(t *testing.T) {
 	assert.NilError(t, err)
 	replyString(mux,
 		fmt.Sprintf("/repos/%s/%s/git/blobs/internaltasksha", runinfo.Owner, runinfo.Repository),
-		fmt.Sprintf(`{"encoding": "base64","content": "%s="}`,
-			base64.RawStdEncoding.EncodeToString(taskB)))
+		fmt.Sprintf(`{"encoding": "base64","content": "%s"}`,
+			base64.StdEncoding.EncodeToString(taskB)))
 
 	// Tekton.yaml
 	tlB, err := ioutil.ReadFile("testdata/tekton.yaml")
 	assert.NilError(t, err)
 	replyString(mux,
 		fmt.Sprintf("/repos/%s/%s/git/blobs/eacad9fa044f3d9039bb04c9452eadf0c43e3195", runinfo.Owner, runinfo.Repository),
-		fmt.Sprintf(`{"encoding": "base64","content": "%s="}`,
-			base64.RawStdEncoding.EncodeToString(tlB)))
+		fmt.Sprintf(`{"encoding": "base64","content": "%s"}`,
+			base64.StdEncoding.EncodeToString(tlB)))
 
 	// Run.yaml
 	prB, err := ioutil.ReadFile("testdata/run.yaml")
@@ -292,15 +293,15 @@ func TestRun(t *testing.T) {
 	replyString(mux,
 		fmt.Sprintf("/repos/%s/%s/git/blobs/9085026cd00516d1db7101191d61a4371933c735", runinfo.Owner, runinfo.Repository),
 		fmt.Sprintf(`{"encoding": "base64","content": "%s"}`,
-			base64.RawStdEncoding.EncodeToString(prB)))
+			base64.StdEncoding.EncodeToString(prB)))
 
 	// Pipeline.yaml
 	pB, err := ioutil.ReadFile("testdata/pipeline.yaml")
 	assert.NilError(t, err)
 	replyString(mux,
 		fmt.Sprintf("/repos/%s/%s/git/blobs/5f44631b24c740288924767c608af932756d6c1a", runinfo.Owner, runinfo.Repository),
-		fmt.Sprintf(`{"encoding": "base64","content": "%s=="}`,
-			base64.RawStdEncoding.EncodeToString(pB)))
+		fmt.Sprintf(`{"encoding": "base64","content": "%s"}`,
+			base64.StdEncoding.EncodeToString(pB)))
 
 	replyString(mux,
 		fmt.Sprintf("/repos/%s/%s/check-runs", runinfo.Owner, runinfo.Repository),

--- a/pkg/pipelineascode/templating.go
+++ b/pkg/pipelineascode/templating.go
@@ -7,6 +7,7 @@ import (
 
 var reTemplate = regexp.MustCompile(`{{([^}]{2,})}}`)
 
+// ReplacePlaceHoldersVariables Replace those {{var}} placeholders to the runinfo variable
 func ReplacePlaceHoldersVariables(template string, dico map[string]string) string {
 	return reTemplate.ReplaceAllStringFunc(template, func(s string) string {
 		parts := reTemplate.FindStringSubmatch(s)

--- a/pkg/pipelineascode/testdata/run.yaml
+++ b/pkg/pipelineascode/testdata/run.yaml
@@ -3,6 +3,9 @@ apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
   name: hello-test-pipeline
+  annotations:
+    pipelinesascode.tekton.dev/on-target-branch: "[main]"
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
 spec:
   pipelineRef:
     name: pipeline1

--- a/pkg/webvcs/github.go
+++ b/pkg/webvcs/github.go
@@ -261,8 +261,9 @@ func (v GithubVCS) GetFileFromDefaultBranch(ctx context.Context, path string, ru
 	return tektonyaml, err
 }
 
-// GetTektonDirTemplate Get all templates in tekton directory
-func (v GithubVCS) GetTektonDirTemplate(ctx context.Context, objects []*github.RepositoryContent, runinfo *RunInfo) (string, error) {
+// ConcatAllYamlFiles concat all yaml files from a directory as one big multi document yaml string
+// TODO: trash the tekton.yaml condition when we don't need it anymore
+func (v GithubVCS) ConcatAllYamlFiles(ctx context.Context, objects []*github.RepositoryContent, runinfo *RunInfo) (string, error) {
 	var allTemplates string
 
 	for _, value := range objects {

--- a/pkg/webvcs/github_test.go
+++ b/pkg/webvcs/github_test.go
@@ -126,7 +126,7 @@ func TestPayLoadFix(t *testing.T) {
 	logger, _ := getLogger()
 	_, err = gvcs.ParsePayload(ctx, logger, "pull_request", payloadFix(string(b)))
 	// would bomb out on "assertion failed: error is not nil: invalid character
-	// '\n' in string literal" if we don't payloadfix
+	// '\n' in string literal" if we don't fix the payload
 	assert.NilError(t, err)
 }
 
@@ -135,9 +135,9 @@ func TestParsePayloadRerequest(t *testing.T) {
 	prOwner := "openshift"
 	repoName := "pipelines"
 	prNumber := "123"
-	checkrunEvent := fmt.Sprintf(`{"action": "rerequested", 
+	checkrunEvent := fmt.Sprintf(`{"action": "rerequested",
 	"sender": {"login": "%s"},
-	"check_run": {"check_suite": {"pull_requests": [{"number": %s}]}}, 
+	"check_run": {"check_suite": {"pull_requests": [{"number": %s}]}},
 	"repository": {"name": "%s", "owner": {"login": "%s"}}}`,
 		checkrunSender, prNumber, repoName, prOwner)
 	fakeclient, mux, _, teardown := ghtesthelper.SetupGH()
@@ -417,7 +417,7 @@ hello runyaml
 	ghr, err := gcvs.GetTektonDir(ctx, ".tekton", runinfo)
 	assert.NilError(t, err)
 
-	got, err := gcvs.GetTektonDirTemplate(ctx, ghr, runinfo)
+	got, err := gcvs.ConcatAllYamlFiles(ctx, ghr, runinfo)
 	assert.NilError(t, err)
 	if d := cmp.Diff(got, expected); d != "" {
 		t.Fatalf("-got, +want: %v", d)


### PR DESCRIPTION
Introduce pipeline annotation based event matching.

If we have multiple pipelineruns in the .tekton directory, we go over the
annotations and match the event on the pipeline annotation.

For example :

```yaml
metadata:
 name: pipeline-pr-main
 annotations:
    pipelinesascode.tekton.dev/on-target-branch: [main]
    pipelinesascode.tekton.dev/on-event: [pull_request]
```

will match the pipelinerun pipeline-pr-main if the github event target the main
branch and is coming from a pull_request.

If there is multiple pipeline matching the same event, it will match the first
one.

TODO: We currently enforce annotations to be in PipelineRun, maybe this can be
optional and by default if there isn't annotation the target branch will be the
repository default branch (ie: main) and the event will be pull_request.

/cc @siamaksade