### PR TITLE
Use friendly branching name in push PR

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -5,7 +5,7 @@ metadata:
   name: pipeline-as-code-on-push
   annotations:
     pipelinesascode.tekton.dev/on-event: '[push]'
-    pipelinesascode.tekton.dev/on-target-branch: '[refs/heads/main]'
+    pipelinesascode.tekton.dev/on-target-branch: '[main]'
     pipelinesascode.tekton.dev/task: '[git-clone]'
 spec:
   params:


### PR DESCRIPTION
since we merged dd38743f5cc6e422ab6a4aeca4245c83b0e26d32 we don't have to use
the full ref main for branch

related infra commit, https://github.com/openshift-pipelines/tekton-asa-code-infra/commit/41a4fa2939e9d2d1801ac39ade63ca447248a80f

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
