### PR TITLE
Removes generated secret after completion of user pipelinerun

### DIFF
--- a/cmd/pipelines-as-code/main.go
+++ b/cmd/pipelines-as-code/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"log"
-	"os"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cmd/pipelineascode"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
@@ -13,6 +12,5 @@ func main() {
 	cmd := pipelineascode.Command(clients)
 	if err := cmd.Execute(); err != nil {
 		log.Fatal(err)
-		os.Exit(1)
 	}
 }

--- a/pkg/cmd/tknpac/bootstrap/bootstrap.go
+++ b/pkg/cmd/tknpac/bootstrap/bootstrap.go
@@ -140,7 +140,7 @@ func Command(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
 	addCommonFlags(cmd, opts, ioStreams)
 	addGithubAppFlag(cmd, opts)
 
-	cmd.PersistentFlags().BoolVar(&opts.forceInstall, "force-install", false, "wether we should force pac install even if it's already installed")
+	cmd.PersistentFlags().BoolVar(&opts.forceInstall, "force-install", false, "whether we should force pac install even if it's already installed")
 	cmd.PersistentFlags().BoolVar(&opts.skipInstall, "skip-install", false, "skip Pipelines as Code installation")
 	cmd.PersistentFlags().BoolVar(&opts.skipGithubAPP, "skip-github-app", false, "skip creating github application")
 

--- a/pkg/kubeinteraction/kubeinteraction.go
+++ b/pkg/kubeinteraction/kubeinteraction.go
@@ -22,6 +22,7 @@ type Interface interface {
 	WaitForPipelineRunSucceed(context.Context, tektonv1beta1client.TektonV1beta1Interface, *v1beta1.PipelineRun, time.Duration) error
 	CleanupPipelines(ctx context.Context, repo *v1alpha1.Repository, pr *v1beta1.PipelineRun, limitnumber int) error
 	CreateBasicAuthSecret(context.Context, *info.Event, *info.PacOpts, string) error
+	DeleteBasicAuthSecret(context.Context, *info.Event, string) error
 	GetSecret(context.Context, GetSecretOpt) (string, error)
 }
 

--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -44,7 +44,7 @@ func Run(ctx context.Context, cs *params.Run, providerintf provider.Interface, k
 		cs.Clients.Log.Warn(msg)
 
 		if cs.Info.Pac.ProviderToken == "" {
-			cs.Clients.Log.Warn("cannot set status since not token has been set")
+			cs.Clients.Log.Warn("cannot set status since no token has been set")
 			return nil
 		}
 
@@ -181,6 +181,14 @@ func Run(ctx context.Context, cs *params.Run, providerintf provider.Interface, k
 		err = k8int.CleanupPipelines(ctx, repo, pr, max)
 		if err != nil {
 			return err
+		}
+	}
+
+	// remove the generated secret after completion of pipelinerun
+	if cs.Info.Pac.SecretAutoCreation {
+		err = k8int.DeleteBasicAuthSecret(ctx, cs.Info.Event, repo.GetNamespace())
+		if err != nil {
+			return fmt.Errorf("deleting basic auth secret has failed: %w ", err)
 		}
 	}
 

--- a/pkg/test/kubernetestint/kubernetesint.go
+++ b/pkg/test/kubernetestint/kubernetesint.go
@@ -30,6 +30,10 @@ func (k *KinterfaceTest) CreateBasicAuthSecret(ctx context.Context, runevent *in
 	return nil
 }
 
+func (k *KinterfaceTest) DeleteBasicAuthSecret(ctx context.Context, runevent *info.Event, targetNamespace string) error {
+	return nil
+}
+
 func (k *KinterfaceTest) GetSecret(ctx context.Context, secretopt kubeinteraction.GetSecretOpt) (string, error) {
 	return k.GetSecretResult, nil
 }


### PR DESCRIPTION
for git clone, we create a secret with credentials for accessing
repo which used to be on cluster even after completion of pipeline.
this removes the secret after completion of user pipeline during
cleanup.

Closes #253 

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI 
- [ ] 📖 If you are adding a user facing feature or make a change of the behaviour, please make sure to document it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakyness in the CI tests then make sure to get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
