### PR TITLE
Do buildah push to quay directly in pipeline

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -54,7 +54,7 @@ spec:
           workspaces:
             - name: source
           steps:
-            - image: registry.access.redhat.com/ubi8/go-toolset@sha256:2d56a94f1e83fe0e874f099dd8d03b876186985a7dbeea118e8c725b1b07b9f0
+            - image: registry.redhat.io/rhel8/go-toolset:1.16.12-7
               env:
                 - name: GOCACHE
                   value: $(workspaces.source.path)/go-build-cache/cache
@@ -80,7 +80,7 @@ spec:
             - name: unittest
               # we get bumped out when usingh the official image with docker.io
               # ratelimit so workaround this.
-              image: registry.access.redhat.com/ubi8/go-toolset@sha256:2d56a94f1e83fe0e874f099dd8d03b876186985a7dbeea118e8c725b1b07b9f0
+              image: registry.redhat.io/rhel8/go-toolset:1.16.12-7
               env:
                 - name: GOCACHE
                   value: $(workspaces.source.path)/go-build-cache/cache
@@ -156,7 +156,7 @@ spec:
           steps:
             - name: codecov-run
               # Has everything we need in there and we already fetched it!
-              image: registry.access.redhat.com/ubi8/go-toolset@sha256:2d56a94f1e83fe0e874f099dd8d03b876186985a7dbeea118e8c725b1b07b9f0
+              image: registry.redhat.io/rhel8/go-toolset:1.16.12-7
               workingDir: $(workspaces.source.path)
               env:
                 - name: CODECOV_TOKEN

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -6,9 +6,12 @@ metadata:
   annotations:
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
-    pipelinesascode.tekton.dev/task: "[git-clone]"
+    pipelinesascode.tekton.dev/task: "[git-clone, .tekton/tasks/buildah-user.yaml]"
     pipelinesascode.tekton.dev/task-1: "[https://git.io/Jn9Ee]"  # send-slack-notifications task
 spec:
+  taskRunSpecs:
+    - pipelineTaskName: push-to-registry
+      taskServiceAccountName: pac-push-sa
   params:
     - name: repo_url
       value: "{{repo_url}}"
@@ -30,7 +33,6 @@ spec:
         workspaces:
           - name: output
             workspace: source
-
       - name: unit
         runAfter:
           - fetch
@@ -41,7 +43,7 @@ spec:
           workspaces:
             - name: source
           steps:
-            - image: registry.access.redhat.com/ubi8/go-toolset@sha256:2d56a94f1e83fe0e874f099dd8d03b876186985a7dbeea118e8c725b1b07b9f0
+            - image: registry.redhat.io/rhel8/go-toolset:1.16.12-7
               name: get-cache
               workingDir: $(workspaces.source.path)
               env:
@@ -56,16 +58,14 @@ spec:
                 set -ex
                 mkdir -p ${GOCACHE} ${GOMODCACHE} ${GOLANGCILINT_CACHE}
                 cd $(dirname ${GOCACHE})
-
                 curl -fsI http://uploader:8080/golang-cache.tar || {
                     echo "no cache found"
                     exit 0
                 }
-
                 echo "Getting cache"
                 curl http://uploader:8080/golang-cache.tar|tar -x -f-
             - name: unittest
-              image: registry.access.redhat.com/ubi8/go-toolset@sha256:2d56a94f1e83fe0e874f099dd8d03b876186985a7dbeea118e8c725b1b07b9f0
+              image: registry.redhat.io/rhel8/go-toolset:1.16.12-7
               workingDir: $(workspaces.source.path)
               env:
                 - name: GOCACHE
@@ -76,6 +76,17 @@ spec:
                 #!/usr/bin/env bash
                 make test \
                     GO_TEST_FLAGS="-v -race -coverprofile=coverage.txt -covermode=atomic"
+      - name: push-to-registry
+        runAfter:
+          - unit
+        params:
+          - name: IMAGE
+            value: quay.io/openshift-pipeline/pipelines-as-code:main
+        taskRef:
+          name: buildah-user
+        workspaces:
+          - name: source
+            workspace: source
       - name: codecov
         runAfter:
           - unit
@@ -88,7 +99,7 @@ spec:
           steps:
             - name: codecov-run
               # Has everything we need in there and we already fetched it!
-              image: registry.access.redhat.com/ubi8/go-toolset@sha256:2d56a94f1e83fe0e874f099dd8d03b876186985a7dbeea118e8c725b1b07b9f0
+              image: registry.redhat.io/rhel8/go-toolset:1.16.12-7
               workingDir: $(workspaces.source.path)
               env:
                 - name: CODECOV_TOKEN
@@ -102,10 +113,10 @@ spec:
 
       - name: upload-release-yaml
         runAfter:
-          - fetch
+          - push-to-registry
         taskSpec:
           steps:
-            - image: registry.access.redhat.com/ubi8/python-39@sha256:86466a8a2b3981c339f84e791e170055eb3f520e8419f955efa98e93ccaaf5b9
+            - image: registry.access.redhat.com/ubi8/python-39:1-35
               name: release
               env:
                 - name: HUB_TOKEN

--- a/.tekton/tasks/buildah-user.yaml
+++ b/.tekton/tasks/buildah-user.yaml
@@ -1,0 +1,88 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: buildah-user
+  labels:
+    app.kubernetes.io/version: "0.4"
+  annotations:
+    tekton.dev/categories: Image Build
+    tekton.dev/pipelines.minVersion: "0.17.0"
+    tekton.dev/tags: image-build
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
+spec:
+  description: >-
+    Buildah task builds source into a container image and
+    then pushes it to a container registry.
+
+    Buildah Task builds source into a container image using Project Atomic's
+    Buildah build tool.It uses Buildah's support for building from Dockerfiles,
+    using its buildah bud command.This command executes the directives in the
+    Dockerfile to assemble a container image, then pushes that image to a
+    container registry.
+
+  params:
+  - name: IMAGE
+    description: Reference of the image buildah will produce.
+  - name: BUILDER_IMAGE
+    description: The location of the buildah builder image.
+    default: "registry.access.redhat.com/ubi8/buildah:8.5-8"
+  - name: STORAGE_DRIVER
+    description: Set buildah storage driver
+    default: vfs
+  - name: DOCKERFILE
+    description: Path to the Dockerfile to build.
+    default: ./Dockerfile
+  - name: CONTEXT
+    description: Path to the directory to use as context.
+    default: .
+  - name: TLSVERIFY
+    description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)
+    default: "true"
+  - name: FORMAT
+    description: The format of the built container, oci or docker
+    default: "oci"
+  - name: BUILD_EXTRA_ARGS
+    description: Extra parameters passed for the build command when building images.
+    default: ""
+  - name: PUSH_EXTRA_ARGS
+    description: Extra parameters passed for the push command when pushing images.
+    type: string
+    default: ""
+  - name: SKIP_PUSH
+    description: Skip pushing the built image
+    default: "false"
+  workspaces:
+  - name: source
+  - name: sslcertdir
+    optional: true
+  - name: imagecache
+    optional: true
+  results:
+  - name: IMAGE_DIGEST
+    description: Digest of the image just built.
+  steps:
+  - name: build
+    image: $(params.BUILDER_IMAGE)
+    workingDir: $(workspaces.source.path)
+    script: |
+      echo "Running as USER ID `id`"
+
+      [[ "$(workspaces.sslcertdir.bound)" == "true" ]] && CERT_DIR_FLAG="--cert-dir $(workspaces.sslcertdir.path)"
+      buildah ${CERT_DIR_FLAG} --storage-driver=$(params.STORAGE_DRIVER) bud \
+        $(params.BUILD_EXTRA_ARGS) --format=$(params.FORMAT) \
+        --tls-verify=$(params.TLSVERIFY) --no-cache \
+        -f $(params.DOCKERFILE) -t $(params.IMAGE) $(params.CONTEXT)
+
+      [[ "$(params.SKIP_PUSH)" == "true" ]] && echo "Push skipped" && exit 0
+      [[ "$(workspaces.sslcertdir.bound)" == "true" ]] && CERT_DIR_FLAG="--cert-dir $(workspaces.sslcertdir.path)"
+      buildah ${CERT_DIR_FLAG} --storage-driver=$(params.STORAGE_DRIVER) push \
+        $(params.PUSH_EXTRA_ARGS) --tls-verify=$(params.TLSVERIFY) \
+        --digestfile $(workspaces.source.path)/image-digest $(params.IMAGE) \
+        docker://$(params.IMAGE)
+    securityContext:
+      runAsUser: 1000
+
+  - name: digest-to-results
+    image: $(params.BUILDER_IMAGE)
+    script: cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST


### PR DESCRIPTION
We had some failures on quay when using their automatic webhook and
imges wasnt pushed properly for 20 days.

Let's now do this on pipeline so when it fails we know it fails

Fixes issue #113

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI 
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please make sure to document it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then make sure to get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
