### PR TITLE
Allow creating a app on organisations

### DIFF
--- a/pkg/cmd/tknpac/bootstrap/bootstrap.go
+++ b/pkg/cmd/tknpac/bootstrap/bootstrap.go
@@ -184,7 +184,7 @@ func GithubApp(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
 }
 
 func addGithubAppFlag(cmd *cobra.Command, opts *bootstrapOpts) {
-	cmd.PersistentFlags().StringVar(&opts.GithubOrganizationName, "github-organization-name", "", "Wether you want to target an organization instead of the current user")
+	cmd.PersistentFlags().StringVar(&opts.GithubOrganizationName, "github-organization-name", "", "Whether you want to target an organization instead of the current user")
 	cmd.PersistentFlags().StringVar(&opts.GithubApplicationName, "github-application-name", "", "Github Application Name")
 	cmd.PersistentFlags().StringVar(&opts.GithubApplicationURL, "github-application-url", "", "Github Application URL")
 	cmd.PersistentFlags().StringVarP(&opts.GithubAPIURL, "github-api-url", "", "", "Github Enteprise API URL")

--- a/pkg/cmd/tknpac/bootstrap/bootstrap.go
+++ b/pkg/cmd/tknpac/bootstrap/bootstrap.go
@@ -35,10 +35,11 @@ type bootstrapOpts struct {
 	targetNamespace string
 	recreateSecret  bool
 
-	RouteName             string
-	GithubAPIURL          string
-	GithubApplicationName string
-	GithubApplicationURL  string
+	RouteName              string
+	GithubAPIURL           string
+	GithubApplicationName  string
+	GithubApplicationURL   string
+	GithubOrganizationName string
 }
 
 const indexTmpl = `
@@ -183,6 +184,7 @@ func GithubApp(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
 }
 
 func addGithubAppFlag(cmd *cobra.Command, opts *bootstrapOpts) {
+	cmd.PersistentFlags().StringVar(&opts.GithubOrganizationName, "github-organization-name", "", "Wether you want to target an organization instead of the current user")
 	cmd.PersistentFlags().StringVar(&opts.GithubApplicationName, "github-application-name", "", "Github Application Name")
 	cmd.PersistentFlags().StringVar(&opts.GithubApplicationURL, "github-application-url", "", "Github Application URL")
 	cmd.PersistentFlags().StringVarP(&opts.GithubAPIURL, "github-api-url", "", "", "Github Enteprise API URL")

--- a/pkg/cmd/tknpac/bootstrap/web.go
+++ b/pkg/cmd/tknpac/bootstrap/web.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
@@ -41,7 +42,11 @@ func startWebServer(ctx context.Context, opts *bootstrapOpts, run *params.Run, j
 			fmt.Fprint(rw, successTmpl)
 			codeCh <- code
 		} else {
-			fmt.Fprintf(rw, indexTmpl, opts.GithubAPIURL, jeez)
+			url := opts.GithubAPIURL
+			if opts.GithubOrganizationName != "" {
+				url = filepath.Join(opts.GithubAPIURL, "organizations", opts.GithubOrganizationName)
+			}
+			fmt.Fprintf(rw, indexTmpl, url, jeez)
 		}
 	})
 	go func() {


### PR DESCRIPTION
We were not able to create on organisation, which got removed at some
point. Let's add back the switch.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [X] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI 
- [X] 📖 If you are adding a user facing feature or make a change of the behavior, please make sure to document it
- [X] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [X] 🔎 If there is a flakiness in the CI tests then make sure to get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
