### PR TITLE
make makefile output quieter

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,9 +46,9 @@ release:
 
     TODO: XXXXX add high level changelog before setting this as released XXXXX
 
-    To install this version you can install the release.yaml with [`kubectl`](https://kubernetes.io/docs/tasks/tools/#kubectl) for your platform :
-
     ## Installation
+
+    To install this version you can install the release.yaml with [`kubectl`](https://kubernetes.io/docs/tasks/tools/#kubectl) for your platform :
 
     ### Openshift
     ```shell
@@ -58,7 +58,6 @@ release:
     ```shell
     kubectl apply -f https://raw.githubusercontent.com/openshift-pipelines/pipelines-as-code/{{.Tags}}/release.k8s.yaml
     ```
-
     ### Documentation
 
     full install documentation is available here:


### PR DESCRIPTION
Make makefile output quieter as what we do on tektoncd/pipeline and add some other makefile target.

For example when there is a failure, it looks like this : 

<img width="1387" alt="image" src="https://user-images.githubusercontent.com/98980/162079201-66888660-7abc-4b23-aa8e-806421c0d8b0.png">

which is much easier on the eyes,

there is make test-unit-verbose  now in case we really want old behaviour.

pro tip you can install [grc](https://github.com/garabik/grc) and have coloured output too : 

```
grc -c conf.go-test make test-unit
```

<img width="1266" alt="image" src="https://user-images.githubusercontent.com/98980/162079772-d199f2b0-b21d-42b9-ac99-87ce17655579.png">

fix some docs bad merge along the way

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com><!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please make sure to document it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then make sure to get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
