### PR TITLE
Allow multiple pipelinerun for the same event

### DIFF
--- a/.github/workflows/kind-e2e-tests.yaml
+++ b/.github/workflows/kind-e2e-tests.yaml
@@ -153,7 +153,7 @@ jobs:
 
       - name: Create Ambassador Route
         run: |
-          sudo echo "127.0.0.1 $EL_NAME" | sudo tee -a /etc/hosts
+          echo "127.0.0.1 $EL_NAME" | sudo tee -a /etc/hosts
           cat <<EOF | kubectl apply -f-
           apiVersion: networking.k8s.io/v1
           kind: Ingress
@@ -235,6 +235,7 @@ jobs:
           kind export logs /tmp/logs
           cp -a /tmp/gosmee-replay /tmp/logs/
 
+          kubectl get repositories.pipelinesascode.tekton.dev -A -o yaml > /tmp/logs/pac-repositories
           kubectl get configmap -n pipelines-as-code -o yaml > /tmp/logs/pac-configmap
 
       - name: Upload artifacts

--- a/docs/content/dev/_index.md
+++ b/docs/content/dev/_index.md
@@ -152,14 +152,18 @@ need to go to this URL:
 Several tools are used on CI and in `pre-commit`, the non exhaustive list you
 need to have on your system:
 
-- [golangci-lint](https://github.com/golangci/golangci-lint)
-- [yamllint](https://github.com/adrienverge/yamllint)
-- [vale](https://github.com/errata-ai/vale)
-- [markdownlint](https://github.com/golangci/golangci-lint)
-- [hugo](https://gohugo.io)
-- [ko](https://github.com/google/ko)
-- [kind](https://kind.sigs.k8s.io/)
-- [sugarjazy](https://github.com/chmouel/sugarjazy)
+- [golangci-lint](https://github.com/golangci/golangci-lint) - For golang lint
+- [yamllint](https://github.com/adrienverge/yamllint) - For YAML lint
+- [vale](https://github.com/errata-ai/vale) - For grammar check
+- [markdownlint](https://github.com/markdownlint/markdownlint) - For markdown lint
+- [hugo](https://gohugo.io) - For documentation
+- [ko](https://github.com/google/ko) - To rebuild and push change to kube cluster.
+- [kind](https://kind.sigs.k8s.io/) - For local devs
+- [sugarjazy](https://github.com/chmouel/sugarjazy) - To parse json logs nicely
+- [pre-commit](https://pre-commit.com/) - For checking commits before sending it
+  to the outer loop.
+- [pass](https://www.passwordstore.org/) - For getting/storing secrets
+- [gosmee](https://github.com/chmouel/gosmee) - For replaying webhooks
 
 # Links
 

--- a/docs/content/docs/guide/authoringprs.md
+++ b/docs/content/docs/guide/authoringprs.md
@@ -92,9 +92,9 @@ tags into your repository.
 Matching annotations are currently mandated or `Pipelines as Code` will not
 match your `PipelineRun`.
 
-If there is multiple pipeline matching an event, it will match the first one. We
-are currently not supporting multiple PipelineRuns on a single event, but this
-may be something we can consider implementing in the future.
+If there is multiple pipelinerun matching an event, it will run all of them in
+parallel and posting the results to the provider as soon the PipelineRun
+finishes.
 
 ## Advanced event matching
 

--- a/docs/content/docs/guide/authoringprs.md
+++ b/docs/content/docs/guide/authoringprs.md
@@ -92,7 +92,7 @@ tags into your repository.
 Matching annotations are currently mandated or `Pipelines as Code` will not
 match your `PipelineRun`.
 
-If there is multiple pipelinerun matching an event, it will run all of them in
+If there are multiple pipelinerun matching an event, it will run all of them in
 parallel and posting the results to the provider as soon the PipelineRun
 finishes.
 

--- a/pkg/matcher/annotation_matcher_test.go
+++ b/pkg/matcher/annotation_matcher_test.go
@@ -266,7 +266,7 @@ func TestMatchPipelinerunAnnotationAndRepositories(t *testing.T) {
 		{
 			name:    "no match a repository with target NS",
 			wantErr: true,
-			wantLog: "matching a pipeline to event: URL",
+			wantLog: "matching pipelineruns to event: URL",
 			args: args{
 				pruns: []*tektonv1beta1.PipelineRun{pipelineTargetNS},
 				runevent: info.Event{
@@ -297,7 +297,7 @@ func TestMatchPipelinerunAnnotationAndRepositories(t *testing.T) {
 				Clients: clients.Clients{PipelineAsCode: cs.PipelineAsCode, Log: logger},
 				Info:    info.Info{},
 			}
-			got, repo, _, err := MatchPipelinerunByAnnotation(ctx,
+			matches, err := MatchPipelinerunByAnnotation(ctx,
 				tt.args.pruns,
 				client, &tt.args.runevent)
 
@@ -310,10 +310,10 @@ func TestMatchPipelinerunAnnotationAndRepositories(t *testing.T) {
 			}
 
 			if tt.wantRepoName != "" {
-				assert.Assert(t, tt.wantRepoName == repo.GetName())
+				assert.Assert(t, tt.wantRepoName == matches[0].Repo.GetName())
 			}
 			if tt.wantPRName != "" {
-				assert.Assert(t, tt.wantPRName == got.GetName())
+				assert.Assert(t, tt.wantPRName == matches[0].PipelineRun.GetName())
 			}
 			if tt.wantLog != "" {
 				logmsg := log.TakeAll()
@@ -529,14 +529,15 @@ func TestMatchPipelinerunByAnnotation(t *testing.T) {
 				},
 				Info: info.Info{},
 			}
-			got, _, _, err := MatchPipelinerunByAnnotation(ctx, tt.args.pruns, cs, &tt.args.runevent)
+			matches, err := MatchPipelinerunByAnnotation(ctx, tt.args.pruns, cs, &tt.args.runevent)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("MatchPipelinerunByAnnotation() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 
 			if tt.wantPrName != "" {
-				assert.Assert(t, got.GetName() == tt.wantPrName, "Pipelinerun hasn't been matched: "+got.GetName()+"!="+tt.wantPrName)
+				assert.Assert(t, matches[0].PipelineRun.GetName() == tt.wantPrName, "Pipelinerun hasn't been matched: %+v",
+					matches[0].PipelineRun.GetName(), tt.wantPrName)
 			}
 			if tt.wantLog != "" {
 				logmsg := log.TakeAll()

--- a/pkg/matcher/annotation_tasks_install.go
+++ b/pkg/matcher/annotation_tasks_install.go
@@ -115,7 +115,7 @@ func getTaskFromLocalFS(taskName string, logger *zap.SugaredLogger) (string, err
 	// let's try by any chance to check locally if the task is here on
 	// the filesystem
 	if _, err := os.Stat(taskName); errors.Is(err, os.ErrNotExist) {
-		logger.Warnf("could not find remote task %s inside repo", taskName)
+		logger.Warnf("could not find remote task %s inside Repo", taskName)
 		return "", nil
 	}
 

--- a/pkg/matcher/annotation_tasks_install_test.go
+++ b/pkg/matcher/annotation_tasks_install_test.go
@@ -142,7 +142,7 @@ spec:
 			annotations: map[string]string{
 				pipelinesascode.GroupName + "/task": "[not/here]",
 			},
-			wantLog: "could not find remote task not/here inside repo",
+			wantLog: "could not find remote task not/here inside Repo",
 		},
 		{
 			name:        "test-get-from-hub-latest",

--- a/pkg/params/info/events.go
+++ b/pkg/params/info/events.go
@@ -33,7 +33,6 @@ type Event struct {
 	// Github
 	Organization string
 	Repository   string
-	CheckRunID   *int64
 
 	// Bitbucket Cloud
 	AccountID string

--- a/pkg/pipelineascode/pipelinesascode_github_test.go
+++ b/pkg/pipelineascode/pipelinesascode_github_test.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -374,10 +375,13 @@ func TestRun(t *testing.T) {
 				GetSecretResult:          secrets,
 			}
 
-			err := Run(ctx, cs, &ghprovider.Provider{
-				Client: fakeclient,
-				Token:  github.String("None"),
-			}, k8int, &tt.runevent)
+			vcx := &ghprovider.Provider{
+				Client:      fakeclient,
+				Token:       github.String("None"),
+				CheckRunIDS: &sync.Map{},
+			}
+			p := NewPacs(&tt.runevent, vcx, cs, k8int)
+			err := p.Run(ctx)
 
 			if tt.wantErr != "" {
 				assert.ErrorContains(t, err, tt.wantErr)

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 
 	"github.com/google/go-github/v43/github"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
@@ -22,6 +23,8 @@ type Provider struct {
 	Client        *github.Client
 	Token, APIURL *string
 	ApplicationID *int64
+
+	CheckRunIDS *sync.Map
 }
 
 func (v *Provider) Validate(ctx context.Context, cs *params.Run, event *info.Event) error {
@@ -63,6 +66,8 @@ func (v *Provider) SetClient(ctx context.Context, event *info.Event) error {
 	if v.Client == nil {
 		v.Client = client
 	}
+	v.CheckRunIDS = &sync.Map{}
+
 	v.APIURL = &apiURL
 
 	return nil

--- a/test/bitbucket_cloud_pullrequest_test.go
+++ b/test/bitbucket_cloud_pullrequest_test.go
@@ -33,7 +33,7 @@ func TestBitbucketCloudPullRequest(t *testing.T) {
 	hash, ok := repobranch.Target["hash"].(string)
 	assert.Assert(t, ok)
 
-	wait.Succeeded(ctx, t, runcnx, opts, options.PullRequestEvent, targetNS, hash, title)
+	wait.Succeeded(ctx, t, runcnx, opts, options.PullRequestEvent, targetNS, 1, hash, title)
 }
 
 // Local Variables:

--- a/test/config_maxkeepruns_test.go
+++ b/test/config_maxkeepruns_test.go
@@ -18,7 +18,7 @@ func TestGithubMaxKeepRuns(t *testing.T) {
 	ctx := context.TODO()
 	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, sha := tgithub.RunPullRequest(ctx, t,
 		"Github MaxKeepRun config",
-		"testdata/pipelinerun-max-keep-run-1.yaml", false)
+		[]string{"testdata/pipelinerun-max-keep-run-1.yaml"}, false)
 	defer tgithub.TearDown(ctx, t, runcnx, ghcnx, prNumber, targetRefName, targetNS, opts)
 
 	runcnx.Clients.Log.Infof("Creating /retest in PullRequest")

--- a/test/github_pullrequest_oktotest_test.go
+++ b/test/github_pullrequest_oktotest_test.go
@@ -23,7 +23,8 @@ import (
 
 func TestGithubPullRequestOkToTest(t *testing.T) {
 	ctx := context.TODO()
-	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, sha := tgithub.RunPullRequest(ctx, t, "Github OkToTest comment", "testdata/pipelinerun.yaml", false)
+	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, sha := tgithub.RunPullRequest(ctx, t,
+		"Github OkToTest comment", []string{"testdata/pipelinerun.yaml"}, false)
 	defer tgithub.TearDown(ctx, t, runcnx, ghcnx, prNumber, targetRefName, targetNS, opts)
 
 	repoinfo, resp, err := ghcnx.Client.Repositories.Get(ctx, opts.Organization, opts.Repo)

--- a/test/github_pullrequest_privaterepository_test.go
+++ b/test/github_pullrequest_privaterepository_test.go
@@ -12,13 +12,15 @@ import (
 
 func TestGithubPullRequestPrivateRepository(t *testing.T) {
 	ctx := context.TODO()
-	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, _ := tgithub.RunPullRequest(ctx, t, "Github Private Repo", "testdata/pipelinerun_git_clone_private.yaml", false)
+	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, _ := tgithub.RunPullRequest(ctx, t,
+		"Github Private Repo", []string{"testdata/pipelinerun_git_clone_private.yaml"}, false)
 	defer tgithub.TearDown(ctx, t, runcnx, ghcnx, prNumber, targetRefName, targetNS, opts)
 }
 
 func TestGithubPullRequestPrivateRepositoryOnWebhook(t *testing.T) {
 	ctx := context.TODO()
-	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, _ := tgithub.RunPullRequest(ctx, t, "Github Private Repo OnWebhook", "testdata/pipelinerun_git_clone_private.yaml", true)
+	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, _ := tgithub.RunPullRequest(ctx, t,
+		"Github Private Repo OnWebhook", []string{"testdata/pipelinerun_git_clone_private.yaml"}, true)
 	defer tgithub.TearDown(ctx, t, runcnx, ghcnx, prNumber, targetRefName, targetNS, opts)
 }
 

--- a/test/github_pullrequest_rerequest_test.go
+++ b/test/github_pullrequest_rerequest_test.go
@@ -22,7 +22,8 @@ import (
 
 func TestGithubPullRerequest(t *testing.T) {
 	ctx := context.TODO()
-	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, sha := tgithub.RunPullRequest(ctx, t, "Github Rerequest", "testdata/pipelinerun.yaml", false)
+	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, sha := tgithub.RunPullRequest(ctx, t, "Github Rerequest",
+		[]string{"testdata/pipelinerun.yaml"}, false)
 	defer tgithub.TearDown(ctx, t, runcnx, ghcnx, prNumber, targetRefName, targetNS, opts)
 
 	repoinfo, resp, err := ghcnx.Client.Repositories.Get(ctx, opts.Organization, opts.Repo)

--- a/test/github_pullrequest_retest_test.go
+++ b/test/github_pullrequest_retest_test.go
@@ -17,7 +17,8 @@ import (
 
 func TestGithubPullRequestRetest(t *testing.T) {
 	ctx := context.TODO()
-	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, sha := tgithub.RunPullRequest(ctx, t, "Github Retest comment", "testdata/pipelinerun.yaml", false)
+	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, sha := tgithub.RunPullRequest(ctx, t,
+		"Github Retest comment", []string{"testdata/pipelinerun.yaml"}, false)
 	defer tgithub.TearDown(ctx, t, runcnx, ghcnx, prNumber, targetRefName, targetNS, opts)
 
 	runcnx.Clients.Log.Infof("Creating /retest in PullRequest")

--- a/test/github_pullrequest_test.go
+++ b/test/github_pullrequest_test.go
@@ -14,7 +14,16 @@ import (
 func TestGithubPullRequest(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, _ := tgithub.RunPullRequest(ctx, t, "Github PullRequest", "testdata/pipelinerun.yaml", false)
+	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, _ := tgithub.RunPullRequest(ctx, t, "Github PullRequest",
+		[]string{"testdata/pipelinerun.yaml"}, false)
+	defer tgithub.TearDown(ctx, t, runcnx, ghcnx, prNumber, targetRefName, targetNS, opts)
+}
+
+func TestGithubPullRequestMultiples(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, _ := tgithub.RunPullRequest(ctx, t, "Github PullRequest",
+		[]string{"testdata/pipelinerun.yaml", "testdata/pipelinerun-clone.yaml"}, false)
 	defer tgithub.TearDown(ctx, t, runcnx, ghcnx, prNumber, targetRefName, targetNS, opts)
 }
 
@@ -22,7 +31,7 @@ func TestGithubPullRequestMatchOnCEL(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, _ := tgithub.RunPullRequest(ctx, t, "Github PullRequest",
-		"testdata/pipelinerun-cel-annotation.yaml", false)
+		[]string{"testdata/pipelinerun-cel-annotation.yaml"}, false)
 	defer tgithub.TearDown(ctx, t, runcnx, ghcnx, prNumber, targetRefName, targetNS, opts)
 }
 
@@ -33,7 +42,8 @@ func TestGithubPullRequestWebhook(t *testing.T) {
 	}
 	ctx := context.Background()
 
-	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, _ := tgithub.RunPullRequest(ctx, t, "Github PullRequest onWebhook", "testdata/pipelinerun.yaml", true)
+	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, _ := tgithub.RunPullRequest(ctx, t,
+		"Github PullRequest onWebhook", []string{"testdata/pipelinerun.yaml"}, true)
 	defer tgithub.TearDown(ctx, t, runcnx, ghcnx, prNumber, targetRefName, targetNS, opts)
 }
 

--- a/test/github_push_test.go
+++ b/test/github_push_test.go
@@ -46,7 +46,8 @@ func TestGithubPush(t *testing.T) {
 		err = tgithub.CreateCRD(ctx, t, repoinfo, runcnx, opts, targetNS)
 		assert.NilError(t, err)
 
-		entries, err := payload.GetEntries("testdata/pipelinerun-on-push.yaml", targetNS, targetBranch, targetEvent)
+		entries, err := payload.GetEntries([]string{"testdata/pipelinerun-on-push.yaml"}, targetNS, targetBranch,
+			targetEvent)
 		assert.NilError(t, err)
 
 		title := "TestPush "

--- a/test/gitlab_merge_request_test.go
+++ b/test/gitlab_merge_request_test.go
@@ -32,7 +32,7 @@ func TestGitlabMergeRequest(t *testing.T) {
 	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, targetNS)
 	assert.NilError(t, err)
 
-	entries, err := payload.GetEntries([]string{"testdata/pipelinerun.yaml"}, targetNS, projectinfo.DefaultBranch,
+	entries, err := payload.GetEntries([]string{"testdata/pipelinerun.yaml", "testdata/pipelinerun-clone.yaml"}, targetNS, projectinfo.DefaultBranch,
 		options.PullRequestEvent)
 	assert.NilError(t, err)
 
@@ -49,7 +49,7 @@ func TestGitlabMergeRequest(t *testing.T) {
 	assert.NilError(t, err)
 	runcnx.Clients.Log.Infof("MergeRequest %s/-/merge_requests/%d has been created", projectinfo.WebURL, mrID)
 	defer tgitlab.TearDown(ctx, t, runcnx, glprovider, mrID, targetRefName, targetNS, opts.ProjectID)
-	wait.Succeeded(ctx, t, runcnx, opts, "Merge_Request", targetNS, 1, "", title)
+	wait.Succeeded(ctx, t, runcnx, opts, "Merge_Request", targetNS, 2, "", title)
 }
 
 // Local Variables:

--- a/test/gitlab_merge_request_test.go
+++ b/test/gitlab_merge_request_test.go
@@ -32,7 +32,8 @@ func TestGitlabMergeRequest(t *testing.T) {
 	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, targetNS)
 	assert.NilError(t, err)
 
-	entries, err := payload.GetEntries("testdata/pipelinerun.yaml", targetNS, projectinfo.DefaultBranch, options.PullRequestEvent)
+	entries, err := payload.GetEntries([]string{"testdata/pipelinerun.yaml"}, targetNS, projectinfo.DefaultBranch,
+		options.PullRequestEvent)
 	assert.NilError(t, err)
 
 	targetRefName := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test")
@@ -48,7 +49,7 @@ func TestGitlabMergeRequest(t *testing.T) {
 	assert.NilError(t, err)
 	runcnx.Clients.Log.Infof("MergeRequest %s/-/merge_requests/%d has been created", projectinfo.WebURL, mrID)
 	defer tgitlab.TearDown(ctx, t, runcnx, glprovider, mrID, targetRefName, targetNS, opts.ProjectID)
-	wait.Succeeded(ctx, t, runcnx, opts, "Merge_Request", targetNS, "", title)
+	wait.Succeeded(ctx, t, runcnx, opts, "Merge_Request", targetNS, 1, "", title)
 }
 
 // Local Variables:

--- a/test/pkg/bitbucketcloud/pr.go
+++ b/test/pkg/bitbucketcloud/pr.go
@@ -22,7 +22,7 @@ func MakePR(t *testing.T, bprovider bitbucketcloud.Provider, runcnx *params.Run,
 	entries, err := payload.GetEntries([]string{"testdata/pipelinerun.yaml"}, targetNS, options.MainBranch,
 		options.PullRequestEvent)
 	assert.NilError(t, err)
-	tmpfile := fs.NewFile(t, "pipelinerun", fs.WithContent(entries[".tekton/pr.yaml"]))
+	tmpfile := fs.NewFile(t, "pipelinerun", fs.WithContent(entries[".tekton/pipelinerun.yaml"]))
 	defer tmpfile.Remove()
 
 	err = bprovider.Client.Workspaces.Repositories.Repository.WriteFileBlob(&bitbucket.RepositoryBlobWriteOptions{

--- a/test/pkg/bitbucketcloud/pr.go
+++ b/test/pkg/bitbucketcloud/pr.go
@@ -19,7 +19,8 @@ func MakePR(t *testing.T, bprovider bitbucketcloud.Provider, runcnx *params.Run,
 	commitAuthor := "OpenShift Pipelines E2E test"
 	commitEmail := "e2e-pipelines@redhat.com"
 
-	entries, err := payload.GetEntries("testdata/pipelinerun.yaml", targetNS, options.MainBranch, options.PullRequestEvent)
+	entries, err := payload.GetEntries([]string{"testdata/pipelinerun.yaml"}, targetNS, options.MainBranch,
+		options.PullRequestEvent)
 	assert.NilError(t, err)
 	tmpfile := fs.NewFile(t, "pipelinerun", fs.WithContent(entries[".tekton/pr.yaml"]))
 	defer tmpfile.Remove()

--- a/test/pkg/github/pr.go
+++ b/test/pkg/github/pr.go
@@ -98,7 +98,7 @@ func PRCreate(ctx context.Context, cs *params.Run, ghcnx ghprovider.Provider, ow
 	return pr.GetNumber(), nil
 }
 
-func RunPullRequest(ctx context.Context, t *testing.T, label string, prFile string, webhook bool) (*params.Run, ghprovider.Provider, options.E2E, string, string, int, string) {
+func RunPullRequest(ctx context.Context, t *testing.T, label string, yamlFiles []string, webhook bool) (*params.Run, ghprovider.Provider, options.E2E, string, string, int, string) {
 	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
 	runcnx, opts, ghcnx, err := Setup(ctx, webhook)
 	assert.NilError(t, err)
@@ -115,7 +115,7 @@ func RunPullRequest(ctx context.Context, t *testing.T, label string, prFile stri
 	err = CreateCRD(ctx, t, repoinfo, runcnx, opts, targetNS)
 	assert.NilError(t, err)
 
-	entries, err := payload.GetEntries(prFile, targetNS, options.MainBranch, options.PullRequestEvent)
+	entries, err := payload.GetEntries(yamlFiles, targetNS, options.MainBranch, options.PullRequestEvent)
 	assert.NilError(t, err)
 
 	targetRefName := fmt.Sprintf("refs/heads/%s",
@@ -130,6 +130,6 @@ func RunPullRequest(ctx context.Context, t *testing.T, label string, prFile stri
 		opts.Repo, targetRefName, repoinfo.GetDefaultBranch(), logmsg)
 	assert.NilError(t, err)
 
-	wait.Succeeded(ctx, t, runcnx, opts, options.PullRequestEvent, targetNS, sha, logmsg)
+	wait.Succeeded(ctx, t, runcnx, opts, options.PullRequestEvent, targetNS, len(yamlFiles), sha, logmsg)
 	return runcnx, ghcnx, opts, targetNS, targetRefName, number, sha
 }

--- a/test/pkg/gitlab/test.go
+++ b/test/pkg/gitlab/test.go
@@ -10,18 +10,21 @@ var (
 )
 
 func PushFilesToRef(client *ghlib.Client, commitMessage, baseBranch, targetRef string, pid int, files map[string]string) error {
-	for fileName, content := range files {
-		_, _, err := client.RepositoryFiles.CreateFile(pid, fileName, &ghlib.CreateFileOptions{
-			Branch:        ghlib.String(targetRef),
-			StartBranch:   ghlib.String(baseBranch),
-			AuthorEmail:   ghlib.String(commitEmail),
-			AuthorName:    ghlib.String(commitAuthor),
-			Content:       ghlib.String(content),
-			CommitMessage: ghlib.String(commitMessage),
-		})
-		if err != nil {
-			return err
-		}
+	fullYaml := ""
+	for _, content := range files {
+		fullYaml += "---\n"
+		fullYaml += content
+	}
+	_, _, err := client.RepositoryFiles.CreateFile(pid, ".tekton/pr.yaml", &ghlib.CreateFileOptions{
+		Branch:        ghlib.String(targetRef),
+		StartBranch:   ghlib.String(baseBranch),
+		AuthorEmail:   ghlib.String(commitEmail),
+		AuthorName:    ghlib.String(commitAuthor),
+		Content:       ghlib.String(fullYaml),
+		CommitMessage: ghlib.String(commitMessage),
+	})
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/test/pkg/payload/get_entries.go
+++ b/test/pkg/payload/get_entries.go
@@ -3,15 +3,18 @@ package payload
 import (
 	"fmt"
 	"io/ioutil"
+	"path/filepath"
 )
 
-func GetEntries(yamlfile, targetNS, targetBranch, targetEvent string) (map[string]string, error) {
-	prun, err := ioutil.ReadFile(yamlfile)
-	if err != nil {
-		return nil, err
+func GetEntries(yamlfile []string, targetNS, targetBranch, targetEvent string) (map[string]string, error) {
+	entries := map[string]string{}
+	for _, file := range yamlfile {
+		yamlprun, err := ioutil.ReadFile(file)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read yaml file: %w", err)
+		}
+		entries[filepath.Join(".tekton", filepath.Base(file))] = fmt.Sprintf(string(yamlprun), targetNS, targetBranch,
+			targetEvent)
 	}
-
-	return map[string]string{
-		".tekton/pr.yaml": fmt.Sprintf(string(prun), targetNS, targetBranch, targetEvent),
-	}, nil
+	return entries, nil
 }

--- a/test/pkg/wait/check.go
+++ b/test/pkg/wait/check.go
@@ -15,7 +15,7 @@ import (
 
 var DefaultTimeout = 10 * time.Minute
 
-func Succeeded(ctx context.Context, t *testing.T, runcnx *params.Run, opts options.E2E, onEvent, targetNS, sha, title string) {
+func Succeeded(ctx context.Context, t *testing.T, runcnx *params.Run, opts options.E2E, onEvent, targetNS string, numberofprmatch int, sha, title string) {
 	runcnx.Clients.Log.Infof("Waiting for Repository to be updated")
 	waitOpts := Opts{
 		RepoName:        targetNS,
@@ -30,31 +30,34 @@ func Succeeded(ctx context.Context, t *testing.T, runcnx *params.Run, opts optio
 	runcnx.Clients.Log.Infof("Check if we have the repository set as succeeded")
 	repo, err := runcnx.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(targetNS).Get(ctx, targetNS, v1.GetOptions{})
 	assert.NilError(t, err)
-	laststatus := repo.Status[len(repo.Status)-1]
-	assert.Equal(t, corev1.ConditionTrue, laststatus.Conditions[0].Status)
-	if sha != "" {
-		assert.Equal(t, sha, *laststatus.SHA)
-		assert.Equal(t, sha, filepath.Base(*laststatus.SHAURL))
-	}
-	assert.Equal(t, title, *laststatus.Title)
-	assert.Assert(t, *laststatus.LogURL != "")
 
-	pr, err := runcnx.Clients.Tekton.TektonV1beta1().PipelineRuns(targetNS).Get(ctx, laststatus.PipelineRunName, v1.GetOptions{})
-	assert.NilError(t, err)
+	for i := 1; i == numberofprmatch; i++ {
+		laststatus := repo.Status[len(repo.Status)-i]
+		assert.Equal(t, corev1.ConditionTrue, laststatus.Conditions[0].Status)
+		if sha != "" {
+			assert.Equal(t, sha, *laststatus.SHA)
+			assert.Equal(t, sha, filepath.Base(*laststatus.SHAURL))
+		}
+		assert.Equal(t, title, *laststatus.Title)
+		assert.Assert(t, *laststatus.LogURL != "")
 
-	assert.Equal(t, onEvent, pr.Labels["pipelinesascode.tekton.dev/event-type"])
-	assert.Equal(t, repo.GetName(), pr.Labels["pipelinesascode.tekton.dev/repository"])
-	// assert.Equal(t, opts.Owner, pr.Labels["pipelinesascode.tekton.dev/sender"]) bitbucket is too weird for that
+		pr, err := runcnx.Clients.Tekton.TektonV1beta1().PipelineRuns(targetNS).Get(ctx, laststatus.PipelineRunName, v1.GetOptions{})
+		assert.NilError(t, err)
 
-	if opts.Organization != "" {
-		assert.Equal(t, opts.Organization, pr.Labels["pipelinesascode.tekton.dev/url-org"])
+		assert.Equal(t, onEvent, pr.Labels["pipelinesascode.tekton.dev/event-type"])
+		assert.Equal(t, repo.GetName(), pr.Labels["pipelinesascode.tekton.dev/repository"])
+		// assert.Equal(t, opts.Owner, pr.Labels["pipelinesascode.tekton.dev/sender"]) bitbucket is too weird for that
+
+		if opts.Organization != "" {
+			assert.Equal(t, opts.Organization, pr.Labels["pipelinesascode.tekton.dev/url-org"])
+		}
+		if opts.Repo != "" {
+			assert.Equal(t, opts.Repo, pr.Labels["pipelinesascode.tekton.dev/url-repository"])
+		}
+		if sha != "" {
+			assert.Equal(t, sha, pr.Labels["pipelinesascode.tekton.dev/sha"])
+			assert.Equal(t, sha, filepath.Base(pr.Annotations["pipelinesascode.tekton.dev/sha-url"]))
+		}
+		assert.Equal(t, title, pr.Annotations["pipelinesascode.tekton.dev/sha-title"])
 	}
-	if opts.Repo != "" {
-		assert.Equal(t, opts.Repo, pr.Labels["pipelinesascode.tekton.dev/url-repository"])
-	}
-	if sha != "" {
-		assert.Equal(t, sha, pr.Labels["pipelinesascode.tekton.dev/sha"])
-		assert.Equal(t, sha, filepath.Base(pr.Annotations["pipelinesascode.tekton.dev/sha-url"]))
-	}
-	assert.Equal(t, title, pr.Annotations["pipelinesascode.tekton.dev/sha-title"])
 }

--- a/test/testdata/pipelinerun-clone.yaml
+++ b/test/testdata/pipelinerun-clone.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: pipeline-clone
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "%s"
+    pipelinesascode.tekton.dev/on-target-branch: "[%s]"
+    pipelinesascode.tekton.dev/on-event: "[%s]"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: task
+        taskSpec:
+          steps:
+            - name: task
+              image: registry.access.redhat.com/ubi8/ubi-micro:8.5
+              command: ["/bin/echo", "HELLOMOTO"]


### PR DESCRIPTION
# Changes

Allow multiple pipelinerun on the same event

Fixes #528 

A bunch of of refactoring to break out .Run which got moved to its own.

We have a `sync.Map` of  checkRunIds to track the checkRuns to which pipelineRun, we use github api "external_id" field for that .

We run a goroutine in a workgroups waiting for all the pr to run This wait that all of them finishes before exiting to the adapter goroutine.
We retries if we can't update the RepoStatus until we are able to do it.

## TODO (before merge):

- [x] Doc
- [x] E2E tests on multiple PR matching
- [ ] Test that webhook and other provider works (should be creating a new comment)

## TODO (post):

- [ ] Increase unittesting scenarios
- [ ] Add `/test prname` support

## Screenshot:

![image](https://user-images.githubusercontent.com/98980/163419727-8b2df6a3-2d7e-498b-933e-c5f3106c30ca.png)
![image](https://user-images.githubusercontent.com/98980/163419763-bef98878-fafc-421d-8eaf-954bf032564d.png)

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [x] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [x] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [x] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [x] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
