### PR TITLE
Add check_run in bootstrap & remove commit comment (not supported)

### DIFF
--- a/docs/content/docs/install/github_apps.md
+++ b/docs/content/docs/install/github_apps.md
@@ -35,7 +35,7 @@ Controller route or ingress endpoint which would listen to GitHub events.
   * **Plan**: `Readonly`
 
 * Select the following user permissions:
-  * Commit comment
+  * Check run
   * Issue comment
   * Pull request
   * Push

--- a/pkg/cmd/tknpac/bootstrap/github.go
+++ b/pkg/cmd/tknpac/bootstrap/github.go
@@ -18,7 +18,7 @@ func generateManifest(opts *bootstrapOpts) ([]byte, error) {
 		Description:    github.String("Pipeline as Code Application"),
 		Public:         github.Bool(true),
 		DefaultEvents: []string{
-			"commit_comment",
+			"check_run",
 			"issue_comment",
 			"pull_request",
 			"push",


### PR DESCRIPTION
this adds check run event in boostrap cmd to configure and
remove commit comment from docs as pac doesn't process it
anymore.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
