### PR TITLE
Read pac installation namespace from env

### DIFF
--- a/pkg/params/info/defaults.go
+++ b/pkg/params/info/defaults.go
@@ -3,8 +3,7 @@ package info
 import "time"
 
 const (
-	PACInstallNS              = "pipelines-as-code"
-	PACConfigmapNS            = "pipelines-as-code"
+	PACConfigmapName          = "pipelines-as-code"
 	PACApplicationName        = "Pipelines as Code CI"
 	HubURL                    = "https://api.hub.tekton.dev/v1"
 	DefaultPipelineRunTimeout = 2 * time.Hour

--- a/pkg/params/run.go
+++ b/pkg/params/run.go
@@ -2,6 +2,7 @@ package params
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -28,7 +29,11 @@ func StringToBool(s string) bool {
 // GetConfigFromConfigMap get config from configmap, we should remove all the
 // logics from cobra flags and just support configmap config and env config in the future.
 func (r *Run) GetConfigFromConfigMap(ctx context.Context) error {
-	cfg, err := r.Clients.Kube.CoreV1().ConfigMaps(info.PACInstallNS).Get(ctx, info.PACConfigmapNS, v1.GetOptions{})
+	ns := os.Getenv("SYSTEM_NAMESPACE")
+	if ns == "" {
+		return fmt.Errorf("failed to find pipelines-as-code installation namespace")
+	}
+	cfg, err := r.Clients.Kube.CoreV1().ConfigMaps(ns).Get(ctx, info.PACConfigmapName, v1.GetOptions{})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
this removes hardcoded pac installation namespace and
read it from env

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI 
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please make sure to document it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then make sure to get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
