### PR TITLE
Make sure we initialize the fake kube client

### DIFF
--- a/pkg/cmd/tknpac/resolve/resolve_test.go
+++ b/pkg/cmd/tknpac/resolve/resolve_test.go
@@ -9,10 +9,12 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
 	"go.uber.org/zap"
 	zapobserver "go.uber.org/zap/zaptest/observer"
 	"gotest.tools/v3/assert"
 	assertfs "gotest.tools/v3/fs"
+	rtesting "knative.dev/pkg/reconciler/testing"
 )
 
 var tmplSimpleNoPrefix = `
@@ -41,9 +43,16 @@ func TestSplitArgsInMap(t *testing.T) {
 }
 
 func TestCommandFilenameSetProperly(t *testing.T) {
+	tdata := testclient.Data{}
+	ctx, _ := rtesting.SetupFakeContext(t)
+
+	stdata, _ := testclient.SeedTestData(t, ctx, tdata)
 	cs := &params.Run{
-		Clients: clients.Clients{ClientInitialized: false},
-		Info:    info.Info{Pac: &info.PacOpts{}},
+		Clients: clients.Clients{
+			Kube:              stdata.Kube,
+			ClientInitialized: false,
+		},
+		Info: info.Info{Pac: &info.PacOpts{}},
 	}
 	cmd := Command(cs)
 	e := bytes.NewBufferString("")


### PR DESCRIPTION
we were trying to access kubernetes data from test which would crash
since we didn't have a fake kube client.

Fixes #395

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [X] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI 
- [X] 📖 If you are adding a user facing feature or make a change of the behavior, please make sure to document it
- [X] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [X] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [X] 🔎 If there is a flakyness in the CI tests then make sure to get the flakiness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
