### PR TITLE
Removing the full log href message

### DIFF
--- a/pkg/pipelineascode/pipelineascode_test.go
+++ b/pkg/pipelineascode/pipelineascode_test.go
@@ -184,7 +184,7 @@ func TestRun(t *testing.T) {
 			},
 			tektondir:    "testdata/pull_request",
 			finalStatus:  "neutral",
-			finalLogText: "Full log available here",
+			finalLogText: "<th>Status</th><th>Duration</th><th>Name</th>",
 		},
 		{
 			name: "No match",

--- a/pkg/pipelineascode/status.go
+++ b/pkg/pipelineascode/status.go
@@ -15,12 +15,7 @@ import (
 	knative1 "knative.dev/pkg/apis/duck/v1beta1"
 )
 
-const checkStatustmpl = `{{.taskStatus}}
-
-<hr>
-
-🗒️ Full log available here <a href="{{.consoleURL}}">here</a>.
-`
+const checkStatustmpl = `{{.taskStatus}}`
 
 const taskStatustmpl = `
 <table>
@@ -157,7 +152,6 @@ func postFinalStatus(ctx context.Context, cs *cli.Clients, k8int cli.KubeInterac
 
 	data := map[string]string{
 		"taskStatus": taskStatus,
-		"consoleURL": consoleURL,
 	}
 
 	t := template.Must(template.New("Pipeline Status").Parse(checkStatustmpl))


### PR DESCRIPTION
It's already available in GitHub checks directly just underneath it

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
