### PR TITLE
Add defaults config for tkn-pc resolv

### DIFF
--- a/pkg/cmd/tknpac/resolve/resolve.go
+++ b/pkg/cmd/tknpac/resolve/resolve.go
@@ -71,6 +71,11 @@ func Command(run *params.Run) *cobra.Command {
 					return err
 				}
 			}
+
+			if err := run.GetConfigFromConfigMap(ctx); err != nil {
+				log.Printf("Warning: cannot get pipelines-as-code config map in pipelines-as-code namespace. Using defaults. Error: %v\n", err)
+			}
+
 			if len(filenames) == 0 {
 				return fmt.Errorf("you need to at least specify a file with -f")
 			}

--- a/pkg/cmd/tknpac/resolve/resolve_test.go
+++ b/pkg/cmd/tknpac/resolve/resolve_test.go
@@ -42,7 +42,7 @@ func TestSplitArgsInMap(t *testing.T) {
 
 func TestCommandFilenameSetProperly(t *testing.T) {
 	cs := &params.Run{
-		Clients: clients.Clients{ClientInitialized: true},
+		Clients: clients.Clients{ClientInitialized: false},
 		Info:    info.Info{Pac: &info.PacOpts{}},
 	}
 	cmd := Command(cs)

--- a/pkg/params/run.go
+++ b/pkg/params/run.go
@@ -70,7 +70,10 @@ func New() *Run {
 	return &Run{
 		Info: info.Info{
 			Event: &info.Event{},
-			Pac:   &info.PacOpts{},
+			Pac: &info.PacOpts{
+				ApplicationName: info.PACApplicationName,
+				HubURL:          info.HubURL,
+			},
 		},
 	}
 }


### PR DESCRIPTION
When it's possible, get the PaC configMap. But when it's not possible, use defaults.