### PR TITLE
Better debug message when we cannot match a PR to event

### DIFF
--- a/pkg/config/annotation_matcher_test.go
+++ b/pkg/config/annotation_matcher_test.go
@@ -100,7 +100,7 @@ func TestMatchPipelinerunByAnnotation(t *testing.T) {
 				runinfo: &webvcs.RunInfo{EventType: "push", BaseBranch: "main"},
 			},
 			wantErr: true,
-			wantLog: "does not have any annotations",
+			wantLog: "cannot match between event and pipelineRuns",
 		},
 		{
 			name: "bad-event-annotation",
@@ -225,8 +225,8 @@ func TestMatchPipelinerunByAnnotation(t *testing.T) {
 			}
 			if tt.wantLog != "" {
 				logmsg := log.TakeAll()
-				assert.Assert(t, len(logmsg) > 0)
-				assert.Assert(t, strings.Contains(logmsg[0].Message, tt.wantLog))
+				assert.Assert(t, len(logmsg) > 0, "We didn't get any log message")
+				assert.Assert(t, strings.Contains(logmsg[0].Message, tt.wantLog), logmsg[0].Message, tt.wantLog)
 			}
 		})
 	}

--- a/pkg/pipelineascode/pipelineascode_test.go
+++ b/pkg/pipelineascode/pipelineascode_test.go
@@ -136,7 +136,7 @@ func TestRun(t *testing.T) {
 				EventType:  "pull_request",
 			},
 			tektondir:   "testdata/pull_request",
-			wantErr:     "cannot match any pipeline",
+			wantErr:     "cannot match pipeline from webhook to pipelineruns",
 			finalStatus: "neutral",
 		},
 		{


### PR DESCRIPTION
When we cannot match a PipelineRun from the tekton directory to event we print
as much as possible in the logs with the configuration available and what we are
supposed to match on.

This would help a lot for debugging pipelineruns.
