### PR TITLE
Use target_branch for the branch to push for

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -81,7 +81,7 @@ spec:
           - unit
         params:
           - name: IMAGE
-            value: quay.io/openshift-pipeline/pipelines-as-code:main
+            value: quay.io/openshift-pipeline/pipelines-as-code:{{target_branch}}
         taskRef:
           name: buildah-user
         workspaces:


### PR DESCRIPTION
Now that we have
https://github.com/openshift-pipelines/pipelines-as-code/pull/454 merged
we can use target_branch as variable which should be main most of the
time.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
