### PR TITLE
Store targetbranch status wo/ refs/heads prefix

### DIFF
--- a/pkg/cmd/tknpac/repository/describe.go
+++ b/pkg/cmd/tknpac/repository/describe.go
@@ -68,7 +68,7 @@ func formatStatus(status v1alpha1.RepositoryRunStatus, cs *cli.ColorScheme, c cl
 	return fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t%s\t%s",
 		cs.ColorStatus(status.Status.Conditions[0].Reason),
 		*status.EventType,
-		formatting.SanitizeBranch(*status.TargetBranch),
+		*status.TargetBranch,
 		cs.HyperLink(formatting.ShortSHA(*status.SHA), *status.SHAURL),
 		formatting.Age(status.StartTime, c),
 		formatting.Duration(status.StartTime, status.CompletionTime),
@@ -173,8 +173,7 @@ func DescribeCommand(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
 	return cmd
 }
 
-func describe(ctx context.Context, cs *params.Run, clock clockwork.Clock, opts *cli.PacCliOpts,
-	ioStreams *cli.IOStreams, repoName string) error {
+func describe(ctx context.Context, cs *params.Run, clock clockwork.Clock, opts *cli.PacCliOpts, ioStreams *cli.IOStreams, repoName string) error {
 	var repository *v1alpha1.Repository
 	var err error
 

--- a/pkg/formatting/vcs.go
+++ b/pkg/formatting/vcs.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 )
 
-// sanitizeBranch remove refs/heads from string if it's a branch or keep it if
-// it's a tag.
+// sanitizeBranch remove refs/heads from string, only removing the first prefix
+// in case we have branch that are actually called refs-heads 🙃
 func SanitizeBranch(s string) string {
 	if strings.HasPrefix(s, "refs/heads/") {
 		return strings.TrimPrefix(s, "refs/heads/")

--- a/pkg/pipelineascode/pipelinesascode_github_test.go
+++ b/pkg/pipelineascode/pipelinesascode_github_test.go
@@ -399,6 +399,9 @@ func TestRun(t *testing.T) {
 				assert.NilError(t, err)
 				assert.Assert(t, got.Status[len(got.Status)-1].PipelineRunName != "pipelinerun1", "'%s'!='%s'",
 					got.Status[len(got.Status)-1].PipelineRunName, "pipelinerun1")
+
+				lastbranchstatus := got.Status[len(got.Status)-1].TargetBranch
+				assert.Assert(t, !strings.HasPrefix(*lastbranchstatus, "refs-heads-"))
 			}
 		})
 	}

--- a/pkg/pipelineascode/status.go
+++ b/pkg/pipelineascode/status.go
@@ -16,6 +16,7 @@ import (
 )
 
 func updateRepoRunStatus(ctx context.Context, cs *params.Run, pr *tektonv1beta1.PipelineRun, repo *pacv1a1.Repository) error {
+	refsanitized := formatting.SanitizeBranch(cs.Info.Event.BaseBranch)
 	repoStatus := pacv1a1.RepositoryRunStatus{
 		Status:          pr.Status.Status,
 		PipelineRunName: pr.Name,
@@ -26,7 +27,7 @@ func updateRepoRunStatus(ctx context.Context, cs *params.Run, pr *tektonv1beta1.
 		Title:           &cs.Info.Event.SHATitle,
 		LogURL:          github.String(cs.Clients.ConsoleUI.DetailURL(pr.GetNamespace(), pr.GetName())),
 		EventType:       &cs.Info.Event.EventType,
-		TargetBranch:    &cs.Info.Event.BaseBranch,
+		TargetBranch:    &refsanitized,
 	}
 
 	// Get repo again in case it was updated while we were running the CI


### PR DESCRIPTION


# Changes

UI would show a refs-heads-main which is weird....

Fixes issue #441
# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI 
- [x] 📖 If you are adding a user facing feature or make a change of the behavior, please make sure to document it
- [x] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [x] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [x] 🔎 If there is a flakiness in the CI tests then make sure to get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
