### PR TITLE
fixes metrics error at start of controller

### DIFF
--- a/config/400-controller.yaml
+++ b/config/400-controller.yaml
@@ -64,3 +64,5 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: K_METRICS_CONFIG
+              value: '{"Domain":"pipelinesascode.tekton.dev/controller","Component":"controller","PrometheusPort":0,"PrometheusHost":"","ConfigMap":{}}'


### PR DESCRIPTION
this fixes the metrics error we get while starting the controller
by providing some values and we will change them while implementing
metrics.

```
{"level":"info","ts":1648716002.8053524,"caller":"params/run.go:49","msg":"using tekton dashboard url on: https://dashboard.kind.pipelines.devcluster.openshift.com"}
{"severity":"INFO","timestamp":"2022-03-31T08:40:02.805469306Z","caller":"logging/config.go:116","message":"Successfully created the logger."}
{"severity":"INFO","timestamp":"2022-03-31T08:40:02.805530383Z","caller":"logging/config.go:117","message":"Logging level set to: info"}
{"severity":"INFO","timestamp":"2022-03-31T08:40:02.805567083Z","caller":"logging/config.go:79","message":"Fetch GitHub commit ID from kodata failed","error":"open /var/run/ko/HEAD: no such file or directory"}
{"severity":"INFO","timestamp":"2022-03-31T08:40:02.805696634Z","logger":"pipelinesascode","caller":"metrics/metrics_worker.go:76","message":"Flushing the existing exporter before setting up the new exporter."}
{"severity":"INFO","timestamp":"2022-03-31T08:40:02.805809204Z","logger":"pipelinesascode","caller":"metrics/prometheus_exporter.go:51","message":"Created Prometheus exporter with config: &{pipelinesascode.tekton.dev/controller controller prometheus 5000000000 <nil>  false 9090 0.0.0.0}. Start the server for Prometheus exporter."}
{"severity":"INFO","timestamp":"2022-03-31T08:40:02.805831427Z","logger":"pipelinesascode","caller":"metrics/metrics_worker.go:91","message":"Successfully updated the metrics exporter; old config: <nil>; new config &{pipelinesascode.tekton.dev/controller controller prometheus 5000000000 <nil>  false 9090 0.0.0.0}"}
{"severity":"WARNING","timestamp":"2022-03-31T08:40:02.805865024Z","logger":"pipelinesascode","caller":"v2/config.go:185","message":"Tracing configuration is invalid, using the no-op default{error 26 0  empty json tracing config}"}
{"severity":"WARNING","timestamp":"2022-03-31T08:40:02.805890561Z","logger":"pipelinesascode","caller":"v2/config.go:178","message":"Sink timeout configuration is invalid, default to -1 (no timeout)"}
{"level":"info","ts":1648716002.805917,"caller":"adapter/adapter.go:52","msg":"Starting Pipelines as Code version: nightly"}

```

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI 
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please make sure to document it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then make sure to get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
