### PR TITLE
Check pipelinerun status while waiting for e2e

### DIFF
--- a/pkg/test/clients/clients.go
+++ b/pkg/test/clients/clients.go
@@ -9,7 +9,7 @@ import (
 	informersv1alpha1 "github.com/openshift-pipelines/pipelines-as-code/pkg/generated/informers/externalversions/pipelinesascode/v1alpha1"
 	fakepacclient "github.com/openshift-pipelines/pipelines-as-code/pkg/generated/injection/client/fake"
 	fakerepositoryinformers "github.com/openshift-pipelines/pipelines-as-code/pkg/generated/injection/informers/pipelinesascode/v1alpha1/repository/fake"
-	pipelinev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	fakepipelineclientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned/fake"
 	pipelineinformersv1alpha1 "github.com/tektoncd/pipeline/pkg/client/informers/externalversions/pipeline/v1alpha1"
 	fakepipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client/fake"
@@ -33,7 +33,7 @@ type Informers struct {
 }
 
 type Data struct {
-	PipelineRuns []*pipelinev1alpha1.PipelineRun
+	PipelineRuns []*pipelinev1beta1.PipelineRun
 	Repositories []*v1alpha1.Repository
 	Namespaces   []*corev1.Namespace
 	Secret       []*corev1.Secret
@@ -57,7 +57,7 @@ func SeedTestData(t *testing.T, ctx context.Context, d Data) (Clients, Informers
 		if err := i.PipelineRun.Informer().GetIndexer().Add(pr); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := c.Pipeline.TektonV1alpha1().PipelineRuns(pr.Namespace).Create(ctx, pr, metav1.CreateOptions{}); err != nil {
+		if _, err := c.Pipeline.TektonV1beta1().PipelineRuns(pr.Namespace).Create(ctx, pr, metav1.CreateOptions{}); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/test/config_maxkeepruns_test.go
+++ b/test/config_maxkeepruns_test.go
@@ -86,11 +86,19 @@ spec:
 		defer tearDown(ctx, t, runcnx, ghcnx, number, targetRefName, targetNS, opts)
 
 		runcnx.Clients.Log.Infof("Waiting for Repository to be updated")
-		err = twait.UntilRepositoryUpdated(ctx, runcnx.Clients.PipelineAsCode, targetNS, targetNS, 0, defaultTimeout)
+		waitOpts := twait.Opts{
+			RepoName:        targetNS,
+			Namespace:       targetNS,
+			MinNumberStatus: 0,
+			PollTimeout:     defaultTimeout,
+			TargetSHA:       sha,
+		}
+		err = twait.UntilRepositoryUpdated(ctx, runcnx.Clients.PipelineAsCode,
+			runcnx.Clients.Tekton.TektonV1beta1(), waitOpts)
 		assert.NilError(t, err)
 	}
 
-	prs, err := runcnx.Clients.Tekton.TektonV1alpha1().PipelineRuns(targetNS).List(ctx, metav1.ListOptions{})
+	prs, err := runcnx.Clients.Tekton.TektonV1beta1().PipelineRuns(targetNS).List(ctx, metav1.ListOptions{})
 	assert.NilError(t, err)
 	assert.Equal(t, len(prs.Items), maxKepRuns)
 }

--- a/test/pkg/wait/wait.go
+++ b/test/pkg/wait/wait.go
@@ -2,24 +2,49 @@ package wait
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	pacversioned "github.com/openshift-pipelines/pipelines-as-code/pkg/generated/clientset/versioned"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
+	tektonv1beta1client "github.com/tektoncd/pipeline/pkg/client/clientset/versioned/typed/pipeline/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func UntilRepositoryUpdated(ctx context.Context,
-	pacintf pacversioned.Interface, repo, ns string,
-	minNumberStatus int, polltimeout time.Duration) error {
-	ctx, cancel := context.WithTimeout(ctx, polltimeout)
+type Opts struct {
+	RepoName        string
+	Namespace       string
+	MinNumberStatus int
+	PollTimeout     time.Duration
+	AdminNS         string
+	TargetSHA       string
+}
+
+func UntilRepositoryUpdated(ctx context.Context, pacintf pacversioned.Interface, tknintf tektonv1beta1client.TektonV1beta1Interface, opts Opts) error {
+	ctx, cancel := context.WithTimeout(ctx, opts.PollTimeout)
 	defer cancel()
 	return kubeinteraction.PollImmediateWithContext(ctx, func() (bool, error) {
-		pacintf.PipelinesascodeV1alpha1().Repositories(ns)
-		r, err := pacintf.PipelinesascodeV1alpha1().Repositories(ns).Get(ctx, repo, metav1.GetOptions{})
+		pacintf.PipelinesascodeV1alpha1().Repositories(opts.Namespace)
+		r, err := pacintf.PipelinesascodeV1alpha1().Repositories(opts.Namespace).Get(ctx, opts.RepoName,
+			metav1.GetOptions{})
 		if err != nil {
 			return true, err
 		}
-		return len(r.Status) > minNumberStatus, nil
+
+		prs, err := tknintf.PipelineRuns(opts.Namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("pipelinesascode.tekton.dev/sha=%s", opts.TargetSHA),
+		})
+		if err != nil {
+			return true, err
+		}
+		if len(prs.Items) > 0 {
+			prConditions := prs.Items[0].Status.Conditions
+			if len(prConditions) != 0 && prConditions[0].Status == corev1.ConditionFalse {
+				return true, fmt.Errorf("pipelinerun has failed")
+			}
+		}
+
+		return len(r.Status) > opts.MinNumberStatus, nil
 	})
 }

--- a/test/pullrequest_oktotest_test.go
+++ b/test/pullrequest_oktotest_test.go
@@ -91,7 +91,15 @@ spec:
 	defer tearDown(ctx, t, runcnx, ghcnx, number, targetRefName, targetNS, opts)
 
 	runcnx.Clients.Log.Infof("Waiting for Repository to be updated")
-	err = twait.UntilRepositoryUpdated(ctx, runcnx.Clients.PipelineAsCode, targetNS, targetNS, 0, defaultTimeout)
+	waitOpts := twait.Opts{
+		RepoName:        targetNS,
+		Namespace:       targetNS,
+		MinNumberStatus: 0,
+		PollTimeout:     defaultTimeout,
+		TargetSHA:       sha,
+	}
+	err = twait.UntilRepositoryUpdated(ctx, runcnx.Clients.PipelineAsCode, runcnx.Clients.Tekton.TektonV1beta1(),
+		waitOpts)
 	assert.NilError(t, err)
 
 	runevent := info.Event{
@@ -146,7 +154,15 @@ spec:
 	assert.NilError(t, err)
 
 	runcnx.Clients.Log.Infof("Wait for the second repository update to be updated")
-	err = twait.UntilRepositoryUpdated(ctx, runcnx.Clients.PipelineAsCode, targetNS, targetNS, 1, defaultTimeout)
+	waitOpts = twait.Opts{
+		RepoName:        targetNS,
+		Namespace:       targetNS,
+		MinNumberStatus: 1,
+		PollTimeout:     defaultTimeout,
+		TargetSHA:       sha,
+	}
+	err = twait.UntilRepositoryUpdated(ctx, runcnx.Clients.PipelineAsCode, runcnx.Clients.Tekton.TektonV1beta1(),
+		waitOpts)
 	assert.NilError(t, err)
 
 	runcnx.Clients.Log.Infof("Check if we have the repository set as succeeded")

--- a/test/pullrequest_rerequest_test.go
+++ b/test/pullrequest_rerequest_test.go
@@ -91,7 +91,15 @@ spec:
 	defer tearDown(ctx, t, runcnx, ghcnx, number, targetRefName, targetNS, opts)
 
 	runcnx.Clients.Log.Infof("Waiting for Repository to be updated")
-	err = twait.UntilRepositoryUpdated(ctx, runcnx.Clients.PipelineAsCode, targetNS, targetNS, 0, defaultTimeout)
+	waitOpts := twait.Opts{
+		RepoName:        targetNS,
+		Namespace:       targetNS,
+		MinNumberStatus: 0,
+		PollTimeout:     defaultTimeout,
+		TargetSHA:       sha,
+	}
+	err = twait.UntilRepositoryUpdated(ctx, runcnx.Clients.PipelineAsCode, runcnx.Clients.Tekton.TektonV1beta1(),
+		waitOpts)
 	assert.NilError(t, err)
 
 	runinfo := info.Event{
@@ -146,7 +154,15 @@ spec:
 	assert.NilError(t, err)
 
 	runcnx.Clients.Log.Infof("Wait for the second repository update to be updated")
-	err = twait.UntilRepositoryUpdated(ctx, runcnx.Clients.PipelineAsCode, targetNS, targetNS, 1, defaultTimeout)
+	waitOpts = twait.Opts{
+		RepoName:        targetNS,
+		Namespace:       targetNS,
+		MinNumberStatus: 1,
+		PollTimeout:     defaultTimeout,
+		TargetSHA:       sha,
+	}
+	err = twait.UntilRepositoryUpdated(ctx, runcnx.Clients.PipelineAsCode, runcnx.Clients.Tekton.TektonV1beta1(),
+		waitOpts)
 	assert.NilError(t, err)
 
 	runcnx.Clients.Log.Infof("Check if we have the repository set as succeeded")

--- a/test/pullrequest_retest_test.go
+++ b/test/pullrequest_retest_test.go
@@ -23,7 +23,7 @@ import (
 func TestPullRequestRetest(t *testing.T) {
 	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
 	ctx := context.Background()
-	run, opts, ghcnx, err := setup(ctx)
+	runcnx, opts, ghcnx, err := setup(ctx)
 	assert.NilError(t, err)
 
 	entries := map[string]string{
@@ -66,7 +66,7 @@ spec:
 		},
 	}
 
-	err = trepo.CreateNSRepo(ctx, targetNS, run, repository)
+	err = trepo.CreateNSRepo(ctx, targetNS, runcnx, repository)
 	assert.NilError(t, err)
 
 	targetRefName := fmt.Sprintf("refs/heads/%s",
@@ -74,31 +74,47 @@ spec:
 
 	sha, err := tgithub.PushFilesToRef(ctx, ghcnx.Client, "TestRetest - "+targetRefName, repoinfo.GetDefaultBranch(), targetRefName, opts.Owner, opts.Repo, entries)
 	assert.NilError(t, err)
-	run.Clients.Log.Infof("Commit %s has been created and pushed to %s", sha, targetRefName)
+	runcnx.Clients.Log.Infof("Commit %s has been created and pushed to %s", sha, targetRefName)
 	title := "TestPullRequestRetest on " + targetRefName
 
-	number, err := tgithub.PRCreate(ctx, run, ghcnx, opts.Owner, opts.Repo, targetRefName, repoinfo.GetDefaultBranch(), title)
+	number, err := tgithub.PRCreate(ctx, runcnx, ghcnx, opts.Owner, opts.Repo, targetRefName, repoinfo.GetDefaultBranch(), title)
 	assert.NilError(t, err)
 
-	defer tearDown(ctx, t, run, ghcnx, number, targetRefName, targetNS, opts)
+	defer tearDown(ctx, t, runcnx, ghcnx, number, targetRefName, targetNS, opts)
 
-	run.Clients.Log.Infof("Waiting for Repository to be updated")
-	err = twait.UntilRepositoryUpdated(ctx, run.Clients.PipelineAsCode, targetNS, targetNS, 0, defaultTimeout)
+	runcnx.Clients.Log.Infof("Waiting for Repository to be updated")
+
+	waitOpts := twait.Opts{
+		RepoName:        targetNS,
+		Namespace:       targetNS,
+		MinNumberStatus: 0,
+		PollTimeout:     defaultTimeout,
+		TargetSHA:       sha,
+	}
+	err = twait.UntilRepositoryUpdated(ctx, runcnx.Clients.PipelineAsCode, runcnx.Clients.Tekton.TektonV1beta1(), waitOpts)
 	assert.NilError(t, err)
 
-	run.Clients.Log.Infof("Creating /retest in PullRequest")
+	runcnx.Clients.Log.Infof("Creating /retest in PullRequest")
 	_, _, err = ghcnx.Client.Issues.CreateComment(ctx,
 		opts.Owner,
 		opts.Repo, number,
 		&github.IssueComment{Body: github.String("/retest")})
 	assert.NilError(t, err)
 
-	run.Clients.Log.Infof("Wait for the second repository update to be updated")
-	err = twait.UntilRepositoryUpdated(ctx, run.Clients.PipelineAsCode, targetNS, targetNS, 1, defaultTimeout)
+	runcnx.Clients.Log.Infof("Wait for the second repository update to be updated")
+	waitOpts = twait.Opts{
+		RepoName:        targetNS,
+		Namespace:       targetNS,
+		MinNumberStatus: 1,
+		PollTimeout:     defaultTimeout,
+		TargetSHA:       sha,
+	}
+	err = twait.UntilRepositoryUpdated(ctx, runcnx.Clients.PipelineAsCode, runcnx.Clients.Tekton.TektonV1beta1(),
+		waitOpts)
 	assert.NilError(t, err)
 
-	run.Clients.Log.Infof("Check if we have the repository set as succeeded")
-	repo, err := run.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(targetNS).Get(ctx, targetNS, metav1.GetOptions{})
+	runcnx.Clients.Log.Infof("Check if we have the repository set as succeeded")
+	repo, err := runcnx.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(targetNS).Get(ctx, targetNS, metav1.GetOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, repo.Status[len(repo.Status)-1].Conditions[0].Status == corev1.ConditionTrue)
 }


### PR DESCRIPTION
E2E test will wait for up to 10minute when failing, we check now the
pipelinerun.

Could not test it properly but i guess that would show when there is
a failure.

nit: Use v1beta1 instead of v1alpha1 to get prs,

Closes #236

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
