### PR TITLE
Fixes annotation bug which used to err out on string value

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -262,7 +262,11 @@ Pipeline or a PipelineSpec it will automatically inlines it.
 An annotation to a remote task looks like this :
 
   ```yaml
-  pipelinesascode.tekton.dev/task: "[git-clone]"
+  pipelinesascode.tekton.dev/task: "git-clone"
+  ```
+or multiple tasks via an array :
+  ```yaml
+  pipelinesascode.tekton.dev/task: ["git-clone", "pylint"]
   ```
 
 this installs the
@@ -279,9 +283,9 @@ You can have multiple lines if you add a `-NUMBER` suffix to the annotation, for
 example :
 
 ```yaml
-  pipelinesascode.tekton.dev/task: "[git-clone]"
-  pipelinesascode.tekton.dev/task-1: "[golang-test]"
-  pipelinesascode.tekton.dev/task-2: "[tkn]"
+  pipelinesascode.tekton.dev/task: "git-clone"
+  pipelinesascode.tekton.dev/task-1: "golang-test"
+  pipelinesascode.tekton.dev/task-2: "tkn" 
 ```
 
 By default `Pipelines as Code` will interpret the string as the `latest` task to

--- a/pkg/matcher/annotation_matcher.go
+++ b/pkg/matcher/annotation_matcher.go
@@ -19,8 +19,11 @@ const (
 	onEventAnnotation        = "on-event"
 	onTargetBranchAnnotation = "on-target-branch"
 	onTargetNamespace        = "target-namespace"
-	reValidateTag            = `^\[(.*)\]$`
 	maxKeepRuns              = "max-keep-runs"
+
+	// regex allows array of string or a single string
+	// eg. ["foo", "bar"], ["foo"] or "foo"
+	reValidateTag = `^\[(.*)\]$|^[^[\]\s]*$`
 )
 
 func branchMatch(prunBranch, baseBranch string) bool {
@@ -38,9 +41,15 @@ func branchMatch(prunBranch, baseBranch string) bool {
 // TODO: move to another file since it's common to all annotations_* files
 func getAnnotationValues(annotation string) ([]string, error) {
 	re := regexp.MustCompile(reValidateTag)
+	annotation = strings.TrimSpace(annotation)
 	match := re.Match([]byte(annotation))
 	if !match {
 		return nil, errors.New("annotations in pipeline are in wrong format")
+	}
+
+	// if it's not an array then it would be a single string
+	if !strings.HasPrefix(annotation, "[") {
+		return []string{annotation}, nil
 	}
 
 	// Split all tasks by comma and make sure to trim spaces in there

--- a/pkg/matcher/annotation_matcher_test.go
+++ b/pkg/matcher/annotation_matcher_test.go
@@ -241,13 +241,13 @@ func TestMatchPipelinerunByAnnotation(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "bad-event-annotation",
+			name: "single-event-annotation",
 			args: args{
 				runevent: info.Event{EventType: "pull_request", BaseBranch: "main"},
 				pruns: []*tektonv1beta1.PipelineRun{
 					{
 						ObjectMeta: metav1.ObjectMeta{
-							Name: "bad-event-annotation",
+							Name: "single-event-annotation",
 							Annotations: map[string]string{
 								pipelinesascode.GroupName + "/" + onEventAnnotation:        "pull_request",
 								pipelinesascode.GroupName + "/" + onTargetBranchAnnotation: "[main]",
@@ -256,16 +256,16 @@ func TestMatchPipelinerunByAnnotation(t *testing.T) {
 					},
 				},
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
-			name: "bad-target-branch-annotation",
+			name: "single-target-branch-annotation",
 			args: args{
 				runevent: info.Event{EventType: "pull_request", BaseBranch: "main"},
 				pruns: []*tektonv1beta1.PipelineRun{
 					{
 						ObjectMeta: metav1.ObjectMeta{
-							Name: "bad-target-branch-annotation",
+							Name: "single-target-branch-annotation",
 							Annotations: map[string]string{
 								pipelinesascode.GroupName + "/" + onEventAnnotation:        "[pull_request]",
 								pipelinesascode.GroupName + "/" + onTargetBranchAnnotation: "main",
@@ -274,7 +274,7 @@ func TestMatchPipelinerunByAnnotation(t *testing.T) {
 					},
 				},
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "empty-annotation",
@@ -390,6 +390,14 @@ func Test_getAnnotationValues(t *testing.T) {
 		wantErr bool
 	}{
 		{
+			name: "get-annotation-string",
+			args: args{
+				annotation: "foo",
+			},
+			want:    []string{"foo"},
+			wantErr: false,
+		},
+		{
 			name: "get-annotation-simple",
 			args: args{
 				annotation: "[foo]",
@@ -404,6 +412,13 @@ func Test_getAnnotationValues(t *testing.T) {
 			},
 			want:    []string{"foo", "bar"},
 			wantErr: false,
+		},
+		{
+			name: "get-annotation-multiple-string-bad-syntax",
+			args: args{
+				annotation: "foo, bar",
+			},
+			wantErr: true,
 		},
 		{
 			name: "get-annotation-bad-syntax",

--- a/test/testdata/pipelinerun_remote_annotations.yaml
+++ b/test/testdata/pipelinerun_remote_annotations.yaml
@@ -6,8 +6,9 @@ metadata:
     pipelinesascode.tekton.dev/target-namespace: "%s"
     pipelinesascode.tekton.dev/on-target-branch: "[%s]"
     pipelinesascode.tekton.dev/on-event: "[%s]"
-    pipelinesascode.tekton.dev/task: "[pylint, .other-tasks/task-referenced-internally.yaml]"
+    pipelinesascode.tekton.dev/task: "[.other-tasks/task-referenced-internally.yaml]"
     pipelinesascode.tekton.dev/task-1: "[https://raw.githubusercontent.com/chmouel/scratchmyback/10c5ea559615c6783aa1a1aa9d93ea988b68dad7/.other-tasks/task-remote.yaml]"
+    pipelinesascode.tekton.dev/task-2: "pylint"
   name: pipelinerun-remote-annotations
 spec:
   pipelineRef:


### PR DESCRIPTION
previoulsy, when the annotation are not array but a string :
eg.  pipelinesascode.tekton.dev/on-event: "pull_request"
pac used to err out.
This patch fixes that and now allows single string along
with array of string.
eg. ["foo", "bar"], ["foo"] or "foo"

Closes #374 

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>