### PR TITLE
Bitbucket-server: adds payload validation using webhook secret

### DIFF
--- a/pkg/provider/bitbucketserver/bitbucketserver.go
+++ b/pkg/provider/bitbucketserver/bitbucketserver.go
@@ -2,21 +2,14 @@ package bitbucketserver
 
 import (
 	"context"
-	"crypto/hmac"
-
-	//nolint
-	"crypto/sha1"
-	"crypto/sha256"
-	"crypto/sha512"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"hash"
 	"net/http"
 	"path/filepath"
 	"strings"
 
 	bbv1 "github.com/gfleury/go-bitbucket-v1"
+	"github.com/google/go-github/v43/github"
 	"github.com/mitchellh/mapstructure"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
@@ -40,35 +33,10 @@ type Provider struct {
 
 func (v *Provider) Validate(ctx context.Context, params *params.Run, event *info.Event) error {
 	signature := event.Request.Header.Get("X-Hub-Signature")
-	key := event.Provider.WebhookSecret
 	if event.Provider.WebhookSecret == "" && signature != "" {
 		return fmt.Errorf("bitbucket-server failed validaton: failed to find webhook secret")
 	}
-
-	sigParts := strings.Split(signature, "=")
-
-	var hashFunc func() hash.Hash
-	switch sigParts[0] {
-	case "sha1":
-		hashFunc = sha1.New
-	case "sha256":
-		hashFunc = sha256.New
-	case "sha512":
-		hashFunc = sha512.New
-	default:
-		return fmt.Errorf("bitbucket-server failed validaton: unknown hash type prefix: %q", sigParts[0])
-	}
-
-	hash := hmac.New(hashFunc, []byte(key))
-	if _, err := hash.Write(event.Request.Payload); err != nil {
-		return fmt.Errorf("bitbucket-server failed validaton: cannot compute the HMAC for request: %w", err)
-	}
-	expectedHash := hex.EncodeToString(hash.Sum(nil))
-
-	if sigParts[1] != expectedHash {
-		return fmt.Errorf("bitbucket-server failed validaton: payload hash doesn't match with computed hash")
-	}
-	return nil
+	return github.ValidateSignature(signature, event.Request.Payload, []byte(event.Provider.WebhookSecret))
 }
 
 // sanitizeTitle make sure we only get the tile by remove everything after \n.


### PR DESCRIPTION
this enables webhook secret validation for bitbucket-server.
user need to defined a secret and reference in repo cr, pac will
look for signature in event header and do a hmac validation of
payload and match it with hash in header.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI 
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please make sure to document it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then make sure to get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
