### PR TITLE
Make sure to set event as PR in retest

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,17 @@ with a short recap of how long each task of your pipeline took and the output of
 `tkn pr describe`.
 
 If there was a failure you can click on the "Re-Run" button on the left to rerun
-the Pipeline.
+the Pipeline or you can issue a issue comment with a line starting and finishing
+with the string `/retest` to ask Pipeline as Code to retest the current PR.
+
+Example :
+
+```
+Thanks for contributing! This is a much needed bugfix! ❤️
+The failure is not with your PR but seems to be an infra issue.
+
+/retest
+```
 
 #### CRD
 

--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -36,7 +36,6 @@ func getRepoByCR(ctx context.Context, cs *cli.Clients, runinfo *webvcs.RunInfo) 
 	for _, value := range repositories.Items {
 		if value.Spec.URL == runinfo.URL && value.Spec.Branch == runinfo.BaseBranch &&
 			value.Spec.EventType == runinfo.EventType {
-
 			// TODO: figure it out when we renable forceNamespace
 			// if forceNamespace != "" && value.Namespace != forceNamespace {
 			//	return repository, fmt.Errorf(
@@ -101,7 +100,7 @@ func Run(ctx context.Context, cs *cli.Clients, k8int cli.KubeInteractionIntf, ru
 		return err
 	}
 	if repo.Spec.Namespace == "" {
-		msg := fmt.Sprintf("Could not find a namespace match for %s/%s on %s", runinfo.Owner, runinfo.Repository, runinfo.BaseBranch)
+		msg := fmt.Sprintf("Could not find a namespace match for %s/%s on target-branch:%s event-type: %s", runinfo.Owner, runinfo.Repository, runinfo.BaseBranch, runinfo.EventType)
 		err = createStatus(ctx, cs, runinfo, "completed", "skipped", msg, "https://tenor.com/search/sad-cat-gifs", true)
 		if err != nil {
 			return err

--- a/pkg/webvcs/github.go
+++ b/pkg/webvcs/github.go
@@ -127,6 +127,7 @@ func (v GithubVCS) getPullRequest(ctx context.Context, runinfo RunInfo, prNumber
 	runinfo.Sender = pr.GetUser().GetLogin()
 	runinfo.HeadBranch = pr.GetHead().GetRef()
 	runinfo.BaseBranch = pr.GetBase().GetRef()
+	runinfo.EventType = "pull_request"
 	return runinfo, nil
 }
 
@@ -150,7 +151,6 @@ func (v GithubVCS) ParsePayload(ctx context.Context, log *zap.SugaredLogger, eve
 			if err != nil {
 				return &runinfo, err
 			}
-
 		}
 	case *github.IssueCommentEvent:
 		runinfo, err = v.handleIssueCommentEvent(ctx, log, event)
@@ -166,6 +166,7 @@ func (v GithubVCS) ParsePayload(ctx context.Context, log *zap.SugaredLogger, eve
 			URL:           event.GetRepo().GetHTMLURL(),
 			Sender:        event.GetSender().GetLogin(),
 			BaseBranch:    event.GetRef(),
+			EventType:     eventType,
 		}
 		runinfo.HeadBranch = runinfo.BaseBranch // in push events Head Branch is the same as Basebranch
 	case *github.PullRequestEvent:
@@ -178,11 +179,11 @@ func (v GithubVCS) ParsePayload(ctx context.Context, log *zap.SugaredLogger, eve
 			BaseBranch:    event.GetPullRequest().Base.GetRef(),
 			HeadBranch:    event.GetPullRequest().Head.GetRef(),
 			Sender:        event.GetPullRequest().GetUser().GetLogin(),
+			EventType:     eventType,
 		}
 	default:
 		return &runinfo, errors.New("this event is not supported")
 	}
-	runinfo.EventType = eventType
 	return &runinfo, nil
 }
 

--- a/pkg/webvcs/github_test.go
+++ b/pkg/webvcs/github_test.go
@@ -95,7 +95,7 @@ func setupFakesURLS() (client GithubVCS, teardown func()) {
 				  "path": ".tekton/tekton.yaml",
 				  "sha": "tektonyaml",
 				  "type": "file"
-		     }]`)
+			 }]`)
 	})
 	mux.HandleFunc("/repos/throw/error/contents/.tekton", func(w http.ResponseWriter, r *http.Request) {
 		_, _ = fmt.Fprint(w, "ERRROR")
@@ -156,7 +156,7 @@ func TestParsePayloadRerequest(t *testing.T) {
 	assert.Equal(t, prOwner, runinfo.Owner)
 	assert.Equal(t, repoName, runinfo.Repository)
 	assert.Assert(t, checkrunSender != runinfo.Sender)
-
+	assert.Equal(t, runinfo.EventType, "pull_request")
 	assert.Assert(t, strings.Contains(observer.TakeAll()[0].Message, "Recheck of PR"))
 }
 
@@ -175,18 +175,18 @@ func TestParsePayLoadRetest(t *testing.T) {
 
 	issueEvent := fmt.Sprintf(`{
   "sender": {
-    "login": "%s"
+	"login": "%s"
   },
   "repository": {
-    "name": "%s",
-    "owner": {
-      "login": "%s"
-    }
+	"name": "%s",
+	"owner": {
+	  "login": "%s"
+	}
   },
   "issue": {
-    "pull_request": {
-      "html_url": "https://github.com/%s/%s/pull/%s"
-    }
+	"pull_request": {
+	  "html_url": "https://github.com/%s/%s/pull/%s"
+	}
   }
 }`, issueSender, repoName, prOwner, repoName, repoOwner, prNumber)
 
@@ -203,6 +203,7 @@ func TestParsePayLoadRetest(t *testing.T) {
 	assert.Assert(t, issueSender != runinfo.Owner)
 	firstObservedMessage := observer.TakeAll()[0].Message
 	assert.Assert(t, strings.Contains(firstObservedMessage, "recheck"))
+	assert.Equal(t, runinfo.EventType, "pull_request")
 }
 
 func TestParsePayload(t *testing.T) {
@@ -218,6 +219,7 @@ func TestParsePayload(t *testing.T) {
 	assert.Assert(t, runinfo.BaseBranch == "master")
 	assert.Assert(t, runinfo.Owner == "chmouel")
 	assert.Assert(t, runinfo.Repository == "scratchpad")
+	assert.Equal(t, runinfo.EventType, "pull_request")
 	assert.Assert(t, runinfo.URL == "https://github.com/chmouel/scratchpad")
 }
 


### PR DESCRIPTION
When we do a retest like /retest or from GitHub UI make sure we set the
eventType as pull request and not issue comment or the retest will fail.

Fixes #66

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
