### PR TITLE
Generate stable refs instead of tags

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -8,6 +8,10 @@ on:
       - "go.mod"
       - "go.sum"
       - "!docs/**"
+    tags-ignore:
+      - '*.*'
+    branches:
+      - main
   pull_request_target:
     types: [opened, synchronize, reopened]
     paths:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -52,17 +52,18 @@ release:
 
     ### Openshift
     ```shell
-    kubectl apply -f https://raw.githubusercontent.com/openshift-pipelines/pipelines-as-code/{{.Tag}}/release.yaml
+    kubectl apply -f https://github.com/openshift-pipelines/pipelines-as-code/releases/download/{{.Tag}}/release.yaml
     ```
     ### Kubernetes
     ```shell
-    kubectl apply -f https://raw.githubusercontent.com/openshift-pipelines/pipelines-as-code/{{.Tag}}/release.k8s.yaml
+    kubectl apply -f https://github.com/openshift-pipelines/pipelines-as-code/releases/download/{{.Tag}}/release.k8s.yaml
     ```
     ### Documentation
 
-    full install documentation is available here:
+    documentation is available here :
 
-    https://github.com/openshift-pipelines/pipelines-as-code/blob/{{.Tag}}/docs/install.md
+    https://pipelineascode.com
+
 
 brews:
   - name: tektoncd-pac

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -131,7 +131,8 @@ spec:
                 set +x # Do not show TOKEN in logs
                 hack/upload-file-to-github.py \
                 --message "Release yaml generated from {{repo_url}}/commit/{{revision}}" \
-                --branch-ref refs/heads/nightly \
+                --from-ref refs/heads/main \
+                --to-ref refs/heads/nightly \
                 --owner-repository openshift-pipelines/pipelines-as-code \
                 --token ${HUB_TOKEN} \
                 -f <(./hack/generate-releaseyaml.sh):release.k8s.yaml  \

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -9,9 +9,6 @@ metadata:
     pipelinesascode.tekton.dev/task: "[git-clone, .tekton/tasks/buildah-user.yaml]"
     pipelinesascode.tekton.dev/task-1: "[https://git.io/Jn9Ee]"
 spec:
-  taskRunSpecs:
-    - pipelineTaskName: push-to-registry
-      taskServiceAccountName: pac-push-sa
   params:
     - name: repo_url
       value: "{{repo_url}}"
@@ -77,17 +74,6 @@ spec:
                 #!/usr/bin/env bash
                 make test \
                     GO_TEST_FLAGS="-v -race -coverprofile=coverage.txt -covermode=atomic"
-      - name: push-to-registry
-        runAfter:
-          - unit
-        params:
-          - name: IMAGE
-            value: quay.io/openshift-pipeline/pipelines-as-code:{{target_branch}}
-        taskRef:
-          name: buildah-user
-        workspaces:
-          - name: source
-            workspace: source
       - name: codecov
         runAfter:
           - unit
@@ -113,8 +99,6 @@ spec:
                 bash <(curl https://codecov.io/bash)
 
       - name: upload-release-yaml
-        runAfter:
-          - push-to-registry
         taskSpec:
           steps:
             - image: registry.access.redhat.com/ubi8/python-39:1-35

--- a/.tekton/release-pipeline.yaml
+++ b/.tekton/release-pipeline.yaml
@@ -55,6 +55,13 @@ spec:
                       key: "hub-token"
               script: |
                 #!/usr/bin/env bash
+                # Grab the latest tag we release in
+                # Generate release.yaml for that version, for stable and for
+                # stable version release
+                # ie:
+                # if we tag 0.5.6
+                # It will generate release yamls and upload to branch
+                # release-0.5.6, release-0.5.x and stable
                 set -euf
                 set -x
                 git fetch --tag -v
@@ -64,18 +71,18 @@ spec:
                     exit
                 }
                 stable_tag=${version%.*}.x
-                msg="Release ${version}, Stable Tag: ${stable_tag}"
-                echo ${msg}
-                # Used by the ./hack/generate-releaseyaml script
-                export PAC_VERSION=${version} TARGET_BRANCH=${version}
-                hack/upload-file-to-github.py \
-                    --message "Release yaml generated for ${msg}" \
-                    --owner-repository openshift-pipelines/pipelines-as-code \
-                    --token ${HUB_TOKEN} \
-                    --update-tags=stable,${stable_tag} \
-                    --from-tag=refs/tags/${version} \
-                    -f <(./hack/generate-releaseyaml.sh):release.k8s.yaml \
-                    -f <(env TARGET_OPENSHIFT=true ./hack/generate-releaseyaml.sh):release.yaml
+                for target in release-${version} release-${stable_tag} stable;do
+                  export PAC_VERSION=${version} TARGET_BRANCH=${target//release-}
+                  msg="pac release ${version} on branch ${target}"
+                  hack/upload-file-to-github.py \
+                      --message "Release yaml generated for ${msg}" \
+                      --owner-repository openshift-pipelines/pipelines-as-code \
+                      --token ${HUB_TOKEN} \
+                      --to-ref=refs/heads/${target} \
+                      --from-ref=refs/tags/${version} \
+                      -f <(./hack/generate-releaseyaml.sh):release.k8s.yaml \
+                      -f <(env TARGET_OPENSHIFT=true ./hack/generate-releaseyaml.sh):release.yaml
+                done
       - name: gorelease
         runAfter:
           - release-yaml


### PR DESCRIPTION
We were force generating tags on release when we really should have done
ref.

Fix when getting multiple tags too to only pickup the right one.

Fix goreleaser generated message to point to the assets on release page

Make CI of e2e only activate on push to main, or it will get crazy on release when we push all those branches.

Generate the proper version and quay tags for each specific push on releaseyamls

Fixes #568 
Fixes #573
Fixes #574

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
