### PR TITLE
Add log url in tkn pac describe

### DIFF
--- a/pkg/cmd/tknpac/repository/testdata/TestCommands-Describe.golden
+++ b/pkg/cmd/tknpac/repository/testdata/TestCommands-Describe.golden
@@ -1,10 +1,8 @@
-Name:        repo1
-Namespace:   ns
-URL:         https://anurl.com/repo/owner
-
-Last Run: 
-
+Name:           repo1
+Namespace:      ns
+URL:            https://anurl.com/repo/owner
 Status:         Success
+Log:            https://everywhere.anwywhere
 PipelineRun:    pipelinerun1
 Event:          pull_request
 Branch:         TargetBranch

--- a/pkg/cmd/tknpac/repository/testdata/TestDescribe-live_run_and_repository_run.golden
+++ b/pkg/cmd/tknpac/repository/testdata/TestDescribe-live_run_and_repository_run.golden
@@ -1,0 +1,20 @@
+Name:        test-run
+Namespace:   ns
+URL:         https://anurl.com
+
+Last Run: 
+
+Status:         Running
+Log:            https://giphy.com/search/random-dogs
+PipelineRun:    running
+Event:          papayolo
+Branch:         tartanpion
+Commit URL:     
+Commit Title:   
+StartTime:      -35 minutes ago
+
+Other Runs:
+
+STATUS    Event               Branch          SHA    STARTED TIME    DURATION   PIPELINERUN
+――――――    ―――――               ――――――          ―――    ――――――――――――    ――――――――   ―――――――――――
+Success   propseryouplaboun   TargetBranch   SHA    16 minutes ago   1 minute   pipelinerun1

--- a/pkg/cmd/tknpac/repository/testdata/TestDescribe-multiple_live_runs.golden
+++ b/pkg/cmd/tknpac/repository/testdata/TestDescribe-multiple_live_runs.golden
@@ -1,0 +1,20 @@
+Name:        test-run
+Namespace:   ns
+URL:         https://anurl.com
+
+Last Run: 
+
+Status:         Running
+Log:            https://giphy.com/search/random-dogs
+PipelineRun:    running
+Event:          
+Branch:         tartanpion
+Commit URL:     
+Commit Title:   
+StartTime:      -35 minutes ago
+
+Other Runs:
+
+STATUS    Event   Branch      SHA    STARTED TIME     DURATION   PIPELINERUN
+――――――    ―――――   ――――――      ―――    ――――――――――――     ――――――――   ―――――――――――
+Running           vavaroom          -35 minutes ago   ---        running2

--- a/pkg/cmd/tknpac/repository/testdata/TestDescribe-multiple_repo_status.golden
+++ b/pkg/cmd/tknpac/repository/testdata/TestDescribe-multiple_repo_status.golden
@@ -5,6 +5,7 @@ URL:         https://anurl.com
 Last Run: 
 
 Status:         Success
+Log:            https://everywhere.anwywhere
 PipelineRun:    pipelinerun1
 Event:          pull_request
 Branch:         TargetBranch

--- a/pkg/cmd/tknpac/repository/testdata/TestDescribe-one_live_run.golden
+++ b/pkg/cmd/tknpac/repository/testdata/TestDescribe-one_live_run.golden
@@ -1,10 +1,8 @@
-Name:        test-run
-Namespace:   ns
-URL:         https://anurl.com
-
-Last Run: 
-
+Name:           test-run
+Namespace:      ns
+URL:            https://anurl.com
 Status:         Running
+Log:            https://giphy.com/search/random-dogs
 PipelineRun:    running
 Event:          
 Branch:         tartanpion

--- a/pkg/cmd/tknpac/repository/testdata/TestDescribe-one_repository_status_and_optnamespace.golden
+++ b/pkg/cmd/tknpac/repository/testdata/TestDescribe-one_repository_status_and_optnamespace.golden
@@ -1,10 +1,8 @@
-Name:        test-run
-Namespace:   optnamespace
-URL:         https://anurl.com
-
-Last Run: 
-
+Name:           test-run
+Namespace:      optnamespace
+URL:            https://anurl.com
 Status:         Success
+Log:            https://everywhere.anwywhere
 PipelineRun:    pipelinerun1
 Event:          <nil>
 Branch:         TargetBranch


### PR DESCRIPTION
* Add an option for kubernetes/tekton dahsboard user to TEKTON_DASHBOARD_URL for at least show the live url.
* Fix getting mixed live running pipelinerun and non live
* Improve testing
* Generally improve the way we show things, when there is only one or multiple runs or no runs.