### PR TITLE
set timeout back to 2 hours

### DIFF
--- a/pkg/kubeinteraction/wait.go
+++ b/pkg/kubeinteraction/wait.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	interval = 1 * time.Second
-	timeout  = 10 * time.Minute
+	timeout  = 120 * time.Minute
 )
 
 type ConditionAccessorFn func(ca knativeapi.ConditionAccessor) (bool, error)

--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -176,8 +176,8 @@ func Run(ctx context.Context, cs *params.Run, providerintf provider.Interface, k
 	cs.Clients.Log.Infof("Waiting for PipelineRun %s/%s to Succeed in a maximum time of %s minutes",
 		pr.Namespace, pr.Name, formatting.HumanDuration(cs.Info.Pac.DefaultPipelineRunTimeout))
 	if err := k8int.WaitForPipelineRunSucceed(ctx, cs.Clients.Tekton.TektonV1beta1(), pr, cs.Info.Pac.DefaultPipelineRunTimeout); err != nil {
-		cs.Clients.Log.Warnf("pipelinerun %s in namespace %s has a failed status",
-			pipelineRun.GetGenerateName(), repo.GetNamespace())
+		return fmt.Errorf("pipelinerun %s in namespace %s has a failed status: %w",
+			pipelineRun.GetGenerateName(), repo.GetNamespace(), err)
 	}
 
 	// Do cleanups


### PR DESCRIPTION
increase timeout which was set at 10 minutes for debug and stayed there for a long time 🙃 
properly set the run as failed if there is errors or timeout.

Closes #542 

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: via [pre-push github hook](../hack/dev/prep-push-hook) no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please make sure to document it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please make sure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then make sure to get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it.

_See [the developer guide](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/docs/development.md) for a bit more details._
