### PR TITLE
GitHub: removes unsupported event from bootstrap cmd and docs

### DIFF
--- a/docs/content/docs/install/github_apps.md
+++ b/docs/content/docs/install/github_apps.md
@@ -38,8 +38,6 @@ Controller route or ingress endpoint which would listen to GitHub events.
   * Commit comment
   * Issue comment
   * Pull request
-  * Pull request review
-  * Pull request review comment
   * Push
 
 {{< hint info >}}

--- a/docs/content/docs/install/github_webhook.md
+++ b/docs/content/docs/install/github_webhook.md
@@ -39,7 +39,6 @@ The only permission needed is the *repo* permission. You will have to note the g
 * Click "Let me select individual events" and select these events:
   * Commit comments
   * Issue comments
-  * Pull request reviews
   * Pull request
   * Pushes
 

--- a/pkg/cmd/tknpac/bootstrap/github.go
+++ b/pkg/cmd/tknpac/bootstrap/github.go
@@ -21,8 +21,6 @@ func generateManifest(opts *bootstrapOpts) ([]byte, error) {
 			"commit_comment",
 			"issue_comment",
 			"pull_request",
-			"pull_request_review",
-			"pull_request_review_comment",
 			"push",
 		},
 		DefaultPermissions: &github.InstallationPermissions{


### PR DESCRIPTION
pac doesn't support comments from `Pull request review` & `Pull request review
comment` events. this removes the events requirement from bootstrap and docs.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
