### PR TITLE
Gitlab: adds payload validation using webhook secret

### DIFF
--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -45,6 +45,13 @@ type Provider struct {
 }
 
 func (v *Provider) Validate(ctx context.Context, params *params.Run, event *info.Event) error {
+	token := event.Request.Header.Get("X-Gitlab-Token")
+	if event.Provider.WebhookSecret == "" && token != "" {
+		return fmt.Errorf("gitlab failed validaton: failed to find webhook secret")
+	}
+	if event.Provider.WebhookSecret != token {
+		return fmt.Errorf("gitlab failed validaton: event's secret doesn't match with webhook secret")
+	}
 	return nil
 }
 

--- a/test/pkg/gitlab/crd.go
+++ b/test/pkg/gitlab/crd.go
@@ -19,8 +19,13 @@ func CreateCRD(ctx context.Context, projectinfo *gitlab.Project, run *params.Run
 	}
 
 	token, _ := os.LookupEnv("TEST_GITLAB_TOKEN")
+	webhookSecret, _ := os.LookupEnv("TEST_EL_WEBHOOK_SECRET")
 	apiURL, _ := os.LookupEnv("TEST_GITLAB_API_URL")
 	err = secret.Create(ctx, run, map[string]string{"token": token}, targetNS, "webhook-token")
+	if err != nil {
+		return err
+	}
+	err = secret.Create(ctx, run, map[string]string{"secret": webhookSecret}, targetNS, "webhook-secret")
 	if err != nil {
 		return err
 	}
@@ -31,8 +36,9 @@ func CreateCRD(ctx context.Context, projectinfo *gitlab.Project, run *params.Run
 		Spec: v1alpha1.RepositorySpec{
 			URL: projectinfo.WebURL,
 			GitProvider: &v1alpha1.GitProvider{
-				URL:    apiURL,
-				Secret: &v1alpha1.GitProviderSecret{Name: "webhook-token", Key: "token"},
+				URL:           apiURL,
+				Secret:        &v1alpha1.GitProviderSecret{Name: "webhook-token", Key: "token"},
+				WebhookSecret: &v1alpha1.GitProviderSecret{Name: "webhook-secret", Key: "secret"},
 			},
 		},
 	}

--- a/test/pkg/gitlab/setup.go
+++ b/test/pkg/gitlab/setup.go
@@ -32,6 +32,12 @@ func Setup(ctx context.Context) (*params.Run, options.E2E, gitlab.Provider, erro
 			return nil, options.E2E{}, gitlab.Provider{}, fmt.Errorf("\"TEST_%s\" env variable is required, cannot continue", value)
 		}
 	}
+
+	gitlabWebhookSecret := os.Getenv("TEST_EL_WEBHOOK_SECRET")
+	if gitlabWebhookSecret == "" {
+		return nil, options.E2E{}, gitlab.Provider{}, fmt.Errorf("TEST_EL_WEBHOOK_SECRET env variable is required, cannot continue")
+	}
+
 	run := &params.Run{}
 	if err := run.Clients.NewClients(ctx, &run.Info); err != nil {
 		return nil, options.E2E{}, gitlab.Provider{}, err


### PR DESCRIPTION
this enables webhook secret validation for gitlab. user
need to defined a secret and referenc in repo cr, pac will
look for secret in event header and try to validate with the
one ref in repo CR.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI 
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please make sure to document it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then make sure to get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
