### PR TITLE
Add Route to release.openshift.yaml

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -104,7 +104,9 @@ spec:
                 #!/usr/bin/env bash
                 set -eu
                 set +x # Do not show TOKEN in logs
-                hack/upload-file-to-github.py --message "Release yaml generated from {{repo_url}}/commit/{{revision}}" --branch-ref refs/heads/nightly --owner-repository openshift-pipelines/pipelines-as-code --token ${HUB_TOKEN} -d release.yaml -f <(./hack/generate-releaseyaml.sh)
+                hack/upload-file-to-github.py --message "Release yaml generated from {{repo_url}}/commit/{{revision}}" --branch-ref refs/heads/nightly --owner-repository openshift-pipelines/pipelines-as-code --token ${HUB_TOKEN} -d release.k8s.yaml -f <(./hack/generate-releaseyaml.sh)
+
+                hack/upload-file-to-github.py --message "OpenShift release yaml generated from {{repo_url}}/commit/{{revision}}" --branch-ref refs/heads/nightly --owner-repository openshift-pipelines/pipelines-as-code --token ${HUB_TOKEN} -d release.yaml -f <(env TARGET_OPENSHIFT=true ./hack/generate-releaseyaml.sh)
               workingDir: $(workspaces.source.path)
           workspaces:
             - name: source

--- a/.tekton/release-pipeline.yaml
+++ b/.tekton/release-pipeline.yaml
@@ -69,7 +69,14 @@ spec:
                     --owner-repository openshift-pipelines/pipelines-as-code \
                     --token ${HUB_TOKEN} \
                     --from-tag=refs/tags/${TARGET_BRANCH} \
-                    -d release-${TARGET_BRANCH}.yaml -f <(./hack/generate-releaseyaml.sh)
+                    -d release-${TARGET_BRANCH}.k8s.yaml -f <(./hack/generate-releaseyaml.sh)
+
+                hack/upload-file-to-github.py \
+                    --message "OpenShift release.yaml generated for Release ${TARGET_BRANCH}" \
+                    --owner-repository openshift-pipelines/pipelines-as-code \
+                    --token ${HUB_TOKEN} \
+                    --from-tag=refs/tags/${TARGET_BRANCH} \
+                    -d release-${TARGET_BRANCH}.yaml -f <(env TARGET_OPENSHIFT=true ./hack/generate-releaseyaml.sh)
                 exit 0
       - name: gorelease
         runAfter:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -29,20 +29,10 @@ admin namespace `pipelines-as-code`, the roles and all other bits needed.
 
 The `pipelines-as-code` namespace is where the Pipelines-as-Code infrastructure runs and is supposed to be accessible only by the admin.
 
-The Pipelines-as-Code EventListener requires an OpenShift route to be accessible from GitHub. Run the following to create a route:
+The Route for the EventListener URL is automatically created when you apply the release.yaml.
+You will need to grab the url for the next section when creating the GitHub App. You can run this command to get the route created on your cluster:
 
-```
-oc expose service el-pipelines-as-code-interceptor -n pipelines-as-code
-```
-
-Enable TLS on the Pipelines-as-Code EventListener:
-
-```
-oc apply -n pipelines-as-code -f <(oc get -n pipelines-as-code route el-pipelines-as-code-interceptor  -o json |jq -r '.spec |= . + {tls: {"insecureEdgeTerminationPolicy": "Redirect", "termination": "edge"}}')
-```
-
-Retrieve the EventListener URL which you will need in the next section when creating the GitHub App:
-```
+```shell
 echo https://$(oc get route -n pipelines-as-code el-pipelines-as-code-interceptor -o jsonpath='{.spec.host}')
 ```
 
@@ -106,3 +96,20 @@ Pipelines as Code supports Github Enterprise.
 
 You don't need to do anything special to get Pipelines as code working with GHE.
 Pipelines as code will automatically detects the header as set from GHE and use it  the GHE API auth url instead of the public github.
+
+## Kubernetes
+
+Pipelines as Code should work directly on kubernetes/minikube/kind. You just need to install the release.yaml for [pipeline](https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml), [triggers](https://storage.googleapis.com/tekton-releases/triggers/latest/release.yaml) and its [interceptors](https://storage.googleapis.com/tekton-releases/triggers/latest/interceptors.yaml) on your cluster. The release yaml to install pipelines are for the relesaed version :
+
+```shell
+VERSION=0.2
+kubectl apply -f https://raw.githubusercontent.com/openshift-pipelines/pipelines-as-code/release-$VERSION/release-$VERSION.k8s.yaml
+```
+
+and for the nightly :
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/openshift-pipelines/pipelines-as-code/release-$VERSION/release.k8s.yaml
+```
+
+Kubernetes Dashboard is not yet supported for logs links but help is always welcome ;)

--- a/config/openshift/10-routes.yaml
+++ b/config/openshift/10-routes.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: EventListener
+    app.kubernetes.io/part-of: Triggers
+    eventlistener: pipelines-as-code-interceptor
+  name: el-pipelines-as-code-interceptor
+  namespace: pipelines-as-code
+spec:
+  port:
+    targetPort: http-listener
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+  to:
+    kind: Service
+    name: el-pipelines-as-code-interceptor
+    weight: 100
+  wildcardPolicy: None

--- a/hack/generate-releaseyaml.sh
+++ b/hack/generate-releaseyaml.sh
@@ -4,6 +4,7 @@ set -euf
 export TARGET_REPO=${TARGET_REPO:-quay.io/openshift-pipeline/pipelines-as-code}
 export TARGET_BRANCH=${TARGET_BRANCH:-main}
 export TARGET_NAMESPACE=${TARGET_NAMESPACE:-pipelines-as-code}
+export TARGET_OPENSHIFT=${TARGET_OPENSHIFT:-""}
 
 MODE=${1:-""}
 
@@ -12,10 +13,20 @@ if [[ -n ${MODE} && ${MODE} == ko ]];then
     clean() { rm -f ${tmpfile}; }
     trap clean EXIT
     ko resolve -f config/ > ${tmpfile}
+
+    if [[ ${TARGET_OPENSHIFT} != "" ]];then
+       ko resolve -f config/openshift >> ${tmpfile}
+    fi
+
     files="${tmpfile}"
 else
     files=$(find config -maxdepth 1 -name '*.yaml'|sort -n)
+
+    if [[ ${TARGET_OPENSHIFT} != "" ]];then
+       files="${files} $(find config/openshift -maxdepth 1 -name '*.yaml'|sort -n)"
+    fi
 fi
+
 
 for file in ${files};do
     head -1 ${file} | grep -q -- "---" || echo "---"


### PR DESCRIPTION
Generate a release.openshift.yaml to use which has a Route that gets
automatically created. This makes a bit easier to INSTALL pac.

Keep a release.yaml without Route for non openshift cluster install (ie:
kind/minikube etc..)

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
