### PR TITLE
Remove payload fix func in github

### DIFF
--- a/pkg/provider/github/events.go
+++ b/pkg/provider/github/events.go
@@ -24,23 +24,6 @@ const (
 	secretName = "pipelines-as-code-secret"
 )
 
-// payloadFix since we are getting a bunch of \r\n or \n and others from triggers/github, so let just
-// workaround it. Originally from https://stackoverflow.com/a/52600147
-func (v *Provider) payloadFix(payload string) []byte {
-	replacement := " "
-	replacer := strings.NewReplacer(
-		"\r\n", replacement,
-		"\r", replacement,
-		"\n", replacement,
-		"\v", replacement,
-		"\f", replacement,
-		"\u0085", replacement,
-		"\u2028", replacement,
-		"\u2029", replacement,
-	)
-	return []byte(replacer.Replace(payload))
-}
-
 func (v *Provider) getAppToken(ctx context.Context, kube kubernetes.Interface, gheURL string, installationID int64) (string, error) {
 	// TODO: move this out of here
 	ns := os.Getenv("SYSTEM_NAMESPACE")
@@ -139,14 +122,13 @@ func (v *Provider) ParsePayload(ctx context.Context, run *params.Run, request *h
 		}
 	}
 
-	payloadTreated := v.payloadFix(payload)
-	eventInt, err := github.ParseWebHook(event.EventType, payloadTreated)
+	eventInt, err := github.ParseWebHook(event.EventType, []byte(payload))
 	if err != nil {
 		return nil, err
 	}
 
 	// should not get invalid json since we already check it in github.ParseWebHook
-	_ = json.Unmarshal(payloadTreated, &eventInt)
+	_ = json.Unmarshal([]byte(payload), &eventInt)
 
 	processedEvent, err := v.processEvent(ctx, run, event, eventInt)
 	if err != nil {

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -207,13 +207,12 @@ func (v *Provider) Detect(reqHeader *http.Header, payload string, logger *zap.Su
 		return isGH, true, logger, nil
 	}
 
-	payloadTreated := v.payloadFix(string(payload))
-	eventInt, err := github.ParseWebHook(event, payloadTreated)
+	eventInt, err := github.ParseWebHook(event, []byte(payload))
 	if err != nil {
 		return isGH, false, logger, err
 	}
 
-	_ = json.Unmarshal(payloadTreated, &eventInt)
+	_ = json.Unmarshal([]byte(payload), &eventInt)
 
 	switch gitEvent := eventInt.(type) {
 	case *github.CheckRunEvent:


### PR DESCRIPTION
as we directly process the payload coming from github, we don't
anymore need to fix it before using as compared to previous
where it was coming from tetkon triggers. this removes the func.

Closes #515 

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI 
- [x] 📖 If you are adding a user facing feature or make a change of the behavior, please make sure to document it
- [x] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [x] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [x] 🔎 If there is a flakiness in the CI tests then make sure to get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
