### PR TITLE
Add documentation on how to let non admin user to create repo

### DIFF
--- a/config/200-role.yaml
+++ b/config/200-role.yaml
@@ -90,7 +90,7 @@ rules:
   # Permissions to list repositories on cluster
   - apiGroups: ["pipelinesascode.tekton.dev"]
     resources: ["repositories"]
-    verbs: ["get", "list", "update"]
+    verbs: ["create", "get", "list", "update"]
   - apiGroups: ["triggers.tekton.dev"]
     resources: ["clustertriggerbindings", "clusterinterceptors"]
     verbs: ["get", "list", "watch"]

--- a/docs/install.md
+++ b/docs/install.md
@@ -22,38 +22,76 @@ Here is a video walkthrough on the install process :
 
 ### Install Pipelines as Code infrastructure
 
-To install Pipelines as Code on your cluster you simply need to run this command :
+To install Pipelines as Code on your cluster you simply need to run this command
+:
 
 ```shell
 VERSION=0.4.4
 kubectl apply -f https://raw.githubusercontent.com/openshift-pipelines/pipelines-as-code/release-$VERSION/release-$VERSION.yaml
 ```
 
-If you would like to install the current development version you can simply install it like this :
+If you would like to install the current development version you can simply
+install it like this :
 
 ```shell
 kubectl apply -f https://raw.githubusercontent.com/openshift-pipelines/pipelines-as-code/nightly/release.yaml
 ```
 
-It will apply the release.yaml to your kubernetes cluster, creating the admin namespace `pipelines-as-code`, the roles
-and all other bits needed.
+It will apply the release.yaml to your kubernetes cluster, creating the admin
+namespace `pipelines-as-code`, the roles and all other bits needed.
 
-The `pipelines-as-code` namespace is where the Pipelines-as-Code infrastructure runs and is supposed to be accessible
-only by the admin.
+The `pipelines-as-code` namespace is where the Pipelines-as-Code infrastructure
+runs and is supposed to be accessible only by the admins.
 
-The Route for the EventListener URL is automatically created when you apply the release.yaml. You will need to grab the
-url for the next section when creating the GitHub App. You can run this command to get the route created on your
+The Route for the EventListener URL is automatically created when you apply the
+release.yaml. You will need to grab the url for the next section when creating
+the GitHub App. You can run this command to get the route created on your
 cluster:
 
 ```shell
 echo https://$(oc get route -n pipelines-as-code el-pipelines-as-code-interceptor -o jsonpath='{.spec.host}')
 ```
 
+### RBAC
+
+Non `system:admin` users needs to be allowed explicited to create repositories
+CRD in their namespace
+
+To allow them you need to create a `RoleBinding` on the namespace to the
+`openshift-pipeline-as-code-clusterrole`.
+
+For example assuming we want `user` being able to create repository CRD in the
+naemspace `user-ci`, if we use the openshift `oc` cli :
+
+```shell
+oc adm policy add-role-to-user openshift-pipeline-as-code-clusterrole user -n user-ci
+```
+
+or via kubectl applying this yaml :
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openshift-pipeline-as-code-clusterrole
+  namespace: user-ci
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-pipeline-as-code-clusterrole
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: user
+```
+
 ### Create a Pipelines-as-Code GitHub App
 
-You should now create a Pipelines-as-Code GitHub App which acts as the integration point with OpenShift Pipelines and
-brings the Git workflow into Tekton pipelines. You need the webhook of the GitHub App pointing to your Pipelines-as-Code
-EventListener route endpoint which would then trigger pipelines on GitHub events.
+You should now create a Pipelines-as-Code GitHub App which acts as the
+integration point with OpenShift Pipelines and brings the Git workflow into
+Tekton pipelines. You need the webhook of the GitHub App pointing to your
+Pipelines-as-Code EventListener route endpoint which would then trigger
+pipelines on GitHub events.
 
 * Go to https://github.com/settings/apps (or *Settings > Developer settings > GitHub Apps*) and click on **New GitHub
   App** button


### PR DESCRIPTION
- Add create permission to openshift-pipeline-as-code-clusterrole
- doc: Add information for non admin user

This partially address #333, I guess the only way to properly do this is to wait when we plugin into the `tektoncd/operator` 

