### PR TITLE
Skip creating status if there is no match on push

### DIFF
--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -67,9 +67,14 @@ func Run(ctx context.Context, cs *cli.Clients, k8int cli.KubeInteractionIntf, ru
 	}
 	if repo.Spec.Namespace == "" {
 		msg := fmt.Sprintf("Could not find a namespace match for %s/%s on target-branch:%s event-type: %s", runinfo.Owner, runinfo.Repository, runinfo.BaseBranch, runinfo.EventType)
-		err = createStatus(ctx, cs, runinfo, "completed", "skipped", msg, "https://tenor.com/search/sad-cat-gifs", true)
-		if err != nil {
-			return err
+
+		if runinfo.EventType == "pull_request" {
+			err = createStatus(ctx, cs, runinfo, "completed", "skipped", msg, "https://tenor.com/search/sad-cat-gifs", true)
+			if err != nil {
+				return err
+			}
+		} else {
+			cs.Log.Infof("Skipping creating status check: %s", msg)
 		}
 		return nil
 	}


### PR DESCRIPTION
The problem when we have a push and pull_request the two would create
status and since the push is meant for pull_request it shoudl not update
the status.

Tested as working on https://github.com/chmouel/scratchmyback/pull/1/checks

Closes #103

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>