### PR TITLE
DNM: Adds clusterrole so that non-admin user can access repository CR

### DIFF
--- a/config/200-role.yaml
+++ b/config/200-role.yaml
@@ -125,3 +125,28 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: openshift-pipeline-as-code-clusterrole
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pipelines-as-code-aggregate
+  labels:
+    app.kubernetes.io/version: "devel"
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: pipelines-as-code
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+  - apiGroups:
+    - pipelinesascode.tekton.dev
+    resources:
+    - repositories
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch

--- a/pkg/provider/github/events.go
+++ b/pkg/provider/github/events.go
@@ -49,7 +49,7 @@ func (v *Provider) getAppToken(ctx context.Context, info *info.PacOpts) error {
 	if err != nil {
 		return fmt.Errorf("could not parse installation_id: %w", err)
 	}
-	v.ApplicationID = &applicationID
+	v.ApplicationID = &installationID
 
 	// check if the path exists
 	if _, err := os.Stat(workspacePath); os.IsNotExist(err) {

--- a/pkg/provider/github/events.go
+++ b/pkg/provider/github/events.go
@@ -49,6 +49,7 @@ func (v *Provider) getAppToken(ctx context.Context, info *info.PacOpts) error {
 	if err != nil {
 		return fmt.Errorf("could not parse installation_id: %w", err)
 	}
+	v.ApplicationID = &applicationID
 
 	// check if the path exists
 	if _, err := os.Stat(workspacePath); os.IsNotExist(err) {

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -17,6 +17,7 @@ const apiPublicURL = "https://api.github.com/"
 type Provider struct {
 	Client        *github.Client
 	Token, APIURL *string
+	ApplicationID *int64
 }
 
 func (v *Provider) GetConfig() *info.ProviderConfig {

--- a/pkg/provider/github/status.go
+++ b/pkg/provider/github/status.go
@@ -35,25 +35,53 @@ func getCheckName(status provider.StatusOpts, pacopts *info.PacOpts) string {
 	return status.OriginalPipelineRunName
 }
 
-// createCheckRunStatus create a status via the checkRun API, which is only
+func (v *Provider) getExistingCheckRunID(ctx context.Context, runevent *info.Event) (*int64, error) {
+	res, _, err := v.Client.Checks.ListCheckRunsForRef(ctx, runevent.Organization, runevent.Repository,
+		runevent.SHA, &github.ListCheckRunsOptions{
+			AppID: v.ApplicationID,
+		})
+	if err != nil {
+		return nil, err
+	}
+	if *res.Total > 0 {
+		// Their should be only one, since we CRUD it.. maybe one day we
+		// will offer the ability to do multiple pipelineruns per commit then
+		// things will get more complicated here.
+		return res.CheckRuns[0].ID, nil
+	}
+	return nil, nil
+}
+
+func (v *Provider) createCheckRunStatus(ctx context.Context, runevent *info.Event, pacopts *info.PacOpts, status provider.StatusOpts) (*int64, error) {
+	now := github.Timestamp{Time: time.Now()}
+	checkrunoption := github.CreateCheckRunOptions{
+		Name:       getCheckName(status, pacopts),
+		HeadSHA:    runevent.SHA,
+		Status:     github.String("in_progress"),
+		DetailsURL: github.String(pacopts.LogURL),
+		StartedAt:  &now,
+	}
+
+	checkRun, _, err := v.Client.Checks.CreateCheckRun(ctx, runevent.Organization, runevent.Repository, checkrunoption)
+	if err != nil {
+		return nil, err
+	}
+	return checkRun.ID, nil
+}
+
+// getOrUpdateCheckRunStatus create a status via the checkRun API, which is only
 // available with Github apps tokens.
-func (v *Provider) createCheckRunStatus(ctx context.Context, runevent *info.Event, pacopts *info.PacOpts, status provider.StatusOpts) error {
+func (v *Provider) getOrUpdateCheckRunStatus(ctx context.Context, runevent *info.Event, pacopts *info.PacOpts, status provider.StatusOpts) error {
+	var err error
+
 	now := github.Timestamp{Time: time.Now()}
 	if runevent.CheckRunID == nil {
-		now := github.Timestamp{Time: time.Now()}
-		checkrunoption := github.CreateCheckRunOptions{
-			Name:       getCheckName(status, pacopts),
-			HeadSHA:    runevent.SHA,
-			Status:     github.String("in_progress"),
-			DetailsURL: github.String(pacopts.LogURL),
-			StartedAt:  &now,
+		if runevent.CheckRunID, _ = v.getExistingCheckRunID(ctx, runevent); runevent.CheckRunID == nil {
+			runevent.CheckRunID, err = v.createCheckRunStatus(ctx, runevent, pacopts, status)
+			if err != nil {
+				return err
+			}
 		}
-
-		checkRun, _, err := v.Client.Checks.CreateCheckRun(ctx, runevent.Organization, runevent.Repository, checkrunoption)
-		if err != nil {
-			return err
-		}
-		runevent.CheckRunID = checkRun.ID
 	}
 
 	checkRunOutput := &github.CheckRunOutput{
@@ -78,7 +106,7 @@ func (v *Provider) createCheckRunStatus(ctx context.Context, runevent *info.Even
 		opts.Conclusion = &status.Conclusion
 	}
 
-	_, _, err := v.Client.Checks.UpdateCheckRun(ctx, runevent.Organization, runevent.Repository, *runevent.CheckRunID, opts)
+	_, _, err = v.Client.Checks.UpdateCheckRun(ctx, runevent.Organization, runevent.Repository, *runevent.CheckRunID, opts)
 	return err
 }
 
@@ -156,5 +184,5 @@ func (v *Provider) CreateStatus(ctx context.Context, runevent *info.Event, pacop
 	if pacopts.ProviderInfoFromRepo {
 		return v.createStatusCommit(ctx, runevent, pacopts, status)
 	}
-	return v.createCheckRunStatus(ctx, runevent, pacopts, status)
+	return v.getOrUpdateCheckRunStatus(ctx, runevent, pacopts, status)
 }

--- a/pkg/provider/github/status_test.go
+++ b/pkg/provider/github/status_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -23,11 +24,43 @@ func TestGithubProviderCreateCheckRun(t *testing.T) {
 	event := &info.Event{
 		Organization: "check",
 		Repository:   "info",
+		SHA:          "createCheckRunSHA",
 	}
 
-	err := gcvs.createCheckRunStatus(ctx, event, &info.PacOpts{LogURL: "http://nowhere"}, provider.StatusOpts{Status: "hello moto"})
+	err := gcvs.getOrUpdateCheckRunStatus(ctx, event, &info.PacOpts{LogURL: "http://nowhere"}, provider.StatusOpts{Status: "hello moto"})
 	assert.NilError(t, err)
 	assert.Equal(t, *event.CheckRunID, int64(555))
+}
+
+func TestGetExistingCheckRunID(t *testing.T) {
+	ctx, _ := rtesting.SetupFakeContext(t)
+	client, mux, _, teardown := ghtesthelper.SetupGH()
+	defer teardown()
+
+	gvcs := &Provider{
+		Client: client,
+	}
+	event := &info.Event{
+		Organization: "owner",
+		Repository:   "repository",
+		SHA:          "sha",
+	}
+
+	checkRunID := int64(55555)
+	mux.HandleFunc(fmt.Sprintf("/repos/%v/%v/commits/%v/check-runs", event.Organization, event.Repository, event.SHA), func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintf(w, `{
+			"total_count": 1,
+			"check_runs": [
+				{
+					"id": %v
+				}
+			]
+		}`, checkRunID)
+	})
+
+	id, err := gvcs.getExistingCheckRunID(ctx, event)
+	assert.NilError(t, err)
+	assert.Equal(t, *id, checkRunID)
 }
 
 func TestGithubProviderCreateStatus(t *testing.T) {
@@ -300,6 +333,66 @@ func TestGetCheckName(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := getCheckName(tt.args.status, tt.args.pacopts); got != tt.want {
 				t.Errorf("getCheckName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProviderGetExistingCheckRunID(t *testing.T) {
+	tests := []struct {
+		name       string
+		jsonret    string
+		expectedID *int64
+		wantErr    bool
+	}{
+		{
+			name: "has check runs",
+			jsonret: `{
+			"total_count": 1,
+			"check_runs": [
+				{
+					"id": 55555
+				}
+			]
+		}`,
+			expectedID: github.Int64(55555),
+		},
+		{
+			name:       "no check runs",
+			jsonret:    `{"total_count": 0,"check_runs": []}`,
+			expectedID: nil,
+		},
+		{
+			name:       "error it",
+			jsonret:    `BLAHALALACLCALWA`,
+			expectedID: nil,
+			wantErr:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			client, mux, _, teardown := ghtesthelper.SetupGH()
+			defer teardown()
+			event := &info.Event{
+				Organization: "owner",
+				Repository:   "repository",
+				SHA:          "sha",
+			}
+			v := &Provider{
+				Client: client,
+			}
+			mux.HandleFunc(fmt.Sprintf("/repos/%v/%v/commits/%v/check-runs", event.Organization, event.Repository, event.SHA), func(w http.ResponseWriter, r *http.Request) {
+				_, _ = fmt.Fprintf(w, tt.jsonret)
+			})
+
+			got, err := v.getExistingCheckRunID(ctx, event)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getExistingCheckRunID() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.expectedID) {
+				t.Errorf("getExistingCheckRunID() got = %v, want %v", got, tt.expectedID)
 			}
 		})
 	}


### PR DESCRIPTION
this adds a clusterrole using which non admin user would be able to
perform crud operations on repository cr.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please make sure to document it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then make sure to get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
