### PR TITLE
Rename cronjobs to beta1 type to be compatible with openshift 4.7

### DIFF
--- a/config/305-cleanup-cron.yaml
+++ b/config/305-cleanup-cron.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: batch/v1
+apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: pipelines-as-code-pr-cleanup


### PR DESCRIPTION
Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
