### PR TITLE
Add tests for pkg/consoleui and kinteract/labels

### DIFF
--- a/pkg/consoleui/interface_test.go
+++ b/pkg/consoleui/interface_test.go
@@ -1,7 +1,6 @@
 package consoleui
 
 import (
-	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -11,20 +10,17 @@ import (
 	rtesting "knative.dev/pkg/reconciler/testing"
 )
 
-func TestTektonDashboard(t *testing.T) {
-	tr := &TektonDashboard{
-		BaseURL: "https://test",
-	}
+func TestFallbackConsole(t *testing.T) {
+	fbc := &FallBackConsole{}
 	ctx, _ := rtesting.SetupFakeContext(t)
-
 	unsf := &unstructured.Unstructured{}
 	unsf.SetUnstructuredContent(map[string]interface{}{
 		"apiVersion": "foo.io/v1",
 		"kind":       "Random",
 	})
 	dynClient := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), unsf)
-	assert.NilError(t, tr.UI(ctx, dynClient))
-	assert.Assert(t, strings.Contains(tr.DetailURL("ns", "pr"), "namespaces/ns"))
-	assert.Assert(t, strings.Contains(tr.TaskLogURL("ns", "pr", "task"), "pipelineTask=task"))
-	assert.Assert(t, strings.Contains(tr.URL(), "test"))
+	assert.NilError(t, fbc.UI(ctx, dynClient))
+	assert.Assert(t, fbc.URL() != "")
+	assert.Assert(t, fbc.DetailURL("ns", "pr") != "")
+	assert.Assert(t, fbc.TaskLogURL("ns", "pr", "task") != "")
 }

--- a/pkg/consoleui/openshift_test.go
+++ b/pkg/consoleui/openshift_test.go
@@ -1,0 +1,106 @@
+package consoleui
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	rtesting "knative.dev/pkg/reconciler/testing"
+)
+
+func TestOpenshiftConsoleUI(t *testing.T) {
+	fakeroute := &unstructured.Unstructured{}
+	fakeroute.SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "route.openshift.io/v1",
+		"kind":       "Route",
+		"metadata": map[string]interface{}{
+			"name":      "console",
+			"namespace": "openshift-console",
+		},
+		"spec": map[string]interface{}{
+			"host": "http://fakeconsole",
+		},
+	})
+	emptys := &unstructured.Unstructured{}
+	emptys.SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "route.openshift.io/v1",
+		"kind":       "Route",
+		"metadata": map[string]interface{}{
+			"name":      "not",
+			"namespace": "console",
+		},
+	})
+	nospeccontent := &unstructured.Unstructured{}
+	nospeccontent.SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "route.openshift.io/v1",
+		"kind":       "Route",
+		"metadata": map[string]interface{}{
+			"name":      "console",
+			"namespace": "openshift-console",
+		},
+		"spec": map[string]interface{}{},
+	})
+
+	nohost := &unstructured.Unstructured{}
+	nohost.SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "route.openshift.io/v1",
+		"kind":       "Route",
+		"metadata": map[string]interface{}{
+			"name":      "console",
+			"namespace": "openshift-console",
+		},
+	})
+
+	tests := []struct {
+		name     string
+		unsf     *unstructured.Unstructured
+		wantErr  bool
+		wantHost string
+	}{
+		{
+			name:     "Get Openshift Console url",
+			unsf:     fakeroute,
+			wantErr:  false,
+			wantHost: "http://fakeconsole",
+		},
+		{
+			name:    "No Openshift Console",
+			unsf:    emptys,
+			wantErr: true,
+		},
+		{
+			name:    "No spec in route",
+			unsf:    nospeccontent,
+			wantErr: true,
+		},
+		{
+			name:    "No host in route.spec",
+			unsf:    nohost,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			o := &OpenshiftConsole{}
+			dynClient := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), tt.unsf)
+			if err := o.UI(ctx, dynClient); (err != nil) != tt.wantErr {
+				t.Fatalf("UI() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantHost != "" {
+				if o.host != tt.wantHost {
+					t.Fatalf("UI() host = %v, want %v", o.host, tt.wantHost)
+				}
+			}
+		})
+	}
+}
+
+func TestOpenshiftConsoleURLs(t *testing.T) {
+	o := OpenshiftConsole{host: "http://fakeconsole"}
+	assert.Assert(t, o.URL() != "")
+	assert.Assert(t, o.DetailURL("ns", "pr") != "")
+	assert.Assert(t, o.TaskLogURL("ns", "pr", "task") != "")
+}

--- a/pkg/kubeinteraction/labels_test.go
+++ b/pkg/kubeinteraction/labels_test.go
@@ -1,0 +1,60 @@
+package kubeinteraction
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
+	apipac "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestAddLabelsAndAnnotations(t *testing.T) {
+	type args struct {
+		event       *info.Event
+		pipelineRun *tektonv1beta1.PipelineRun
+		repo        *apipac.Repository
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "test label and annotation added to pr",
+			args: args{
+				event: &info.Event{
+					Organization: "org",
+					Repository:   "repo",
+					SHA:          "sha",
+					Sender:       "sender",
+					EventType:    "pull_request",
+					BaseBranch:   "main",
+					SHAURL:       "https://url/sha",
+				},
+				pipelineRun: &tektonv1beta1.PipelineRun{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels:      map[string]string{},
+						Annotations: map[string]string{},
+					},
+				},
+				repo: &apipac.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "repo",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			AddLabelsAndAnnotations(tt.args.event, tt.args.pipelineRun, tt.args.repo)
+			assert.Assert(t, tt.args.pipelineRun.Labels[filepath.Join(pipelinesascode.GroupName, "url-org")] == tt.args.event.Organization, "'%s' != %s",
+				tt.args.pipelineRun.Labels[filepath.Join(pipelinesascode.GroupName, "url-org")], tt.args.event.Organization)
+			assert.Assert(t, tt.args.pipelineRun.Annotations[filepath.Join(pipelinesascode.GroupName,
+				"sha-url")] == tt.args.event.SHAURL)
+		})
+	}
+}


### PR DESCRIPTION
just to improve the coverage number really tbh, since i don't expect
those to break anytime soon.

but since we are doing a large redesign/refactor better to be safe than
sorry.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [X] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI 
- [X] 📖 If you are adding a user facing feature or make a change of the behavior, please make sure to document it
- [X] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [X] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [X] 🔎 If there is a flakiness in the CI tests then make sure to get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
