### PR TITLE
Restart controller after configmap changes in CI

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -117,6 +117,19 @@ jobs:
           # Test with kind load
           ko apply -f ./config
 
+      - name: Wait for pac controller to start
+        run: |
+          i=0
+          for tt in pipelines-as-code-controller;do
+            while true;do
+              [[ ${i} == 120 ]] && exit 1
+              ep=$(kubectl get ep -n pipelines-as-code ${tt} -o jsonpath='{.subsets[*].addresses[*].ip}')
+              [[ -n ${ep} ]] && break
+              sleep 2
+              i=$((i+1))
+            done
+          done
+
       - name: Create Ambassador Route
         run: |
           sudo echo "127.0.0.1 $EL_NAME" | sudo tee -a /etc/hosts
@@ -157,6 +170,21 @@ jobs:
           # Disable Bitbucket Cloud Source IP check, since we should be god here.
           kubectl patch configmap -n pipelines-as-code -p "{\"data\":{\"bitbucket-cloud-check-source-ip\": \"false\"}}" \
           --type merge pipelines-as-code
+
+          # restart controller
+          kubectl -n pipelines-as-code delete pod -l app.kubernetes.io/name=controller
+
+          # wait for controller to start
+          i=0
+          for tt in pipelines-as-code-controller;do
+            while true;do
+              [[ ${i} == 120 ]] && exit 1
+              ep=$(kubectl get ep -n pipelines-as-code ${tt} -o jsonpath='{.subsets[*].addresses[*].ip}')
+              [[ -n ${ep} ]] && break
+              sleep 2
+              i=$((i+1))
+            done
+          done
 
       - name: Install and Run pysmee
         run: |

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -95,14 +95,12 @@ jobs:
       - name: Install Tekton
         run: |
           kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
-          kubectl apply --filename https://storage.googleapis.com/tekton-releases/triggers/latest/release.yaml
-          kubectl apply --filename https://storage.googleapis.com/tekton-releases/triggers/latest/interceptors.yaml
           kubectl apply --filename https://storage.googleapis.com/tekton-releases/dashboard/latest/tekton-dashboard-release.yaml
 
       - name: Wait for Tekton to be installed
         run: |
           i=0
-          for tt in pipelines triggers;do
+          for tt in pipelines;do
             while true;do
               [[ ${i} == 120 ]] && exit 1
               ep=$(kubectl get ep -n tekton-pipelines tekton-${tt}-webhook -o jsonpath='{.subsets[*].addresses[*].ip}')
@@ -219,8 +217,7 @@ jobs:
           mkdir -p /tmp/logs
           kind export logs /tmp/logs
 
-          mkdir /tmp/logs/pac-runs
-          for pod in $(kubectl get pod -o name -n pipelines-as-code -l triggers.tekton.dev/eventlistener=pipelines-as-code-interceptor|sed 's,.*/,,');do kubectl -n pipelines-as-code logs ${pod} > /tmp/logs/pac-runs/${pod}.log 2>&1 || true; done
+          kubectl get configmap -n pipelines-as-code -o yaml > /tmp/logs/pac-configmap
 
       - name: Upload artifacts
         if: ${{ always() }}


### PR DESCRIPTION
as we read configmap only once while starting the controller
after updating configmap, we need to restart controller.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI 
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please make sure to document it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then make sure to get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
