### PR TITLE
Add repository name to PR

### DIFF
--- a/config/401-trigger-issue-recheck.yaml
+++ b/config/401-trigger-issue-recheck.yaml
@@ -81,7 +81,7 @@ spec:
         generateName: pipelines-as-code-run-
         labels:
           app.kubernetes.io/managed-by: pipelines-as-code
-          tekton.dev/pipelines-as-code-event: $(tt.params.event_type)
+          pipelinesascode.tekton.dev/event: $(tt.params.event_type)
       spec:
         serviceAccountName: pipelines-as-code-sa-el
         params:

--- a/config/402-trigger-pull-request.yaml
+++ b/config/402-trigger-pull-request.yaml
@@ -78,7 +78,7 @@ spec:
         generateName: pipelines-as-code-run-
         labels:
           app.kubernetes.io/managed-by: pipelines-as-code
-          tekton.dev/pipelines-as-code-event: $(tt.params.event_type)
+          pipelinesascode.tekton.dev/event: $(tt.params.event_type)
       spec:
         serviceAccountName: pipelines-as-code-sa-el
         params:

--- a/config/403-trigger-push.yaml
+++ b/config/403-trigger-push.yaml
@@ -78,7 +78,7 @@ spec:
         generateName: pipelines-as-code-run-
         labels:
           app.kubernetes.io/managed-by: pipelines-as-code
-          tekton.dev/pipelines-as-code-event: $(tt.params.event_type)
+          pipelinesascode.tekton.dev/event: $(tt.params.event_type)
       spec:
         serviceAccountName: pipelines-as-code-sa-el
         params:

--- a/config/404-trigger-retest-comment.yaml
+++ b/config/404-trigger-retest-comment.yaml
@@ -68,7 +68,7 @@ spec:
         generateName: pipelines-as-code-run-
         labels:
           app.kubernetes.io/managed-by: pipelines-as-code
-          tekton.dev/pipelines-as-code-event: $(tt.params.event_type)
+          pipelinesascode.tekton.dev/event: $(tt.params.event_type)
       spec:
         serviceAccountName: pipelines-as-code-sa-el
         params:

--- a/pkg/cli/interface.go
+++ b/pkg/cli/interface.go
@@ -48,5 +48,5 @@ type KubeInteractionIntf interface {
 	GetNamespace(context.Context, string) error
 	// TODO: we don't need tektonv1beta1client stuff here
 	WaitForPipelineRunSucceed(context.Context, tektonv1beta1client.TektonV1beta1Interface, *v1beta1.PipelineRun, time.Duration) error
-	CleanupPipelines(context.Context, string, *webvcs.RunInfo, int) error
+	CleanupPipelines(context.Context, string, string, int) error
 }

--- a/pkg/kubeinteraction/cleanups.go
+++ b/pkg/kubeinteraction/cleanups.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"strings"
 
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/webvcs"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
@@ -27,12 +25,8 @@ func (prs prByCompletionTime) Less(i, j int) bool {
 	return prs[j].Status.CompletionTime.Before(prs[i].Status.CompletionTime)
 }
 
-func (k Interaction) CleanupPipelines(ctx context.Context, namespace string, runinfo *webvcs.RunInfo, maxKeep int) error {
-	refTomakeK8Happy := strings.ReplaceAll(runinfo.BaseBranch, "/", "-")
-	labelSelector := fmt.Sprintf("tekton.dev/pipeline-ascode-owner=%s,"+
-		"tekton.dev/pipeline-ascode-repository=%s, tekton.dev/pipeline-ascode-event-type=%s, "+
-		"tekton.dev/pipeline-ascode-branch=%s",
-		runinfo.Owner, runinfo.Repository, runinfo.EventType, refTomakeK8Happy)
+func (k Interaction) CleanupPipelines(ctx context.Context, namespace string, repositoryName string, maxKeep int) error {
+	labelSelector := fmt.Sprintf("pipelinesascode.tekton.dev/repository=%s", repositoryName)
 
 	pruns, err := k.Clients.Tekton.TektonV1beta1().PipelineRuns(namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: labelSelector,

--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -154,12 +154,13 @@ func Run(ctx context.Context, cs *cli.Clients, k8int cli.KubeInteractionIntf, ru
 	// be aware of it when querying.
 	refTomakeK8Happy := strings.ReplaceAll(runinfo.BaseBranch, "/", "-")
 	pipelineRun.Labels = map[string]string{
-		"tekton.dev/pipeline-ascode-owner":      runinfo.Owner,
-		"tekton.dev/pipeline-ascode-repository": runinfo.Repository,
-		"tekton.dev/pipeline-ascode-sha":        runinfo.SHA,
-		"tekton.dev/pipeline-ascode-sender":     runinfo.Sender,
-		"tekton.dev/pipeline-ascode-event-type": runinfo.EventType,
-		"tekton.dev/pipeline-ascode-branch":     refTomakeK8Happy,
+		"pipelinesascode.tekton.dev/url-org":        runinfo.Owner,
+		"pipelinesascode.tekton.dev/url-repository": runinfo.Repository,
+		"pipelinesascode.tekton.dev/sha":            runinfo.SHA,
+		"pipelinesascode.tekton.dev/sender":         runinfo.Sender,
+		"pipelinesascode.tekton.dev/event-type":     runinfo.EventType,
+		"pipelinesascode.tekton.dev/branch":         refTomakeK8Happy,
+		"pipelinesascode.tekton.dev/repository":     repo.GetName(),
 	}
 
 	// Create the actual pipeline
@@ -196,7 +197,7 @@ func Run(ctx context.Context, cs *cli.Clients, k8int cli.KubeInteractionIntf, ru
 			return err
 		}
 
-		err = k8int.CleanupPipelines(ctx, repo.Spec.Namespace, runinfo, max)
+		err = k8int.CleanupPipelines(ctx, repo.Spec.Namespace, repo.Name, max)
 		if err != nil {
 			return err
 		}

--- a/pkg/test/kubernetestint/kubernetesint.go
+++ b/pkg/test/kubernetestint/kubernetesint.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/webvcs"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	tektonv1beta1client "github.com/tektoncd/pipeline/pkg/client/clientset/versioned/typed/pipeline/v1beta1"
 )
@@ -32,7 +31,7 @@ func (k *KinterfaceTest) WaitForPipelineRunSucceed(ctx context.Context, tektonbe
 	return nil
 }
 
-func (k *KinterfaceTest) CleanupPipelines(ctx context.Context, namespace string, runinfo *webvcs.RunInfo, maxKeep int) error {
+func (k *KinterfaceTest) CleanupPipelines(ctx context.Context, namespace string, repoName string, maxKeep int) error {
 	if k.ExpectedNumberofCleanups != maxKeep {
 		return fmt.Errorf("we wanted %d and we got %d", k.ExpectedNumberofCleanups, maxKeep)
 	}


### PR DESCRIPTION
* Add `pipelinesascode.tekton.dev/repository` label pointing to repository name
* Rename all the `tekton.dev/` label prefix to `pipelinesascode.tekton.dev/`
* Rename the labels `tekton.dev/pipeline-ascode-owner` to
`pipelinesascode.tekton.dev/url-org`
* Rename label `tekton.dev/pipeline-ascode-repository` to
`pipelinesascode.tekton.dev/url-repository`
* Simplify the cleanup code since now we have the repository name we can just filter by this as they should be unique un namespace.