### PR TITLE
Create stable tags on release

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -7,7 +7,7 @@ metadata:
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/task: "[git-clone, .tekton/tasks/buildah-user.yaml]"
-    pipelinesascode.tekton.dev/task-1: "[https://git.io/Jn9Ee]"  # send-slack-notifications task
+    pipelinesascode.tekton.dev/task-1: "[https://git.io/Jn9Ee]"
 spec:
   taskRunSpecs:
     - pipelineTaskName: push-to-registry
@@ -129,9 +129,13 @@ spec:
                 #!/usr/bin/env bash
                 set -eu
                 set +x # Do not show TOKEN in logs
-                hack/upload-file-to-github.py --message "Release yaml generated from {{repo_url}}/commit/{{revision}}" --branch-ref refs/heads/nightly --owner-repository openshift-pipelines/pipelines-as-code --token ${HUB_TOKEN} -d release.k8s.yaml -f <(./hack/generate-releaseyaml.sh)
-
-                hack/upload-file-to-github.py --message "OpenShift release yaml generated from {{repo_url}}/commit/{{revision}}" --branch-ref refs/heads/nightly --owner-repository openshift-pipelines/pipelines-as-code --token ${HUB_TOKEN} -d release.yaml -f <(env TARGET_OPENSHIFT=true ./hack/generate-releaseyaml.sh)
+                hack/upload-file-to-github.py \
+                --message "Release yaml generated from {{repo_url}}/commit/{{revision}}" \
+                --branch-ref refs/heads/nightly \
+                --owner-repository openshift-pipelines/pipelines-as-code \
+                --token ${HUB_TOKEN} \
+                -f <(./hack/generate-releaseyaml.sh):release.k8s.yaml  \
+                -f <(env TARGET_OPENSHIFT=true ./hack/generate-releaseyaml.sh):release.yaml
               workingDir: $(workspaces.source.path)
           workspaces:
             - name: source

--- a/.tekton/release-pipeline.yaml
+++ b/.tekton/release-pipeline.yaml
@@ -63,24 +63,17 @@ spec:
                     echo "No tags detected"
                     exit
                 }
-                msg="Release version ${version}"
+                stable_tag=${version%.*}.x
+                msg="Release ${version}, Stable Tag: ${stable_tag}"
                 echo ${msg}
-                export TARGET_BRANCH=${version}
-                export PAC_VERSION=${version}
                 hack/upload-file-to-github.py \
-                    --message "Release yaml generated for Release ${TARGET_BRANCH}" \
+                    --message "Release yaml generated for ${msg}" \
                     --owner-repository openshift-pipelines/pipelines-as-code \
                     --token ${HUB_TOKEN} \
-                    --from-tag=refs/tags/${TARGET_BRANCH} \
-                    -d release-${TARGET_BRANCH}.k8s.yaml -f <(./hack/generate-releaseyaml.sh)
-
-                hack/upload-file-to-github.py \
-                    --message "OpenShift release.yaml generated for Release ${TARGET_BRANCH}" \
-                    --owner-repository openshift-pipelines/pipelines-as-code \
-                    --token ${HUB_TOKEN} \
-                    --branch-ref refs/heads/release-${TARGET_BRANCH} \
-                    -d release-${TARGET_BRANCH}.yaml -f <(env TARGET_OPENSHIFT=true ./hack/generate-releaseyaml.sh)
-                exit 0
+                    --update-tags=stable,${stable_tag} \
+                    --from-tag=refs/tags/${version} \
+                    -f <(./hack/generate-releaseyaml.sh):release.k8s.yaml \
+                    -f <(env TARGET_OPENSHIFT=true ./hack/generate-releaseyaml.sh):release.yaml
       - name: gorelease
         runAfter:
           - release-yaml

--- a/docs/content/docs/install/installation.md
+++ b/docs/content/docs/install/installation.md
@@ -9,7 +9,7 @@ To install Pipelines as Code on your cluster you simply need to run this command
 
 ```shell
 VERSION=0.5.5
-kubectl apply -f https://raw.githubusercontent.com/openshift-pipelines/pipelines-as-code/release-$VERSION/release-$VERSION.yaml
+kubectl apply -f https://raw.githubusercontent.com/openshift-pipelines/pipelines-as-code/stable/release.yaml
 ```
 
 If you would like to install the current development version you can simply

--- a/docs/content/docs/install/kubernetes.md
+++ b/docs/content/docs/install/kubernetes.md
@@ -12,16 +12,15 @@ The release yaml to install pipelines are for the released version :
 
 ```shell
 VERSION=0.5.3
-kubectl apply -f https://raw.githubusercontent.com/openshift-pipelines/pipelines-as-code/release-$VERSION/release-$VERSION.k8s.yaml
+kubectl apply -f https://raw.githubusercontent.com/openshift-pipelines/pipelines-as-code/stable/release.k8s.yaml
 ```
 
 and for the nightly :
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/openshift-pipelines/pipelines-as-code/release-$VERSION/release.k8s.yaml
+kubectl apply -f https://raw.githubusercontent.com/openshift-pipelines/pipelines-as-code/nightly/release.k8s.yaml
 ```
 
 If you have [Tekton Dashboard](https://github.com/tektoncd/dashboard). You can
 just add the key `tekton-dashboard-url` in the `pipelines-as-code` configmap
 set to the full url of the `Ingress` host to get tekton dashboard logs url.
-


### PR DESCRIPTION
* Change the release script, this will (if we push the tag 0.5.5 to repo) :

- On Github owner/repo use the refs/heads/0.5.5 tag
- Create a branch from 0.5.5 tag
- Create the branch release-0.5.5
- Upload the file file.txt to the destination dest.txt on the release-0.5.5 branch
- Upload another file hello.txt to the destination moto.txt on the release-0.5.5 branch
- Force update or create the tag stable to point to the release-0.5.5 branch
- Force update or create the tag 0.5.x to point to the release-0.5.5 branch

* Support now force push a tag, if we have made a bad release it will
  overwrite it.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI 
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please make sure to document it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then make sure to get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
