### PR TITLE
Remove showing help usage when there is an error

### DIFF
--- a/pkg/cmd/pipelineascode/pipelineascode.go
+++ b/pkg/cmd/pipelineascode/pipelineascode.go
@@ -28,6 +28,7 @@ func Command(p cli.Params) *cobra.Command {
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			return flags.GetWebCVSOptions(p, cmd)
 		},
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			token, err := cmd.LocalFlags().GetString("token")
 			if token == "" || err != nil {


### PR DESCRIPTION
Add SilenceUsage to cobra command root to not exit with a cryptic usage
error.

Closes #182

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
