### PR TITLE
fix: don't error out when we cannot match

### DIFF
--- a/pkg/matcher/annotation_matcher.go
+++ b/pkg/matcher/annotation_matcher.go
@@ -115,15 +115,15 @@ func MatchPipelinerunByAnnotation(ctx context.Context, pruns []*v1beta1.Pipeline
 		return prun, repo, configurations[prun.GetGenerateName()], nil
 	}
 
-	cs.Clients.Log.Warn("could not find a match to a pipelinerun in .tekton/ dir")
+	cs.Clients.Log.Warn("could not find a match to a pipelinerun in the .tekton/ dir")
 	cs.Clients.Log.Warn("available configuration in pipelineRuns annotations")
-	for prunname, maps := range configurations {
+	for name, maps := range configurations {
 		cs.Clients.Log.Infof("pipelineRun: %s, target-branch=%s, target-event=%s",
-			prunname, maps["target-branch"], maps["target-event"])
+			name, maps["target-branch"], maps["target-event"])
 	}
 
 	// TODO: more descriptive error message
-	return nil, nil, map[string]string{}, fmt.Errorf("cannot match pipeline from webhook to pipelineruns")
+	return nil, nil, map[string]string{}, fmt.Errorf("cannot match pipeline from webhook to pipelineruns on event=%s, branch=%s", cs.Info.Event.EventType, cs.Info.Event.BaseBranch)
 }
 
 func matchOnAnnotation(annotations string, eventType string, branchMatching bool) (bool, error) {

--- a/pkg/pipelineascode/pipelinesascode_github_test.go
+++ b/pkg/pipelineascode/pipelinesascode_github_test.go
@@ -172,22 +172,6 @@ func TestRun(t *testing.T) {
 			ProviderInfoFromRepo: true,
 		},
 		{
-			name: "No match",
-			runevent: info.Event{
-				SHA:          "principale",
-				Organization: "organizationes",
-				Repository:   "lagaffe",
-				URL:          "https://service/documentation",
-				HeadBranch:   "press",
-				Sender:       "fantasio",
-				BaseBranch:   "nomatch",
-				EventType:    "pull_request",
-			},
-			tektondir:   "testdata/pull_request",
-			wantErr:     "cannot match pipeline from webhook to pipelineruns",
-			finalStatus: "neutral",
-		},
-		{
 			name: "Push/branch",
 			runevent: info.Event{
 				SHA:          "principale",
@@ -407,7 +391,8 @@ func TestRun(t *testing.T) {
 				got, err := stdata.PipelineAsCode.PipelinesascodeV1alpha1().Repositories("namespace").Get(
 					ctx, "test-run", metav1.GetOptions{})
 				assert.NilError(t, err)
-				assert.Assert(t, got.Status[len(got.Status)-1].PipelineRunName != "pipelinerun1")
+				assert.Assert(t, got.Status[len(got.Status)-1].PipelineRunName != "pipelinerun1", "'%s'!='%s'",
+					got.Status[len(got.Status)-1].PipelineRunName, "pipelinerun1")
 			}
 		})
 	}


### PR DESCRIPTION
When we could not match a pipelinerun to the event, we would bug out and
set the commit as failed in Provider, which is right but the user would
not care much.

let's just warn it and exit.

better debugging logs too.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
