### PR TITLE
Fixes bootstrap cmd for OpenShift cluster

### DIFF
--- a/pkg/cmd/tknpac/bootstrap/install.go
+++ b/pkg/cmd/tknpac/bootstrap/install.go
@@ -46,11 +46,11 @@ func kubectlApply(uri string) error {
 }
 
 func installPac(ctx context.Context, run *params.Run, opts *bootstrapOpts) error {
-	var latestversion, latestReleaseYaml, nightlyReleaseYaml string
+	var latestVersion, latestReleaseYaml, nightlyReleaseYaml string
 	k8Ext := ""
 
-	routeURL, _ := detectOpenShiftRoute(ctx, run, opts)
-	if routeURL != "" {
+	routeExist, _ := checkOpenshiftRoute(run)
+	if routeExist {
 		nightlyReleaseYaml = openshiftReleaseYaml
 	} else {
 		nightlyReleaseYaml = k8ReleaseYaml
@@ -60,10 +60,10 @@ func installPac(ctx context.Context, run *params.Run, opts *bootstrapOpts) error
 	if opts.installNightly {
 		latestReleaseYaml = fmt.Sprintf("%s/%s/%s/nightly/%s",
 			rawGHURL, pacGHRepoOwner, pacGHRepoName, nightlyReleaseYaml)
-		latestversion = "nightly"
+		latestVersion = "nightly"
 	} else {
 		var err error
-		latestversion, latestReleaseYaml, err = getLatestRelease(ctx, k8Ext)
+		latestVersion, latestReleaseYaml, err = getLatestRelease(ctx, k8Ext)
 		if err != nil {
 			return err
 		}
@@ -72,7 +72,7 @@ func installPac(ctx context.Context, run *params.Run, opts *bootstrapOpts) error
 	if !opts.forceInstall {
 		doinstall, err := askYN(true,
 			fmt.Sprintf("🕵️ Pipelines as Code doesn't seems to be installed in %s namespace", opts.targetNamespace),
-			fmt.Sprintf("Do you want me to install Pipelines as Code %s?", latestversion))
+			fmt.Sprintf("Do you want me to install Pipelines as Code %s?", latestVersion))
 		if err != nil {
 			return err
 		}
@@ -86,6 +86,6 @@ func installPac(ctx context.Context, run *params.Run, opts *bootstrapOpts) error
 	}
 
 	// nolint:forbidigo
-	fmt.Printf("✓ Pipelines-as-Code %s has been installed\n", latestversion)
+	fmt.Printf("✓ Pipelines-as-Code %s has been installed\n", latestVersion)
 	return nil
 }

--- a/pkg/cmd/tknpac/bootstrap/kubestuff.go
+++ b/pkg/cmd/tknpac/bootstrap/kubestuff.go
@@ -64,15 +64,23 @@ func checkNS(ctx context.Context, run *params.Run, targetNamespace string) (bool
 }
 
 func checkPipelinesInstalled(run *params.Run) (bool, error) {
+	return checkGroupInstalled(run, "tekton.dev")
+}
+
+func checkOpenshiftRoute(run *params.Run) (bool, error) {
+	return checkGroupInstalled(run, openShiftRouteGroup)
+}
+
+func checkGroupInstalled(run *params.Run, resourceGroup string) (bool, error) {
 	sg, err := run.Clients.Kube.Discovery().ServerGroups()
 	if err != nil {
 		return false, err
 	}
-	tektonFound := false
+	found := false
 	for _, t := range sg.Groups {
-		if t.Name == "tekton.dev" {
-			tektonFound = true
+		if t.Name == resourceGroup {
+			found = true
 		}
 	}
-	return tektonFound, nil
+	return found, nil
 }


### PR DESCRIPTION
on openshift, bootstrap used to install k8s release yaml
instead of openshift, this fixes it.
it use to check for controller url to decide which release
yaml to use but before installation we don't have controller url
so it always used k8s release yaml while installing.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
