### PR TITLE
Document resolve behaviour between cli and live

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -93,10 +93,25 @@ It has some basic language detection and add extra task depending of the languag
 
 ### Resolve
 
-`tkn-pac resolve`: will run a pipelinerun as if it were executed by pipelines as code on service. It will try to detect the current git information if you run the command from your source code. To make it works you need to push the current revision to the target git repository and iterate the pipelinerun change with the `tkn-pac resolve` command. For example if you have a pipelinerun in the `.tekton/pull-request.yaml` file you can run the command `tkn-pac resolve` to see it running:
+`tkn-pac resolve`: will run a pipelinerun as if it were executed by pipelines
+as code on service.
+
+For example if you have a pipelinerun in the `.tekton/pull-request.yaml` file you can run the command `tkn-pac resolve` to see it running:
 
 ```yaml
 tkn pac resolve -f .tekton/pull-request.yaml|kubectl apply -f -
 ```
 
 Combined with a kubernetes install running on your local machine (like[Code Ready Containers](https://developers.redhat.com/products/codeready-containers/overview) or [Kubernetes Kind](https://kind.sigs.k8s.io/docs/user/quick-start/) ) you can see your run in action without having to generate a new commit.
+
+If you run the command from your source code repository it will try to detect the current git information and resolve the parameters like current revision or branch. You can override those params with the `-p` option. For example if you want to use a git branch as revision and another repo name than the current repo name you can just use :
+
+`tkn pac resolve -f .tekton/pr.yaml -p revision=main -p repo_name=othername`
+
+`-f` can as well accept a directory path instead of just a filename and grab every `yaml`/`yml` from the directory.
+
+You can specify multiple `-f` on the command line.
+
+You need to make sure that git-clone task (if you use it) can access the repository to the SHA. Which mean if you test your current source code you need to push it first tbefore using `tkn pac resolve|kubectl apply`.
+
+Compared with running directly on CI, you need to explicitely specify the list of filenames or directory where you have the templates.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -13,7 +13,7 @@ The purposes of the Repository CRD  is :
 
 The flow looks like this :
 
-Via the tkn pac CLI or other method the user creates a `Repository` CR 
+Via the tkn pac CLI or other method the user creates a `Repository` CR
 inside the target namespace `my-pipeline-ci` :
 
 ```yaml
@@ -244,6 +244,9 @@ Everything that runs your pipelinerun and its references need to be inside the
 `.tekton/` directory or referenced via a remote task (see below on how the
 remote tasks are referenced).
 
+If you have a taskRef to a task located in the `.tekton/` directory it will be
+automatically embedded even if it's not in the annotations.
+
 If pipelines as code cannot resolve the referenced tasks in the `Pipeline` or
 `PipelineSpec` it will fails before applying the pipelinerun onto the cluster.
 
@@ -287,7 +290,7 @@ example :
 ```yaml
   pipelinesascode.tekton.dev/task: "git-clone"
   pipelinesascode.tekton.dev/task-1: "golang-test"
-  pipelinesascode.tekton.dev/task-2: "tkn" 
+  pipelinesascode.tekton.dev/task-2: "tkn"
 ```
 
 By default `Pipelines as Code` will interpret the string as the `latest` task to

--- a/pkg/resolve/resolve_test.go
+++ b/pkg/resolve/resolve_test.go
@@ -163,6 +163,14 @@ func TestNotKubernetesDocumentIgnore(t *testing.T) {
 	assert.Assert(t, resolved.Spec.PipelineSpec != nil)
 }
 
+// test if we have the task in .tekton dir not referenced in annotations but taskRef in a task.
+// should embed since in repo.
+func TestInRepoShouldNotEmbedIfNoAnnotations(t *testing.T) {
+	resolved, _, err := readTDfile(t, "in-repo-in-ref-no-annotation", false, true)
+	assert.NilError(t, err)
+	assert.Assert(t, resolved.Spec.PipelineSpec.Tasks[0].TaskRef == nil, "task should have been embedded")
+}
+
 func TestNoPipelineRuns(t *testing.T) {
 	_, _, err := readTDfile(t, "no-pipelinerun", false, true)
 	assert.Error(t, err, "we need at least one pipelinerun to start with")

--- a/pkg/resolve/testdata/in-repo-in-ref-no-annotation.yaml
+++ b/pkg/resolve/testdata/in-repo-in-ref-no-annotation.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: pr
+spec:
+  pipelineRef:
+    name: pipeline-test
+  params:
+    - name: key
+      value: "{{value}}"
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: pipeline-test
+spec:
+  params:
+    - name: repo_url
+    - name: revision
+  tasks:
+    - name: task
+      taskRef:
+        name: should-expand
+  steps:
+    - name: first-step
+      image: image
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: should-expand
+spec:
+  steps:
+    - name: second-step
+      image: image


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

There is a difference in behaviour between cli and running on CI.

On live, we grab everything in .tekton and resolve it even if it's not specified
in annotations. Added an explicite test for it.

On CLI the user need to explicitely specify the templates/dir to grab
from.

Document this and rework a bit the documentation.

# Submitter Checklist

- [X] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI 
- [X] 📖 If you are adding a user facing feature or make a change of the behavior, please make sure to document it
- [X] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [X] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [X] 🔎 If there is a flakiness in the CI tests then make sure to get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
