### PR TITLE
Don't fail immediately when we have an error

### DIFF
--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -186,11 +186,10 @@ func Run(ctx context.Context, cs *params.Run, providerintf provider.Interface, k
 	if err := k8int.WaitForPipelineRunSucceed(ctx, cs.Clients.Tekton.TektonV1beta1(), pr, duration); err != nil {
 		// if we have a timeout from the pipeline run, we would not know it. We would need to get the PR status to know.
 		// maybe something to improve in the future.
-		return fmt.Errorf("pipelinerun %s in namespace %s has a failed status: %w",
-			pipelineRun.GetGenerateName(), repo.GetNamespace(), err)
+		cs.Clients.Log.Errorf("pipelinerun has failed: %s", err.Error())
 	}
 
-	// Do cleanups
+	// Cleanup old succeeded pipelineruns
 	if keepMaxPipeline, ok := config["max-keep-runs"]; ok {
 		max, err := strconv.Atoi(keepMaxPipeline)
 		if err != nil {


### PR DESCRIPTION
When we made the fix for timeout (which include any errors) we would
exit straight away which would cause issues.

We are now just logging and let the flow continue to report.

Make sure we are not cleaning up pipeline with failures.

No tests in that flow....

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
