### PR TITLE
Skip triggers check in bootstrap and rbac cleanup

### DIFF
--- a/config/200-role.yaml
+++ b/config/200-role.yaml
@@ -36,20 +36,8 @@ metadata:
     app.kubernetes.io/part-of: pipelines-as-code
 rules:
   - apiGroups: [""]
-    # secrets are only needed for Github/Gitlab interceptors, serviceaccounts only for per trigger authorization
-    resources: ["configmaps", "secrets"]
+    resources: ["configmaps"]
     verbs: ["get", "list", "watch"]
-  # Permissions to create resources in associated TriggerTemplates
-  - apiGroups: ["tekton.dev"]
-    resources: ["pipelineruns", "taskruns"]
-    verbs: ["create"]
-  - apiGroups: [""]
-    resources: ["serviceaccounts"]
-    verbs: ["impersonate"]
-  - apiGroups: ["policy"]
-    resources: ["podsecuritypolicies"]
-    resourceNames: ["tekton-triggers"]
-    verbs: ["use"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -91,9 +79,6 @@ rules:
   - apiGroups: ["pipelinesascode.tekton.dev"]
     resources: ["repositories"]
     verbs: ["create", "get", "list", "update"]
-  - apiGroups: ["triggers.tekton.dev"]
-    resources: ["clustertriggerbindings", "clusterinterceptors"]
-    verbs: ["get", "list", "watch"]
   - apiGroups: ["tekton.dev"]
     resources: ["pipelineruns"]
     verbs: ["get", "delete", "list", "create", "watch"]

--- a/pkg/cmd/tknpac/bootstrap/kubestuff.go
+++ b/pkg/cmd/tknpac/bootstrap/kubestuff.go
@@ -69,14 +69,10 @@ func checkPipelinesInstalled(run *params.Run) (bool, error) {
 		return false, err
 	}
 	tektonFound := false
-	triggersFound := false
 	for _, t := range sg.Groups {
 		if t.Name == "tekton.dev" {
 			tektonFound = true
 		}
-		if t.Name == "triggers.tekton.dev" {
-			triggersFound = true
-		}
 	}
-	return tektonFound && triggersFound, nil
+	return tektonFound, nil
 }


### PR DESCRIPTION
skip checking triggers in bootstrap command
as pac doesn't use triggers anymore, we can skip triggers
requirement while bootstraping.
&
 Cleanup: removes unnecessary rbac role for controller 


# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI 
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please make sure to document it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then make sure to get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
