### PR TITLE
Rename github-app-secret to pipelines-as-code-secret

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -51,8 +51,8 @@ SETUP
   ```
 
   Then generate a token for that installation_id using the `gen-token.py`
-  script, it will use your private.key and application_id from the
-  `github-app-secret` secret :
+  script, it will use your github-private-key and github-application-id from the
+  `pipelines-as-code-secret` secret :
 
   ```shell
   ./hack/dev/gen-token.py --installation-id 123456789 --cache-file /tmp/token.for.my.repo

--- a/config/400-trigger-eventlistenner.yaml
+++ b/config/400-trigger-eventlistenner.yaml
@@ -32,7 +32,7 @@ spec:
           params:
             - name: "secretRef"
               value:
-                secretName: "github-app-secret"
+                secretName: "pipelines-as-code-secret"
                 secretKey: "webhook.secret"
             - name: "eventTypes"
               value: ["issue_comment"]
@@ -60,7 +60,7 @@ spec:
           params:
             - name: "secretRef"
               value:
-                secretName: "github-app-secret"
+                secretName: "pipelines-as-code-secret"
                 secretKey: "webhook.secret"
             - name: "eventTypes"
               value: ["issue_comment"]
@@ -89,7 +89,7 @@ spec:
           params:
             - name: "secretRef"
               value:
-                secretName: "github-app-secret"
+                secretName: "pipelines-as-code-secret"
                 secretKey: "webhook.secret"
             - name: "eventTypes"
               value: ["push"]
@@ -113,7 +113,7 @@ spec:
           params:
             - name: "secretRef"
               value:
-                secretName: "github-app-secret"
+                secretName: "pipelines-as-code-secret"
                 secretKey: "webhook.secret"
             - name: "eventTypes"
               value: ["check_run"]
@@ -138,7 +138,7 @@ spec:
           params:
             - name: "secretRef"
               value:
-                secretName: "github-app-secret"
+                secretName: "pipelines-as-code-secret"
                 secretKey: "webhook.secret"
             - name: "eventTypes"
               value: ["pull_request"]

--- a/config/401-github-issue-recheck.yaml
+++ b/config/401-github-issue-recheck.yaml
@@ -255,4 +255,4 @@ spec:
         workspaces:
           - name: secrets
             secret:
-              secretName: github-app-secret
+              secretName: pipelines-as-code-secret

--- a/config/402-github-pull-request.yaml
+++ b/config/402-github-pull-request.yaml
@@ -264,4 +264,4 @@ spec:
         workspaces:
           - name: secrets
             secret:
-              secretName: github-app-secret
+              secretName: pipelines-as-code-secret

--- a/config/403-github-push.yaml
+++ b/config/403-github-push.yaml
@@ -239,4 +239,4 @@ spec:
         workspaces:
           - name: secrets
             secret:
-              secretName: github-app-secret
+              secretName: pipelines-as-code-secret

--- a/config/404-github-retest-comment.yaml
+++ b/config/404-github-retest-comment.yaml
@@ -207,4 +207,4 @@ spec:
         workspaces:
           - name: secrets
             secret:
-              secretName: github-app-secret
+              secretName: pipelines-as-code-secret

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -107,9 +107,9 @@ Run the following command and replace:
 * `PATH_PRIVATE_KEY` with the path to the private key that was downloaded in the previous section
 
 ```bash
-kubectl -n pipelines-as-code create secret generic github-app-secret \
-        --from-literal private.key="$(cat PATH_PRIVATE_KEY)" \
-        --from-literal application_id="APP_ID" \
+kubectl -n pipelines-as-code create secret generic pipelines-as-code-secret \
+        --from-literal github-private-key="$(cat PATH_PRIVATE_KEY)" \
+        --from-literal github-application-id="APP_ID" \
         --from-literal webhook.secret="WEBHOOK_SECRET"
 ```
 
@@ -165,7 +165,7 @@ will have to recreate it.
 * On your cluster you need create the webhook secret as generated previously in the *pipelines-as-code* namespace.
 
 ```shell
-kubectl -n pipelines-as-code create secret generic github-app-secret \
+kubectl -n pipelines-as-code create secret generic pipelines-as-code-secret \
         --from-literal webhook.secret="$WEBHOOK_SECRET_AS_GENERATED"
 ```
 

--- a/hack/dev/gen-token.py
+++ b/hack/dev/gen-token.py
@@ -10,7 +10,7 @@ import time
 import requests
 from jwcrypto import jwk, jwt
 
-SECRET_NAME = "github-app-secret"
+SECRET_NAME = "pipelines-as-code-secret"
 NAMESPACE = "pipelines-as-code"
 EXPIRE_MINUTES_AS_SECONDS = int(
     os.environ.get('GITHUBAPP_TOKEN_EXPIRATION_MINUTES', 10)) * 60
@@ -92,8 +92,8 @@ def get_private_key(ns):
                             check=True,
                             capture_output=True)
     jeez = json.loads(secret.stdout)
-    return (base64.b64decode(jeez["data"]["application_id"]).decode(),
-            base64.b64decode(jeez["data"]["private.key"]))
+    return (base64.b64decode(jeez["data"]["github-application-id"]).decode(),
+            base64.b64decode(jeez["data"]["github-private-key"]))
 
 
 def main(args):

--- a/hack/dev/replay-gh-events.py
+++ b/hack/dev/replay-gh-events.py
@@ -14,7 +14,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 """Will replay a json file in Eventlistenner, it automatically detects the
-EventListenner, the webhook secret from github-app-secret secret name
+EventListenner, the webhook secret from pipelines-as-code-secret secret name
 require requests library"""
 import argparse
 import base64
@@ -27,7 +27,7 @@ import os
 import requests
 
 NAMESPACE = "pipelines-as-code"
-SECRET_NAME = "github-app-secret"
+SECRET_NAME = "pipelines-as-code-secret"
 ELNAME = "pipelines-as-code"
 
 
@@ -48,7 +48,7 @@ def get_installation_id_and_webhook_secret():
         check=True,
         capture_output=True)
     jeez = json.loads(secret.stdout)
-    return (jeez["data"]["application_id"],
+    return (jeez["data"]["github-application-id"],
             base64.b64decode(jeez["data"]["webhook.secret"]).decode())
 
 

--- a/pkg/cmd/bootstrap/bootstrap.go
+++ b/pkg/cmd/bootstrap/bootstrap.go
@@ -16,9 +16,8 @@ const (
 	openShiftRouteGroup    = "route.openshift.io"
 	openShiftRouteVersion  = "v1"
 	openShiftRouteResource = "routes"
-	// nolint: gosec
-	secretName     = "github-app-secret"
-	defaultVCSType = "github-app"
+	secretName             = "pipelines-as-code-secret"
+	defaultVCSType         = "github-app"
 )
 
 var vcsTargets = []string{"github-app", "github-enteprise-app"}

--- a/pkg/cmd/bootstrap/kubestuff.go
+++ b/pkg/cmd/bootstrap/kubestuff.go
@@ -22,9 +22,9 @@ func createPacSecret(ctx context.Context, run *params.Run, opts *bootstrapOpts, 
 			Name: secretName,
 		},
 		Data: map[string][]byte{
-			"application_id": []byte(fmt.Sprintf("%d", manifest.GetID())),
-			"private.key":    []byte(manifest.GetPEM()),
-			"webhook.secret": []byte(manifest.GetWebhookSecret()),
+			"github-application-id": []byte(fmt.Sprintf("%d", manifest.GetID())),
+			"github-private-key":    []byte(manifest.GetPEM()),
+			"webhook.secret":        []byte(manifest.GetWebhookSecret()),
 		},
 	}, metav1.CreateOptions{})
 	if err != nil {

--- a/pkg/webvcs/github/events.go
+++ b/pkg/webvcs/github/events.go
@@ -55,8 +55,8 @@ func (v *VCS) getAppToken() error {
 		return fmt.Errorf("workspace path %s in env PAC_WORKSPACE_SECRET does not exist", workspacePath)
 	}
 
-	// read application_id from the secret workspace
-	b, err := ioutil.ReadFile(filepath.Join(workspacePath, "application_id"))
+	// read github-application-id from the secret workspace
+	b, err := ioutil.ReadFile(filepath.Join(workspacePath, "github-application-id"))
 	if err != nil {
 		return err
 	}
@@ -66,7 +66,7 @@ func (v *VCS) getAppToken() error {
 	}
 
 	// read private_key from the secret workspace
-	privatekey := filepath.Join(workspacePath, "private.key")
+	privatekey := filepath.Join(workspacePath, "github-private-key")
 	tr := http.DefaultTransport
 	itr, err := ghinstallation.NewKeyFromFile(tr, applicationID, installationID, privatekey)
 	if err != nil {

--- a/pkg/webvcs/github/events_test.go
+++ b/pkg/webvcs/github/events_test.go
@@ -346,7 +346,7 @@ func TestAppTokenGeneration(t *testing.T) {
 				"PAC_WORKSPACE_SECRET": "here",
 			},
 			wsSecretFiles: map[string]string{
-				"noapplication_id": "Foo",
+				"nogithub-application-id": "Foo",
 			},
 			wantErr: true,
 		},
@@ -357,7 +357,7 @@ func TestAppTokenGeneration(t *testing.T) {
 				"PAC_WORKSPACE_SECRET": "here",
 			},
 			wsSecretFiles: map[string]string{
-				"application_id": "BAD",
+				"github-application-id": "BAD",
 			},
 			wantErr: true,
 		},
@@ -368,7 +368,7 @@ func TestAppTokenGeneration(t *testing.T) {
 				"PAC_WORKSPACE_SECRET": "here",
 			},
 			wsSecretFiles: map[string]string{
-				"application_id": "2222",
+				"github-application-id": "2222",
 			},
 			wantErr: true,
 		},
@@ -380,8 +380,8 @@ func TestAppTokenGeneration(t *testing.T) {
 				"PAC_WEBVCS_APIURL":    "foo.bar.com",
 			},
 			wsSecretFiles: map[string]string{
-				"application_id": "2222",
-				"private.key":    "hello",
+				"github-application-id": "2222",
+				"github-private-key":    "hello",
 			},
 			wantErr: true,
 		},
@@ -393,8 +393,8 @@ func TestAppTokenGeneration(t *testing.T) {
 				"PAC_WEBVCS_APIURL":    "foo.bar.com",
 			},
 			wsSecretFiles: map[string]string{
-				"application_id": "2222",
-				"private.key":    fakePrivateKey,
+				"github-application-id": "2222",
+				"github-private-key":    fakePrivateKey,
 			},
 			resultBaseURL: "https://foo.bar.com/api/v3/",
 		},
@@ -406,8 +406,8 @@ func TestAppTokenGeneration(t *testing.T) {
 				"PAC_WEBVCS_APIURL":    "https://alpha.beta.com",
 			},
 			wsSecretFiles: map[string]string{
-				"application_id": "2222",
-				"private.key":    fakePrivateKey,
+				"github-application-id": "2222",
+				"github-private-key":    fakePrivateKey,
 			},
 			resultBaseURL: "https://alpha.beta.com/api/v3/",
 		},
@@ -418,8 +418,8 @@ func TestAppTokenGeneration(t *testing.T) {
 				"PAC_WORKSPACE_SECRET": "here",
 			},
 			wsSecretFiles: map[string]string{
-				"application_id": "2222",
-				"private.key":    fakePrivateKey,
+				"github-application-id": "2222",
+				"github-private-key":    fakePrivateKey,
 			},
 			resultBaseURL: "https://api.github.com/",
 		},


### PR DESCRIPTION
Better do it now than later so we can handle properly the other VCS platforms in the future :

SecretName: github-app-secret > pipelines-as-code-secret
Key: application_id -> github-application-id
Key: private_key -> github-private-key

Closes #272

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
