### PR TITLE
Add `commandType` annotations to cobra.Command

### DIFF
--- a/pkg/cmd/pipelineascode/pipelineascode.go
+++ b/pkg/cmd/pipelineascode/pipelineascode.go
@@ -47,6 +47,9 @@ func Command(cs *params.Run) *cobra.Command {
 			}
 			return runWrap(ctx, cs, providerintf, kinteract)
 		},
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
 	}
 
 	err := cs.Info.Pac.AddFlags(cmd)

--- a/pkg/cmd/tknpac/bootstrap/bootstrap.go
+++ b/pkg/cmd/tknpac/bootstrap/bootstrap.go
@@ -134,6 +134,9 @@ func Command(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
 			}
 			return nil
 		},
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
 	}
 	cmd.AddCommand(GithubApp(run, ioStreams))
 
@@ -169,6 +172,9 @@ func GithubApp(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
 			}
 
 			return createSecret(ctx, run, opts)
+		},
+		Annotations: map[string]string{
+			"commandType": "main",
 		},
 	}
 	addCommonFlags(cmd, opts, ioStreams)

--- a/pkg/cmd/tknpac/completion/cmd.go
+++ b/pkg/cmd/tknpac/completion/cmd.go
@@ -70,7 +70,7 @@ func Command() *cobra.Command {
 		ValidArgs: []string{"bash", "zsh", "fish", "powershell"},
 		Example:   eg,
 		Annotations: map[string]string{
-			"commandType": "utility",
+			"commandType": "main",
 		},
 		Args: cobra.ExactValidArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/tknpac/generate/generate.go
+++ b/pkg/cmd/tknpac/generate/generate.go
@@ -62,6 +62,9 @@ func Command(ioStreams *cli.IOStreams) *cobra.Command {
 			gopt.GitInfo = git.GetGitInfo(cwd)
 			return Generate(gopt)
 		},
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
 	}
 	cmd.PersistentFlags().StringVar(&gopt.event.BaseBranch, "branch", "",
 		"The target branch of the repository  event to handle (eg: main, nightly)")

--- a/pkg/cmd/tknpac/repository/create.go
+++ b/pkg/cmd/tknpac/repository/create.go
@@ -76,6 +76,9 @@ func CreateCommand(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
 
 			return generate.Generate(gopt)
 		},
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
 	}
 
 	cmd.PersistentFlags().BoolP(noColorFlag, "C", !ioStreams.ColorEnabled(), "disable coloring")

--- a/pkg/cmd/tknpac/repository/list.go
+++ b/pkg/cmd/tknpac/repository/list.go
@@ -50,6 +50,9 @@ func ListCommand(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
 			cw := clockwork.NewRealClock()
 			return list(ctx, run, opts, ioStreams, cw, selectors, noheaders)
 		},
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
 	}
 
 	cmd.PersistentFlags().BoolVarP(&allNamespaces, allNamespacesFlag, "A", false, "If present, "+

--- a/pkg/cmd/tknpac/repository/root.go
+++ b/pkg/cmd/tknpac/repository/root.go
@@ -13,6 +13,9 @@ func Root(clients *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
 		Short:        "Pipelines as Code repositories",
 		Long:         `Manage Pipelines as Code repositories`,
 		SilenceUsage: true,
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
 	}
 	cmd.AddCommand(ListCommand(clients, ioStreams))
 	cmd.AddCommand(DescribeCommand(clients, ioStreams))

--- a/pkg/cmd/tknpac/resolve/resolve.go
+++ b/pkg/cmd/tknpac/resolve/resolve.go
@@ -104,6 +104,9 @@ func Command(run *params.Run) *cobra.Command {
 			fmt.Println(s)
 			return err
 		},
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
 	}
 	cmd.Flags().StringSliceVarP(&parameters, "params", "p", filenames,
 		"Params to resolve (ie: revision, repo_url)")

--- a/pkg/cmd/tknpac/root.go
+++ b/pkg/cmd/tknpac/root.go
@@ -18,6 +18,9 @@ func Root(clients *params.Run) *cobra.Command {
 		Short:        "Pipelines as Code CLI",
 		Long:         `This is the the tkn plugin for Pipelines as Code CLI`,
 		SilenceUsage: true,
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
 	}
 	clients.Info.Kube.AddFlags(cmd)
 

--- a/pkg/cmd/tknpac/version/version.go
+++ b/pkg/cmd/tknpac/version/version.go
@@ -15,6 +15,9 @@ func Command(ioStreams *cli.IOStreams) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Fprintln(ioStreams.ErrOut, version.Version)
 		},
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
 	}
 	return cmd
 }


### PR DESCRIPTION
# Changes

This commit adds a `commandType` annotation to all new `cobra.Command`,
specifically:
```
		Annotations: map[string]string{
			"commandType": "main",
		},

```

This is primarily done so the commands and subcommands can be discovered
by `tkn` CLI which looks for this annotation while collating usage
documentation for all subcommands, see here:
https://github.com/tektoncd/cli/blob/3c9ece67610d3be38cd56847305108effad93c77/pkg/cmd/root.go#L52

Co-authored-by: Piyush Garg <pgarg@redhat.com>

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI 
- [x] 📖 If you are adding a user facing feature or make a change of the behavior, please make sure to document it
- [x] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [x] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [x] 🔎 If there is a flakiness in the CI tests then make sure to get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
