### PR TITLE
Generate documentation preview URL

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -4,7 +4,6 @@ on:
   push: # yamllint disable-line
     paths:
       - "**.go"
-      - "**.yaml"
       - "Makefile"
       - "go.mod"
       - "go.sum"
@@ -13,7 +12,6 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - "**.go"
-      - "**.yaml"
       - "Makefile"
       - "go.mod"
       - "go.sum"

--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -60,10 +60,15 @@ spec:
                     secretKeyRef:
                       name: "nightly-ci-github-hub-token"
                       key: "hub-token"
+                - name: UPLOADER_UPLOAD_CREDENTIALS
+                  valueFrom:
+                    secretKeyRef:
+                      name: "uploader-upload-credentials"
+                      key: "credentials"
               script: |
                 cd docs
                 [[ -d {{ revision }} ]]  || exit 0
-                tar czf - {{ revision }} | curl -F path=docs -F targz=true -X POST -F file=@- http://uploader:8080/upload
+                tar czf - {{ revision }} | curl -u ${UPLOADER_UPLOAD_CREDENTIALS} -F path=docs -F targz=true -X POST -F file=@- http://uploader:8080/upload
                 # Post as status
                 set +x
                 curl -H "Authorization: Bearer ${HUB_TOKEN}" -H 'Accept: application/vnd.github.v3+json' -X POST https://api.github.com/repos/{{repo_owner}}/{{repo_name}}/statuses/{{revision}} -d '{"state": "success", "target_url": "https://preview-pipelines-as-code-ci.apps.paac.devcluster.openshift.com/docs/{{ revision }}", "description": "Generated with brio.", "context": "Pipelines as Code Preview URL"}'
@@ -135,6 +140,11 @@ spec:
                   value: $(workspaces.source.path)/go-build-cache/mod
                 - name: GOLANGCILINT_CACHE
                   value: $(workspaces.source.path)/go-build-cache/golangci-cache
+                - name: UPLOADER_UPLOAD_CREDENTIALS
+                  valueFrom:
+                    secretKeyRef:
+                      name: "uploader-upload-credentials"
+                      key: "credentials"
               name: get-cache
               workingDir: $(workspaces.source.path)
               script: |
@@ -149,7 +159,7 @@ spec:
                 }
 
                 echo "Getting cache"
-                curl http://uploader:8080/golang-cache.tar|tar -x -f- || \
+                curl -u ${UPLOADER_UPLOAD_CREDENTIALS} http://uploader:8080/golang-cache.tar|tar -x -f- || \
                    curl -X DELETE -F "file=golang-cache.tar" http://uploader:8080/upload
             - name: unittest
               # we get bumped out when usingh the official image with docker.io
@@ -198,6 +208,12 @@ spec:
               # Has everything we need in there and we already fetched it!
               image: registry.access.redhat.com/ubi8/python-39@sha256:86466a8a2b3981c339f84e791e170055eb3f520e8419f955efa98e93ccaaf5b9
               workingDir: $(workspaces.source.path)
+              env:
+                - name: UPLOADER_UPLOAD_CREDENTIALS
+                  valueFrom:
+                    secretKeyRef:
+                      name: "uploader-upload-credentials"
+                      key: "credentials"
               script: |
                 #!/usr/bin/env bash
                 set -eux
@@ -216,7 +232,8 @@ spec:
                 fi
 
                 cd $(workspaces.source.path)/go-build-cache
-                tar cf - . |curl -# -L -f -F path=golang-cache.tar -X POST -F "file=@-" http://uploader:8080/upload
+                tar cf - . |curl -u ${UPLOADER_UPLOAD_CREDENTIALS} \
+                    -# -L -f -F path=golang-cache.tar -X POST -F "file=@-" http://uploader:8080/upload
 
       - name: codecov
         runAfter:

--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -25,10 +25,51 @@ spec:
             value: $(params.repo_url)
           - name: revision
             value: $(params.revision)
+          - name: depth
+            value: "1000000"
         taskRef:
           name: git-clone
         workspaces:
           - name: output
+            workspace: source
+
+      - name: build-doc
+        runAfter:
+          - fetchit
+        taskSpec:
+          workspaces:
+            - name: source
+          steps:
+            - name: hugo-gen
+              image: quay.io/thegeeklab/hugo
+              workingDir: $(workspaces.source.path)
+              script: |
+                git fetch origin main && \
+                  git diff --name-only FETCH_HEAD | grep -q '^docs/' || exit 0
+                cd docs
+                sed -i '1acanonifyURLs = true' config.toml
+                hugo --gc --minify -d {{ revision }} -b https://preview-pipelines-as-code-ci.apps.paac.devcluster.openshift.com/docs/{{ revision }}
+                echo "Preview URL: https://preview-pipelines-as-code-ci.apps.paac.devcluster.openshift.com/docs/{{ revision }}"
+            - name: upload-to-static-server
+              # it has curl and we already pulled it
+              image: registry.redhat.io/rhel8/go-toolset:1.16.12-7
+              workingDir: $(workspaces.source.path)
+              env:
+                - name: HUB_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: "nightly-ci-github-hub-token"
+                      key: "hub-token"
+              script: |
+                cd docs
+                [[ -d {{ revision }} ]]  || exit 0
+                tar czf - {{ revision }} | curl -F path=docs -F targz=true -X POST -F file=@- http://uploader:8080/upload
+                # Post as status
+                set +x
+                curl -H "Authorization: Bearer ${HUB_TOKEN}" -H 'Accept: application/vnd.github.v3+json' -X POST https://api.github.com/repos/{{repo_owner}}/{{repo_name}}/statuses/{{revision}} -d '{"state": "success", "target_url": "https://preview-pipelines-as-code-ci.apps.paac.devcluster.openshift.com/docs/{{ revision }}", "description": "Generated with brio.", "context": "Pipelines as Code Preview URL"}'
+
+        workspaces:
+          - name: source
             workspace: source
 
       - name: yamllint
@@ -62,7 +103,6 @@ spec:
         workspaces:
           - name: source
             workspace: source
-
 
       - name: vale
         runAfter:

--- a/docs/content/docs/guide/privaterepo.md
+++ b/docs/content/docs/guide/privaterepo.md
@@ -38,18 +38,18 @@ Secret :
 And inside your pipeline, you are referencing them for the `git-clone` to reuse  :
 
 ```yaml
-[...]
+[…]
 workspaces:
   - name basic-auth
 params:
     - name: repo_url
     - name: revision
-[...]
+[…]
 tasks:
   workspaces:
     - name: basic-auth
       workspace: basic-auth
-  [...]
+  […]
   tasks:
   - name: git-clone-from-catalog
       taskRef:

--- a/docs/content/docs/guide/statuses.md
+++ b/docs/content/docs/guide/statuses.md
@@ -17,8 +17,8 @@ with the string `/retest` to ask Pipelines as Code to retest the current PR.
 Example :
 
 ```text
-Thanks for contributing! This is a much needed bugfix! ❤️
-The failure is not with your PR but seems to be an infra issue.
+Thanks for contributing, This is a much needed bugfix, and we love it ❤️ The
+failure is not with your PR but seems to be an infra issue.
 
 /retest
 ```
@@ -67,7 +67,7 @@ directly like this :
     "pipelineRunName": "pipelines-as-code-test-run-2fhhg",
     "startTime": "2021-05-05T11:11:20Z"
   },
-  [...]
+  […]
 ```
 
 ## Notifications

--- a/docs/content/docs/install/bitbucket_cloud.md
+++ b/docs/content/docs/install/bitbucket_cloud.md
@@ -27,8 +27,8 @@ check these boxes to add the permissions to the token :
 
 Keep the generated token noted somewhere or otherwise you will have to recreate it.
 
-- Go to you **"Repository setting"** tab on your **Repository** and click on the
-  **WebHooks** tab and **"Add webhook"** button.
+- Go to you **“Repository setting“** tab on your **Repository** and click on the
+  **WebHooks** tab and **“Add webhook“** button.
 
 - Set a **Title** (i.e: Pipelines as Code)
 
@@ -60,27 +60,27 @@ Keep the generated token noted somewhere or otherwise you will have to recreate 
 
   ```shell
   kubectl -n target-namespace create secret generic bitbucket-cloud-token \
-          --from-literal "APP_PASSWORD_AS_GENERATED_PREVIOUSLY"
+          --from-literal “APP_PASSWORD_AS_GENERATED_PREVIOUSLY“
   ```
 
 - And then create the Repository CRD with the secret field referencing it, for example:
 
 ```yaml
 ---
-apiVersion: "pipelinesascode.tekton.dev/v1alpha1"
+apiVersion: “pipelinesascode.tekton.dev/v1alpha1“
 kind: Repository
 metadata:
   name: my-repo
   namespace: target-namespace
 spec:
-  url: "https://bitbucket.com/workspace/repo"
-  branch: "main"
+  url: “https://bitbucket.com/workspace/repo“
+  branch: “main“
   git_provider:
-    user: "yourbitbucketusername"
+    user: “yourbitbucketusername“
     secret:
-      name: "bitbucket-cloud-token"
+      name: “bitbucket-cloud-token“
       # Set this if you have a different key in your secret
-      # key: "token"
+      # key: “token“
 ```
 
 ## Bitbucket Cloud Notes

--- a/docs/content/docs/install/github_webhook.md
+++ b/docs/content/docs/install/github_webhook.md
@@ -22,7 +22,7 @@ Follow this guide to create a personal token :
 
 The only permission needed is the *repo* permission. You will have to note the generated token somewhere or otherwise you will have to recreate it.
 
-* Go to you repository or organization setting and click on *Hooks* and *"Add webhook"* links.
+* Go to you repository or organization setting and click on *Hooks* and *“Add webhook“* links.
 
 * Set the payload URL to Pipeline as Code public URL. On OpenShift you can get the public URL of the Pipelines-as-Code controller like this:
 

--- a/docs/content/docs/install/gitlab.md
+++ b/docs/content/docs/install/gitlab.md
@@ -18,7 +18,7 @@ Following the [infrastructure installation](install.md#install-pipelines-as-code
   token needs to be able to have `api` access to the forked repository from where
   the MR come from, it will fail to do it with a project scoped token. We try
   to fallback nicely by showing the status of the pipeline directly as comment
-  of the the Merge Request.
+  of the Merge Request.
 
 * Go to your project and click on *Settings* and *"Webhooks"* from the sidebar on the left.
 

--- a/docs/content/docs/install/settings.md
+++ b/docs/content/docs/install/settings.md
@@ -11,7 +11,7 @@ There is a few things you can configure through the configmap
 * `application-name`
 
   The name of the application showing for example in the GitHub Checks
-  labels. Default to `"Pipelines as Code CI"`
+  labels. Default to `Pipelines as Code CI`
 
 * `max-keep-days`
 


### PR DESCRIPTION
Generate a preview URL whenever there is a change to the doc site...

Need to figure out how to report it, on pull request, we get our token rate limited too quickly... maybe on slack channel?

best way to get the logs url currently is  to : 

<img width="1386" alt="image" src="https://user-images.githubusercontent.com/98980/162204013-d4552f2d-5d7b-4f2d-b506-e885c56f4b34.png">
