### PR TITLE
DNM: Release-0.5.6

### DIFF
--- a/config/401-github-issue-recheck.yaml
+++ b/config/401-github-issue-recheck.yaml
@@ -163,6 +163,10 @@ spec:
                   value: $(workspaces.secrets.path)
                 - name: PAC_PAYLOAD_FILE
                   value: "/tmp/payload.json"
+                - name: PAC_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
               script: |
                 #!/usr/bin/env bash
                 set -euf

--- a/config/402-github-pull-request.yaml
+++ b/config/402-github-pull-request.yaml
@@ -166,6 +166,10 @@ spec:
                   value: "$(params.trigger_target)"
                 - name: PAC_WEBHOOK_TYPE
                   value: "$(params.event_type)"
+                - name: PAC_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
               imagePullPolicy: Always
               image: "ko://github.com/openshift-pipelines/pipelines-as-code/cmd/pipelines-as-code"
               script: |

--- a/config/403-github-push.yaml
+++ b/config/403-github-push.yaml
@@ -155,6 +155,10 @@ spec:
                   value: $(workspaces.secrets.path)
                 - name: PAC_PAYLOAD_FILE
                   value: "/tmp/payload.json"
+                - name: PAC_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
               script: |
                 #!/usr/bin/env bash
                 set -euf

--- a/config/404-github-retest-comment.yaml
+++ b/config/404-github-retest-comment.yaml
@@ -133,6 +133,10 @@ spec:
                   value: "$(params.event_type)"
                 - name: PAC_PAYLOAD_FILE
                   value: "/tmp/payload.json"
+                - name: PAC_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
               script: |
                 #!/usr/bin/env bash
                 set -euf

--- a/config/422-bitbucket-cloud-pull-request.yaml
+++ b/config/422-bitbucket-cloud-pull-request.yaml
@@ -171,6 +171,10 @@ spec:
                   value: "/tmp/payload.json"
                 - name: PAC_SOURCE_IP
                   value: $(params.source_ip)
+                - name: PAC_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
               imagePullPolicy: Always
               image: "ko://github.com/openshift-pipelines/pipelines-as-code/cmd/pipelines-as-code"
               script: |

--- a/config/423-bitbucket-cloud-push.yaml
+++ b/config/423-bitbucket-cloud-push.yaml
@@ -149,6 +149,10 @@ spec:
                   value: "/tmp/payload.json"
                 - name: PAC_SOURCE_IP
                   value: $(params.source_ip)
+                - name: PAC_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
               imagePullPolicy: Always
               image: "ko://github.com/openshift-pipelines/pipelines-as-code/cmd/pipelines-as-code"
               script: |

--- a/config/442-bitbucket-server-pull-request.yaml
+++ b/config/442-bitbucket-server-pull-request.yaml
@@ -201,6 +201,10 @@ spec:
                   value: "$(params.event_type)"
                 - name: PAC_PAYLOAD_FILE
                   value: "/tmp/payload.json"
+                - name: PAC_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
               imagePullPolicy: Always
               image: "ko://github.com/openshift-pipelines/pipelines-as-code/cmd/pipelines-as-code"
               script: |

--- a/config/443-bitbucket-server-push.yaml
+++ b/config/443-bitbucket-server-push.yaml
@@ -140,6 +140,10 @@ spec:
                   value: "$(params.event_type)"
                 - name: PAC_PAYLOAD_FILE
                   value: "/tmp/payload.json"
+                - name: PAC_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
               imagePullPolicy: Always
               image: "ko://github.com/openshift-pipelines/pipelines-as-code/cmd/pipelines-as-code"
               script: |

--- a/pkg/formatting/vcs.go
+++ b/pkg/formatting/vcs.go
@@ -38,7 +38,7 @@ func GetRepoOwnerFromGHURL(ghURL string) (string, error) {
 	if len(sp) == 1 {
 		return "", fmt.Errorf("not a URL with a REPO/OWNER at the end")
 	}
-	return fmt.Sprintf("%s/%s", sp[len(sp)-2], sp[len(sp)-1]), nil
+	return fmt.Sprintf("%s/%s", strings.ToLower(sp[len(sp)-2]), strings.ToLower(sp[len(sp)-1])), nil
 }
 
 // CamelCasit pull_request > PullRequest

--- a/pkg/formatting/vcs_test.go
+++ b/pkg/formatting/vcs_test.go
@@ -57,6 +57,14 @@ func TestGetRepoOwnerFromGHURL(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "repoowner with capital letters",
+			args: args{
+				ghURL: "https://allo/HELLO/moto",
+			},
+			want:    "hello/moto",
+			wantErr: false,
+		},
+		{
 			name: "bad url",
 			args: args{
 				ghURL: "xx",

--- a/pkg/params/run.go
+++ b/pkg/params/run.go
@@ -2,6 +2,7 @@ package params
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -28,7 +29,12 @@ func StringToBool(s string) bool {
 // GetConfigFromConfigMap get config from configmap, we should remove all the
 // logics from cobra flags and just support configmap config and env config in the future.
 func (r *Run) GetConfigFromConfigMap(ctx context.Context) error {
-	cfg, err := r.Clients.Kube.CoreV1().ConfigMaps(info.PACInstallNS).Get(ctx, info.PACConfigmapNS, v1.GetOptions{})
+	ns := os.Getenv("PAC_NAMESPACE")
+	if ns == "" {
+		return fmt.Errorf("failed to find pipelines-as-code installation namespace")
+	}
+
+	cfg, err := r.Clients.Kube.CoreV1().ConfigMaps(ns).Get(ctx, info.PACConfigmapNS, v1.GetOptions{})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
for fetching configmap, read pac installation namespace
from env, this would make pac work in any other ns other
than pipelines as code.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI 
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please make sure to document it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then make sure to get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
