### PR TITLE
Better error reporting when Hub API is down

### DIFF
--- a/pkg/hub/get.go
+++ b/pkg/hub/get.go
@@ -52,12 +52,12 @@ func GetTask(ctx context.Context, cli *params.Run, task string) (string, error) 
 		rawURL, err = getLatestVersion(ctx, cli, task)
 	}
 	if err != nil {
-		return "", fmt.Errorf("could not fetch remote task %s: %w", task, err)
+		return "", fmt.Errorf("could not fetch remote task %s, hub API returned: %w", task, err)
 	}
 
 	data, err := cli.Clients.GetURL(ctx, rawURL)
 	if err != nil {
-		return "", fmt.Errorf("could not fetch remote task %s: %w", task, err)
+		return "", fmt.Errorf("could not fetch remote task %s, hub API returned: %w", task, err)
 	}
 	return string(data), err
 }


### PR DESCRIPTION
When hub api is down, point the error at it so people would know it's
not pac who failed.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
