### PR TITLE
add -l to the replay script for localhost debug

### DIFF
--- a/hack/dev/gh-replay-events.py
+++ b/hack/dev/gh-replay-events.py
@@ -226,9 +226,10 @@ def app_get_delivery(
 def save_script(target: str, el_route: str, headers: dict, payload: str):
     s = f"""#!/usr/bin/env python3
 import requests
+import sys
 payload = \"\"\"{json.dumps(payload)}\"\"\"
 headers={headers}
-el_route = "{el_route}"
+el_route = "http://localhost:8080" if (len(sys.argv) > 1 and sys.argv[1] == "-l") else "{el_route}"
 r = requests.request("POST",el_route,data=payload.encode("utf-8"),headers=headers)
 r.raise_for_status()
 print("Request has been replayed on " + el_route)


### PR DESCRIPTION
I do back and forth between the contoller running on kind and
localhost. so may as well add a switch

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
