### PR TITLE
fix getting repo spec credentials with no api url

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -344,6 +344,10 @@ Pipelines-As-Code has a full support on Bitbucket Cloud on
 
 <https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/>
 
+Add those permissions to the token : 
+
+![image](https://user-images.githubusercontent.com/98980/154526912-75c52ded-45e9-42d4-8c09-908b86eb57b4.png)
+
 Make sure you note somewhere the generated token or otherwise you will have to
 recreate it.
 

--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -57,7 +57,7 @@ func Run(ctx context.Context, cs *params.Run, providerintf provider.Interface, k
 		return nil
 	}
 
-	if repo.Spec.GitProvider != nil && repo.Spec.GitProvider.URL != "" {
+	if repo.Spec.GitProvider != nil {
 		err := secretFromRepository(ctx, cs, k8int, providerintf.GetConfig(), repo)
 		if err != nil {
 			return err

--- a/pkg/test/repository/repository.go
+++ b/pkg/test/repository/repository.go
@@ -66,12 +66,16 @@ func NewRepo(opts RepoTestcreationOpts) *v1alpha1.Repository {
 		},
 		Spec: v1alpha1.RepositorySpec{
 			URL: opts.URL,
-			GitProvider: &v1alpha1.GitProvider{
-				Secret: &v1alpha1.GitProviderSecret{},
-			},
 		},
 		Status: opts.RepoStatus,
 	}
+
+	if opts.SecretName != "" || opts.ProviderURL != "" {
+		repo.Spec.GitProvider = &v1alpha1.GitProvider{
+			Secret: &v1alpha1.GitProviderSecret{},
+		}
+	}
+
 	if opts.SecretName != "" {
 		repo.Spec.GitProvider.Secret = &v1alpha1.GitProviderSecret{
 			Name: opts.SecretName,


### PR DESCRIPTION
# Changes

fix getting repo spec credentials with no api url

When we run in bitbucket cloud we don't need to set a api url and
documented as is. Don't bail out on one. The other providers who need an
api url will anyway check for it in SetClient and bail out if not set
properly.

This was introduced as a side effect when running the tests since we
were constructing the tests with GitProvider struct set and we check in
the code when it's not nil. Fix the test fixture to not passing the
strucs unless we have a URL or user passed.

update doc along the way to show what rights is needed for bitbucket 
cloud token creation.

Closes #416


# Submitter Checklist

- [X] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI 
- [X] 📖 If you are adding a user facing feature or make a change of the behavior, please make sure to document it
- [X] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [X] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [X] 🔎 If there is a flakiness in the CI tests then make sure to get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
