### PR TITLE
Allow redefining ns for multiple installs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+TARGET_NAMESPACE=pipelines-as-code
 QUAY_REPOSITORY=quay.io/openshift-pipeline/pipelines-as-code
 QUAY_REPOSITORY_BRANCH=main
 GO_TEST_FLAGS=-v -cover
@@ -21,8 +22,13 @@ bin/%: cmd/% FORCE
 
 .PHONY: releaseyaml
 releaseyaml: ## Generate release.yaml, use it like this `make releaseyaml|kubectl apply -f-`
-	@env TARGET_REPO=$(QUAY_REPOSITORY) TARGET_BRANCH=$(QUAY_REPOSITORY_BRANCH) \
-		sh ./hack/generate-releaseyaml.sh
+	@env TARGET_REPO=$(QUAY_REPOSITORY) TARGET_BRANCH=$(QUAY_REPOSITORY_BRANCH) TARGET_NAMESPACE=$(TARGET_NAMESPACE) \
+		./hack/generate-releaseyaml.sh
+
+.PHONY: releaseko
+releaseko: ## Generate release.yaml with ko but changing the target_namespace and branch if needed
+	@env TARGET_BRANCH=$(QUAY_REPOSITORY_BRANCH) TARGET_NAMESPACE=$(TARGET_NAMESPACE) \
+		./hack/generate-releaseyaml.sh ko
 
 check: lint test
 

--- a/hack/generate-releaseyaml.sh
+++ b/hack/generate-releaseyaml.sh
@@ -1,10 +1,26 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 set -euf
 
 export TARGET_REPO=${TARGET_REPO:-quay.io/openshift-pipeline/pipelines-as-code}
 export TARGET_BRANCH=${TARGET_BRANCH:-main}
+export TARGET_NAMESPACE=${TARGET_NAMESPACE:-pipelines-as-code}
 
-for file in $(find config -maxdepth 1 -name '*.yaml'|sort -n);do
+MODE=${1:-""}
+
+if [[ -n ${MODE} && ${MODE} == ko ]];then
+    tmpfile=$(mktemp /tmp/.mm.XXXXXX)
+    clean() { rm -f ${tmpfile}; }
+    trap clean EXIT
+    ko resolve -f config/ > ${tmpfile}
+    files="${tmpfile}"
+else
+    files=$(find config -maxdepth 1 -name '*.yaml'|sort -n)
+fi
+
+for file in ${files};do
     head -1 ${file} | grep -q -- "---" || echo "---"
-    sed -r "s,(.*image:.*)ko://github.com/openshift-pipelines/pipelines-as-code/cmd/.*,\1${TARGET_REPO}:${TARGET_BRANCH}\"," ${file}
+    sed -r -e "s,(.*image:.*)ko://github.com/openshift-pipelines/pipelines-as-code/cmd/.*,\1${TARGET_REPO}:${TARGET_BRANCH}\"," \
+        -e "s/(namespace: )\w+.*/\1${TARGET_NAMESPACE}/g" \
+        -e "/kind: Namespace$/ { n;n;s/name: .*/name: ${TARGET_NAMESPACE}/;}" \
+        ${file}
 done


### PR DESCRIPTION
Add a ko mode too to Makefile, so we can redefine target namespace and as well
ko resolve the images.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
