### PR TITLE
[status] Fix PR status when no tasks has run

### DIFF
--- a/pkg/pipelineascode/pipelinesascode_github_test.go
+++ b/pkg/pipelineascode/pipelinesascode_github_test.go
@@ -134,7 +134,7 @@ func TestRun(t *testing.T) {
 		ProviderInfoFromRepo         bool
 	}{
 		{
-			name: "pull request/apps",
+			name: "pull request/fail-to-start-apps",
 			runevent: info.Event{
 				SHA:          "principale",
 				Organization: "organizationes",
@@ -147,7 +147,7 @@ func TestRun(t *testing.T) {
 			},
 			tektondir:       "testdata/pull_request",
 			finalStatus:     "neutral",
-			finalStatusText: "<th>Status</th><th>Duration</th><th>Name</th>",
+			finalStatusText: "PipelineRun has failed to start",
 		},
 		{
 			name: "pull request/with webhook",
@@ -294,7 +294,7 @@ func TestRun(t *testing.T) {
 			},
 			tektondir:                "testdata/max-keep-runs",
 			finalStatus:              "neutral",
-			finalStatusText:          "<th>Status</th><th>Duration</th><th>Name</th>",
+			finalStatusText:          "PipelineRun has failed to start",
 			expectedNumberofCleanups: 10,
 		},
 	}

--- a/pkg/sort/task_status.go
+++ b/pkg/sort/task_status.go
@@ -42,8 +42,7 @@ func TaskStatusTmpl(pr *tektonv1beta1.PipelineRun, console consoleui.Interface, 
 	outputBuffer := bytes.Buffer{}
 
 	if len(pr.Status.TaskRuns) == 0 {
-		// Nada?
-		return statusTemplate + "No tasks has been found", nil
+		return "<b>PipelineRun has failed to start</b><br>", nil
 	}
 
 	for _, taskrunStatus := range pr.Status.TaskRuns {

--- a/pkg/sort/task_status_test.go
+++ b/pkg/sort/task_status_test.go
@@ -52,7 +52,7 @@ func TestStatusTmpl(t *testing.T) {
 		},
 		{
 			name:       "test sorted status nada",
-			wantRegexp: regexp.MustCompile("No tasks has been found"),
+			wantRegexp: regexp.MustCompile("PipelineRun has failed to start"),
 			pr:         tektontest.MakePR("nada", "ns", nil, nil),
 		},
 	}


### PR DESCRIPTION
When no task has started (ie: bad pr spec) we were showing the raw template.
The test as well was buggy since we were testing for that raw template
🤮, I am not sure how I came to that point but such is life.

We are now showing properly that no tasks has been detecred since PR has
not been run.

Closes #414

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [X] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI 
- [X] 📖 If you are adding a user facing feature or make a change of the behavior, please make sure to document it
- [X] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [X] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [X] 🔎 If there is a flakiness in the CI tests then make sure to get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
