### PR TITLE
Add E2E Tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,10 @@ check: lint test
 .PHONY: test
 test: test-unit ## run all tests
 
+.PHONY: test-e2e
+test-e2e:  ## run e2e tests
+	@go test -failfast -count=1 -tags=e2e $(GO_TEST_FLAGS) ./test
+
 .PHONY: lint
 lint: lint-go lint-yaml ## run all linters
 

--- a/pkg/kubeinteraction/wait.go
+++ b/pkg/kubeinteraction/wait.go
@@ -83,7 +83,7 @@ func PipelineRunSucceed(name string) ConditionAccessorFn {
 	return Succeed(name)
 }
 
-func pollImmediateWithContext(ctx context.Context, fn func() (bool, error)) error {
+func PollImmediateWithContext(ctx context.Context, fn func() (bool, error)) error {
 	return wait.PollImmediate(interval, timeout, func() (bool, error) {
 		select {
 		case <-ctx.Done():
@@ -101,7 +101,7 @@ func pollImmediateWithContext(ctx context.Context, fn func() (bool, error)) erro
 func waitForPipelineRunState(ctx context.Context, tektonbeta1 tektonv1beta1client.TektonV1beta1Interface, pr *v1beta1.PipelineRun, polltimeout time.Duration, inState ConditionAccessorFn) error {
 	ctx, cancel := context.WithTimeout(ctx, polltimeout)
 	defer cancel()
-	return pollImmediateWithContext(ctx, func() (bool, error) {
+	return PollImmediateWithContext(ctx, func() (bool, error) {
 		r, err := tektonbeta1.PipelineRuns(pr.Namespace).Get(ctx, pr.Name, metav1.GetOptions{})
 		if err != nil {
 			return true, err

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,39 @@
+# E2E Tests
+
+The E2E Tests make sure we have the repositories getting updated if we have a
+repo with PAC installed on it.
+
+It will checks if the repository have been updated at the end.
+
+Most E2E tests has this basic flow :
+
+- Create a temporary Namespace
+- Create a Repository CR into it
+- Create a Branch on a GitHUB repo
+- Create a commmit with files like pipelinerun inside that branch, the
+  pipelinerun with have the namespace annotation to force the repository match
+  on the namespace we have created and not catching other CR that may matching
+  it.
+- Wait that the Repository is updated.
+- Some other stuff are done directly on the eventlistenner sink, bypassing a bit
+  the GitHUB apis and generating the webhook ourselves.
+
+## Requirements
+
+You need to have those env variable set :
+
+- `TEST_GITHUB_API_URL` -- GitHub Api URL, needs to be set
+- `TEST_GITHUB_TOKEN` -- Github token used to talk to the api url
+- `TEST_GITHUB_REPO_OWNER` - The repo and owner (i.e: organization/repo)
+- `TEST_GITHUB_REPO_INSTALLATION_ID` - The installation id when you have
+  installed the repo on the app. (get it from the webhook event on the console)
+- `TEST_EL_URL` - The eventlistenner public url, ingress or openshfit's route
+- `TEST_EL_WEBHOOK_SECRET` - The webhook secret.
+
+## Running
+
+As long you have env variables set, you can just do a :
+
+`make test-e2e`
+
+and it will run the test-suite and cleans after itself,

--- a/test/init_test.go
+++ b/test/init_test.go
@@ -1,0 +1,89 @@
+// +build e2e
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-github/v34/github"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/webvcs"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	defaultTimeout   = 10 * time.Minute
+	mainBranch       = "main"
+	pullRequestEvent = "pull_request"
+)
+
+type E2EOptions struct {
+	Repo, Owner string
+}
+
+func tearDown(ctx context.Context, t *testing.T, cs *cli.Clients, prNumber int, ref string, targetNS string, opts E2EOptions) {
+	cs.Log.Infof("Closing PR %d", prNumber)
+	if prNumber != -1 {
+		state := "closed"
+		_, _, err := cs.GithubClient.Client.PullRequests.Edit(ctx,
+			opts.Owner, opts.Repo, prNumber,
+			&github.PullRequest{State: &state})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cs.Log.Infof("Deleting NS %s", targetNS)
+	err := cs.Kube.CoreV1().Namespaces().Delete(ctx, targetNS, metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cs.Log.Infof("Deleting Ref %s", ref)
+	_, err = cs.GithubClient.Client.Git.DeleteRef(ctx, opts.Owner, opts.Repo, ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func setup() (*cli.Clients, E2EOptions, error) {
+	githubURL := os.Getenv("TEST_GITHUB_API_URL")
+	githubToken := os.Getenv("TEST_GITHUB_TOKEN")
+	githubRepoOwner := os.Getenv("TEST_GITHUB_REPO_OWNER")
+
+	for _, value := range []string{
+		"EL_URL", "GITHUB_API_URL", "GITHUB_TOKEN",
+		"GITHUB_REPO_OWNER", "EL_WEBHOOK_SECRET",
+	} {
+		if env := os.Getenv("TEST_" + value); env == "" {
+			return nil, E2EOptions{}, fmt.Errorf("\"TEST_%s\" env variable is required, cannot continue", value)
+		}
+	}
+
+	if githubURL == "" || githubToken == "" || githubRepoOwner == "" {
+		return nil, E2EOptions{}, fmt.Errorf("TEST_GITHUB_API_URL TEST_GITHUB_TOKEN TEST_GITHUB_REPO_OWNER need to be set")
+	}
+
+	splitted := strings.Split(githubRepoOwner, "/")
+	webvcs := webvcs.NewGithubVCS(githubToken, githubURL)
+
+	p := cli.PacParams{}
+	cs, err := p.Clients()
+	if err != nil {
+		return nil, E2EOptions{}, err
+	}
+	cs.GithubClient = webvcs
+	return cs, E2EOptions{Owner: splitted[0], Repo: splitted[1]}, nil
+}
+
+func TestMain(m *testing.M) {
+	rand.Seed(time.Now().UTC().UnixNano())
+	v := m.Run()
+	os.Exit(v)
+}

--- a/test/pkg/github/pr.go
+++ b/test/pkg/github/pr.go
@@ -1,0 +1,88 @@
+package github
+
+import (
+	"context"
+	"encoding/base64"
+
+	"github.com/google/go-github/v34/github"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
+)
+
+func PushFilesToRef(ctx context.Context, client *github.Client, commitMessage, baseBranch, targetRef, owner, repo string, files map[string]string) (string, error) {
+	maintree, _, err := client.Git.GetTree(ctx, owner, repo, baseBranch, false)
+	if err != nil {
+		return "", err
+	}
+	mainSha := maintree.GetSHA()
+	entries := []*github.TreeEntry{}
+	defaultMode := "100644"
+	for path, fcontent := range files {
+		content := base64.StdEncoding.EncodeToString([]byte(fcontent))
+		encoding := "base64"
+		blob, _, err := client.Git.CreateBlob(ctx, owner, repo, &github.Blob{
+			Content:  &content,
+			Encoding: &encoding,
+		})
+		if err != nil {
+			return "", err
+		}
+		sha := blob.GetSHA()
+
+		_path := path
+		entries = append(entries,
+			&github.TreeEntry{
+				Path: &_path,
+				Mode: &defaultMode,
+				SHA:  &sha,
+			})
+	}
+
+	tree, _, err := client.Git.CreateTree(ctx, owner, repo, mainSha, entries)
+	if err != nil {
+		return "", err
+	}
+
+	commitAuthor := "OpenShift Pipelines E2E test"
+	commitEmail := "e2e-pipelines@redhat.com"
+	commit, _, err := client.Git.CreateCommit(ctx, owner, repo, &github.Commit{
+		Author: &github.CommitAuthor{
+			Name:  &commitAuthor,
+			Email: &commitEmail,
+		},
+		Message: &commitMessage,
+		Tree:    tree,
+		Parents: []*github.Commit{{
+			SHA: &mainSha,
+		}},
+	})
+	if err != nil {
+		return "", err
+	}
+
+	ref := &github.Reference{
+		Ref: &targetRef,
+		Object: &github.GitObject{
+			SHA: commit.SHA,
+		},
+	}
+	_, _, err = client.Git.CreateRef(ctx, owner, repo, ref)
+	if err != nil {
+		return "", err
+	}
+
+	return commit.GetSHA(), nil
+}
+
+func PRCreate(ctx context.Context, cs *cli.Clients, owner, repo, targetRef, defaultBranch, title string) (int, error) {
+	pr, _, err := cs.GithubClient.Client.PullRequests.Create(ctx, owner, repo, &github.NewPullRequest{
+		Title: &title,
+		Head:  &targetRef,
+		Base:  &defaultBranch,
+		Body:  github.String("Add a new PR for testing"),
+	})
+	if err != nil {
+		return -1, err
+	}
+	cs.Log.Infof("Pull request created: %s", pr.GetHTMLURL())
+	return pr.GetNumber(), nil
+}

--- a/test/pkg/payload/send.go
+++ b/test/pkg/payload/send.go
@@ -1,0 +1,59 @@
+package payload
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"os"
+
+	// nolint:gosec
+	"crypto/sha1"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
+)
+
+func Send(ctx context.Context, cs *cli.Clients, elURL, elWebHookSecret, githubURL, installationID string, event interface{}, eventType string) error {
+	jeez, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+	cs.Log.Infof("Sending a payload directly to the EL on %s: %s", os.Getenv("TEST_EL_URL"), string(jeez))
+
+	mac := hmac.New(sha1.New, []byte(elWebHookSecret))
+	mac.Write(jeez)
+	sha1secret := hex.EncodeToString(mac.Sum(nil))
+	mac = hmac.New(sha256.New, []byte(elWebHookSecret))
+	mac.Write(jeez)
+	sha256secret := hex.EncodeToString(mac.Sum(nil))
+
+	req, err := http.NewRequestWithContext(ctx, "POST", elURL, bytes.NewBuffer(jeez))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Event", eventType)
+	req.Header.Set("X-Hub-Signature", fmt.Sprintf("sha1=%s", sha1secret))
+	req.Header.Set("X-Hub-Signature-256", fmt.Sprintf("sha256=%s", sha256secret))
+	req.Header.Set("X-GitHub-Hook-Installation-Target-Type", "integration")
+	req.Header.Set("X-GitHub-Hook-Installation-Target-ID", installationID)
+	u, err := url.Parse(githubURL)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("X-GitHub-Enterprise-Host", u.Host)
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	_, err = ioutil.ReadAll(resp.Body)
+	return err
+}

--- a/test/pkg/repository/create.go
+++ b/test/pkg/repository/create.go
@@ -1,0 +1,25 @@
+package repository
+
+import (
+	"context"
+
+	pacv1alpha1 "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func CreateNSRepo(ctx context.Context, targetNS string, cs *cli.Clients,
+	repository *pacv1alpha1.Repository) error {
+	nsSpec := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: targetNS}}
+	_, err := cs.Kube.CoreV1().Namespaces().Create(ctx, nsSpec, metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+	repo, err := cs.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(targetNS).Create(ctx, repository, metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+	cs.Log.Infof("Repository created in %s", repo.GetNamespace())
+	return nil
+}

--- a/test/pkg/wait/wait.go
+++ b/test/pkg/wait/wait.go
@@ -1,0 +1,25 @@
+package wait
+
+import (
+	"context"
+	"time"
+
+	pacversioned "github.com/openshift-pipelines/pipelines-as-code/pkg/generated/clientset/versioned"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func UntilRepositoryUpdated(ctx context.Context,
+	pacintf pacversioned.Interface, repo, ns string,
+	minNumberStatus int, polltimeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(ctx, polltimeout)
+	defer cancel()
+	return kubeinteraction.PollImmediateWithContext(ctx, func() (bool, error) {
+		pacintf.PipelinesascodeV1alpha1().Repositories(ns)
+		r, err := pacintf.PipelinesascodeV1alpha1().Repositories(ns).Get(ctx, repo, metav1.GetOptions{})
+		if err != nil {
+			return true, err
+		}
+		return len(r.Status) > minNumberStatus, nil
+	})
+}

--- a/test/pullrequest_oktotest_test.go
+++ b/test/pullrequest_oktotest_test.go
@@ -1,0 +1,155 @@
+// +build e2e
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/google/go-github/v34/github"
+	pacv1alpha1 "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/webvcs"
+	tgithub "github.com/openshift-pipelines/pipelines-as-code/test/pkg/github"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
+	trepo "github.com/openshift-pipelines/pipelines-as-code/test/pkg/repository"
+	twait "github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
+	"github.com/tektoncd/pipeline/pkg/names"
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestPullRequestOkToTest(t *testing.T) {
+	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
+	ctx := context.Background()
+	cs, opts, err := setup()
+	assert.NilError(t, err)
+
+	entries := map[string]string{
+		".tekton/run.yaml": fmt.Sprintf(`---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: pipeline
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "%s"
+    pipelinesascode.tekton.dev/on-target-branch: "[%s]"
+    pipelinesascode.tekton.dev/on-event: "[%s]"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: task
+        taskSpec:
+          steps:
+            - name: task
+              image: gcr.io/google-containers/busybox
+              command: ["/bin/echo", "HELLOMOTO"]
+`, targetNS, mainBranch, pullRequestEvent),
+	}
+
+	repoinfo, resp, err := cs.GithubClient.Client.Repositories.Get(ctx, opts.Owner, opts.Repo)
+	assert.NilError(t, err)
+	if resp != nil && resp.Response.StatusCode == http.StatusNotFound {
+		t.Errorf("Repository %s not found in %s", opts.Owner, opts.Repo)
+	}
+
+	repository := &pacv1alpha1.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: targetNS,
+		},
+		Spec: pacv1alpha1.RepositorySpec{
+			Namespace: targetNS,
+			URL:       repoinfo.GetHTMLURL(),
+			EventType: pullRequestEvent,
+			Branch:    mainBranch,
+		},
+	}
+
+	err = trepo.CreateNSRepo(ctx, targetNS, cs, repository)
+	assert.NilError(t, err)
+
+	targetRefName := fmt.Sprintf("refs/heads/%s",
+		names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test"))
+
+	sha, err := tgithub.PushFilesToRef(ctx, cs.GithubClient.Client,
+		"TestPullRequest - "+targetRefName, repoinfo.GetDefaultBranch(),
+		targetRefName,
+		opts.Owner,
+		opts.Repo,
+		entries)
+	assert.NilError(t, err)
+	cs.Log.Infof("Commit %s has been created and pushed to %s", sha, targetRefName)
+	title := "TestPullRequestOkToTest on " + targetRefName
+	number, err := tgithub.PRCreate(ctx, cs, opts.Owner, opts.Repo, targetRefName, repoinfo.GetDefaultBranch(), title)
+	assert.NilError(t, err)
+
+	defer tearDown(ctx, t, cs, number, targetRefName, targetNS, opts)
+
+	cs.Log.Infof("Waiting for Repository to be updated")
+	err = twait.UntilRepositoryUpdated(ctx, cs.PipelineAsCode, targetNS, targetNS, 0, defaultTimeout)
+	assert.NilError(t, err)
+
+	runinfo := webvcs.RunInfo{
+		BaseBranch:    repoinfo.GetDefaultBranch(),
+		DefaultBranch: repoinfo.GetDefaultBranch(),
+		HeadBranch:    targetRefName,
+		Owner:         opts.Owner,
+		Repository:    opts.Repo,
+		URL:           repoinfo.GetHTMLURL(),
+		SHA:           sha,
+		Sender:        opts.Owner,
+	}
+
+	installID, err := strconv.ParseInt(os.Getenv("TEST_GITHUB_REPO_INSTALLATION_ID"), 10, 64)
+	assert.NilError(t, err)
+	event := github.IssueCommentEvent{
+		Comment: &github.IssueComment{
+			Body: github.String(`/ok-to-test`),
+		},
+		Installation: &github.Installation{
+			ID: &installID,
+		},
+		Action: github.String("created"),
+		Issue: &github.Issue{
+			State: github.String("open"),
+			PullRequestLinks: &github.PullRequestLinks{
+				HTMLURL: github.String(fmt.Sprintf("%s/%s/pull/%d",
+					os.Getenv("TEST_GITHUB_API_URL"),
+					os.Getenv("TEST_GITHUB_REPO_OWNER"), number)),
+			},
+		},
+		Repo: &github.Repository{
+			DefaultBranch: &runinfo.DefaultBranch,
+			HTMLURL:       &runinfo.URL,
+			Name:          &runinfo.Repository,
+			Owner:         &github.User{Login: &runinfo.Owner},
+		},
+		Sender: &github.User{
+			Login: &runinfo.Sender,
+		},
+	}
+
+	err = payload.Send(ctx,
+		cs,
+		os.Getenv("TEST_EL_URL"),
+		os.Getenv("TEST_EL_WEBHOOK_SECRET"),
+		os.Getenv("TEST_GITHUB_API_URL"),
+		os.Getenv("TEST_GITHUB_REPO_INSTALLATION_ID"),
+		event,
+		"issue_comment",
+	)
+	assert.NilError(t, err)
+
+	cs.Log.Infof("Wait for the second repository update to be updated")
+	err = twait.UntilRepositoryUpdated(ctx, cs.PipelineAsCode, targetNS, targetNS, 1, defaultTimeout)
+	assert.NilError(t, err)
+
+	cs.Log.Infof("Check if we have the repository set as succeeded")
+	repo, err := cs.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(targetNS).Get(ctx, targetNS, metav1.GetOptions{})
+	assert.NilError(t, err)
+	assert.Assert(t, repo.Status[len(repo.Status)-1].Conditions[0].Status == corev1.ConditionTrue)
+}

--- a/test/pullrequest_rerequest_test.go
+++ b/test/pullrequest_rerequest_test.go
@@ -1,0 +1,155 @@
+// +build e2e
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/google/go-github/v34/github"
+	pacv1alpha1 "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/webvcs"
+	tgithub "github.com/openshift-pipelines/pipelines-as-code/test/pkg/github"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
+	trepo "github.com/openshift-pipelines/pipelines-as-code/test/pkg/repository"
+	twait "github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
+	"github.com/tektoncd/pipeline/pkg/names"
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestPullRerequest(t *testing.T) {
+	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
+	ctx := context.Background()
+	cs, opts, err := setup()
+	assert.NilError(t, err)
+
+	entries := map[string]string{
+		".tekton/run.yaml": fmt.Sprintf(`---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: pipeline
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "%s"
+    pipelinesascode.tekton.dev/on-target-branch: "[%s]"
+    pipelinesascode.tekton.dev/on-event: "[%s]"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: task
+        taskSpec:
+          steps:
+            - name: task
+              image: gcr.io/google-containers/busybox
+              command: ["/bin/echo", "HELLOMOTO"]
+`, targetNS, mainBranch, pullRequestEvent),
+	}
+
+	repoinfo, resp, err := cs.GithubClient.Client.Repositories.Get(ctx, opts.Owner, opts.Repo)
+	assert.NilError(t, err)
+	if resp != nil && resp.Response.StatusCode == http.StatusNotFound {
+		t.Errorf("Repository %s not found in %s", opts.Owner, opts.Repo)
+	}
+
+	repository := &pacv1alpha1.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: targetNS,
+		},
+		Spec: pacv1alpha1.RepositorySpec{
+			Namespace: targetNS,
+			URL:       repoinfo.GetHTMLURL(),
+			EventType: pullRequestEvent,
+			Branch:    mainBranch,
+		},
+	}
+
+	err = trepo.CreateNSRepo(ctx, targetNS, cs, repository)
+	assert.NilError(t, err)
+
+	targetRefName := fmt.Sprintf("refs/heads/%s",
+		names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test"))
+
+	sha, err := tgithub.PushFilesToRef(ctx, cs.GithubClient.Client,
+		"TestPullRequest - "+targetRefName, repoinfo.GetDefaultBranch(),
+		targetRefName,
+		opts.Owner,
+		opts.Repo,
+		entries)
+	assert.NilError(t, err)
+	cs.Log.Infof("Commit %s has been created and pushed to %s", sha, targetRefName)
+	title := "TestPullRerequest on " + targetRefName
+	number, err := tgithub.PRCreate(ctx, cs, opts.Owner, opts.Repo, targetRefName, repoinfo.GetDefaultBranch(), title)
+	assert.NilError(t, err)
+
+	defer tearDown(ctx, t, cs, number, targetRefName, targetNS, opts)
+
+	cs.Log.Infof("Waiting for Repository to be updated")
+	err = twait.UntilRepositoryUpdated(ctx, cs.PipelineAsCode, targetNS, targetNS, 0, defaultTimeout)
+	assert.NilError(t, err)
+
+	runinfo := webvcs.RunInfo{
+		BaseBranch:    repoinfo.GetDefaultBranch(),
+		DefaultBranch: repoinfo.GetDefaultBranch(),
+		HeadBranch:    targetRefName,
+		Owner:         opts.Owner,
+		Repository:    opts.Repo,
+		URL:           repoinfo.GetHTMLURL(),
+		SHA:           sha,
+		Sender:        opts.Owner,
+	}
+
+	installID, err := strconv.ParseInt(os.Getenv("TEST_GITHUB_REPO_INSTALLATION_ID"), 10, 64)
+	assert.NilError(t, err)
+	event := github.CheckRunEvent{
+		Action: github.String("rerequested"),
+		Installation: &github.Installation{
+			ID: &installID,
+		},
+		CheckRun: &github.CheckRun{
+			CheckSuite: &github.CheckSuite{
+				HeadBranch: &runinfo.HeadBranch,
+				HeadSHA:    &runinfo.SHA,
+				PullRequests: []*github.PullRequest{
+					{
+						Number: github.Int(number),
+					},
+				},
+			},
+		},
+		Repo: &github.Repository{
+			DefaultBranch: &runinfo.DefaultBranch,
+			HTMLURL:       &runinfo.URL,
+			Name:          &runinfo.Repository,
+			Owner:         &github.User{Login: &runinfo.Owner},
+		},
+		Sender: &github.User{
+			Login: &runinfo.Sender,
+		},
+	}
+
+	err = payload.Send(ctx,
+		cs,
+		os.Getenv("TEST_EL_URL"),
+		os.Getenv("TEST_EL_WEBHOOK_SECRET"),
+		os.Getenv("TEST_GITHUB_API_URL"),
+		os.Getenv("TEST_GITHUB_REPO_INSTALLATION_ID"),
+		event,
+		"check_run",
+	)
+	assert.NilError(t, err)
+
+	cs.Log.Infof("Wait for the second repository update to be updated")
+	err = twait.UntilRepositoryUpdated(ctx, cs.PipelineAsCode, targetNS, targetNS, 1, defaultTimeout)
+	assert.NilError(t, err)
+
+	cs.Log.Infof("Check if we have the repository set as succeeded")
+	repo, err := cs.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(targetNS).Get(ctx, targetNS, metav1.GetOptions{})
+	assert.NilError(t, err)
+	assert.Assert(t, repo.Status[len(repo.Status)-1].Conditions[0].Status == corev1.ConditionTrue)
+}

--- a/test/pullrequest_retest_test.go
+++ b/test/pullrequest_retest_test.go
@@ -1,0 +1,103 @@
+// +build e2e
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-github/v34/github"
+	pacv1alpha1 "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	tgithub "github.com/openshift-pipelines/pipelines-as-code/test/pkg/github"
+	trepo "github.com/openshift-pipelines/pipelines-as-code/test/pkg/repository"
+	twait "github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
+	"github.com/tektoncd/pipeline/pkg/names"
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestPullRequestRetest(t *testing.T) {
+	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
+	ctx := context.Background()
+	cs, opts, err := setup()
+	assert.NilError(t, err)
+
+	entries := map[string]string{
+		".tekton/run.yaml": fmt.Sprintf(`---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: pipeline
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "%s"
+    pipelinesascode.tekton.dev/on-target-branch: "[%s]"
+    pipelinesascode.tekton.dev/on-event: "[%s]"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: task
+        taskSpec:
+          steps:
+            - name: task
+              image: gcr.io/google-containers/busybox
+              command: ["/bin/echo", "HELLOMOTO"]
+`, targetNS, mainBranch, pullRequestEvent),
+	}
+
+	repoinfo, resp, err := cs.GithubClient.Client.Repositories.Get(ctx, opts.Owner, opts.Repo)
+	assert.NilError(t, err)
+	if resp != nil && resp.Response.StatusCode == http.StatusNotFound {
+		t.Errorf("Repository %s not found in %s", opts.Owner, opts.Repo)
+	}
+
+	repository := &pacv1alpha1.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: targetNS,
+		},
+		Spec: pacv1alpha1.RepositorySpec{
+			Namespace: targetNS,
+			URL:       repoinfo.GetHTMLURL(),
+			EventType: pullRequestEvent,
+			Branch:    mainBranch,
+		},
+	}
+
+	err = trepo.CreateNSRepo(ctx, targetNS, cs, repository)
+	assert.NilError(t, err)
+
+	targetRefName := fmt.Sprintf("refs/heads/%s",
+		names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test"))
+
+	sha, err := tgithub.PushFilesToRef(ctx, cs.GithubClient.Client, "TestRetest - "+targetRefName, repoinfo.GetDefaultBranch(), targetRefName, opts.Owner, opts.Repo, entries)
+	assert.NilError(t, err)
+	cs.Log.Infof("Commit %s has been created and pushed to %s", sha, targetRefName)
+	title := "TestPullRequestRetest on " + targetRefName
+
+	number, err := tgithub.PRCreate(ctx, cs, opts.Owner, opts.Repo, targetRefName, repoinfo.GetDefaultBranch(), title)
+	assert.NilError(t, err)
+
+	defer tearDown(ctx, t, cs, number, targetRefName, targetNS, opts)
+
+	cs.Log.Infof("Waiting for Repository to be updated")
+	err = twait.UntilRepositoryUpdated(ctx, cs.PipelineAsCode, targetNS, targetNS, 0, defaultTimeout)
+	assert.NilError(t, err)
+
+	cs.Log.Infof("Creating /retest in PullRequest")
+	_, _, err = cs.GithubClient.Client.Issues.CreateComment(ctx,
+		opts.Owner,
+		opts.Repo, number,
+		&github.IssueComment{Body: github.String("/retest")})
+	assert.NilError(t, err)
+
+	cs.Log.Infof("Wait for the second repository update to be updated")
+	err = twait.UntilRepositoryUpdated(ctx, cs.PipelineAsCode, targetNS, targetNS, 1, defaultTimeout)
+	assert.NilError(t, err)
+
+	cs.Log.Infof("Check if we have the repository set as succeeded")
+	repo, err := cs.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(targetNS).Get(ctx, targetNS, metav1.GetOptions{})
+	assert.NilError(t, err)
+	assert.Assert(t, repo.Status[len(repo.Status)-1].Conditions[0].Status == corev1.ConditionTrue)
+}

--- a/test/pullrequest_test.go
+++ b/test/pullrequest_test.go
@@ -1,0 +1,91 @@
+// +build e2e
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	pacv1alpha1 "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	tgithub "github.com/openshift-pipelines/pipelines-as-code/test/pkg/github"
+	trepo "github.com/openshift-pipelines/pipelines-as-code/test/pkg/repository"
+	twait "github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
+	"github.com/tektoncd/pipeline/pkg/names"
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestPullRequest(t *testing.T) {
+	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
+	ctx := context.Background()
+	cs, opts, err := setup()
+	assert.NilError(t, err)
+
+	entries := map[string]string{
+		".tekton/run.yaml": fmt.Sprintf(`---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: pipeline
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "%s"
+    pipelinesascode.tekton.dev/on-target-branch: "[%s]"
+    pipelinesascode.tekton.dev/on-event: "[%s]"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: task
+        taskSpec:
+          steps:
+            - name: task
+              image: gcr.io/google-containers/busybox
+              command: ["/bin/echo", "HELLOMOTO"]
+`, targetNS, mainBranch, pullRequestEvent),
+	}
+
+	repoinfo, resp, err := cs.GithubClient.Client.Repositories.Get(ctx, opts.Owner, opts.Repo)
+	assert.NilError(t, err)
+	if resp != nil && resp.Response.StatusCode == http.StatusNotFound {
+		t.Errorf("Repository %s not found in %s", opts.Owner, opts.Repo)
+	}
+
+	repository := &pacv1alpha1.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: targetNS,
+		},
+		Spec: pacv1alpha1.RepositorySpec{
+			Namespace: targetNS,
+			URL:       repoinfo.GetHTMLURL(),
+			EventType: pullRequestEvent,
+			Branch:    mainBranch,
+		},
+	}
+
+	err = trepo.CreateNSRepo(ctx, targetNS, cs, repository)
+	assert.NilError(t, err)
+
+	targetRefName := fmt.Sprintf("refs/heads/%s",
+		names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test"))
+
+	sha, err := tgithub.PushFilesToRef(ctx, cs.GithubClient.Client, "TestPullRequest - "+targetRefName, repoinfo.GetDefaultBranch(), targetRefName, opts.Owner, opts.Repo, entries)
+	assert.NilError(t, err)
+	cs.Log.Infof("Commit %s has been created and pushed to %s", sha, targetRefName)
+
+	title := "TestPullRequest on " + targetRefName
+	number, err := tgithub.PRCreate(ctx, cs, opts.Owner, opts.Repo, targetRefName, repoinfo.GetDefaultBranch(), title)
+	assert.NilError(t, err)
+
+	defer tearDown(ctx, t, cs, number, targetRefName, targetNS, opts)
+
+	cs.Log.Infof("Waiting for Repository to be updated")
+	err = twait.UntilRepositoryUpdated(ctx, cs.PipelineAsCode, targetNS, targetNS, 0, defaultTimeout)
+	assert.NilError(t, err)
+
+	cs.Log.Infof("Check if we have the repository set as succeeded")
+	repo, err := cs.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(targetNS).Get(ctx, targetNS, metav1.GetOptions{})
+	assert.NilError(t, err)
+	assert.Assert(t, repo.Status[len(repo.Status)-1].Conditions[0].Status == corev1.ConditionTrue)
+}

--- a/test/push_test.go
+++ b/test/push_test.go
@@ -1,0 +1,87 @@
+// +build e2e
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	pacv1alpha1 "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	tgithub "github.com/openshift-pipelines/pipelines-as-code/test/pkg/github"
+	trepo "github.com/openshift-pipelines/pipelines-as-code/test/pkg/repository"
+	twait "github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
+	"github.com/tektoncd/pipeline/pkg/names"
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestPush(t *testing.T) {
+	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-push")
+	targetBranch := targetNS
+	targetEvent := "push"
+
+	ctx := context.Background()
+	cs, opts, err := setup()
+	assert.NilError(t, err)
+
+	repoinfo, resp, err := cs.GithubClient.Client.Repositories.Get(ctx, opts.Owner, opts.Repo)
+	assert.NilError(t, err)
+	if resp != nil && resp.Response.StatusCode == http.StatusNotFound {
+		t.Errorf("Repository %s not found in %s", opts.Owner, opts.Repo)
+	}
+
+	repository := &pacv1alpha1.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: targetNS,
+		},
+		Spec: pacv1alpha1.RepositorySpec{
+			Namespace: targetNS,
+			URL:       repoinfo.GetHTMLURL(),
+			EventType: targetEvent,
+			Branch:    targetBranch,
+		},
+	}
+
+	err = trepo.CreateNSRepo(ctx, targetNS, cs, repository)
+	assert.NilError(t, err)
+
+	entries := map[string]string{
+		".tekton/run.yaml": fmt.Sprintf(`---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: pipeline
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "%s"
+    pipelinesascode.tekton.dev/on-target-branch: "[%s]"
+    pipelinesascode.tekton.dev/on-event: "[%s]"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: task
+        taskSpec:
+          steps:
+            - name: task
+              image: gcr.io/google-containers/busybox
+              command: ["/bin/echo", "HELLOMOTO"]
+`, targetNS, targetBranch, targetEvent),
+	}
+
+	targetRefName := fmt.Sprintf("refs/heads/%s", targetBranch)
+	sha, err := tgithub.PushFilesToRef(ctx, cs.GithubClient.Client, "TestPush - "+targetBranch, repoinfo.GetDefaultBranch(), targetRefName, opts.Owner, opts.Repo, entries)
+	cs.Log.Infof("Commit %s has been created and pushed to %s", sha, targetRefName)
+	assert.NilError(t, err)
+	defer tearDown(ctx, t, cs, -1, targetRefName, targetNS, opts)
+
+	cs.Log.Infof("Waiting for Repository to be updated")
+	err = twait.UntilRepositoryUpdated(ctx, cs.PipelineAsCode, targetNS, targetNS, 0, defaultTimeout)
+	assert.NilError(t, err)
+
+	cs.Log.Infof("Check if we have the repository set as succeeded")
+	repo, err := cs.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(targetNS).Get(ctx, targetNS, metav1.GetOptions{})
+	assert.NilError(t, err)
+	assert.Assert(t, repo.Status[len(repo.Status)-1].Conditions[0].Status == corev1.ConditionTrue)
+}

--- a/vendor/github.com/tektoncd/pipeline/pkg/names/generate.go
+++ b/vendor/github.com/tektoncd/pipeline/pkg/names/generate.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package names
+
+import (
+	"fmt"
+	"regexp"
+
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
+)
+
+// NameGenerator generates names for objects. Some backends may have more information
+// available to guide selection of new names and this interface hides those details.
+type NameGenerator interface {
+	// RestrictLengthWithRandomSuffix generates a valid name from the base name, adding a random suffix to the
+	// the base. If base is valid, the returned name must also be valid. The generator is
+	// responsible for knowing the maximum valid name length.
+	RestrictLengthWithRandomSuffix(base string) string
+
+	// RestrictLength generates a valid name from the name of a step specified in a Task,
+	// shortening it to the maximum valid name length if needed.
+	RestrictLength(base string) string
+}
+
+// simpleNameGenerator generates random names.
+type simpleNameGenerator struct{}
+
+// SimpleNameGenerator is a generator that returns the name plus a random suffix of five alphanumerics
+// when a name is requested. The string is guaranteed to not exceed the length of a standard Kubernetes
+// name (63 characters)
+var SimpleNameGenerator NameGenerator = simpleNameGenerator{}
+
+const (
+	// TODO: make this flexible for non-core resources with alternate naming rules.
+	maxNameLength          = 63
+	randomLength           = 5
+	maxGeneratedNameLength = maxNameLength - randomLength - 1
+)
+
+func (simpleNameGenerator) RestrictLengthWithRandomSuffix(base string) string {
+	if len(base) > maxGeneratedNameLength {
+		base = base[:maxGeneratedNameLength]
+	}
+	return fmt.Sprintf("%s-%s", base, utilrand.String(randomLength))
+}
+
+var alphaNumericRE = regexp.MustCompile(`^[a-zA-Z0-9]+$`)
+
+func (simpleNameGenerator) RestrictLength(base string) string {
+	if len(base) > maxNameLength {
+		base = base[:maxNameLength]
+	}
+
+	for !alphaNumericRE.MatchString(base[len(base)-1:]) {
+		base = base[:len(base)-1]
+	}
+	return base
+}

--- a/vendor/k8s.io/apimachinery/pkg/util/rand/rand.go
+++ b/vendor/k8s.io/apimachinery/pkg/util/rand/rand.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package rand provides utilities related to randomization.
+package rand
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+)
+
+var rng = struct {
+	sync.Mutex
+	rand *rand.Rand
+}{
+	rand: rand.New(rand.NewSource(time.Now().UnixNano())),
+}
+
+// Int returns a non-negative pseudo-random int.
+func Int() int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Int()
+}
+
+// Intn generates an integer in range [0,max).
+// By design this should panic if input is invalid, <= 0.
+func Intn(max int) int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Intn(max)
+}
+
+// IntnRange generates an integer in range [min,max).
+// By design this should panic if input is invalid, <= 0.
+func IntnRange(min, max int) int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Intn(max-min) + min
+}
+
+// IntnRange generates an int64 integer in range [min,max).
+// By design this should panic if input is invalid, <= 0.
+func Int63nRange(min, max int64) int64 {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Int63n(max-min) + min
+}
+
+// Seed seeds the rng with the provided seed.
+func Seed(seed int64) {
+	rng.Lock()
+	defer rng.Unlock()
+
+	rng.rand = rand.New(rand.NewSource(seed))
+}
+
+// Perm returns, as a slice of n ints, a pseudo-random permutation of the integers [0,n)
+// from the default Source.
+func Perm(n int) []int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Perm(n)
+}
+
+const (
+	// We omit vowels from the set of available characters to reduce the chances
+	// of "bad words" being formed.
+	alphanums = "bcdfghjklmnpqrstvwxz2456789"
+	// No. of bits required to index into alphanums string.
+	alphanumsIdxBits = 5
+	// Mask used to extract last alphanumsIdxBits of an int.
+	alphanumsIdxMask = 1<<alphanumsIdxBits - 1
+	// No. of random letters we can extract from a single int63.
+	maxAlphanumsPerInt = 63 / alphanumsIdxBits
+)
+
+// String generates a random alphanumeric string, without vowels, which is n
+// characters long.  This will panic if n is less than zero.
+// How the random string is created:
+// - we generate random int63's
+// - from each int63, we are extracting multiple random letters by bit-shifting and masking
+// - if some index is out of range of alphanums we neglect it (unlikely to happen multiple times in a row)
+func String(n int) string {
+	b := make([]byte, n)
+	rng.Lock()
+	defer rng.Unlock()
+
+	randomInt63 := rng.rand.Int63()
+	remaining := maxAlphanumsPerInt
+	for i := 0; i < n; {
+		if remaining == 0 {
+			randomInt63, remaining = rng.rand.Int63(), maxAlphanumsPerInt
+		}
+		if idx := int(randomInt63 & alphanumsIdxMask); idx < len(alphanums) {
+			b[i] = alphanums[idx]
+			i++
+		}
+		randomInt63 >>= alphanumsIdxBits
+		remaining--
+	}
+	return string(b)
+}
+
+// SafeEncodeString encodes s using the same characters as rand.String. This reduces the chances of bad words and
+// ensures that strings generated from hash functions appear consistent throughout the API.
+func SafeEncodeString(s string) string {
+	r := make([]byte, len(s))
+	for i, b := range []rune(s) {
+		r[i] = alphanums[(int(b) % len(alphanums))]
+	}
+	return string(r)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -236,6 +236,7 @@ github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1alpha1
 github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1beta1
 github.com/tektoncd/pipeline/pkg/contexts
 github.com/tektoncd/pipeline/pkg/list
+github.com/tektoncd/pipeline/pkg/names
 github.com/tektoncd/pipeline/pkg/reconciler/pipeline/dag
 github.com/tektoncd/pipeline/pkg/substitution
 # go.opencensus.io v0.23.0
@@ -569,6 +570,7 @@ k8s.io/apimachinery/pkg/util/json
 k8s.io/apimachinery/pkg/util/mergepatch
 k8s.io/apimachinery/pkg/util/naming
 k8s.io/apimachinery/pkg/util/net
+k8s.io/apimachinery/pkg/util/rand
 k8s.io/apimachinery/pkg/util/runtime
 k8s.io/apimachinery/pkg/util/sets
 k8s.io/apimachinery/pkg/util/strategicpatch


### PR DESCRIPTION
Add E2E Tests

The tests assume there is a cluster with pipeline as code setup. There
is a test repo available with a URL and TOKEN set.

It will be flexible enough to test multiple scenarios and finally have
e2e tests here.