### PR TITLE
feat: add pipelinerunname to the github check

### DIFF
--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -3,9 +3,11 @@ package pipelineascode
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strconv"
 	"time"
 
+	apipac "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/matcher"
@@ -150,11 +152,12 @@ func Run(ctx context.Context, cs *params.Run, providerintf provider.Interface, k
 	// Create status with the log url
 	msg := fmt.Sprintf(startingPipelineRunText, pr.GetName(), repo.GetNamespace(), consoleURL, repo.GetNamespace(), pr.GetName())
 	status := provider.StatusOpts{
-		Status:          "in_progress",
-		Conclusion:      "pending",
-		Text:            msg,
-		DetailsURL:      consoleURL,
-		PipelineRunName: pr.GetName(),
+		Status:                  "in_progress",
+		Conclusion:              "pending",
+		Text:                    msg,
+		DetailsURL:              consoleURL,
+		PipelineRunName:         pr.GetName(),
+		OriginalPipelineRunName: pr.GetLabels()[filepath.Join(apipac.GroupName, "original-prname")],
 	}
 	if err := providerintf.CreateStatus(ctx, cs.Info.Event, cs.Info.Pac, status); err != nil {
 		return fmt.Errorf("cannot create a in_progress status on the provider platform: %w", err)

--- a/pkg/provider/interface.go
+++ b/pkg/provider/interface.go
@@ -8,13 +8,14 @@ import (
 )
 
 type StatusOpts struct {
-	PipelineRunName string
-	Status          string
-	Conclusion      string
-	Text            string
-	DetailsURL      string
-	Summary         string
-	Title           string
+	PipelineRunName         string
+	OriginalPipelineRunName string
+	Status                  string
+	Conclusion              string
+	Text                    string
+	DetailsURL              string
+	Summary                 string
+	Title                   string
 }
 
 type Interface interface {


### PR DESCRIPTION
We add the pipelinrunname on github. This probably be more useful whenever we
implement multi pipeline match on events but this gives a nice way to
see the pipeline that has been tested.

maybe improvement in the future to allow via an annotation to customize
the label output instead of just the PR name like Github actions has.

if user set application name in configmap to an empty string it will only show the pr name

Sshots how it look like : 

![image](https://user-images.githubusercontent.com/98980/140302867-c704deb4-4c73-47d3-bb49-9f92ae0dc468.png)

![image](https://user-images.githubusercontent.com/98980/140302904-eb492c91-f0d7-4608-b894-6f7bb868d755.png)
