### PR TITLE
Use ubi-micro as base image

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,1 +1,1 @@
-defaultBaseImage: registry.access.redhat.com/ubi8/ubi-minimal:8.4
+defaultBaseImage: registry.access.redhat.com/ubi8/ubi-micro:8.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY . /src
 WORKDIR /src
 RUN go build -mod=vendor -v -o /tmp/pipelines-as-code ./cmd/pipelines-as-code
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
+FROM registry.access.redhat.com/ubi8/ubi-micro:8.4
 
 LABEL com.redhat.component=pipelines-as-code \ 
     name=openshift-pipelines/pipelines-as-code \ 


### PR DESCRIPTION
Use UBI micro which is 13MB compared to the gigantic 35MB of the mini image

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
