### PR TITLE
[For stable Release DNM] Fix watching pipelinerun timeout (and error with timeout)

### DIFF
--- a/config/401-github-issue-recheck.yaml
+++ b/config/401-github-issue-recheck.yaml
@@ -88,6 +88,7 @@ spec:
           pipelinesascode.tekton.dev/event: $(tt.params.event_type)
       spec:
         serviceAccountName: pipelines-as-code-sa-el
+        timeout: 24h0m0s
         params:
           - name: action
             value: $(tt.params.action)

--- a/config/402-github-pull-request.yaml
+++ b/config/402-github-pull-request.yaml
@@ -89,6 +89,7 @@ spec:
           app.kubernetes.io/managed-by: pipelines-as-code
           pipelinesascode.tekton.dev/event: $(tt.params.event_type)
       spec:
+        timeout: 24h0m0s
         serviceAccountName: pipelines-as-code-sa-el
         params:
           - name: ghe_host

--- a/config/403-github-push.yaml
+++ b/config/403-github-push.yaml
@@ -84,6 +84,7 @@ spec:
           app.kubernetes.io/managed-by: pipelines-as-code
           pipelinesascode.tekton.dev/event: $(tt.params.event_type)
       spec:
+        timeout: 24h0m0s
         serviceAccountName: pipelines-as-code-sa-el
         params:
           - name: ghe_host

--- a/config/404-github-retest-comment.yaml
+++ b/config/404-github-retest-comment.yaml
@@ -74,6 +74,7 @@ spec:
           app.kubernetes.io/managed-by: pipelines-as-code
           pipelinesascode.tekton.dev/event: $(tt.params.event_type)
       spec:
+        timeout: 24h0m0s
         serviceAccountName: pipelines-as-code-sa-el
         params:
           - name: ghe_host

--- a/config/422-bitbucket-cloud-pull-request.yaml
+++ b/config/422-bitbucket-cloud-pull-request.yaml
@@ -97,6 +97,7 @@ spec:
           # pipelinesascode.tekton.dev/event: $(tt.params.event_type)
       spec:
         serviceAccountName: pipelines-as-code-sa-el
+        timeout: 24h0m0s
         params:
           - name: source_ip
             value: $(tt.params.source_ip)

--- a/config/423-bitbucket-cloud-push.yaml
+++ b/config/423-bitbucket-cloud-push.yaml
@@ -79,6 +79,7 @@ spec:
           app.kubernetes.io/managed-by: pipelines-as-code
       spec:
         serviceAccountName: pipelines-as-code-sa-el
+        timeout: 24h0m0s
         params:
           - name: source_ip
             value: $(tt.params.source_ip)

--- a/config/442-bitbucket-server-pull-request.yaml
+++ b/config/442-bitbucket-server-pull-request.yaml
@@ -122,6 +122,7 @@ spec:
           app.kubernetes.io/version: "devel"
           app.kubernetes.io/managed-by: pipelines-as-code
       spec:
+        timeout: 24h0m0s
         serviceAccountName: pipelines-as-code-sa-el
         params:
           - name: trigger_target

--- a/config/443-bitbucket-server-push.yaml
+++ b/config/443-bitbucket-server-push.yaml
@@ -81,6 +81,7 @@ spec:
           app.kubernetes.io/version: "devel"
           app.kubernetes.io/managed-by: pipelines-as-code
       spec:
+        timeout: 24h0m0s
         serviceAccountName: pipelines-as-code-sa-el
         params:
           - name: "event_type"

--- a/docs/install.md
+++ b/docs/install.md
@@ -468,6 +468,18 @@ the `pipelines-as-code` namespace.
 
   <https://api.hub.tekton.dev/v1>
 
+* `default-pipelinerun-timeout`: Default timeout to wait for pipelinerun
+  (default value is 2 hours).
+  Note that PaaC doesn't respect the user pipelinerun timeout if it's greater than
+  this value.
+  In other words, if you set paac `default-pipelinerun-timeout` to 2h and
+  your PipelineRun timeout is set to 3h the PipelineRun will timeout after 2h.
+  If your pipelinerun timeout is set to 1h and your
+  `default-pipelinerun-timeout` value is 2h, the PipelineRun will timeout after
+  1h by the tekton controller.
+
+  This value cannot exceed 24 hours.
+
 ## Kubernetes
 
 Pipelines as Code should work directly on kubernetes/minikube/kind. You just need to install the release.yaml

--- a/pkg/cmd/tknpac/generate/template.go
+++ b/pkg/cmd/tknpac/generate/template.go
@@ -2,7 +2,10 @@ package generate
 
 import (
 	"bytes"
+	"embed"
 	"fmt"
+	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -52,98 +55,8 @@ var languageDetection = map[string]langOpts{
 	},
 }
 
-var pipelineRunTmpl = `---
-apiVersion: tekton.dev/v1beta1
-kind: PipelineRun
-metadata:
-  name: << .prName >>
-  annotations:
-    # The event we are targeting as seen from the webhook payload
-    # this can be an array too, i.e: [pull_request, push]
-    pipelinesascode.tekton.dev/on-event: "<< .event.EventType >>"
-
-    # The branch or tag we are targeting (ie: main, refs/tags/*)
-    pipelinesascode.tekton.dev/on-target-branch: "<< .event.BaseBranch >>"
-
-    # Fetch the git-clone task from hub, we are able to reference later on it
-    # with taskRef and it will automatically be embedded into our pipeline.
-    pipelinesascode.tekton.dev/task: "git-clone"
-    <<- if .extra_task.AnnotationTask >>
-
-    # Task for <<.extra_task.Language >>
-    pipelinesascode.tekton.dev/task-1: "[<< .extra_task.AnnotationTask >>]"
-    << end >>
-    # You can add more tasks in here to reuse, browse the one you like from here
-    # https://hub.tekton.dev/
-    # example:
-    # pipelinesascode.tekton.dev/task-2: "[maven, buildah]"
-
-    # How many runs we want to keep attached to this event
-    pipelinesascode.tekton.dev/max-keep-runs: "5"
-spec:
-  params:
-    # The variable with brackets are special to Pipelines as Code
-    # They will automatically be expanded with the events from Github.
-    - name: repo_url
-      value: "{{ repo_url }}"
-    - name: revision
-      value: "{{ revision }}"
-  pipelineSpec:
-    params:
-      - name: repo_url
-      - name: revision
-    workspaces:
-      - name: source
-      - name: basic-auth
-    tasks:
-      - name: fetch-repository
-        taskRef:
-          name: git-clone
-        workspaces:
-          - name: output
-            workspace: source
-          - name: basic-auth
-            workspace: basic-auth
-        params:
-          - name: url
-            value: $(params.repo_url)
-          - name: revision
-            value: $(params.revision)      
-      << if .extra_task.Task>>
-      << .extra_task.Task >>
-      <<- end >>
-      # Customize this task if you like, or just do a taskRef
-      # to one of the hub task.
-      - name: noop-task
-        runAfter:
-          - fetch-repository
-        workspaces:
-          - name: source
-            workspace: source
-        taskSpec:
-          workspaces:
-            - name: source
-          steps:
-            - name: noop-task
-              image: registry.access.redhat.com/ubi8/ubi-micro:8.4
-              workingDir: $(workspaces.source.path)
-              script: |
-                exit 0
-  workspaces:
-  - name: source
-    volumeClaimTemplate:
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: 1Gi
-  # This workspace will inject secret to help the git-clone task to be able to
-  # checkout the private repositories
-  - name: basic-auth
-    secret:
-      secretName: "pac-git-basic-auth-{{repo_owner}}-{{repo_name}}"
-`
+//go:embed templates
+var resource embed.FS
 
 func (o *Opts) detectLanguage() (langOpts, error) {
 	if o.language != "" {
@@ -169,7 +82,15 @@ func (o *Opts) detectLanguage() (langOpts, error) {
 
 func (o *Opts) genTmpl() (bytes.Buffer, error) {
 	var outputBuffer bytes.Buffer
-	t := template.Must(template.New("PipelineRun").Delims("<<", ">>").Parse(pipelineRunTmpl))
+	embedfile, err := resource.Open("templates/pipelinerun.yaml.tmpl")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer embedfile.Close()
+	tmplB, _ := ioutil.ReadAll(embedfile)
+	// can't figure out how ParseFS works, so doing this manually..
+	t := template.Must(template.New("PipelineRun").Delims("<<", ">>").Parse(string(tmplB)))
+
 	prName := fmt.Sprintf("%s-%s",
 		filepath.Base(o.GitInfo.URL),
 		strings.ReplaceAll(o.event.EventType, "_", "-"))
@@ -181,6 +102,7 @@ func (o *Opts) genTmpl() (bytes.Buffer, error) {
 		"prName":                  prName,
 		"event":                   o.event,
 		"extra_task":              lang,
+		"use_cluster_task":        o.generateWithClusterTask,
 		"language_specific_tasks": "",
 	}
 	if err := t.Execute(&outputBuffer, data); err != nil {

--- a/pkg/cmd/tknpac/generate/templates/pipelinerun.yaml.tmpl
+++ b/pkg/cmd/tknpac/generate/templates/pipelinerun.yaml.tmpl
@@ -1,0 +1,104 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: << .prName >>
+  annotations:
+    # The event we are targeting as seen from the webhook payload
+    # this can be an array too, i.e: [pull_request, push]
+    pipelinesascode.tekton.dev/on-event: "<< .event.EventType >>"
+
+    # The branch or tag we are targeting (ie: main, refs/tags/*)
+    pipelinesascode.tekton.dev/on-target-branch: "<< .event.BaseBranch >>"
+    << if .use_cluster_task >>
+    # If we wanted to use the git-clone task from hub we could specify the
+    # annotation `pipelinesascode.tekton.dev/task annotation` and reference it
+    # in the taskRef. Pipelines as Code when it sees this will grab it from hub
+    # and automatically use the latest version. right know by default we will
+    # use the `git-clone` ClusterTasks as shipped on this cluster.
+    #
+    # pipelinesascode.tekton.dev/task: "git-clone"
+
+    <<- else >>
+    # Fetch the git-clone task from hub, we are able to reference later on it
+    # with taskRef and it will automatically be embedded into our pipeline.
+    pipelinesascode.tekton.dev/task: "git-clone"
+    << end >>
+    <<- if .extra_task.AnnotationTask >>
+
+    # Task for <<.extra_task.Language >>
+    pipelinesascode.tekton.dev/task-1: "[<< .extra_task.AnnotationTask >>]"
+    << end >>
+    # You can add more tasks in here to reuse, browse the one you like from here
+    # https://hub.tekton.dev/
+    # example:
+    # pipelinesascode.tekton.dev/task-2: "[maven, buildah]"
+
+    # How many runs we want to keep attached to this event
+    pipelinesascode.tekton.dev/max-keep-runs: "5"
+spec:
+  params:
+    # The variable with brackets are special to Pipelines as Code
+    # They will automatically be expanded with the events from Github.
+    - name: repo_url
+      value: "{{ repo_url }}"
+    - name: revision
+      value: "{{ revision }}"
+  pipelineSpec:
+    params:
+      - name: repo_url
+      - name: revision
+    workspaces:
+      - name: source
+      - name: basic-auth
+    tasks:
+      - name: fetch-repository
+        taskRef:
+          name: git-clone
+          <<- if .use_cluster_task >>
+          kind: ClusterTask
+          <<- end >>
+        workspaces:
+          - name: output
+            workspace: source
+          - name: basic-auth
+            workspace: basic-auth
+        params:
+          - name: url
+            value: $(params.repo_url)
+          - name: revision
+            value: $(params.revision)
+      <<- if .extra_task.Task>>
+      << .extra_task.Task >>
+      <<- end >>
+      # Customize this task if you like, or just do a taskRef
+      # to one of the hub task.
+      - name: noop-task
+        runAfter:
+          - fetch-repository
+        workspaces:
+          - name: source
+            workspace: source
+        taskSpec:
+          workspaces:
+            - name: source
+          steps:
+            - name: noop-task
+              image: registry.access.redhat.com/ubi8/ubi-micro:8.5
+              workingDir: $(workspaces.source.path)
+              script: |
+                exit 0
+  workspaces:
+  - name: source
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+  # This workspace will inject secret to help the git-clone task to be able to
+  # checkout the private repositories
+  - name: basic-auth
+    secret:
+      secretName: "pac-git-basic-auth-{{repo_owner}}-{{repo_name}}"

--- a/pkg/cmd/tknpac/root.go
+++ b/pkg/cmd/tknpac/root.go
@@ -31,6 +31,6 @@ func Root(clients *params.Run) *cobra.Command {
 	cmd.AddCommand(resolve.Command(clients))
 	cmd.AddCommand(completion.Command())
 	cmd.AddCommand(bootstrap.Command(clients, ioStreams))
-	cmd.AddCommand(generate.Command(ioStreams))
+	cmd.AddCommand(generate.Command(clients, ioStreams))
 	return cmd
 }

--- a/pkg/kubeinteraction/cleanups.go
+++ b/pkg/kubeinteraction/cleanups.go
@@ -14,7 +14,8 @@ import (
 )
 
 func (k Interaction) CleanupPipelines(ctx context.Context, repo *v1alpha1.Repository, pr *v1beta1.PipelineRun,
-	maxKeep int) error {
+	maxKeep int,
+) error {
 	repoLabel := filepath.Join(pipelinesascode.GroupName, "repository")
 	originalPRLabel := filepath.Join(pipelinesascode.GroupName, "original-prname")
 	if _, ok := pr.GetLabels()[originalPRLabel]; !ok {

--- a/pkg/matcher/annotation_tasks_install.go
+++ b/pkg/matcher/annotation_tasks_install.go
@@ -85,7 +85,8 @@ func (rt RemoteTasks) getTask(ctx context.Context, providerintf provider.Interfa
 
 // GetTaskFromAnnotations Get task remotely if they are on Annotations
 func (rt RemoteTasks) GetTaskFromAnnotations(ctx context.Context, providerintf provider.Interface,
-	annotations map[string]string) ([]*tektonv1beta1.Task, error) {
+	annotations map[string]string,
+) ([]*tektonv1beta1.Task, error) {
 	var ret []*tektonv1beta1.Task
 	rtareg := regexp.MustCompile(fmt.Sprintf("%s/%s", pipelinesascode.GroupName, taskAnnotationsRegexp))
 	for annotationK, annotationV := range annotations {

--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -164,8 +164,7 @@ func Run(ctx context.Context, cs *params.Run, providerintf provider.Interface, k
 	cs.Clients.Log.Infof("Waiting for PipelineRun %s/%s to Succeed in a maximum time of %s minutes",
 		pr.Namespace, pr.Name, formatting.HumanDuration(cs.Info.Pac.DefaultPipelineRunTimeout))
 	if err := k8int.WaitForPipelineRunSucceed(ctx, cs.Clients.Tekton.TektonV1beta1(), pr, cs.Info.Pac.DefaultPipelineRunTimeout); err != nil {
-		cs.Clients.Log.Warnf("pipelinerun %s in namespace %s has a failed status",
-			pipelineRun.GetGenerateName(), repo.GetNamespace())
+		return fmt.Errorf("pipelinerun %s in namespace %s has failed: %w", pipelineRun.GetGenerateName(), repo.GetNamespace(), err)
 	}
 
 	// Do cleanups

--- a/pkg/pipelineascode/pipelinesascode_github_test.go
+++ b/pkg/pipelineascode/pipelinesascode_github_test.go
@@ -70,7 +70,8 @@ func testSetupTektonDir(mux *http.ServeMux, runevent info.Event, directory strin
 }
 
 func testSetupCommonGhReplies(t *testing.T, mux *http.ServeMux, runevent info.Event,
-	finalStatus, finalStatusText string, noReplyOrgPublicMembers bool) {
+	finalStatus, finalStatusText string, noReplyOrgPublicMembers bool,
+) {
 	// Take a directory and generate replies as Github for it
 	replyString(mux,
 		fmt.Sprintf("/repos/%s/%s/contents/internal/task", runevent.Organization, runevent.Repository),

--- a/pkg/pipelineascode/status.go
+++ b/pkg/pipelineascode/status.go
@@ -56,7 +56,8 @@ func updateRepoRunStatus(ctx context.Context, cs *params.Run, pr *tektonv1beta1.
 }
 
 func postFinalStatus(ctx context.Context, cs *params.Run, providerintf provider.Interface, createdPR *tektonv1beta1.PipelineRun) (
-	*tektonv1beta1.PipelineRun, error) {
+	*tektonv1beta1.PipelineRun, error,
+) {
 	pr, err := cs.Clients.Tekton.TektonV1beta1().PipelineRuns(createdPR.GetNamespace()).Get(
 		ctx, createdPR.GetName(), metav1.GetOptions{},
 	)

--- a/pkg/resolve/resolve.go
+++ b/pkg/resolve/resolve.go
@@ -80,7 +80,8 @@ func skippingTask(taskName string, skippedTasks []string) bool {
 }
 
 func inlineTasks(tasks []tektonv1beta1.PipelineTask, ropt *Opts, types Types) ([]tektonv1beta1.PipelineTask,
-	error) {
+	error,
+) {
 	pipelineTasks := []tektonv1beta1.PipelineTask{}
 	for _, task := range tasks {
 		if task.TaskRef != nil && task.TaskRef.Bundle == "" &&
@@ -109,7 +110,8 @@ type Opts struct {
 // generateName can be set as True to set the name as a generateName + "-" for
 // unique pipelinerun
 func Resolve(ctx context.Context, cs *params.Run, providerintf provider.Interface, data string, ropt *Opts) (
-	[]*tektonv1beta1.PipelineRun, error) {
+	[]*tektonv1beta1.PipelineRun, error,
+) {
 	s := k8scheme.Scheme
 	if err := tektonv1beta1.AddToScheme(s); err != nil {
 		return []*tektonv1beta1.PipelineRun{}, err

--- a/test/pkg/wait/wait.go
+++ b/test/pkg/wait/wait.go
@@ -23,7 +23,7 @@ type Opts struct {
 func UntilRepositoryUpdated(ctx context.Context, clients clients.Clients, opts Opts) error {
 	ctx, cancel := context.WithTimeout(ctx, opts.PollTimeout)
 	defer cancel()
-	return kubeinteraction.PollImmediateWithContext(ctx, func() (bool, error) {
+	return kubeinteraction.PollImmediateWithContext(ctx, opts.PollTimeout, func() (bool, error) {
 		clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(opts.Namespace)
 		r, err := clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(opts.Namespace).Get(ctx, opts.RepoName,
 			metav1.GetOptions{})


### PR DESCRIPTION
First we define a ridiculous large number for taskrun timeout, so the
pac taskrun doesn't timeout before the user defined one.

Second we are making sure we are not using the timeout configuration
instead of the constant (which was 10minutes by default)

Document which may explains it better : 

```
* `default-pipelinerun-timeout`: Default timeout to wait for pipelinerun
  (default value is 2 hours).
  Note that PaaC doesn't respect the user pipelinerun timeout if it's greater than
  this value.
  In other words, if you set paac `default-pipelinerun-timeout` to 2h and
  your PipelineRun timeout is set to 3h the PipelineRun will timeout after 2h.
  If your pipelinerun timeout is set to 1h and your
  `default-pipelinerun-timeout` value is 2h, the PipelineRun will timeout after
  1h by the tekton controller.

  This value cannot exceed 24 hours.
```

Third we are not just warning anymore but actually exit.

as an example with a 30s timeout in the global default : 

![image](https://user-images.githubusercontent.com/98980/162699448-021e5ce7-fb64-4e87-82c9-a353daa83100.png)

and properly report it to the user when exceeding timeout : 

![image](https://user-images.githubusercontent.com/98980/162699564-fb16bb98-6dee-4107-8ac9-fbfcef18a6fe.png)


Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
