### PR TITLE
Don't match a pipeline if we don't have annotation

### DIFF
--- a/pkg/matcher/annotation_matcher_test.go
+++ b/pkg/matcher/annotation_matcher_test.go
@@ -103,6 +103,97 @@ func TestMatchPipelinerunAnnotationAndRepositories(t *testing.T) {
 			},
 		},
 		{
+			name:    "error on only when on annotation",
+			wantErr: true,
+			args: args{
+				pruns: []*tektonv1beta1.PipelineRun{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: targetNamespace,
+							Name:      "only-one-annotation",
+							Annotations: map[string]string{
+								pipelinesascode.GroupName + "/" + onEventAnnotation: "[pull_request]",
+							},
+						},
+					},
+				},
+				runevent: info.Event{URL: targetURL, EventType: "pull_request", BaseBranch: mainBranch},
+				data: testclient.Data{
+					Repositories: []*v1alpha1.Repository{
+						testnewrepo.NewRepo(
+							testnewrepo.RepoTestcreationOpts{
+								Name:             "test-oldest",
+								URL:              targetURL,
+								InstallNamespace: targetNamespace,
+								CreateTime:       metav1.Time{Time: cw.Now().Add(-55 * time.Minute)},
+							},
+						),
+					},
+				},
+			},
+		},
+		{
+			name:    "error when no pac annotation has been set",
+			wantErr: true,
+			args: args{
+				pruns: []*tektonv1beta1.PipelineRun{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: targetNamespace,
+							Name:      "no pac annotation",
+							Annotations: map[string]string{
+								"foo": "bar",
+							},
+						},
+					},
+				},
+				runevent: info.Event{URL: targetURL, EventType: "pull_request", BaseBranch: mainBranch},
+				data: testclient.Data{
+					Repositories: []*v1alpha1.Repository{
+						testnewrepo.NewRepo(
+							testnewrepo.RepoTestcreationOpts{
+								Name:             "test-oldest",
+								URL:              targetURL,
+								InstallNamespace: targetNamespace,
+								CreateTime:       metav1.Time{Time: cw.Now().Add(-55 * time.Minute)},
+							},
+						),
+					},
+				},
+			},
+		},
+		{
+			name:    "error when pac annotation has been set but empty",
+			wantErr: true,
+			args: args{
+				pruns: []*tektonv1beta1.PipelineRun{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: targetNamespace,
+							Name:      "no pac annotation",
+							Annotations: map[string]string{
+								pipelinesascode.GroupName + "/" + onEventAnnotation:        "",
+								pipelinesascode.GroupName + "/" + onTargetBranchAnnotation: "",
+							},
+						},
+					},
+				},
+				runevent: info.Event{URL: targetURL, EventType: "pull_request", BaseBranch: mainBranch},
+				data: testclient.Data{
+					Repositories: []*v1alpha1.Repository{
+						testnewrepo.NewRepo(
+							testnewrepo.RepoTestcreationOpts{
+								Name:             "test-oldest",
+								URL:              targetURL,
+								InstallNamespace: targetNamespace,
+								CreateTime:       metav1.Time{Time: cw.Now().Add(-55 * time.Minute)},
+							},
+						),
+					},
+				},
+			},
+		},
+		{
 			name:    "no match a repository with target NS",
 			wantErr: true,
 			wantLog: "matching a pipeline to event: URL",
@@ -146,8 +237,8 @@ func TestMatchPipelinerunAnnotationAndRepositories(t *testing.T) {
 				t.Error("We should have get an error")
 			}
 
-			if !tt.wantErr && err != nil {
-				t.Errorf("We should have not get an error %s", err)
+			if !tt.wantErr {
+				assert.NilError(t, err)
 			}
 
 			if tt.wantRepoName != "" {


### PR DESCRIPTION
previously we were just picking the first pipeline if there was an
annotation and no on-target-branch/event.

We now make sure that both has been set and matching.

Fixes #446  

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [X] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI 
- [X] 📖 If you are adding a user facing feature or make a change of the behavior, please make sure to document it
- [X] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [X] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [X] 🔎 If there is a flakiness in the CI tests then make sure to get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
