### PR TITLE
Fix e2e test TestPullRequestRemoteAnnotations

### DIFF
--- a/test/pullrequest_remote_annotations_test.go
+++ b/test/pullrequest_remote_annotations_test.go
@@ -71,7 +71,7 @@ func TestPullRequestRemoteAnnotations(t *testing.T) {
 	assert.NilError(t, err)
 	runcnx.Clients.Log.Infof("Commit %s has been created and pushed to %s", sha, targetRefName)
 
-	title := "TestPullRequestPrivateRepository - " + targetRefName
+	title := "TestPullRequestRemoteAnnotations - " + targetRefName
 	number, err := tgithub.PRCreate(ctx, runcnx, ghcnx, opts.Owner, opts.Repo, targetRefName, repoinfo.GetDefaultBranch(), title)
 	assert.NilError(t, err)
 

--- a/test/testdata/pipeline_remote_annotations.yaml
+++ b/test/testdata/pipeline_remote_annotations.yaml
@@ -11,7 +11,6 @@ spec:
     - name: repo_url
     - name: revision
   tasks:
-
     - name: task-spec
       taskSpec:
         steps:
@@ -19,7 +18,7 @@ spec:
             image: registry.access.redhat.com/ubi8/ubi-minimal:8.2
             script: |
               echo "Hello from taskSpec"
-              exit 1
+              exit 0
 
     - name: task-from-remote
       taskRef:


### PR DESCRIPTION
We were exit 1 and since now we detect failures of pipelinerun then we
would get screwed :facepalm:

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
