### PR TITLE
Use defaults for pipelinerun template in repo create cmd

### DIFF
--- a/docs/content/docs/guide/cli.md
+++ b/docs/content/docs/guide/cli.md
@@ -106,7 +106,7 @@ github application and the secret with all the information needed in the
 {{< details "tkn pac repo create" >}}
 ### Repository creation
 
-`tkn pac repo create` -- will create a new Pipelines as Code Repository and a namespace where the pipelineruns command. It will launch the `tkn pac generate` command right after the creation.
+`tkn pac repo create` -- will create a new Pipelines as Code Repository and a namespace where the pipelineruns command. It will also generate a sample file with a [PipelineRun](./autoringprs/) in the `.tekton` directory called `pipelinerun.yaml` targeting the `main` branch and the `pull_request` and `push` events.  You can customize this by editing the [PipelineRun](./autoringprs/) to target a different branch or event. 
 {{< /details >}}
 
 {{< details "tkn pac repo list" >}}

--- a/pkg/cmd/tknpac/generate/generate_test.go
+++ b/pkg/cmd/tknpac/generate/generate_test.go
@@ -130,7 +130,7 @@ func TestGetRepoURL(t *testing.T) {
 			}
 
 			err := Generate(&Opts{
-				event:     &tt.event,
+				Event:     &tt.event,
 				GitInfo:   &tt.gitinfo,
 				IOStreams: io,
 				CLIOpts:   &cli.PacCliOpts{},

--- a/pkg/cmd/tknpac/generate/template.go
+++ b/pkg/cmd/tknpac/generate/template.go
@@ -172,14 +172,14 @@ func (o *Opts) genTmpl() (bytes.Buffer, error) {
 	t := template.Must(template.New("PipelineRun").Delims("<<", ">>").Parse(pipelineRunTmpl))
 	prName := fmt.Sprintf("%s-%s",
 		filepath.Base(o.GitInfo.URL),
-		strings.ReplaceAll(o.event.EventType, "_", "-"))
+		strings.ReplaceAll(o.Event.EventType, "_", "-"))
 	lang, err := o.detectLanguage()
 	if err != nil {
 		return bytes.Buffer{}, err
 	}
 	data := map[string]interface{}{
 		"prName":                  prName,
-		"event":                   o.event,
+		"event":                   o.Event,
 		"extra_task":              lang,
 		"language_specific_tasks": "",
 	}

--- a/pkg/cmd/tknpac/repository/create.go
+++ b/pkg/cmd/tknpac/repository/create.go
@@ -74,6 +74,10 @@ func CreateCommand(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
 			gopt.IOStreams = createOpts.ioStreams
 			gopt.CLIOpts = createOpts.cliOpts
 
+			// defaulting the values for repo create command
+			gopt.Event.EventType = "[pull_request, push]"
+			gopt.Event.BaseBranch = "main"
+
 			return generate.Generate(gopt)
 		},
 		Annotations: map[string]string{


### PR DESCRIPTION
this updates the repo create cmd to skip asking event type to user
and use default '[pull_request, push]' as event type for template
generation. the focus of repo create cmd is to create repo and
generation of template is an additional feature so we use defaults
for that now and skip asking user for input.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Updated Behaviour:

new template:
```
 > ~/go/src/github.com/openshift-pipelines/pac-demo (main) > tkn pac repo new
? Enter the Git repository url containing the pipelines (default: https://github.com/sm43/pac-demo):  
? Please enter the namespace where the pipeline will be created (default: pac-demo-pipelines): pac-demo
! Namespace pac-demo is not found
? Would you like me to create the namespace pac-demo? Yes
✓ Repository sm43-pac-demo has been created in pac-demo namespace
ℹ Directory .tekton has been created.
✓ A basic template has been created in /home/smukhade/go/src/github.com/openshift-pipelines/pac-demo/.tekton/sample-pipelinerun.yaml, feel free to customize it.
ℹ You can test your pipeline manually with: tkn-pac resolve -f .tekton/sample-pipelinerun.yaml | kubectl create -f-
```
template already exist:
```
tkn pac repo new
? Enter the Git repository url containing the pipelines (default: https://github.com/sm43/pac-demo):  
? Please enter the namespace where the pipeline will be created (default: pac-demo-pipelines): pac-demo
✓ Repository sm43-pac-demo has been created in pac-demo namespace
? There is already a file named: .tekton/sample-pipelinerun.yaml would you like me to override it? No
! Not overwriting file, exiting...
ℹ Feel free to use the -f flag if you want to target another file name
```

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI 
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please make sure to document it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then make sure to get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
