### PR TITLE
Use provider url from header for GHE 

### DIFF
--- a/pkg/provider/github/events_test.go
+++ b/pkg/provider/github/events_test.go
@@ -425,7 +425,6 @@ func TestAppTokenGeneration(t *testing.T) {
 			mux.HandleFunc(fmt.Sprintf("/app/installations/%s/access_tokens", string(testInstallID)), func(w http.ResponseWriter, r *http.Request) {
 				_, _ = fmt.Fprint(w, `{"commit": {"message": "HELLO"}}`)
 			})
-			tt.envs["PAC_GIT_PROVIDER_APIURL"] = fakeGithubAuthURL
 			tt.envs["PAC_GIT_PROVIDER_TOKEN_APIURL"] = url + "/api/v3"
 
 			envRemove := env.PatchAll(t, tt.envs)
@@ -441,6 +440,7 @@ func TestAppTokenGeneration(t *testing.T) {
 			logger := getLogger()
 			request := &http.Request{Header: map[string][]string{}}
 			request.Header.Set("X-GitHub-Event", "pull_request")
+			request.Header.Set("X-GitHub-Enterprise-Host", fakeGithubAuthURL)
 
 			run := &params.Run{
 				Clients: clients.Clients{


### PR DESCRIPTION
on ghe pac was failing to process events because it was
    using git public url, now it reads the git enterpise url
    from header of event and use that.
    
 Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI 
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please make sure to document it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then make sure to get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
