### PR TITLE
Fix bitbucket eventlistenner

### DIFF
--- a/config/400-trigger-eventlistenner.yaml
+++ b/config/400-trigger-eventlistenner.yaml
@@ -222,7 +222,7 @@ spec:
         - ref: pipelines-as-code-bitbucket-cloud-push
       interceptors:
         - ref:
-            name: "bitbucket-cloud"
+            name: "bitbucket"
           params:
             # TODO: secrets! this should come from Repository CRD so we need to do this from the pac binary :\
             - name: eventTypes


### PR DESCRIPTION
the interceptors is called bitbucket not bitbucket-cloud.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
