### PR TITLE
Check labels/ano created from PR/Repo in E2E

### DIFF
--- a/test/pullrequest_test.go
+++ b/test/pullrequest_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"path/filepath"
 	"testing"
 
 	pacv1alpha1 "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
@@ -74,7 +75,7 @@ spec:
 	assert.NilError(t, err)
 	cs.Log.Infof("Commit %s has been created and pushed to %s", sha, targetRefName)
 
-	title := "TestPullRequest on " + targetRefName
+	title := "TestPullRequest - " + targetRefName
 	number, err := tgithub.PRCreate(ctx, cs, opts.Owner, opts.Repo, targetRefName, repoinfo.GetDefaultBranch(), title)
 	assert.NilError(t, err)
 
@@ -87,5 +88,27 @@ spec:
 	cs.Log.Infof("Check if we have the repository set as succeeded")
 	repo, err := cs.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(targetNS).Get(ctx, targetNS, metav1.GetOptions{})
 	assert.NilError(t, err)
-	assert.Assert(t, repo.Status[len(repo.Status)-1].Conditions[0].Status == corev1.ConditionTrue)
+	laststatus := repo.Status[len(repo.Status)-1]
+	assert.Equal(t, corev1.ConditionTrue, laststatus.Conditions[0].Status)
+	assert.Equal(t, sha, *laststatus.SHA)
+	assert.Equal(t, sha, filepath.Base(*laststatus.SHAURL))
+	assert.Equal(t, title, *laststatus.Title)
+	assert.Assert(t, *laststatus.LogURL != "")
+
+	pr, err := cs.Tekton.TektonV1alpha1().PipelineRuns(targetNS).Get(ctx, laststatus.PipelineRunName, metav1.GetOptions{})
+	assert.NilError(t, err)
+
+	assert.Equal(t, "pull_request", pr.Labels["pipelinesascode.tekton.dev/event-type"])
+	assert.Equal(t, repo.GetName(), pr.Labels["pipelinesascode.tekton.dev/repository"])
+	assert.Equal(t, opts.Owner, pr.Labels["pipelinesascode.tekton.dev/sender"])
+	assert.Equal(t, sha, pr.Labels["pipelinesascode.tekton.dev/sha"])
+	assert.Equal(t, opts.Owner, pr.Labels["pipelinesascode.tekton.dev/url-org"])
+	assert.Equal(t, opts.Repo, pr.Labels["pipelinesascode.tekton.dev/url-repository"])
+
+	assert.Equal(t, sha, filepath.Base(pr.Annotations["pipelinesascode.tekton.dev/sha-url"]))
+	assert.Equal(t, title, pr.Annotations["pipelinesascode.tekton.dev/sha-title"])
 }
+
+// Local Variables:
+// compile-command: "go test -tags=e2e -v -run TestPullRequest$ ."
+// End:


### PR DESCRIPTION
Since I don't know how to do that from the unit tests and it wasn't
tested, let's do this in the E2E.

We checks labels and annotations that was created properly and not mess
things up.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
