### PR TITLE
Add cleanup script for E2E tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,12 @@ check: lint test
 .PHONY: test
 test: test-unit ## run all tests
 
+.PHONY: test-e2e-cleanup
+test-e2e-cleanup: ## cleanup test e2e namespace/pr left open
+	@./hack/dev/e2e-tests-cleanup.sh
+
 .PHONY: test-e2e
-test-e2e:  ## run e2e tests
+test-e2e:  test-e2e-cleanup ## run e2e tests
 	@go test -failfast -count=1 -tags=e2e $(GO_TEST_FLAGS) ./test
 
 .PHONY: lint

--- a/hack/dev/e2e-tests-cleanup.sh
+++ b/hack/dev/e2e-tests-cleanup.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -eu
+
+type -p gh >/dev/null || { echo "You need gh installed and configured for ${TEST_GITHUB_API_URL}"; exit 1 ;}
+
+export GH_REPO=${TEST_GITHUB_REPO_OWNER}
+export GH_HOST=$(echo ${TEST_GITHUB_API_URL}|sed 's,https://,,')
+
+echo "Closing lingering PR on ${TEST_GITHUB_API_URL}"
+for prn in $(gh pr list --jq .[].number --json number);do
+    gh pr close ${prn}
+done
+
+echo "Cleaning Namespaces"
+{ kubectl get ns -o name|grep pac-e2e|sed 's/namespace.//'|xargs -r -P5 kubectl delete ns ;}
+


### PR DESCRIPTION
Add cleanup script for E2E tests to cleanup the open PR and namespace
created.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
