### PR TITLE
Try to import the same fix as what we have on push

### DIFF
--- a/.tekton/release-pipeline.yaml
+++ b/.tekton/release-pipeline.yaml
@@ -62,8 +62,7 @@ spec:
                 # if we tag 0.5.6
                 # It will generate release yamls and upload to branch
                 # release-0.5.6, release-0.5.x and stable
-                set -euf
-                set -x
+                set -eufx
                 git fetch --tag -v
                 version=$(git  --no-pager tag --points-at HEAD)
                 [[ -z ${version} ]] && {
@@ -73,17 +72,13 @@ spec:
                 stable_tag=${version%.*}.x
                 for target in release-${version} release-${stable_tag} stable;do
                   export PAC_VERSION=${version} TARGET_BRANCH=${target//release-}
-                  hack/generate-releaseyaml.sh > release.k8s.yaml
-                  env TARGET_OPENSHIFT=true hack/generate-releaseyaml.sh > release.yaml
+                  bash hack/generate-releaseyaml.sh > release.k8s.yaml
+                  env TARGET_OPENSHIFT=true bash hack/generate-releaseyaml.sh > release.yaml
                   msg="pac release ${version} on branch ${target}"
-                  hack/upload-file-to-github.py \
-                      --message "Release yaml generated for ${msg}" \
-                      --owner-repository openshift-pipelines/pipelines-as-code \
-                      --token ${HUB_TOKEN} \
-                      --to-ref=refs/heads/${target} \
-                      --from-ref=refs/tags/${version} \
-                      -f release.k8s.yaml:release.k8s.yaml \
-                      -f release.yaml:release.yaml
+                  set +x
+                  echo python hack/upload-file-to-github.py --message "Release yaml generated for ${msg}" --owner-repository openshift-pipelines/pipelines-as-code --token "TOKEN" --to-ref=refs/heads/${target} --from-ref=refs/tags/${version} -f release.k8s.yaml:release.k8s.yaml -f release.yaml:release.yaml
+                  python hack/upload-file-to-github.py --message "Release yaml generated for ${msg}" --owner-repository openshift-pipelines/pipelines-as-code --token ${HUB_TOKEN} --to-ref=refs/heads/${target} --from-ref=refs/tags/${version} -f release.k8s.yaml:release.k8s.yaml -f release.yaml:release.yaml
+                  set -x
                 done
       - name: gorelease
         runAfter:


### PR DESCRIPTION
On push pipeline we did a weird fix which make no sense but works.

https://github.com/openshift-pipelines/pipelines-as-code/commit/92de7b4f2d0dfae5afbbf013068c3d4600e08c07

It was failing before because for whatever reasons it could not find the
shell scripts in hack  :

```
[release] /tekton/scripts/script-0-vkrmt: line 4: hack/generate-releaseyaml.sh: No such file or directory
```

while the PATH are set properly and everything,

doesn't make sense at all but with this "fix" it was working :

```
[upload-release-yaml : release] TAG SHA: 92de7b4f2d0dfae5afbbf013068c3d4600e08c07
[upload-release-yaml : release] Create or update branch: nightly
[upload-release-yaml : release] refs/heads/nightly has been updated to 92de7b4f2d0dfae5afbbf013068c3d4600e08c07
[upload-release-yaml : release] Upload file release.k8s.yaml to release.k8s.yaml based on 92de7b4f2d0dfae5afbbf013068c3d4600e08c07
[upload-release-yaml : release] Upload file release.yaml to release.yaml based on 34f810968d2a4ee5deb79b9feabadcc7b95cae9a
```

so we import that same "fix" here on release pipeline since those are
harder to debug we just pray that the "fix" fixes it

again i have no idea what i am doing!

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
