### PR TITLE
Improve logging for skipped event and validate payload before processing

### DIFF
--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -2,6 +2,7 @@ package adapter
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -84,6 +85,14 @@ func (l listener) handleEvent() http.HandlerFunc {
 		if err != nil {
 			l.run.Clients.Log.Errorf("failed to read body : %v", err)
 			response.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		// payload validation
+		var event map[string]interface{}
+		if err := json.Unmarshal(payload, &event); err != nil {
+			l.run.Clients.Log.Errorf("Invalid event body format format: %s", err)
+			response.WriteHeader(http.StatusBadRequest)
 			return
 		}
 

--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -85,6 +85,11 @@ func (l listener) handleEvent() http.HandlerFunc {
 	return func(response http.ResponseWriter, request *http.Request) {
 		ctx := context.Background()
 
+		if request.Method != http.MethodPost {
+			l.writeResponse(response, http.StatusOK, "ok")
+			return
+		}
+
 		// event body
 		payload, err := ioutil.ReadAll(request.Body)
 		if err != nil {

--- a/test/invalid_event_test.go
+++ b/test/invalid_event_test.go
@@ -84,3 +84,27 @@ func TestSkippedEvent(t *testing.T) {
 
 	assert.Equal(t, resp.StatusCode, http.StatusOK)
 }
+
+func TestGETCall(t *testing.T) {
+	ctx := context.TODO()
+
+	elURL := os.Getenv("TEST_EL_URL")
+	if elURL == "" {
+		t.Fatal("failed to find event listener url")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", elURL, nil)
+	if err != nil {
+		t.Fatal("failed to build request : ", err)
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal("failed to send request : ", err)
+	}
+	assert.NilError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, resp.StatusCode, http.StatusOK)
+}

--- a/test/invalid_event_test.go
+++ b/test/invalid_event_test.go
@@ -1,0 +1,86 @@
+//go:build e2e
+// +build e2e
+
+package test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/google/go-github/v43/github"
+	"gotest.tools/v3/assert"
+)
+
+func TestUnsupportedEvent(t *testing.T) {
+	ctx := context.TODO()
+
+	event := github.ReleaseEvent{}
+	eventType := "release_event"
+
+	jeez, err := json.Marshal(event)
+	if err != nil {
+		t.Fatal("failed to marshal event: ", err)
+	}
+
+	elURL := os.Getenv("TEST_EL_URL")
+	if elURL == "" {
+		t.Fatal("failed to find event listener url")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", elURL, bytes.NewBuffer(jeez))
+	if err != nil {
+		t.Fatal("failed to build request : ", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Event", eventType)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal("failed to send request : ", err)
+	}
+	assert.NilError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, resp.StatusCode, http.StatusOK)
+}
+
+func TestSkippedEvent(t *testing.T) {
+	ctx := context.TODO()
+
+	event := github.PullRequestEvent{
+		Action: github.String("closed"),
+	}
+	eventType := "pull_request"
+
+	jeez, err := json.Marshal(event)
+	if err != nil {
+		t.Fatal("failed to marshal event: ", err)
+	}
+
+	elURL := os.Getenv("TEST_EL_URL")
+	if elURL == "" {
+		t.Fatal("failed to find event listener url")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", elURL, bytes.NewBuffer(jeez))
+	if err != nil {
+		t.Fatal("failed to build request : ", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Event", eventType)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal("failed to send request : ", err)
+	}
+	assert.NilError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, resp.StatusCode, http.StatusOK)
+}


### PR DESCRIPTION
 log skipped event as info and log error only for unsupported
controller used to log error for skipped event, now we log skipped
event as info with their id in log, for easy debugging and log
error for unsupported event and when necessary.
&
validate payload for valid json before processing

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI 
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please make sure to document it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then make sure to get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
