### PR TITLE
Repo create cmd: convert username to lowercase and then use it

### DIFF
--- a/pkg/formatting/vcs.go
+++ b/pkg/formatting/vcs.go
@@ -41,7 +41,7 @@ func GetRepoOwnerFromGHURL(ghURL string) (string, error) {
 	if len(sp) == 1 {
 		return "", fmt.Errorf("not a URL with a REPO/OWNER at the end")
 	}
-	return fmt.Sprintf("%s/%s", sp[len(sp)-2], sp[len(sp)-1]), nil
+	return fmt.Sprintf("%s/%s", strings.ToLower(sp[len(sp)-2]), strings.ToLower(sp[len(sp)-1])), nil
 }
 
 // CamelCasit pull_request > PullRequest

--- a/pkg/formatting/vcs_test.go
+++ b/pkg/formatting/vcs_test.go
@@ -52,6 +52,14 @@ func TestGetRepoOwnerFromGHURL(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "repoowner with capital letters",
+			args: args{
+				ghURL: "https://allo/HELLO/moto",
+			},
+			want:    "hello/moto",
+			wantErr: false,
+		},
+		{
 			name: "bad url",
 			args: args{
 				ghURL: "xx",


### PR DESCRIPTION
if a user has capital letters in username then repo create cmd
returns an error:
```
Error: Repository.pipelinesascode.tekton.dev "VeereshAradhya-pac-test" is invalid: metadata.name: Invalid value: "VeereshAradhya-pac-test": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
```
this fixes by converting to lowercase and then use it.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI 
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please make sure to document it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then make sure to get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
