### PR TITLE
Supporting same kind of events across providers:

### DIFF
--- a/pkg/provider/bitbucketserver/bitbucketserver.go
+++ b/pkg/provider/bitbucketserver/bitbucketserver.go
@@ -270,7 +270,7 @@ func (v *Provider) Detect(reqHeader *http.Header, payload string, logger *zap.Su
 		if provider.Valid(event, []string{"pr:from_ref_updated", "pr:opened"}) {
 			return setLoggerAndProceed()
 		}
-		if provider.Valid(event, []string{"pr:comment:added", "pr:comment:edited"}) {
+		if provider.Valid(event, []string{"pr:comment:added"}) {
 			if provider.IsRetestComment(e.Comment.Text) {
 				return setLoggerAndProceed()
 			}

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -243,7 +243,7 @@ func (v *Provider) Detect(reqHeader *http.Header, payload string, logger *zap.Su
 		return isGH, false, logger, nil
 
 	case *github.PullRequestEvent:
-		if provider.Valid(gitEvent.GetAction(), []string{"created", "synchronize", "opened"}) {
+		if provider.Valid(gitEvent.GetAction(), []string{"opened", "synchronize", "reopened"}) {
 			return setLoggerAndProceed()
 		}
 		return isGH, false, logger, nil

--- a/pkg/provider/github/github_test.go
+++ b/pkg/provider/github/github_test.go
@@ -678,7 +678,7 @@ func TestProvider_Detect(t *testing.T) {
 		{
 			name: "pull request event",
 			event: github.PullRequestEvent{
-				Action: github.String("created"),
+				Action: github.String("opened"),
 			},
 			eventType:  "pull_request",
 			isGH:       true,

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -73,7 +73,10 @@ func (v *Provider) Detect(reqHeader *http.Header, payload string, logger *zap.Su
 
 	switch gitEvent := eventInt.(type) {
 	case *gitlab.MergeEvent:
-		return setLoggerAndProceed()
+		if provider.Valid(gitEvent.ObjectAttributes.Action, []string{"open", "update", "reopen"}) {
+			return setLoggerAndProceed()
+		}
+		return isGL, false, logger, nil
 	case *gitlab.PushEvent:
 		return setLoggerAndProceed()
 	case *gitlab.MergeCommentEvent:

--- a/pkg/provider/gitlab/test/test.go
+++ b/pkg/provider/gitlab/test/test.go
@@ -181,6 +181,7 @@ func (t TEvent) MREventAsJSON() string {
         "default_branch": "%s"
     },
     "object_attributes": {
+		"action": "open",
         "iid": %d,
         "source_project_id": %d,
         "title": "%s",


### PR DESCRIPTION
this updates providers to process same kind of events
- pull request (open, updated, reopened)
- push,
- comment (only when created) : /retest, /ok-to-test

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI 
- [x] 📖 If you are adding a user facing feature or make a change of the behavior, please make sure to document it
- [x] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [x] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [x] 🔎 If there is a flakiness in the CI tests then make sure to get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
