### PR TITLE
Better error message when we fail to apply PR

### DIFF
--- a/pkg/kubeinteraction/wait.go
+++ b/pkg/kubeinteraction/wait.go
@@ -69,7 +69,7 @@ func Succeed(name string) ConditionAccessorFn {
 			if c.Status == corev1.ConditionTrue {
 				return true, nil
 			} else if c.Status == corev1.ConditionFalse {
-				return true, fmt.Errorf("%q failed", name)
+				return true, fmt.Errorf("%q failed: %s", name, c.Message)
 			}
 		}
 		return false, nil

--- a/pkg/pipelineascode/pipelinesascode_github_test.go
+++ b/pkg/pipelineascode/pipelinesascode_github_test.go
@@ -118,7 +118,7 @@ func TestRun(t *testing.T) {
 			},
 			tektondir:       "testdata/pull_request",
 			finalStatus:     "neutral",
-			finalStatusText: "PipelineRun has failed to start",
+			finalStatusText: "PipelineRun has no taskruns",
 		},
 		{
 			name: "pull request/with webhook",
@@ -271,7 +271,7 @@ func TestRun(t *testing.T) {
 			},
 			tektondir:                "testdata/max-keep-runs",
 			finalStatus:              "neutral",
-			finalStatusText:          "PipelineRun has failed to start",
+			finalStatusText:          "PipelineRun has no taskruns",
 			expectedNumberofCleanups: 10,
 		},
 	}


### PR DESCRIPTION
When there is an error in PR, we were showing just a "has failed". We
now show the error message from kube and in the controller log with the
whole message.

Fixes #598

![image](https://user-images.githubusercontent.com/98980/163980942-2e632a59-82c4-4a8f-98f8-72efca1a7968.png)


Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
