### PR TITLE
display pipelinerunname when posting as comment

### DIFF
--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"sync"
 	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -155,7 +156,7 @@ func (l listener) detectProvider(reqHeader *http.Header, reqBody string) (provid
 		return nil, logger, fmt.Errorf("skips processing event")
 	}
 
-	gitHub := &github.Provider{}
+	gitHub := &github.Provider{CheckRunIDS: &sync.Map{}}
 	isGH, processReq, logger, err := gitHub.Detect(reqHeader, reqBody, &log)
 	if isGH {
 		return processRes(processReq, gitHub, logger, err)

--- a/pkg/cmd/tknpac/resolve/resolve.go
+++ b/pkg/cmd/tknpac/resolve/resolve.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/git"
@@ -149,7 +150,7 @@ func resolveFilenames(cs *params.Run, filenames []string, params map[string]stri
 		SkipInlining: skipInlining,
 	}
 	// We use github here but since we don't do remotetask we would not care
-	providerintf := &github.Provider{}
+	providerintf := &github.Provider{CheckRunIDS: &sync.Map{}}
 	event := info.NewEvent()
 	prun, err := resolve.Resolve(ctx, cs, providerintf, event, allTemplates, ropt)
 	if err != nil {

--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -243,8 +243,8 @@ func (p *PacRun) startPR(ctx context.Context, match matcher.Match) error {
 	if err := p.k8int.WaitForPipelineRunSucceed(ctx, p.run.Clients.Tekton.TektonV1beta1(), pr, duration); err != nil {
 		// if we have a timeout from the pipeline run, we would not know it. We would need to get the PR status to know.
 		// maybe something to improve in the future.
-		p.run.Clients.Log.Errorf("pipelinerun %s in namespace %s has failed: %w",
-			match.PipelineRun.GetGenerateName(), match.Repo.GetNamespace(), err)
+		p.run.Clients.Log.Errorf("pipelinerun %s in namespace %s has failed: %s",
+			match.PipelineRun.GetGenerateName(), match.Repo.GetNamespace(), err.Error())
 	}
 
 	// Cleanup old succeeded pipelineruns

--- a/pkg/provider/bitbucketcloud/bitbucket.go
+++ b/pkg/provider/bitbucketcloud/bitbucket.go
@@ -88,13 +88,16 @@ func (v *Provider) CreateStatus(_ context.Context, event *info.Event, pacopts *i
 			return err
 		}
 
+		onPr := ""
+		if statusopts.OriginalPipelineRunName != "" {
+			onPr = "/" + statusopts.OriginalPipelineRunName
+		}
 		_, err = v.Client.Repositories.PullRequests.AddComment(
 			&bitbucket.PullRequestCommentOptions{
 				Owner:         event.Organization,
 				RepoSlug:      event.Repository,
 				PullRequestID: prNumber,
-				Content: fmt.Sprintf("**%s** - %s\n\n%s", pacopts.ApplicationName,
-					statusopts.Title, statusopts.Text),
+				Content:       fmt.Sprintf("**%s%s** - %s\n\n%s", pacopts.ApplicationName, onPr, statusopts.Title, statusopts.Text),
 			})
 		if err != nil {
 			return err

--- a/pkg/provider/bitbucketserver/bitbucketserver.go
+++ b/pkg/provider/bitbucketserver/bitbucketserver.go
@@ -88,8 +88,12 @@ func (v *Provider) CreateStatus(ctx context.Context, event *info.Event, pacOpts 
 		return err
 	}
 
+	onPr := ""
+	if statusOpts.OriginalPipelineRunName != "" {
+		onPr = "/" + statusOpts.OriginalPipelineRunName
+	}
 	bbcomment := bbv1.Comment{
-		Text: fmt.Sprintf("**%s** - %s\n\n%s", pacOpts.ApplicationName,
+		Text: fmt.Sprintf("**%s%s** - %s\n\n%s", pacOpts.ApplicationName, onPr,
 			statusOpts.Title, statusOpts.Text),
 	}
 

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -264,8 +264,12 @@ func (v *Provider) CreateStatus(ctx context.Context, event *info.Event, pacOpts 
 		detailsURL = statusOpts.DetailsURL
 	}
 
-	body := fmt.Sprintf("**%s** has %s\n\n%s\n\n<small>Full log available [here](%s)</small>",
-		pacOpts.ApplicationName, statusOpts.Title, statusOpts.Text, detailsURL)
+	onPr := ""
+	if statusOpts.OriginalPipelineRunName != "" {
+		onPr = "/" + statusOpts.OriginalPipelineRunName
+	}
+	body := fmt.Sprintf("**%s%s** has %s\n\n%s\n\n<small>Full log available [here](%s)</small>",
+		pacOpts.ApplicationName, onPr, statusOpts.Title, statusOpts.Text, detailsURL)
 
 	// in case we have access set the commit status, typically on MR from
 	// another users we won't have it but it would work on push or MR from a

--- a/pkg/resolve/resolve.go
+++ b/pkg/resolve/resolve.go
@@ -109,11 +109,6 @@ type Opts struct {
 // generateName can be set as True to set the name as a generateName + "-" for
 // unique pipelinerun
 func Resolve(ctx context.Context, cs *params.Run, providerintf provider.Interface, event *info.Event, data string, ropt *Opts) ([]*tektonv1beta1.PipelineRun, error) {
-	s := k8scheme.Scheme
-	if err := tektonv1beta1.AddToScheme(s); err != nil {
-		return []*tektonv1beta1.PipelineRun{}, err
-	}
-
 	types := readTypes(cs.Clients.Log, data)
 	if len(types.PipelineRuns) == 0 {
 		return []*tektonv1beta1.PipelineRun{}, errors.New("we need at least one pipelinerun to start with")
@@ -198,4 +193,9 @@ func Resolve(ctx context.Context, cs *params.Run, providerintf provider.Interfac
 		pipelinerun.ObjectMeta.Labels[filepath.Join(apipac.GroupName, "original-prname")] = originPipelinerunName
 	}
 	return types.PipelineRuns, nil
+}
+
+// nolint:gochecknoinits
+func init() {
+	_ = tektonv1beta1.AddToScheme(k8scheme.Scheme)
 }


### PR DESCRIPTION
when we are runing webhooks we didn't show properly the pipelinerun. we
now do it properly, which would show nicely for comment on multiple
pipelineruns to know which one is what.

Closes #604 and fix #619 

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
