### PR TITLE
Omit empty on WebvcsAPIURL and WebvcsAPIURL fields

### DIFF
--- a/pkg/apis/pipelinesascode/v1alpha1/types.go
+++ b/pkg/apis/pipelinesascode/v1alpha1/types.go
@@ -54,8 +54,8 @@ type RepositorySpec struct {
 	URL           string            `json:"url"`
 	EventType     string            `json:"event_type"`
 	Branch        string            `json:"branch"`
-	WebvcsAPIURL  string            `json:"webvcs_api_url"`
-	WebvcsAPIUser string            `json:"webvcs_api_user"`
+	WebvcsAPIURL  string            `json:"webvcs_api_url,omitempty"`
+	WebvcsAPIUser string            `json:"webvcs_api_user,omitempty"`
 	WebvcsSecret  *WebvcsSecretSpec `json:"webvcs_secret,omitempty"`
 }
 


### PR DESCRIPTION
It otherwise show weirdly when not set i.e:

webvcs_api_url: ""
webvcs_api_user: ""

![image](https://user-images.githubusercontent.com/98980/136976698-b917ec5b-c23f-4e21-8ace-1acdf261096c.png)
