### PR TITLE
Reads default pipelinerun timeout value from configmap

### DIFF
--- a/config/302-pac-configmap.yaml
+++ b/config/302-pac-configmap.yaml
@@ -20,13 +20,13 @@ data:
   # The application name, you can customize this label
   application-name: "Pipelines as Code CI"
 
-  # Wether to automatically create a secret with the token to be use by git-clone
+  # Whether to automatically create a secret with the token to be use by git-clone
   secret-auto-create: "true"
 
   # Tekton HUB API urls
   hub-url: "https://api.hub.tekton.dev/v1"
 
-  # Wether to allow fetching remote tasks
+  # Whether to allow fetching remote tasks
   remote-tasks: "true"
 
   # Since public bitbucket doesn't have the concept of Secret, we need to be
@@ -41,6 +41,9 @@ data:
 
   # Add extra IPS (ie: 127.0.0.1) or networks (127.0.0.0/16) separated by commas.
   bitbucket-cloud-additional-source-ip: ""
+
+  # The default time to wait for a pipelineRun
+  default-pipelinerun-timeout: "2h"
 
 kind: ConfigMap
 metadata:

--- a/pkg/params/info/defaults.go
+++ b/pkg/params/info/defaults.go
@@ -1,8 +1,11 @@
 package info
 
+import "time"
+
 const (
-	PACInstallNS       = "pipelines-as-code"
-	PACConfigmapNS     = "pipelines-as-code"
-	PACApplicationName = "Pipelines as Code CI"
-	HubURL             = "https://api.hub.tekton.dev/v1"
+	PACInstallNS              = "pipelines-as-code"
+	PACConfigmapNS            = "pipelines-as-code"
+	PACApplicationName        = "Pipelines as Code CI"
+	HubURL                    = "https://api.hub.tekton.dev/v1"
+	DefaultPipelineRunTimeout = 2 * time.Hour
 )

--- a/pkg/params/info/pac.go
+++ b/pkg/params/info/pac.go
@@ -4,23 +4,25 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 )
 
 type PacOpts struct {
-	LogURL               string
-	ApplicationName      string // the Application Name for example "Pipelines as Code"
-	SecretAutoCreation   bool   // secret auto creation in target namespace
-	ProviderToken        string
-	ProviderURL          string
-	ProviderUser         string
-	ProviderInfoFromRepo bool // whether the provider info come from the repository
-	WebhookType          string
-	PayloadFile          string
-	TektonDashboardURL   string
-	HubURL               string
-	RemoteTasks          bool
+	LogURL                    string
+	ApplicationName           string // the Application Name for example "Pipelines as Code"
+	SecretAutoCreation        bool   // secret auto creation in target namespace
+	ProviderToken             string
+	ProviderURL               string
+	ProviderUser              string
+	ProviderInfoFromRepo      bool // whether the provider info come from the repository
+	WebhookType               string
+	PayloadFile               string
+	TektonDashboardURL        string
+	HubURL                    string
+	RemoteTasks               bool
+	DefaultPipelineRunTimeout time.Duration
 }
 
 func (p *PacOpts) AddFlags(cmd *cobra.Command) error {

--- a/pkg/params/run.go
+++ b/pkg/params/run.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/consoleui"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
@@ -61,6 +62,19 @@ func (r *Run) GetConfigFromConfigMap(ctx context.Context) error {
 
 	if remoteTask, ok := cfg.Data["remote-tasks"]; ok {
 		r.Info.Pac.RemoteTasks = StringToBool(remoteTask)
+	}
+
+	if timeout, ok := cfg.Data["default-pipelinerun-timeout"]; ok {
+		parsedTimeout, err := time.ParseDuration(timeout)
+		if err != nil {
+			r.Clients.Log.Infof("failed to parse default-pipelinerun-timeout: %s, using %v as default timeout",
+				cfg.Data["default-pipelinerun-timeout"], info.DefaultPipelineRunTimeout)
+			r.Info.Pac.DefaultPipelineRunTimeout = info.DefaultPipelineRunTimeout
+		} else {
+			r.Info.Pac.DefaultPipelineRunTimeout = parsedTimeout
+		}
+	} else {
+		r.Info.Pac.DefaultPipelineRunTimeout = info.DefaultPipelineRunTimeout
 	}
 
 	return nil

--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"strconv"
-	"time"
 
 	apipac "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
@@ -26,8 +25,6 @@ const (
   <b>%s</b><br><br>You can follow the execution on the [OpenShift console](%s) pipelinerun viewer or via
   the command line with :
 	<br><code>tkn pr logs -f -n %s %s</code>`
-	// The time to wait for a pipelineRun, maybe we should not restrict this?
-	pipelineRunTimeout = 2 * time.Hour
 )
 
 func Run(ctx context.Context, cs *params.Run, providerintf provider.Interface, k8int kubeinteraction.Interface) error {
@@ -165,8 +162,8 @@ func Run(ctx context.Context, cs *params.Run, providerintf provider.Interface, k
 	}
 
 	cs.Clients.Log.Infof("Waiting for PipelineRun %s/%s to Succeed in a maximum time of %s minutes",
-		pr.Namespace, pr.Name, formatting.HumanDuration(pipelineRunTimeout))
-	if err := k8int.WaitForPipelineRunSucceed(ctx, cs.Clients.Tekton.TektonV1beta1(), pr, pipelineRunTimeout); err != nil {
+		pr.Namespace, pr.Name, formatting.HumanDuration(cs.Info.Pac.DefaultPipelineRunTimeout))
+	if err := k8int.WaitForPipelineRunSucceed(ctx, cs.Clients.Tekton.TektonV1beta1(), pr, cs.Info.Pac.DefaultPipelineRunTimeout); err != nil {
 		cs.Clients.Log.Warnf("pipelinerun %s in namespace %s has a failed status",
 			pipelineRun.GetGenerateName(), repo.GetNamespace())
 	}


### PR DESCRIPTION
we had hardcoded default timeout for pipelinerun to 2h
in code. this patch update it to read from configmap
and if not available in cm then it would use 2h
as default.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI 
- [ ] 📖 If you are adding a user facing feature or make a change of the behaviour, please make sure to document it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakyness in the CI tests then make sure to get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
