### PR TITLE
Add an easy to install cli for resolving pipelines

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -138,8 +138,8 @@ spec:
                 if [[ -n ${lm} ]];then
                     expired=$(python -c "import datetime, sys;print(datetime.datetime.now() > datetime.datetime.strptime(sys.argv[1], '%a, %d %b %Y %X %Z') + datetime.timedelta(days=1))" "${lm}")
                     [[ ${expired} == "False" ]] && {
-                    echo "Cache is younger than a day"
-                    exit
+                      echo "Cache is younger than a day"
+                      exit
                     }
                 fi
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ Pipelines as Code is built on the following technologies :
   EventListener is spun up in a central namespace (`pipelines-as-code`). The
   EventListener is the service responsible for listening to webhook events and acting upon it.
 
-- Repository CRD: The Repository CRD is a new API introduced in the Pipelines as Code project. This CRD is used to define the association between the source code repository and the 
-Kubernetes namespace in which the corresponding Pipelines are run.
+- Repository CRD: The Repository CRD is a new API introduced in the Pipelines as
+  Code project. This CRD is used to define the association between the source
+  code repository and the Kubernetes namespace in which the corresponding
+  Pipelines are run.
 
 - Web VCS support. When iterating over a Pull Request, status and control is
   done on the platform.
@@ -121,9 +123,11 @@ Multiple target branch can be specified separated by comma, i.e:
 `[main, release-nightly]`
 
 If there is multiple pipeline matching the event, it will match the first one.
+We are currently not supporting multiple PipelineRuns on a single event but
+this may be something we can consider to implement in the future.
 
-You can match on `pull_request` events as above and on git `push` events to a
-repo.
+You can match on `pull_request` events as above and you can as well match
+pipelineRuns on `push` events to a repository
 
 For example this will match the pipeline when there is a push to a commit in
 the `main` branch :
@@ -136,9 +140,9 @@ the `main` branch :
     pipelinesascode.tekton.dev/on-event: "[push]"
 ```
 
-
-You need to specify the refs and not just the branch, this allows to as well
-match on tags. For example :
+On `push` you need to specify the full [git
+refs](https://git-scm.com/docs/git-check-ref-format). You can then match a
+branch like `refs/heads/main` or tags. For example :
 
 ```yaml
  metadata:
@@ -156,21 +160,39 @@ match your `PiplineRun`.
 
 #### Pipelines as Code resolver
 
-If `Pipelines as Code` sees multiple documents, it tries to *resolves* it as a
-  single PiplineSpec embedded to a `PipelineRun`. It will add a `generateName`
-  based on the Pipeline name as well. This allows you to have multiple runs in
-  the same namespace without risk of conflicts.
+If `Pipelines as Code` sees a PipelineRun with a reference to a `Task` or a
+`Pipeline`, it will tries to *resolves* it as a single PipelineRun with an embedded `PipelineSpec` to a `PipelineRun`.
 
-Everything that runs your pipelinerun should be self contained inside the
-`.tekton/` directory or from some remote tasks (see below).  If pipelines as
-code cannot resolve the referenced tasks in the `Pipeline` or `PipelineSpec`
-it will fails before applying the pipelinerun onto the cluster.
+It will as well transform the Pipeline Name  to a `generateName`
+based on the Pipeline name as well.
+
+This allows you to have multiple runs in the same namespace from the same
+PipelineRun with no risk of conflicts.
+
+Everything that runs your pipelinerun and its references neeed to inside the
+`.tekton/` directory or referenced as remote tasks (see below on how the remote
+tasks are specified).  If pipelines as code cannot resolve the referenced tasks
+in the `Pipeline` or `PipelineSpec` it will fails before applying the
+pipelinerun onto the cluster.
+
+If you need to test your `PipelineRun` locally before sending it in a PR, you can use
+the `tkresolver` CLI, by installing it like this :
+
+```shell
+go install github.com/openshift-pipelines/pipelines-as-code/cmd/tknresolve
+```
+
+and you can use the tknresolve binary to generate the PipelineRun the say way it
+is generated on events. See the `--help` of the `tknresolve` to learn about how
+this CLI and on how to use it.
 
 #### Remote Task support
 
-`Pipelines as Code` support fetching remote tasks from remote location via  annotation on PipelineRun.
+`Pipelines as Code` support fetching remote tasks from remote location via
+annotations on PipelineRun.
 
-If the resolver sees a PipelineRun referencing a remote task via its name in a  Pipeline or a PipelineSpec it will automatically inlines it.
+If the resolver sees a PipelineRun referencing a remote task via its name in a
+Pipeline or a PipelineSpec it will automatically inlines it.
 
 An annotation to a remote task looks like this :
 
@@ -374,3 +396,9 @@ key in a file named for example `/tmp/github.app.key` and issue those commands :
 
 This secret is used to generate a token on behalf of the user running the event
 and make sure to validate the webhook via the webhook secret.
+
+You will then need to make sure to expose the `EventListenner` via a
+[Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) or a
+[OpenShift
+Route](https://docs.openshift.com/container-platform/latest/networking/routes/route-configuration.html)
+so GitHub can get send the webhook to it.

--- a/cmd/tknresolve/main.go
+++ b/cmd/tknresolve/main.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"os"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/cmd"
+)
+
+func main() {
+	tp := &cli.PacParams{}
+	tkn := cmd.Root(tp)
+
+	cmd, _, err := tkn.Find(os.Args[1:])
+	// default cmd if no cmd is given
+	if err != nil || cmd.Use == "" {
+		args := append([]string{"resolve"}, os.Args[1:]...)
+		tkn.SetArgs(args)
+	}
+
+	if err := tkn.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/pkg/cmd/resolve/resolve.go
+++ b/pkg/cmd/resolve/resolve.go
@@ -26,21 +26,39 @@ var (
 	remoteTask   bool
 )
 
-const example = `
-Resolve the .tekton/pulle-request as a single pipelinerun, fetching the remote
-tasks and apply the parameters substitions : 
+const longhelp = `
+
+tknresolve - resolve a PipelineRun and all its referenced Pipeline/Tasks embedded.
+
+Resolve the .tekton/pull-request as a single pipelinerun, fetching the remote
+tasks according to the annotations in the pipelineRun, apply the parameters
+substitutions with -p flags. Output on the standard output the full PipelineRun
+resolved.
+
+A simple example that would parse the .tekton/pull-request.yaml with all the
+remote task embedded into it applying the parameters substitutions: 
 
 pipelines-as-code resolve \
 		-f .tekton/pull-request.yaml \
 		-p revision=main \
 		-p repo_url=https://github.com/openshift-pipelines/pipelines-as-code
-`
+
+You can specify multiple template files to combine :
+
+pipelines-as-code resolve -f .tekton/pull-request.yaml -f task/referenced.yaml
+
+or a directory where it will get all the files ending by .yaml  :
+
+pipelines-as-code resolve -f .tekton/
+
+*It does not support task from local directory referenced in annotations at the
+ moment*.`
 
 func Command(p cli.Params) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "resolve",
-		Example: example,
-		Short:   "Resolve a bunch of yaml file in a single PipelineRun",
+		Use:   "resolve",
+		Long:  longhelp,
+		Short: "Resolve a bunch of yaml file in a single PipelineRun",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cs, err := p.Clients()
 			if err != nil {


### PR DESCRIPTION
Make it easy to install the resolver cli directly and use it. Since this
would be a good independent tool to use output pipeline as code and if
the user would like to debug/develop or rekick manually a pipelineRun.

Update README.md as well