### PR TITLE
Add support for inlining finally tasks in resolver

### DIFF
--- a/pkg/resolve/resolve_test.go
+++ b/pkg/resolve/resolve_test.go
@@ -86,6 +86,19 @@ func TestPipelineRunPipelineSpecTaskSpec(t *testing.T) {
 	assert.Equal(t, resolved.Spec.PipelineSpec.Tasks[0].TaskSpec.Steps[0].Name, "hello-moto")
 }
 
+func TestPipelineRunWithFinally(t *testing.T) {
+	resolved, _, err := readTDfile(t, "pipelinerun-finally", false)
+	assert.NilError(t, err)
+	assert.Equal(t, resolved.Spec.PipelineSpec.Finally[0].TaskSpec.Steps[0].Name, "finally-task")
+}
+
+func TestPipelineWithFinally(t *testing.T) {
+	resolved, _, err := readTDfile(t, "pipeline-finally", false)
+	assert.NilError(t, err)
+	assert.Equal(t, resolved.Spec.PipelineSpec.Tasks[0].TaskSpec.Steps[0].Name, "normal-task")
+	assert.Equal(t, resolved.Spec.PipelineSpec.Finally[0].TaskSpec.Steps[0].Name, "finally-task")
+}
+
 func TestPipelineRunPipelineSpecTaskRef(t *testing.T) {
 	resolved, _, err := readTDfile(t, "pipelinerun-pipelinespec-taskref", false)
 	assert.NilError(t, err)

--- a/pkg/resolve/testdata/pipeline-finally.yaml
+++ b/pkg/resolve/testdata/pipeline-finally.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: pr-test1
+spec:
+  pipelineRef:
+    name: pipeline-with-finally
+  params:
+    - name: key
+      value: "{{value}}"
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: pipeline-with-finally
+spec:
+  params:
+    - name: repo_url
+    - name: revision
+  finally:
+    - name: finally-task
+      taskRef:
+        name: finally-task
+  tasks:
+    - name: normal-task
+      taskRef:
+        name: normal-task
+  steps:
+    - name: first-step
+      image: image
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: normal-task
+spec:
+  steps:
+    - name: normal-task
+      image: image
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: finally-task
+spec:
+  steps:
+    - name: finally-task
+      image: image

--- a/pkg/resolve/testdata/pipelinerun-finally.yaml
+++ b/pkg/resolve/testdata/pipelinerun-finally.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: finally-task
+spec:
+  steps:
+    - name: finally-task
+      image: finally-image
+
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: pipelinespec-taskspecs-embedded
+spec:
+  pipelineSpec:
+    finally:
+      - name: finally-task
+        taskRef:
+          name: finally-task
+    tasks:
+      - name: hello1
+        taskSpec:
+          steps:
+            - name: hello-moto
+              image: scratch


### PR DESCRIPTION
We were not inlining finally tasks, let's make sure we do.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
