### PR TITLE
Fix private repo with Github Application

### DIFF
--- a/pkg/cmd/pipelineascode/pipelineascode.go
+++ b/pkg/cmd/pipelineascode/pipelineascode.go
@@ -96,6 +96,7 @@ func runWrap(ctx context.Context, cs *params.Run, vcx webvcs.Interface, kinterac
 	// If we already have the Token (ie: github apps) set as soon as possible the client,
 	// There is more things supported when we already have a github apps and some that are not
 	// (ie: /ok-to-test or /rerequest)
+	// TODO: probably not needed since we generate our token and not getting them beforehand
 	if cs.Info.Pac.VCSToken != "" {
 		err := vcx.SetClient(ctx, cs.Info.Pac)
 		if err != nil {

--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -68,12 +68,13 @@ func Run(ctx context.Context, cs *params.Run, vcsintf webvcs.Interface, k8int ku
 		if err != nil {
 			return err
 		}
-		// We already SetClient before ParseWebhook in case if we already set
-		// the token (ie: github apps) and not coming from the repository
-		err = vcsintf.SetClient(ctx, cs.Info.Pac)
-		if err != nil {
-			return err
-		}
+	}
+
+	// Set the client, we should error out if there is a problem with
+	// token or secret or we won't be able to do much.
+	err = vcsintf.SetClient(ctx, cs.Info.Pac)
+	if err != nil {
+		return err
 	}
 
 	// Get the SHA commit info, we want to get the URL and commit title

--- a/pkg/test/github/github.go
+++ b/pkg/test/github/github.go
@@ -13,7 +13,7 @@ import (
 const (
 	// baseURLPath is a non-empty Client.BaseURL path to use during tests,
 	// to ensure relative URLs are used for all endpoints. See issue #752.
-	githubBaseURLPath = "/api-v3"
+	githubBaseURLPath = "/api/v3"
 )
 
 // SetupGH Setup a GitHUB httptest connexion, from go-github test-suit

--- a/pkg/webvcs/github/github.go
+++ b/pkg/webvcs/github/github.go
@@ -31,7 +31,6 @@ func (v *VCS) SetClient(ctx context.Context, info *info.PacOpts) error {
 		&oauth2.Token{AccessToken: info.VCSToken},
 	)
 	tc := oauth2.NewClient(ctx, ts)
-
 	var client *github.Client
 	apiURL := info.VCSAPIURL
 	if apiURL != "" {
@@ -52,7 +51,6 @@ func (v *VCS) SetClient(ctx context.Context, info *info.PacOpts) error {
 		v.Client = client
 	}
 	v.APIURL = &apiURL
-	v.Token = &info.VCSToken
 
 	return nil
 }
@@ -79,6 +77,11 @@ func (v *VCS) GetTektonDir(ctx context.Context, runevent *info.Event, path strin
 // GetCommitInfo get info (url and title) on a commit in runevent, this needs to
 // be run after parsewebhook while we already matched a token.
 func (v *VCS) GetCommitInfo(ctx context.Context, runevent *info.Event) error {
+	if v.Client == nil {
+		return fmt.Errorf("no github client has been initiliazed, " +
+			"exiting... (hint: did you forget setting a secret on your repo?)")
+	}
+
 	commit, _, err := v.Client.Git.GetCommit(ctx, runevent.Owner, runevent.Repository, runevent.SHA)
 	if err != nil {
 		return err

--- a/test/github_pullrequest_privaterepository_test.go
+++ b/test/github_pullrequest_privaterepository_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestGithubPullRequestPrivateRepository(t *testing.T) {
-	t.Skip("PSI E2E Infra is borked atm")
 	for _, onWebhook := range []bool{false, true} {
 		targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
 		ctx := context.Background()


### PR DESCRIPTION
While reenabling the E2E tests on private repo, i figured that Github Apps was
broken and wasn't generating the private repo properly.

We have a hack in there for runing the e2e/unittests which probably need to be
figured later but that should not bring any defects.
