### PR TITLE
Output a json message at the end after processing

### DIFF
--- a/hack/dev/gh-replay-events.py
+++ b/hack/dev/gh-replay-events.py
@@ -65,6 +65,9 @@ def get_token_secret(github_api_url=ghapp_token.GITHUB_API_URL,
     private_key = base64.b64decode(jeez["data"]["github-private-key"])
     app_id = base64.b64decode(jeez["data"]["github-application-id"])
     webhook_secret = base64.b64decode(jeez["data"]["webhook.secret"]).decode()
+    if not private_key or not app_id or not webhook_secret:
+        print(f"private_key={private_key[1:10]} or app_id={app_id} or webhook_secret={webhook_secret} are empty")
+        sys.exit(1)
 
     gh = ghapp_token.GitHub(
         private_key,

--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -108,7 +108,7 @@ func (l listener) handleEvent() http.HandlerFunc {
 		go func() {
 			s.processEvent(ctx, localRequest, payload)
 		}()
-
+		fmt.Fprintf(response, `{"status": "%d", "message": "accepted"}`, http.StatusAccepted)
 		response.WriteHeader(http.StatusAccepted)
 	}
 }


### PR DESCRIPTION
to make it easier to know that event is processed. it currently returns no message and unless we look at the header there is no way to process when talking to the controller via  API/binding

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI 
- [x] 📖 If you are adding a user facing feature or make a change of the behavior, please make sure to document it
- [x] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [x] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [x] 🔎 If there is a flakiness in the CI tests then make sure to get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
