### PR TITLE
[resolve] Don't crash when not connected to kube

### DIFF
--- a/pkg/cmd/tknpac/resolve/resolve.go
+++ b/pkg/cmd/tknpac/resolve/resolve.go
@@ -70,9 +70,7 @@ func Command(run *params.Run) *cobra.Command {
 				if !noConfigErr {
 					return err
 				}
-			}
-
-			if err := run.GetConfigFromConfigMap(ctx); err != nil {
+			} else if err := run.GetConfigFromConfigMap(ctx); err != nil {
 				log.Printf("Warning: cannot get pipelines-as-code config map in pipelines-as-code namespace. Using defaults. Error: %v\n", err)
 			}
 


### PR DESCRIPTION
tkn pac resolve is supposed to be abled to be used even when not
connected to the kube cluster.

let's make sure we are not accessing GetConfigFromConfigMap if we don't
have access to the Kube Cluster

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

Fixes #399 

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI 
- [x] 📖 If you are adding a user facing feature or make a change of the behavior, please make sure to document it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [x] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [x] 🔎 If there is a flakiness in the CI tests then make sure to get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
