### PR TITLE
Try to detect if pac is installed via operator

### DIFF
--- a/pkg/cmd/tknpac/bootstrap/bootstrap.go
+++ b/pkg/cmd/tknpac/bootstrap/bootstrap.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	pacNS                  = "pipelines-as-code"
-	pacLabel               = "pipelines-as-code/route=controller"
+	openshiftpacNS         = "openshift-pipelines"
 	openShiftRouteGroup    = "route.openshift.io"
 	openShiftRouteVersion  = "v1"
 	openShiftRouteResource = "routes"
@@ -69,8 +69,17 @@ func install(ctx context.Context, run *params.Run, opts *bootstrapOpts) error {
 	if !tektonInstalled {
 		return errors.New("tekton API not found on the cluster. Please install Tekton first")
 	}
-	installed, _ := checkNS(ctx, run, opts)
-	if !opts.forceInstall && installed {
+
+	// if we gt a ns back it means it has been detected in here so keep it as is.
+	// or else just set the default to pacNS
+	ns, err := detectPacInstallation(ctx, opts.targetNamespace, run)
+	if ns != "" {
+		opts.targetNamespace = ns
+	} else if opts.targetNamespace == "" {
+		opts.targetNamespace = pacNS
+	}
+
+	if !opts.forceInstall && err == nil {
 		// nolint:forbidigo
 		fmt.Println("👌 Pipelines as Code is already installed.")
 	} else if err := installPac(ctx, run, opts); err != nil {
@@ -138,7 +147,7 @@ func Command(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
 	}
 	cmd.AddCommand(GithubApp(run, ioStreams))
 
-	addCommonFlags(cmd, opts, ioStreams)
+	addCommonFlags(cmd, ioStreams)
 	addGithubAppFlag(cmd, opts)
 
 	cmd.PersistentFlags().BoolVar(&opts.forceInstall, "force-install", false, "whether we should force pac install even if it's already installed")
@@ -165,6 +174,12 @@ func GithubApp(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
 				return err
 			}
 
+			var err error
+			opts.targetNamespace, err = detectPacInstallation(ctx, opts.targetNamespace, run)
+			if err != nil {
+				return err
+			}
+
 			if b, _ := askYN(false, "", "Are you using Github Enterprise?"); b {
 				opts.providerType = "github-enteprise-app"
 			}
@@ -175,9 +190,38 @@ func GithubApp(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
 			"commandType": "main",
 		},
 	}
-	addCommonFlags(cmd, opts, ioStreams)
+	addCommonFlags(cmd, ioStreams)
 	addGithubAppFlag(cmd, opts)
+
+	cmd.PersistentFlags().StringVarP(&opts.targetNamespace, "namespace", "n", "", "target namespace where pac is installed")
 	return cmd
+}
+
+func detectPacInstallation(ctx context.Context, wantedNS string, run *params.Run) (string, error) {
+	// detect which namespace pac is installed in
+	// verify first if the targetNamespace actually exists
+	if wantedNS != "" {
+		installed, err := checkNS(ctx, run, wantedNS)
+		if err != nil {
+			return "", err
+		}
+		if !installed {
+			return "", fmt.Errorf("PAC is not installed in namespace: %s", wantedNS)
+		}
+		return wantedNS, nil
+		// if openshift pipelines ns is installed try it from there
+	}
+
+	if installed, _ := checkNS(ctx, run, openshiftpacNS); installed {
+		return openshiftpacNS, nil
+	}
+
+	if installed, _ := checkNS(ctx, run, pacNS); installed {
+		return pacNS, nil
+	}
+
+	return "", fmt.Errorf("could not detect an installation of Pipelines as Code, " +
+		"use the -n switch to specify a namespace")
 }
 
 func addGithubAppFlag(cmd *cobra.Command, opts *bootstrapOpts) {
@@ -192,7 +236,6 @@ func addGithubAppFlag(cmd *cobra.Command, opts *bootstrapOpts) {
 		fmt.Sprintf("target install type, choices are: %s ", strings.Join(providerTargets, ", ")))
 }
 
-func addCommonFlags(cmd *cobra.Command, opts *bootstrapOpts, ioStreams *cli.IOStreams) {
+func addCommonFlags(cmd *cobra.Command, ioStreams *cli.IOStreams) {
 	cmd.PersistentFlags().BoolP("no-color", "C", !ioStreams.ColorEnabled(), "disable coloring")
-	cmd.PersistentFlags().StringVarP(&opts.targetNamespace, "namespace", "n", pacNS, "target namespace where pac is installed")
 }

--- a/pkg/cmd/tknpac/bootstrap/install.go
+++ b/pkg/cmd/tknpac/bootstrap/install.go
@@ -71,7 +71,7 @@ func installPac(ctx context.Context, run *params.Run, opts *bootstrapOpts) error
 
 	if !opts.forceInstall {
 		doinstall, err := askYN(true,
-			"🕵️ Pipelines as Code doesn't seems to be installed",
+			fmt.Sprintf("🕵️ Pipelines as Code doesn't seems to be installed in %s namespace", opts.targetNamespace),
 			fmt.Sprintf("Do you want me to install Pipelines as Code %s?", latestversion))
 		if err != nil {
 			return err

--- a/pkg/cmd/tknpac/bootstrap/route.go
+++ b/pkg/cmd/tknpac/bootstrap/route.go
@@ -12,13 +12,15 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+const routePacLabel = "pipelines-as-code/route=controller"
+
 // detectOpenShiftRoute detect the openshift route where the pac controller is running
 func detectOpenShiftRoute(ctx context.Context, run *params.Run, opts *bootstrapOpts) (string, error) {
 	gvr := schema.GroupVersionResource{
 		Group: openShiftRouteGroup, Version: openShiftRouteVersion, Resource: openShiftRouteResource,
 	}
 	routes, err := run.Clients.Dynamic.Resource(gvr).Namespace(opts.targetNamespace).List(ctx, metav1.ListOptions{
-		LabelSelector: pacLabel,
+		LabelSelector: routePacLabel,
 	})
 	if err != nil {
 		return "", err


### PR DESCRIPTION
When installing via openshift-pipelines "downstream" operator. PAC would
get installed in openshift-pipelines.

Strategy to detection is then :

if user has a `-n` ns flag, try to see if pac is installed in ns
try to detect pac in openshift-pipelines ns (downstream)
try to detect pac in pipelines-as-code ns  (upstream)

The way to detect it is to check the configmap installed in the
openshift-pipelines namespace. This makes this detection compatible with
old way (via taskrun) and the new way via controller.

As far goes for for permissions usually the folks who tries to do
bootstrap will have to have anyway right access to that ns to be able to
bootstrap so we should be good.

Still no tests in that code flow, and still too annoying to add tests there 🤷🏻 

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [X] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI 
- [X] 📖 If you are adding a user facing feature or make a change of the behavior, please make sure to document it
- [X] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [X] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [X] 🔎 If there is a flakiness in the CI tests then make sure to get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
