### PR TITLE
Add eventtype and branch to repo CR format print

### DIFF
--- a/config/300-repositories.yaml
+++ b/config/300-repositories.yaml
@@ -16,8 +16,11 @@ spec:
         - jsonPath: .spec.url
           name: URL
           type: string
-        - jsonPath: .spec.namespace
-          name: Namespace
+        - jsonPath: .spec.event_type
+          name: EventType
+          type: string
+        - jsonPath: .spec.branch
+          name: Branch
           type: string
         - name: Succeeded
           type: string


### PR DESCRIPTION
This would look like this : 

![image](https://user-images.githubusercontent.com/98980/118983996-54d18580-b97d-11eb-80b3-599a681f2bbe.png)


probably need to figure out how to make it more succint