### PR TITLE
Add direct link to TaskRun in CheckRun task list

### DIFF
--- a/pkg/pipelineascode/status_test.go
+++ b/pkg/pipelineascode/status_test.go
@@ -103,7 +103,7 @@ func TestTaskRunListMapSort(t *testing.T) {
 		"middle": pstatus(10),
 	}
 
-	trlist := newTaskrunListFromMap(status)
+	trlist := newTaskrunListFromMap(status, "http://hello")
 	sort.Sort(trlist)
 	assert.Equal(t, trlist[0].TaskrunName, "last")
 	assert.Equal(t, trlist[1].TaskrunName, "middle")
@@ -111,13 +111,13 @@ func TestTaskRunListMapSort(t *testing.T) {
 
 	// Not sorting the middle one since no status, comes first then
 	status["middle"].Status.TaskRunStatusFields.StartTime = nil
-	trlist = newTaskrunListFromMap(status)
+	trlist = newTaskrunListFromMap(status, "http://moto")
 	sort.Sort(trlist)
 	assert.Equal(t, trlist[0].TaskrunName, "middle")
 
 	// Only last become sorted because middle and first has been removed
 	status["first"].Status.TaskRunStatusFields.StartTime = nil
-	trlist = newTaskrunListFromMap(status)
+	trlist = newTaskrunListFromMap(status, "http://moto")
 	sort.Sort(trlist)
 	assert.Equal(t, trlist[len(trlist)-1].TaskrunName, "last")
 }


### PR DESCRIPTION
Adding a clickable full link to the taskrun

GitHUB markdown format was pretty weird to figure out why it wasn't
parsing the links, converting all of this as HTML, you still need some
weird space so link can appears see (https://git.io/JGBZ9)

Will show like this : 

![image](https://user-images.githubusercontent.com/98980/120208597-f2ef0680-c22d-11eb-9125-888c3db38618.png)


We probably should start thinking introducing golden to test template output.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>