### PR TITLE
Enables bitbucket server provider in controller

### DIFF
--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/version"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketserver"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/github"
 	"go.uber.org/zap"
 	"knative.dev/eventing/pkg/adapter/v2"
@@ -125,6 +126,18 @@ func (l listener) detectProvider(reqHeader *http.Header, reqBody string) (provid
 		}
 		if processReq {
 			return gitHub, logger, nil
+		}
+		return nil, nil, nil
+	}
+
+	bitServer := &bitbucketserver.Provider{}
+	isBitServer, processReq, logger, err := bitServer.Detect(reqHeader, reqBody, &log)
+	if isBitServer {
+		if err != nil {
+			return nil, logger, err
+		}
+		if processReq {
+			return bitServer, logger, nil
 		}
 		return nil, nil, nil
 	}

--- a/pkg/provider/bitbucketserver/types/types.go
+++ b/pkg/provider/bitbucketserver/types/types.go
@@ -12,6 +12,7 @@ type EventActor struct {
 type PullRequestEvent struct {
 	Actor      EventActor
 	PulRequest bbv1.PullRequest `json:"pullRequest"`
+	Comment    bbv1.Comment     `json:"comment"`
 }
 
 type PushRequestEventChange struct {
@@ -20,7 +21,7 @@ type PushRequestEventChange struct {
 }
 
 type PushRequestEvent struct {
-	Actor      EventActor `json:"actor"`
-	Repository bbv1.Repository
-	Changes    []PushRequestEventChange
+	Actor      EventActor               `json:"actor"`
+	Repository bbv1.Repository          `json:"repository"`
+	Changes    []PushRequestEventChange `json:"changes"`
 }

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -1,0 +1,15 @@
+package provider
+
+const (
+	RetestRegex   = "(^|\\\\r\\\\n)/retest([ ]*$|$|\\\\r\\\\n)"
+	OktotestRegex = "(^|\\\\r\\\\n)/ok-to-test([ ]*$|$|\\\\r\\\\n)"
+)
+
+func Valid(value string, validValues []string) bool {
+	for _, v := range validValues {
+		if v == value {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
controller now support bitbucket server which can configured
using a webhook.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI 
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please make sure to document it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then make sure to get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
