### PR TITLE
resolve, don't print error if pac is not insllaed

### DIFF
--- a/pkg/cmd/tknpac/resolve/resolve.go
+++ b/pkg/cmd/tknpac/resolve/resolve.go
@@ -70,8 +70,9 @@ func Command(run *params.Run) *cobra.Command {
 				if !noConfigErr {
 					return err
 				}
-			} else if err := run.GetConfigFromConfigMap(ctx); err != nil {
-				log.Printf("Warning: cannot get pipelines-as-code config map in pipelines-as-code namespace. Using defaults. Error: %v\n", err)
+			} else {
+				// it's okay if pac is not installed, ignore the error
+				_ = run.GetConfigFromConfigMap(ctx)
 			}
 
 			if len(filenames) == 0 {


### PR DESCRIPTION
when pac is not installed it's okay to not be able to ge the config from
configmap just go on with life because we can test pr on local kind or
others

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
