### PR TITLE
bitbucket cloud Fix getting files from API

### DIFF
--- a/pkg/provider/bitbucketcloud/acl_test.go
+++ b/pkg/provider/bitbucketcloud/acl_test.go
@@ -60,8 +60,11 @@ func TestIsAllowed(t *testing.T) {
 			want: true,
 		},
 		{
-			name:  "allowed/from owner file who is not part of workspace",
-			event: bbcloudtest.MakeEvent(&info.Event{Sender: "NotAllowedAtFirst"}),
+			name: "allowed/from owner file who is not part of workspace",
+			event: bbcloudtest.MakeEvent(&info.Event{
+				SHA:    "abcd",
+				Sender: "NotAllowedAtFirst",
+			}),
 			fields: fields{
 				comments: []types.Comment{
 					{
@@ -72,7 +75,7 @@ func TestIsAllowed(t *testing.T) {
 					},
 				},
 				filescontents: map[string]string{
-					"OWNERS": "---\n approvers:\n  - AllowedFromOwnerFile\n",
+					"OWNERS": "---\n approvers:\n  - accountid\n",
 				},
 			},
 			want: true,
@@ -167,7 +170,7 @@ func TestIsAllowed(t *testing.T) {
 
 			bbcloudtest.MuxOrgMember(t, mux, tt.event, tt.fields.workspaceMembers)
 			bbcloudtest.MuxComments(t, mux, tt.event, tt.fields.comments)
-			bbcloudtest.MuxFiles(t, mux, tt.event, tt.event.DefaultBranch, tt.fields.filescontents)
+			bbcloudtest.MuxFiles(t, mux, tt.event, tt.fields.filescontents)
 
 			v := &Provider{Client: bbclient}
 

--- a/pkg/provider/bitbucketcloud/bitbucket.go
+++ b/pkg/provider/bitbucketcloud/bitbucket.go
@@ -30,8 +30,7 @@ func (v *Provider) GetConfig() *info.ProviderConfig {
 	}
 }
 
-func (v *Provider) CreateStatus(_ context.Context, event *info.Event, pacopts *info.PacOpts,
-	statusopts provider.StatusOpts) error {
+func (v *Provider) CreateStatus(_ context.Context, event *info.Event, pacopts *info.PacOpts, statusopts provider.StatusOpts) error {
 	switch statusopts.Conclusion {
 	case "skipped":
 		statusopts.Conclusion = "STOPPED"
@@ -115,13 +114,8 @@ func (v *Provider) GetTektonDir(_ context.Context, event *info.Event, path strin
 	return v.concatAllYamlFiles(repositoryFiles, event)
 }
 
-func (v *Provider) GetFileInsideRepo(_ context.Context, runevent *info.Event, path string, targetBranch string) (string,
-	error) {
-	branch := runevent.HeadBranch
-	if targetBranch != "" {
-		branch = targetBranch
-	}
-	return v.getBlob(runevent, branch, path)
+func (v *Provider) GetFileInsideRepo(_ context.Context, runevent *info.Event, path string, targetBranch string) (string, error) {
+	return v.getBlob(runevent, runevent.SHA, path)
 }
 
 func (v *Provider) SetClient(_ context.Context, opts *info.PacOpts) error {
@@ -186,7 +180,7 @@ func (v *Provider) concatAllYamlFiles(objects []bitbucket.RepositoryFile, runeve
 	for _, value := range objects {
 		if strings.HasSuffix(value.Path, ".yaml") ||
 			strings.HasSuffix(value.Path, ".yml") {
-			data, err := v.getBlob(runevent, runevent.HeadBranch, value.Path)
+			data, err := v.getBlob(runevent, runevent.SHA, value.Path)
 			if err != nil {
 				return "", err
 			}

--- a/pkg/provider/bitbucketcloud/test/bbcloudtest.go
+++ b/pkg/provider/bitbucketcloud/test/bbcloudtest.go
@@ -80,9 +80,9 @@ func MuxOrgMember(t *testing.T, mux *http.ServeMux, event *info.Event, members [
 		})
 }
 
-func MuxFiles(t *testing.T, mux *http.ServeMux, event *info.Event, targetBranch string, filescontents map[string]string) {
+func MuxFiles(t *testing.T, mux *http.ServeMux, event *info.Event, filescontents map[string]string) {
 	for key := range filescontents {
-		target := fmt.Sprintf("/repositories/%s/%s/src/%s", event.Organization, event.Repository, targetBranch)
+		target := fmt.Sprintf("/repositories/%s/%s/src/%s", event.Organization, event.Repository, event.SHA)
 		mux.HandleFunc(target+"/"+key, func(rw http.ResponseWriter, r *http.Request) {
 			s := strings.ReplaceAll(r.URL.String(), target, "")
 			s = strings.TrimPrefix(s, "/")
@@ -193,7 +193,7 @@ func MuxDirContent(t *testing.T, mux *http.ServeMux, event *info.Event, testDir 
 	MuxListDir(t, mux, event, map[string][]bitbucket.RepositoryFile{
 		targetDirName: repofiles,
 	})
-	MuxFiles(t, mux, event, event.HeadBranch, filecontents)
+	MuxFiles(t, mux, event, filecontents)
 }
 
 func MakePREvent(accountid, nickname, sha string) types.PullRequestEvent {


### PR DESCRIPTION
seems like we are not able to specify a ref anymore but we can do with
the sha ref directly so let's use this.

Fixes #439 

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [X] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI 
- [X] 📖 If you are adding a user facing feature or make a change of the behavior, please make sure to document it
- [X] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [X] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [X] 🔎 If there is a flakiness in the CI tests then make sure to get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
