### PR TITLE
fixes comment regex to allow string along with /retest and /ok-to-test

### DIFF
--- a/pkg/provider/github/github_test.go
+++ b/pkg/provider/github/github_test.go
@@ -622,11 +622,11 @@ func TestProvider_Detect(t *testing.T) {
 				Installation: &github.Installation{
 					ID: github.Int64(123),
 				},
-				Comment: &github.IssueComment{Body: github.String("/ok-to-test \n, don't let me in :)")},
+				Comment: &github.IssueComment{Body: github.String("/ok-to-test \n let me in :)")},
 			},
 			eventType:  "issue_comment",
 			isGH:       true,
-			processReq: false,
+			processReq: true,
 		},
 		{
 			name: "issue comment Event with retest",
@@ -664,7 +664,7 @@ func TestProvider_Detect(t *testing.T) {
 			},
 			eventType:  "issue_comment",
 			isGH:       true,
-			processReq: false,
+			processReq: true,
 		},
 		{
 			name: "push event",

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -1,10 +1,12 @@
 package provider
 
-import "regexp"
+import (
+	"regexp"
+)
 
-const (
-	retestRegex   = "(^|\\\\r\\\\n)/retest([ ]*$|$|\\\\r\\\\n)"
-	oktotestRegex = "(^|\\\\r\\\\n)/ok-to-test([ ]*$|$|\\\\r\\\\n)"
+var (
+	retestRegex   = regexp.MustCompile(`(?m)^/retest\s*$`)
+	oktotestRegex = regexp.MustCompile(`(?m)^/ok-to-test\s*$`)
 )
 
 func Valid(value string, validValues []string) bool {
@@ -17,11 +19,9 @@ func Valid(value string, validValues []string) bool {
 }
 
 func IsRetestComment(comment string) bool {
-	matches, _ := regexp.MatchString(retestRegex, comment)
-	return matches
+	return retestRegex.MatchString(comment)
 }
 
 func IsOkToTestComment(comment string) bool {
-	matches, _ := regexp.MatchString(oktotestRegex, comment)
-	return matches
+	return oktotestRegex.MatchString(comment)
 }

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -18,8 +18,28 @@ func TestIsOkToTestComment(t *testing.T) {
 			want:    true,
 		},
 		{
+			name:    "valid with some string before",
+			comment: "/lgtm \n/ok-to-test",
+			want:    true,
+		},
+		{
+			name:    "valid with some string before and after",
+			comment: "hi, trigger the ci \n/ok-to-test \n then report the status back",
+			want:    true,
+		},
+		{
+			name:    "valid comments",
+			comment: "/lgtm \n/ok-to-test \n/approve",
+			want:    true,
+		},
+		{
 			name:    "invalid",
 			comment: "/ok",
+			want:    false,
+		},
+		{
+			name:    "invalid comment",
+			comment: "/ok-to-test abc",
 			want:    false,
 		},
 	}
@@ -44,8 +64,28 @@ func TestIsRetestComment(t *testing.T) {
 			want:    true,
 		},
 		{
+			name:    "valid with some string before",
+			comment: "/lgtm \n/retest",
+			want:    true,
+		},
+		{
+			name:    "valid with some string before and after",
+			comment: "hi, trigger the ci \n/retest \n then report the status back",
+			want:    true,
+		},
+		{
+			name:    "valid comments",
+			comment: "/lgtm \n/retest \n/approve",
+			want:    true,
+		},
+		{
 			name:    "invalid",
 			comment: "/ok",
+			want:    false,
+		},
+		{
+			name:    "invalid comment",
+			comment: "/retest abc",
 			want:    false,
 		},
 	}


### PR DESCRIPTION
comments with some string and (retest)/(ok-to-test) were failing as regex
was failing to parse it, this update the regex.
(/retest and /ok-to-test must be on a separate line with nothing else on
that line, then the comment will be processed)
now, following comments are allowed
valid eg.
```
abcde
/retest
xyz
```

```
/lgtm
/ok-to-test
```

invalid eg.

```
/retest abc
```
or
```
/ok-to-test xyz
```

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI 
- [x] 📖 If you are adding a user facing feature or make a change of the behavior, please make sure to document it
- [x] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [x] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [x] 🔎 If there is a flakiness in the CI tests then make sure to get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
