### PR TITLE
[DNM] Generate documentation in different branch for stable and nightly

### DIFF
--- a/.github/workflows/doc.yaml
+++ b/.github/workflows/doc.yaml
@@ -1,0 +1,35 @@
+name: github pages
+
+on:
+  push:
+    branches:
+      - main  # Set a branch to deploy
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
+          persist-credentials: false
+          # otherwise, there would be errors pushing refs to the destination repository.
+          fetch-depth: 0
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: 'latest'
+          extended: true
+
+      - name: Build
+        run: hugo --minify --gc
+        working-directory: ./docs
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        if: github.ref == 'refs/heads/main'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/public

--- a/.github/workflows/doc.yaml
+++ b/.github/workflows/doc.yaml
@@ -2,8 +2,11 @@ name: github pages
 
 on:
   push:
+    tags:
+      - stable
     branches:
-      - main  # Set a branch to deploy
+      - nightly
+
 jobs:
   deploy:
     runs-on: ubuntu-20.04
@@ -13,9 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
           persist-credentials: false
-          # otherwise, there would be errors pushing refs to the destination repository.
           fetch-depth: 0
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
@@ -27,9 +28,18 @@ jobs:
         run: hugo --minify --gc
         working-directory: ./docs
 
-      - name: Deploy
+      - name: Nightly Doc
         uses: peaceiris/actions-gh-pages@v3
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/nightly'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/public
+          publish_branch: docs-nightly
+
+      - name: Stable Doc
+        uses: peaceiris/actions-gh-pages@v3
+        if: github.ref == 'refs/tags/stable'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/public
+          publish_branch: docs-stable

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ FROM registry.access.redhat.com/ubi8/go-toolset:latest	 AS builder
 
 COPY . /src
 WORKDIR /src
-RUN \
-    make /tmp/tkn-pac /tmp/pipelines-as-code-controller LDFLAGS="-s -w" OUTPUT_DIR=/tmp
+RUN make /tmp/tkn-pac /tmp/pipelines-as-code-controller LDFLAGS="-s -w" OUTPUT_DIR=/tmp
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
 

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -5,7 +5,7 @@ title = 'Pipelines as Code'
 theme = "hugo-book"
 # Book configuration
 disablePathToLower = true
-#enableGitInfo = true
+enableGitInfo = true
 
 [outputs]
 home = [ "HTML", "RSS", "JSON"]


### PR DESCRIPTION
Use github actions to generate documentation on docs-stable and docs-nightly which we can point from cloudfare and github pages...

There is maybe some other way which I can see after we make 0.6 release (because stable branch needs to have the hugo files) so dnm yet...

Fixes #563 

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
