### PR TITLE
Test should use already initialized k8s client

### DIFF
--- a/pkg/cmd/tknpac/resolve/resolve_test.go
+++ b/pkg/cmd/tknpac/resolve/resolve_test.go
@@ -50,7 +50,7 @@ func TestCommandFilenameSetProperly(t *testing.T) {
 	cs := &params.Run{
 		Clients: clients.Clients{
 			Kube:              stdata.Kube,
-			ClientInitialized: false,
+			ClientInitialized: true,
 		},
 		Info: info.Info{Pac: &info.PacOpts{}},
 	}


### PR DESCRIPTION
Small fix. Found it when running unit test with a GCP kubeconfig set.