### PR TITLE
Readd the RunE to cobra to parse InitParams

### DIFF
--- a/pkg/cmd/pipelineascode/pipelineascode.go
+++ b/pkg/cmd/pipelineascode/pipelineascode.go
@@ -24,6 +24,9 @@ func Command(p cli.Params) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "run",
 		Short: "Run pipelines as code",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return flags.InitParams(p, cmd)
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			token, err := cmd.LocalFlags().GetString("token")
 			if token == "" || err != nil {

--- a/pkg/cmd/resolve/resolve.go
+++ b/pkg/cmd/resolve/resolve.go
@@ -62,7 +62,12 @@ func Command(p cli.Params) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cs, err := p.Clients()
 			if err != nil {
-				return err
+				// this check allows resolve to be run without
+				// a kubeconfig so users can verify the tkn version
+				noConfigErr := strings.Contains(err.Error(), "Couldn't get kubeConfiguration namespace")
+				if !noConfigErr {
+					return err
+				}
 			}
 			if len(filenames) == 0 {
 				return fmt.Errorf("you need to at least specify a file with -f")


### PR DESCRIPTION
I removed too much code previously, the InitParams wasn't called anymore
and token were never sent.

Don't bug out on kubernetest cluster not available when using the
tknresolve command since this can be used without.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>