### PR TITLE
Updates docs to have one secret with both keys for webhook

### DIFF
--- a/docs/content/docs/install/bitbucket_cloud.md
+++ b/docs/content/docs/install/bitbucket_cloud.md
@@ -59,7 +59,7 @@ Keep the generated token noted somewhere, or otherwise you will have to recreate
 
   ```shell
   kubectl -n target-namespace create secret generic bitbucket-cloud-token \
-          --from-literal “APP_PASSWORD_AS_GENERATED_PREVIOUSLY“
+          --from-literal provider.token="APP_PASSWORD_AS_GENERATED_PREVIOUSLY"
   ```
 
 - And then create the Repository CRD with the secret field referencing it, for example:
@@ -79,7 +79,7 @@ Keep the generated token noted somewhere, or otherwise you will have to recreate
       secret:
         name: “bitbucket-cloud-token“
         # Set this if you have a different key in your secret
-        # key: “token“
+        # key: “provider.token“
 ```
 
 ## Bitbucket Cloud Notes

--- a/docs/content/docs/install/bitbucket_server.md
+++ b/docs/content/docs/install/bitbucket_server.md
@@ -48,20 +48,14 @@ recreate it.
   * Pull Request -> Source branch updated
   * Pull Request -> Comments added
 
-* Create a secret with personal token in the `target-namespace`
+  * Create a secret with personal token in the `target-namespace`
 
   ```shell
-  kubectl -n target-namespace create secret generic bitbucket-server-token \
-    --from-literal token="TOKEN_AS_GENERATED_PREVIOUSLY"
+  kubectl -n target-namespace create secret generic bitbucket-server-webhook-config \
+    --from-literal provider.token="TOKEN_AS_GENERATED_PREVIOUSLY" \
+    --from-literal webhook.secret="SECRET_AS_SET_IN_WEBHOOK_CONFIGURATION"
   ```
-
-* Then create the secret with the secret name as set in the Webhook configuration :
-
-  ```shell
-  kubectl -n target-namespace create secret generic bitbucket-server-webhook-secret \
-    --from-literal secret="SECRET_NAME_AS_SET_IN_WEBHOOK_CONFIGURATION"
-  ```
-
+  
 * And finally create Repository CRD with the secret field referencing it.
 
   * Here is an example of a Repository CRD :
@@ -79,13 +73,13 @@ recreate it.
       url: "https://bitbucket.server.api.url"
       user: "your-bitbucket-username"
       secret:
-        name: "bitbucket-server-token"
+        name: "bitbucket-server-webhook-config"
         # Set this if you have a different key in your secret
-        # key: "token"
+        # key: "provider.token"
       webhook_secret::
-        name: "bitbucket-server-webhook-secret"
+        name: "bitbucket-server-webhook-config"
         # Set this if you have a different key for your secret
-        # key: "secret-name"
+        # key: "webhook.secret"
 ```
 
 ## Notes

--- a/docs/content/docs/install/github_webhook.md
+++ b/docs/content/docs/install/github_webhook.md
@@ -49,20 +49,14 @@ The only permission needed is the *repo* permission. You will have to note the g
 * You are now able to create a Repository CRD. The repository CRD will reference a
   Kubernetes Secret containing the Personal token as generated previously and another reference to a Kubernetes secret to validate the Webhook payload as set previously in your Webhook configuration .
 
-* First create the secret with the personal token in the `target-namespace` :
+* First create the secret with the personal token and webhook secret in the `target-namespace` :
 
   ```shell
-  kubectl -n target-namespace create secret generic github-personal-token \
-    --from-literal token="TOKEN_AS_GENERATED_PREVIOUSLY"
+  kubectl -n target-namespace create secret generic github-webhook-config \
+    --from-literal provider.token="TOKEN_AS_GENERATED_PREVIOUSLY" \
+    --from-literal webhook.secret="SECRET_AS_SET_IN_WEBHOOK_CONFIGURATION"
   ```
-
-* Then create the secret with the secret name as set in the Webhook configuration :
-
-  ```shell
-  kubectl -n target-namespace create secret generic github-webhook-secret \
-    --from-literal secret="SECRET_NAME_AS_SET_IN_WEBHOOK_CONFIGURATION"
-  ```
-
+  
 * And now create Repository CRD referencing everything :
 
   ```yaml
@@ -76,13 +70,13 @@ The only permission needed is the *repo* permission. You will have to note the g
     url: "https://github.com/owner/repo"
     git_provider:
       secret:
-        name: "github-personal-token"
+        name: "github-webhook-config"
         # Set this if you have a different key in your secret
-        # key: "token"
+        # key: "provider.token"
       webhook_secret:
-        name: "github-webhook-secret"
+        name: "github-webhook-config"
         # Set this if you have a different key for your secret
-        # key: "secret-name"
+        # key: "webhook.secret"
   ```
 
 ## GitHub webhook Notes

--- a/docs/content/docs/install/gitlab.md
+++ b/docs/content/docs/install/gitlab.md
@@ -46,20 +46,14 @@ Follow the pipelines-as-code [installation](/docs/install/installation) accordin
 * You are now able to create a Repository CRD. The repository CRD will reference a Kubernetes Secret containing the Personal token
 and another reference to a Kubernetes secret to validate the Webhook payload as set previously in your Webhook configuration.
 
-* First create the secret with the personal token in the `target-namespace` (where you are planning to run your pipeline CI) :
+* First create the secret with the personal token and webhook secret in the `target-namespace` (where you are planning to run your pipeline CI) :
 
   ```shell
-  kubectl -n target-namespace create secret generic gitlab-personal-token \
-    --from-literal token="TOKEN_AS_GENERATED_PREVIOUSLY"
+  kubectl -n target-namespace create secret generic gitlab-webhook-config \
+    --from-literal provider.token="TOKEN_AS_GENERATED_PREVIOUSLY" \
+    --from-literal webhook.secret="SECRET_AS_SET_IN_WEBHOOK_CONFIGURATION"
   ```
-
-* Then create the secret with the secret name as set in the Webhook configuration :
-
-  ```shell
-  kubectl -n target-namespace create secret generic gitlab-webhook-secret \
-    --from-literal secret="SECRET_NAME_AS_SET_IN_WEBHOOK_CONFIGURATION"
-  ```
-
+  
 * And now create Repository CRD with the secret field referencing it.
 
 Here is an example of a Repository CRD :
@@ -75,13 +69,13 @@ Here is an example of a Repository CRD :
     url: "https://gitlab.com/group/project"
     git_provider:
       secret:
-        name: "gitlab-personal-token"
+        name: "gitlab-webhook-config"
         # Set this if you have a different key in your secret
-        # key: "token"
+        # key: "provider.token"
       webhook_secret:
-        name: "gitlab-webhook-secret"
+        name: "gitlab-webhook-config"
         # Set this if you have a different key in your secret
-        # key: "secret-name"
+        # key: "webhook.secret"
   ```
 
 ## Notes

--- a/pkg/pipelineascode/secret.go
+++ b/pkg/pipelineascode/secret.go
@@ -13,8 +13,8 @@ import (
 )
 
 const (
-	defaultGitProviderSecretKey                  = "token"
-	defaultGitProviderWebhookSecretKey           = "secret"
+	defaultGitProviderSecretKey                  = "provider.token"
+	defaultGitProviderWebhookSecretKey           = "webhook.secret"
 	defaultPipelinesAscodeSecretName             = "pipelines-as-code-secret"
 	defaultPipelinesAscodeSecretWebhookSecretKey = "webhook.secret"
 )


### PR DESCRIPTION
this updates the docs to create one key instead of two for webhook,
provider token and webhook secret and updates the default keys.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
