### PR TITLE
Update cleanup cron to remove taskrun instead of pipelineRun

### DIFF
--- a/config/305-cleanup-cron.yaml
+++ b/config/305-cleanup-cron.yaml
@@ -31,11 +31,11 @@ spec:
           - command:
             - /bin/bash
             - -c
-            - test -e /etc/config/max-keep-days && export MAX_DAY_KEEP=$(cat /etc/config/max-keep-days);for pr in $(kubectl get pipelineruns -l app.kubernetes.io/managed-by=pipelines-as-code -o json | python3 -c "import
+            - test -e /etc/config/max-keep-days && export MAX_DAY_KEEP=$(cat /etc/config/max-keep-days);for pr in $(kubectl get taskruns -l app.kubernetes.io/managed-by=pipelines-as-code -o json | python3 -c "import
               os, sys, datetime, json;jeez=json.load(sys.stdin);res=[ i['metadata']['name']
               for i in jeez['items'] if datetime.datetime.now() > datetime.datetime.strptime(i['metadata']['creationTimestamp'],
               '%Y-%m-%dT%H:%M:%SZ') + datetime.timedelta(days=int(os.environ.get('MAX_DAY_KEEP', 1))) ];print(' '.join(res))");do
-              kubectl delete pipelinerun ${pr};done
+              kubectl delete taskrun ${pr};done
             image: quay.io/openshift/origin-cli:4.8
             imagePullPolicy: IfNotPresent
             name: cleanup


### PR DESCRIPTION
pac is ran inside a taskrun now instead of pipelineRun which was
earlier. this update the cleanup cron for it.

Fixes #417 

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI 
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please make sure to document it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then make sure to get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
