### PR TITLE
check if PAC_WEBVCS_TOKEN is a file to read

### DIFF
--- a/pkg/cmd/pipelineascode/pipelineascode.go
+++ b/pkg/cmd/pipelineascode/pipelineascode.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
@@ -44,7 +45,10 @@ func Command(cs *params.Run) *cobra.Command {
 		},
 	}
 
-	cs.Info.Pac.AddFlags(cmd)
+	err := cs.Info.Pac.AddFlags(cmd)
+	if err != nil {
+		log.Fatal(err)
+	}
 	cs.Info.Kube.AddFlags(cmd)
 
 	cmd.Flags().StringVarP(&cs.Info.Event.EventType, "webhook-type", "", os.Getenv("PAC_EVENT_TYPE"), "Payload event type as set from Github (ie: X-GitHub-Event header)")

--- a/pkg/cmd/resolve/resolve.go
+++ b/pkg/cmd/resolve/resolve.go
@@ -87,7 +87,10 @@ func Command(run *params.Run) *cobra.Command {
 		"Wether to switch name to a generateName on pipelinerun")
 	cmd.Flags().BoolVar(&remoteTask, "remoteTask", true,
 		"Wether parse annotation to fetch remote task")
-	run.Info.Pac.AddFlags(cmd)
+	err := run.Info.Pac.AddFlags(cmd)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	return cmd
 }

--- a/pkg/params/info/pac.go
+++ b/pkg/params/info/pac.go
@@ -19,11 +19,22 @@ type PacOpts struct {
 	PayloadFile        string
 }
 
-func (p *PacOpts) AddFlags(cmd *cobra.Command) {
+func (p *PacOpts) AddFlags(cmd *cobra.Command) error {
 	cmd.PersistentFlags().StringVarP(&p.VCSType, "webvcs-type", "", os.Getenv("PAC_WEBVCS_TYPE"),
 		"Web VCS (ie: GitHub) Token")
 
-	cmd.PersistentFlags().StringVarP(&p.VCSToken, "webvcs-token", "", os.Getenv("PAC_WEBVCS_TOKEN"),
+	webvcsToken := os.Getenv("PAC_WEBVCS_TOKEN")
+	if webvcsToken != "" {
+		if _, err := os.Stat(webvcsToken); !os.IsNotExist(err) {
+			data, err := os.ReadFile(webvcsToken)
+			if err != nil {
+				return err
+			}
+			webvcsToken = string(data)
+		}
+	}
+
+	cmd.PersistentFlags().StringVarP(&p.VCSToken, "webvcs-token", "", webvcsToken,
 		"Web VCS (ie: GitHub) Token")
 
 	cmd.PersistentFlags().StringVarP(&p.VCSAPIURL, "webvcs-api-url", "", os.Getenv("PAC_WEBVCS_URL"),
@@ -50,4 +61,6 @@ func (p *PacOpts) AddFlags(cmd *cobra.Command) {
 		"secret-auto-creation",
 		secretAutoCreation,
 		"Wether to create automatically secrets.")
+
+	return nil
 }


### PR DESCRIPTION
if PAC_WEBVCS_TOKEN is a file and exist then read it.
this make it  easier for  running this under debuggers to autogenerate
before the file.

(we may we use that to hide token too in pipelinerun if needed)

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
