### PR TITLE
filter request before processing (GitHub)

### DIFF
--- a/pkg/provider/github/github_test.go
+++ b/pkg/provider/github/github_test.go
@@ -1,11 +1,13 @@
 package github
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"path/filepath"
 	"testing"
 
+	"github.com/google/go-github/v43/github"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	ghtesthelper "github.com/openshift-pipelines/pipelines-as-code/pkg/test/github"
 	rtesting "knative.dev/pkg/reconciler/testing"
@@ -493,6 +495,217 @@ func TestGithubSetClient(t *testing.T) {
 			} else {
 				assert.Equal(t, "/", v.Client.BaseURL.Path)
 			}
+		})
+	}
+}
+
+func TestProvider_Detect(t *testing.T) {
+	tests := []struct {
+		name          string
+		wantErrString string
+		isGH          bool
+		processReq    bool
+		event         interface{}
+		eventType     string
+	}{
+		{
+			name:       "not a github Event",
+			eventType:  "",
+			isGH:       false,
+			processReq: false,
+		},
+		{
+			name:          "invalid github Event",
+			eventType:     "validator",
+			wantErrString: "unknown X-Github-Event in message: validator",
+			isGH:          false,
+			processReq:    false,
+		},
+		{
+			name: "valid check run Event",
+			event: github.CheckRunEvent{
+				Action: github.String("rerequested"),
+				CheckRun: &github.CheckRun{
+					ID: github.Int64(123),
+				},
+			},
+			eventType:  "check_run",
+			isGH:       true,
+			processReq: true,
+		},
+		{
+			name: "unsupported Event",
+			event: github.CommitCommentEvent{
+				Action: github.String("something"),
+			},
+			eventType:     "commit_comment",
+			wantErrString: "github: event commit_comment is not supported",
+			isGH:          true,
+			processReq:    false,
+		},
+		{
+			name: "invalid check run Event",
+			event: github.CheckRunEvent{
+				Action: github.String("not rerequested"),
+			},
+			eventType:  "check_run",
+			isGH:       true,
+			processReq: false,
+		},
+		{
+			name: "invalid issue comment Event",
+			event: github.IssueCommentEvent{
+				Action: github.String("deleted"),
+			},
+			eventType:  "issue_comment",
+			isGH:       true,
+			processReq: false,
+		},
+		{
+			name: "issue comment Event with no valid comment",
+			event: github.IssueCommentEvent{
+				Action: github.String("created"),
+				Issue: &github.Issue{
+					PullRequestLinks: &github.PullRequestLinks{
+						URL: github.String("url"),
+					},
+					State: github.String("open"),
+				},
+				Installation: &github.Installation{
+					ID: github.Int64(123),
+				},
+				Comment: &github.IssueComment{Body: github.String("abc")},
+			},
+			eventType:  "issue_comment",
+			isGH:       true,
+			processReq: false,
+		},
+		{
+			name: "issue comment Event with ok-to-test comment",
+			event: github.IssueCommentEvent{
+				Action: github.String("created"),
+				Issue: &github.Issue{
+					PullRequestLinks: &github.PullRequestLinks{
+						URL: github.String("url"),
+					},
+					State: github.String("open"),
+				},
+				Installation: &github.Installation{
+					ID: github.Int64(123),
+				},
+				Comment: &github.IssueComment{Body: github.String("/ok-to-test")},
+			},
+			eventType:  "issue_comment",
+			isGH:       true,
+			processReq: true,
+		},
+		{
+			name: "issue comment Event with ok-to-test and some string",
+			event: github.IssueCommentEvent{
+				Action: github.String("created"),
+				Issue: &github.Issue{
+					PullRequestLinks: &github.PullRequestLinks{
+						URL: github.String("url"),
+					},
+					State: github.String("open"),
+				},
+				Installation: &github.Installation{
+					ID: github.Int64(123),
+				},
+				Comment: &github.IssueComment{Body: github.String("/ok-to-test \n, don't let me in :)")},
+			},
+			eventType:  "issue_comment",
+			isGH:       true,
+			processReq: false,
+		},
+		{
+			name: "issue comment Event with retest",
+			event: github.IssueCommentEvent{
+				Action: github.String("created"),
+				Issue: &github.Issue{
+					PullRequestLinks: &github.PullRequestLinks{
+						URL: github.String("url"),
+					},
+					State: github.String("open"),
+				},
+				Installation: &github.Installation{
+					ID: github.Int64(123),
+				},
+				Comment: &github.IssueComment{Body: github.String("/retest")},
+			},
+			eventType:  "issue_comment",
+			isGH:       true,
+			processReq: true,
+		},
+		{
+			name: "issue comment Event with retest with some string",
+			event: github.IssueCommentEvent{
+				Action: github.String("created"),
+				Issue: &github.Issue{
+					PullRequestLinks: &github.PullRequestLinks{
+						URL: github.String("url"),
+					},
+					State: github.String("open"),
+				},
+				Installation: &github.Installation{
+					ID: github.Int64(123),
+				},
+				Comment: &github.IssueComment{Body: github.String("/retest \n will you retest?")},
+			},
+			eventType:  "issue_comment",
+			isGH:       true,
+			processReq: false,
+		},
+		{
+			name: "push event",
+			event: github.PushEvent{
+				Pusher: &github.User{ID: github.Int64(11)},
+			},
+			eventType:  "push",
+			isGH:       true,
+			processReq: true,
+		},
+		{
+			name: "pull request event",
+			event: github.PullRequestEvent{
+				Action: github.String("created"),
+			},
+			eventType:  "pull_request",
+			isGH:       true,
+			processReq: true,
+		},
+		{
+			name: "pull request event not supported action",
+			event: github.PullRequestEvent{
+				Action: github.String("deleted"),
+			},
+			eventType:  "pull_request",
+			isGH:       true,
+			processReq: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gprovider := Provider{}
+			logger := getLogger()
+
+			jeez, err := json.Marshal(tt.event)
+			if err != nil {
+				assert.NilError(t, err)
+			}
+
+			header := &http.Header{}
+			header.Set("X-GitHub-Event", tt.eventType)
+
+			isGh, processReq, _, err := gprovider.Detect(header, string(jeez), logger)
+			if tt.wantErrString != "" {
+				assert.ErrorContains(t, err, tt.wantErrString)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, tt.isGH, isGh)
+			assert.Equal(t, tt.processReq, processReq)
 		})
 	}
 }

--- a/pkg/provider/interface.go
+++ b/pkg/provider/interface.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"go.uber.org/zap"
 )
 
 type StatusOpts struct {
@@ -20,6 +21,7 @@ type StatusOpts struct {
 }
 
 type Interface interface {
+	Detect(*http.Header, string, *zap.SugaredLogger) (bool, bool, *zap.SugaredLogger, error)
 	ParsePayload(context.Context, *params.Run, *http.Request, string) (*info.Event, error)
 	IsAllowed(context.Context, *info.Event) (bool, error)
 	CreateStatus(context.Context, *info.Event, *info.PacOpts, StatusOpts) error

--- a/pkg/test/provider/testwebvcs.go
+++ b/pkg/test/provider/testwebvcs.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
+	"go.uber.org/zap"
 )
 
 type TestProviderImp struct {
@@ -21,6 +22,10 @@ type TestProviderImp struct {
 // func (v *TestProviderImp) ParseEventType(request *http.Request, event *info.Event) error {
 //	return nil
 // }
+
+func (v *TestProviderImp) Detect(request *http.Header, body string, logger *zap.SugaredLogger) (bool, bool, *zap.SugaredLogger, error) {
+	return true, true, nil, nil
+}
 
 func (v *TestProviderImp) ParsePayload(ctx context.Context, run *params.Run, request *http.Request, payload string) (*info.Event, error) {
 	return v.Event, nil


### PR DESCRIPTION
now controller filters request and then process if they
are valid, before we had triggers interceptor doing this
part. for ex.
```
 - name: "filter"
   value: >-
     body.action in `['created', 'synchronize', 'opened']`
```
now Detect func filter out request while figuring out which provider
the reqest is from.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI 
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please make sure to document it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then make sure to get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
