### PR TITLE
Uses separate logger while processing event to easily filter out logs

### DIFF
--- a/pkg/adapter/adapter_test.go
+++ b/pkg/adapter/adapter_test.go
@@ -32,7 +32,6 @@ func TestHandleEvent(t *testing.T) {
 		run: &params.Run{
 			Clients: clients.Clients{
 				PipelineAsCode: cs.PipelineAsCode,
-				Log:            getLogger(),
 			},
 		},
 		logger: getLogger(),

--- a/pkg/adapter/sinker.go
+++ b/pkg/adapter/sinker.go
@@ -10,20 +10,22 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/pipelineascode"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
+	"go.uber.org/zap"
 )
 
 type sinker struct {
-	run   *params.Run
-	vcx   provider.Interface
-	kint  *kubeinteraction.Interaction
-	event *info.Event
+	run    *params.Run
+	vcx    provider.Interface
+	kint   *kubeinteraction.Interaction
+	event  *info.Event
+	logger *zap.SugaredLogger
 }
 
 func (s *sinker) processEvent(ctx context.Context, request *http.Request, payload []byte) error {
 	var err error
 	s.event, err = s.vcx.ParsePayload(ctx, s.run, request, string(payload))
 	if err != nil {
-		s.run.Clients.Log.Errorf("failed to parse event: %v", err)
+		s.logger.Errorf("failed to parse event: %v", err)
 		return err
 	}
 	s.event.Request = &info.Request{
@@ -31,6 +33,6 @@ func (s *sinker) processEvent(ctx context.Context, request *http.Request, payloa
 		Payload: bytes.TrimSpace(payload),
 	}
 
-	p := pipelineascode.NewPacs(s.event, s.vcx, s.run, s.kint)
+	p := pipelineascode.NewPacs(s.event, s.vcx, s.run, s.kint, s.logger)
 	return p.Run(ctx)
 }

--- a/pkg/cmd/tknpac/resolve/resolve.go
+++ b/pkg/cmd/tknpac/resolve/resolve.go
@@ -152,7 +152,7 @@ func resolveFilenames(cs *params.Run, filenames []string, params map[string]stri
 	// We use github here but since we don't do remotetask we would not care
 	providerintf := &github.Provider{CheckRunIDS: &sync.Map{}}
 	event := info.NewEvent()
-	prun, err := resolve.Resolve(ctx, cs, providerintf, event, allTemplates, ropt)
+	prun, err := resolve.Resolve(ctx, cs, cs.Clients.Log, providerintf, event, allTemplates, ropt)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/kubeinteraction/cleanups.go
+++ b/pkg/kubeinteraction/cleanups.go
@@ -9,11 +9,12 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	psort "github.com/openshift-pipelines/pipelines-as-code/pkg/sort"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 )
 
-func (k Interaction) CleanupPipelines(ctx context.Context, repo *v1alpha1.Repository, pr *v1beta1.PipelineRun, maxKeep int) error {
+func (k Interaction) CleanupPipelines(ctx context.Context, logger *zap.SugaredLogger, repo *v1alpha1.Repository, pr *v1beta1.PipelineRun, maxKeep int) error {
 	repoLabel := filepath.Join(pipelinesascode.GroupName, "repository")
 	originalPRLabel := filepath.Join(pipelinesascode.GroupName, "original-prname")
 	if _, ok := pr.GetLabels()[originalPRLabel]; !ok {
@@ -25,7 +26,7 @@ func (k Interaction) CleanupPipelines(ctx context.Context, repo *v1alpha1.Reposi
 	// Select PR by repository and by its true pipelineRun name (not auto generated one)
 	labelSelector := fmt.Sprintf("%s=%s,%s=%s",
 		repoLabel, repo.GetName(), originalPRLabel, pr.GetLabels()[originalPRLabel])
-	k.Run.Clients.Log.Infof("selecting pipelineruns by labels \"%s\" for deletion", labelSelector)
+	logger.Infof("selecting pipelineruns by labels \"%s\" for deletion", labelSelector)
 
 	pruns, err := k.Run.Clients.Tekton.TektonV1beta1().PipelineRuns(repo.GetNamespace()).List(ctx,
 		metav1.ListOptions{LabelSelector: labelSelector})
@@ -35,12 +36,12 @@ func (k Interaction) CleanupPipelines(ctx context.Context, repo *v1alpha1.Reposi
 
 	for c, prun := range psort.PipelineRunSortByCompletionTime(pruns.Items) {
 		if prun.GetStatusCondition().GetCondition(apis.ConditionSucceeded).GetReason() == "Running" {
-			k.Run.Clients.Log.Infof("skipping %s since currently running", prun.GetName())
+			logger.Infof("skipping %s since currently running", prun.GetName())
 			continue
 		}
 
 		if c >= maxKeep {
-			k.Run.Clients.Log.Infof("cleaning old PipelineRun: %s", prun.GetName())
+			logger.Infof("cleaning old PipelineRun: %s", prun.GetName())
 			err := k.Run.Clients.Tekton.TektonV1beta1().PipelineRuns(repo.GetNamespace()).Delete(
 				ctx, prun.GetName(), metav1.DeleteOptions{})
 			if err != nil {

--- a/pkg/kubeinteraction/cleanups_test.go
+++ b/pkg/kubeinteraction/cleanups_test.go
@@ -110,13 +110,12 @@ func TestCleanupPipelines(t *testing.T) {
 				Run: &params.Run{
 					Clients: clients.Clients{
 						Kube:   stdata.Kube,
-						Log:    fakelogger,
 						Tekton: stdata.Pipeline,
 					},
 				},
 			}
 
-			err := kint.CleanupPipelines(ctx, repo, tt.args.prunCurrent, tt.args.maxKeep)
+			err := kint.CleanupPipelines(ctx, fakelogger, repo, tt.args.prunCurrent, tt.args.maxKeep)
 			if tt.wantErr {
 				assert.Assert(t, err != nil)
 			}

--- a/pkg/kubeinteraction/kubeinteraction.go
+++ b/pkg/kubeinteraction/kubeinteraction.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"go.uber.org/zap"
 
 	tektonv1beta1client "github.com/tektoncd/pipeline/pkg/client/clientset/versioned/typed/pipeline/v1beta1"
 )
@@ -20,9 +21,9 @@ type GetSecretOpt struct {
 
 type Interface interface {
 	WaitForPipelineRunSucceed(context.Context, tektonv1beta1client.TektonV1beta1Interface, *v1beta1.PipelineRun, time.Duration) error
-	CleanupPipelines(ctx context.Context, repo *v1alpha1.Repository, pr *v1beta1.PipelineRun, limitnumber int) error
-	CreateBasicAuthSecret(context.Context, *info.Event, string) error
-	DeleteBasicAuthSecret(context.Context, *info.Event, string) error
+	CleanupPipelines(context.Context, *zap.SugaredLogger, *v1alpha1.Repository, *v1beta1.PipelineRun, int) error
+	CreateBasicAuthSecret(context.Context, *zap.SugaredLogger, *info.Event, string) error
+	DeleteBasicAuthSecret(context.Context, *zap.SugaredLogger, *info.Event, string) error
 	GetSecret(context.Context, GetSecretOpt) (string, error)
 }
 

--- a/pkg/kubeinteraction/secrets.go
+++ b/pkg/kubeinteraction/secrets.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
+	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,7 +36,7 @@ func (k Interaction) createSecret(ctx context.Context, secretData map[string]str
 }
 
 // CreateBasicAuthSecret Create a secret for git-clone basic-auth workspace
-func (k Interaction) CreateBasicAuthSecret(ctx context.Context, runevent *info.Event, targetNamespace string) error {
+func (k Interaction) CreateBasicAuthSecret(ctx context.Context, logger *zap.SugaredLogger, runevent *info.Event, targetNamespace string) error {
 	// Bitbucket Server have a different Clone URL than it's Repo URL, so we
 	// have to separate them 👨‍🏭
 	cloneURL := runevent.URL
@@ -85,7 +86,7 @@ func (k Interaction) CreateBasicAuthSecret(ctx context.Context, runevent *info.E
 		return fmt.Errorf("cannot create secret: %w", err)
 	}
 
-	k.Run.Clients.Log.Infof("Secret %s has been generated in namespace %s", secretName, targetNamespace)
+	logger.Infof("Secret %s has been generated in namespace %s", secretName, targetNamespace)
 	return nil
 }
 
@@ -103,13 +104,13 @@ func getBasicAuthSecretName(runEvent *info.Event) string {
 }
 
 // DeleteBasicAuthSecret deletes the secret created for git-clone basic-auth
-func (k Interaction) DeleteBasicAuthSecret(ctx context.Context, runEvent *info.Event, targetNamespace string) error {
+func (k Interaction) DeleteBasicAuthSecret(ctx context.Context, logger *zap.SugaredLogger, runEvent *info.Event, targetNamespace string) error {
 	secretName := getBasicAuthSecretName(runEvent)
 	err := k.Run.Clients.Kube.CoreV1().Secrets(targetNamespace).Delete(ctx, secretName, metav1.DeleteOptions{})
 	if err != nil && !errors.IsNotFound(err) {
 		return err
 	}
 
-	k.Run.Clients.Log.Infof("Secret %s has been deleted in namespace %s", secretName, targetNamespace)
+	logger.Infof("Secret %s has been deleted in namespace %s", secretName, targetNamespace)
 	return nil
 }

--- a/pkg/kubeinteraction/secrets_test.go
+++ b/pkg/kubeinteraction/secrets_test.go
@@ -100,12 +100,11 @@ func TestCreateBasicAuthSecret(t *testing.T) {
 				Run: &params.Run{
 					Clients: clients.Clients{
 						Kube: stdata.Kube,
-						Log:  fakelogger,
 					},
 				},
 			}
 			tt.event.Provider.Token = secrete
-			err := kint.CreateBasicAuthSecret(ctx, tt.event, tt.targetNS)
+			err := kint.CreateBasicAuthSecret(ctx, fakelogger, tt.event, tt.targetNS)
 			assert.NilError(t, err)
 
 			slist, err := kint.Run.Clients.Kube.CoreV1().Secrets(tt.targetNS).List(ctx, metav1.ListOptions{})
@@ -185,11 +184,10 @@ func TestDeleteBasicAuthSecret(t *testing.T) {
 				Run: &params.Run{
 					Clients: clients.Clients{
 						Kube: stdata.Kube,
-						Log:  fakelogger,
 					},
 				},
 			}
-			err := kint.DeleteBasicAuthSecret(ctx, &tt.event, tt.targetNS)
+			err := kint.DeleteBasicAuthSecret(ctx, fakelogger, &tt.event, tt.targetNS)
 			assert.NilError(t, err)
 
 			slist, err := kint.Run.Clients.Kube.CoreV1().Secrets(tt.targetNS).List(ctx, metav1.ListOptions{})

--- a/pkg/matcher/annotation_matcher_test.go
+++ b/pkg/matcher/annotation_matcher_test.go
@@ -294,10 +294,10 @@ func TestMatchPipelinerunAnnotationAndRepositories(t *testing.T) {
 			observer, log := zapobserver.New(zap.InfoLevel)
 			logger := zap.New(observer).Sugar()
 			client := &params.Run{
-				Clients: clients.Clients{PipelineAsCode: cs.PipelineAsCode, Log: logger},
+				Clients: clients.Clients{PipelineAsCode: cs.PipelineAsCode},
 				Info:    info.Info{},
 			}
-			matches, err := MatchPipelinerunByAnnotation(ctx,
+			matches, err := MatchPipelinerunByAnnotation(ctx, logger,
 				tt.args.pruns,
 				client, &tt.args.runevent)
 
@@ -524,12 +524,10 @@ func TestMatchPipelinerunByAnnotation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, _ := rtesting.SetupFakeContext(t)
 			cs := &params.Run{
-				Clients: clients.Clients{
-					Log: logger,
-				},
-				Info: info.Info{},
+				Clients: clients.Clients{},
+				Info:    info.Info{},
 			}
-			matches, err := MatchPipelinerunByAnnotation(ctx, tt.args.pruns, cs, &tt.args.runevent)
+			matches, err := MatchPipelinerunByAnnotation(ctx, logger, tt.args.pruns, cs, &tt.args.runevent)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("MatchPipelinerunByAnnotation() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/matcher/annotation_tasks_install.go
+++ b/pkg/matcher/annotation_tasks_install.go
@@ -42,7 +42,7 @@ func (rt RemoteTasks) convertTotask(data string) (*tektonv1beta1.Task, error) {
 	return task, nil
 }
 
-func (rt RemoteTasks) getTask(ctx context.Context, providerintf provider.Interface, event *info.Event, task string) (*tektonv1beta1.Task, error) {
+func (rt RemoteTasks) getTask(ctx context.Context, logger *zap.SugaredLogger, providerintf provider.Interface, event *info.Event, task string) (*tektonv1beta1.Task, error) {
 	var ret *tektonv1beta1.Task
 
 	// TODO: print a log info when getting the task from which location
@@ -65,7 +65,7 @@ func (rt RemoteTasks) getTask(ctx context.Context, providerintf provider.Interfa
 				return ret, err
 			}
 		} else {
-			data, err = getTaskFromLocalFS(task, rt.Run.Clients.Log)
+			data, err = getTaskFromLocalFS(task, logger)
 			if err != nil {
 				return nil, err
 			}
@@ -85,7 +85,7 @@ func (rt RemoteTasks) getTask(ctx context.Context, providerintf provider.Interfa
 }
 
 // GetTaskFromAnnotations Get task remotely if they are on Annotations
-func (rt RemoteTasks) GetTaskFromAnnotations(ctx context.Context, providerintf provider.Interface, event *info.Event, annotations map[string]string) ([]*tektonv1beta1.Task, error) {
+func (rt RemoteTasks) GetTaskFromAnnotations(ctx context.Context, logger *zap.SugaredLogger, providerintf provider.Interface, event *info.Event, annotations map[string]string) ([]*tektonv1beta1.Task, error) {
 	var ret []*tektonv1beta1.Task
 	rtareg := regexp.MustCompile(fmt.Sprintf("%s/%s", pipelinesascode.GroupName, taskAnnotationsRegexp))
 	for annotationK, annotationV := range annotations {
@@ -97,7 +97,7 @@ func (rt RemoteTasks) GetTaskFromAnnotations(ctx context.Context, providerintf p
 			return ret, err
 		}
 		for _, v := range tasks {
-			task, err := rt.getTask(ctx, providerintf, event, v)
+			task, err := rt.getTask(ctx, logger, providerintf, event, v)
 			if err != nil {
 				return ret, err
 			}

--- a/pkg/matcher/annotation_tasks_install_test.go
+++ b/pkg/matcher/annotation_tasks_install_test.go
@@ -200,7 +200,7 @@ spec:
 				Run: cs,
 			}
 
-			got, err := rt.GetTaskFromAnnotations(ctx, &provider.TestProviderImp{
+			got, err := rt.GetTaskFromAnnotations(ctx, logger, &provider.TestProviderImp{
 				FilesInsideRepo: tt.filesInsideRepo,
 			}, &tt.runevent, tt.annotations)
 			if tt.wantErr != "" {

--- a/pkg/pipelineascode/pipelinesascode_github_test.go
+++ b/pkg/pipelineascode/pipelinesascode_github_test.go
@@ -380,7 +380,7 @@ func TestRun(t *testing.T) {
 				Token:       github.String("None"),
 				CheckRunIDS: &sync.Map{},
 			}
-			p := NewPacs(&tt.runevent, vcx, cs, k8int)
+			p := NewPacs(&tt.runevent, vcx, cs, k8int, logger)
 			err := p.Run(ctx)
 
 			if tt.wantErr != "" {

--- a/pkg/pipelineascode/secret.go
+++ b/pkg/pipelineascode/secret.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"go.uber.org/zap"
 )
 
 const (
@@ -20,7 +21,7 @@ const (
 )
 
 // secretFromRepository grab the secret from the repository CRD
-func secretFromRepository(ctx context.Context, cs *params.Run, k8int kubeinteraction.Interface, config *info.ProviderConfig, event *info.Event, repo *apipac.Repository) error {
+func secretFromRepository(ctx context.Context, cs *params.Run, k8int kubeinteraction.Interface, config *info.ProviderConfig, event *info.Event, repo *apipac.Repository, logger *zap.SugaredLogger) error {
 	var err error
 	if repo.Spec.GitProvider.URL == "" {
 		repo.Spec.GitProvider.URL = config.APIURL
@@ -76,7 +77,7 @@ func secretFromRepository(ctx context.Context, cs *params.Run, k8int kubeinterac
 			repo.Spec.GitProvider.WebhookSecret.Name,
 			gitProviderWebhookSecretKey)
 	}
-	cs.Clients.Log.Infof(logmsg)
+	logger.Infof(logmsg)
 	return nil
 }
 

--- a/pkg/pipelineascode/secret_test.go
+++ b/pkg/pipelineascode/secret_test.go
@@ -108,9 +108,7 @@ func TestSecretFromRepository(t *testing.T) {
 				GetSecretResult: retsecret,
 			}
 			cs := &params.Run{
-				Clients: clients.Clients{
-					Log: logger,
-				},
+				Clients: clients.Clients{},
 				Info: info.Info{
 					Pac: &info.PacOpts{
 						WebhookType: tt.providerType,
@@ -118,7 +116,7 @@ func TestSecretFromRepository(t *testing.T) {
 				},
 			}
 			event := info.NewEvent()
-			err := secretFromRepository(ctx, cs, k8int, tt.providerconfig, event, tt.repo)
+			err := secretFromRepository(ctx, cs, k8int, tt.providerconfig, event, tt.repo, logger)
 			assert.NilError(t, err)
 			logs := log.TakeAll()
 			assert.Equal(t, len(tt.logmatch), len(logs), "we didn't get the number of logging message: %+v", logs)

--- a/pkg/provider/bitbucketcloud/bitbucket.go
+++ b/pkg/provider/bitbucketcloud/bitbucket.go
@@ -11,10 +11,12 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketcloud/types"
+	"go.uber.org/zap"
 )
 
 type Provider struct {
 	Client        *bitbucket.Client
+	Logger        *zap.SugaredLogger
 	Token, APIURL *string
 	Username      *string
 }
@@ -26,6 +28,10 @@ const taskStatusTemplate = `| **Status** | **Duration** | **Name** |
 
 func (v *Provider) Validate(ctx context.Context, params *params.Run, event *info.Event) error {
 	return nil
+}
+
+func (v *Provider) SetLogger(logger *zap.SugaredLogger) {
+	v.Logger = logger
 }
 
 func (v *Provider) GetConfig() *info.ProviderConfig {

--- a/pkg/provider/bitbucketserver/bitbucketserver.go
+++ b/pkg/provider/bitbucketserver/bitbucketserver.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
+	"go.uber.org/zap"
 )
 
 const taskStatusTemplate = `
@@ -20,11 +21,16 @@ const taskStatusTemplate = `
 
 type Provider struct {
 	Client                    *bbv1.APIClient
+	Logger                    *zap.SugaredLogger
 	baseURL                   string
 	defaultBranchLatestCommit string
 	pullRequestNumber         int
 	apiURL                    string
 	projectKey                string
+}
+
+func (v *Provider) SetLogger(logger *zap.SugaredLogger) {
+	v.Logger = logger
 }
 
 func (v *Provider) Validate(ctx context.Context, params *params.Run, event *info.Event) error {

--- a/pkg/provider/github/events.go
+++ b/pkg/provider/github/events.go
@@ -130,7 +130,7 @@ func (v *Provider) ParsePayload(ctx context.Context, run *params.Run, request *h
 	// should not get invalid json since we already check it in github.ParseWebHook
 	_ = json.Unmarshal([]byte(payload), &eventInt)
 
-	processedEvent, err := v.processEvent(ctx, run, event, eventInt)
+	processedEvent, err := v.processEvent(ctx, event, eventInt)
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +138,7 @@ func (v *Provider) ParsePayload(ctx context.Context, run *params.Run, request *h
 	return processedEvent, nil
 }
 
-func (v *Provider) processEvent(ctx context.Context, run *params.Run, event *info.Event, eventInt interface{}) (*info.Event, error) {
+func (v *Provider) processEvent(ctx context.Context, event *info.Event, eventInt interface{}) (*info.Event, error) {
 	var processedEvent *info.Event
 	var err error
 

--- a/pkg/provider/github/events_test.go
+++ b/pkg/provider/github/events_test.go
@@ -248,17 +248,15 @@ func TestParsePayLoad(t *testing.T) {
 					fmt.Fprint(rw, string(bjeez))
 				})
 			}
+			logger := getLogger()
 			gprovider := Provider{
 				Client: tt.githubClient,
+				Logger: logger,
 			}
-			logger := getLogger()
 			request := &http.Request{Header: map[string][]string{}}
 			request.Header.Set("X-GitHub-Event", tt.eventType)
 
 			run := &params.Run{
-				Clients: clients.Clients{
-					Log: logger,
-				},
 				Info: info.Info{},
 			}
 			bjeez, _ := json.Marshal(tt.payloadEventStruct)
@@ -399,15 +397,14 @@ func TestAppTokenGeneration(t *testing.T) {
 			}
 
 			jeez, _ := json.Marshal(samplePRevent)
-			gprovider := Provider{}
 			logger := getLogger()
+			gprovider := Provider{Logger: logger}
 			request := &http.Request{Header: map[string][]string{}}
 			request.Header.Set("X-GitHub-Event", "pull_request")
 			request.Header.Set("X-GitHub-Enterprise-Host", fakeGithubAuthURL)
 
 			run := &params.Run{
 				Clients: clients.Clients{
-					Log:  logger,
 					Kube: tt.seedData.Kube,
 				},
 				Info: info.Info{

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -21,10 +21,15 @@ const apiPublicURL = "https://api.github.com/"
 
 type Provider struct {
 	Client        *github.Client
+	Logger        *zap.SugaredLogger
 	Token, APIURL *string
 	ApplicationID *int64
 
 	CheckRunIDS *sync.Map
+}
+
+func (v *Provider) SetLogger(logger *zap.SugaredLogger) {
+	v.Logger = logger
 }
 
 func (v *Provider) Validate(ctx context.Context, cs *params.Run, event *info.Event) error {

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -35,12 +35,17 @@ const (
 
 type Provider struct {
 	Client            *gitlab.Client
+	Logger            *zap.SugaredLogger
 	Token             *string
 	targetProjectID   int
 	sourceProjectID   int
 	userID            int
 	pathWithNamespace string
 	repoURL           string
+}
+
+func (v *Provider) SetLogger(logger *zap.SugaredLogger) {
+	v.Logger = logger
 }
 
 func (v *Provider) Validate(ctx context.Context, params *params.Run, event *info.Event) error {

--- a/pkg/provider/interface.go
+++ b/pkg/provider/interface.go
@@ -21,6 +21,7 @@ type StatusOpts struct {
 }
 
 type Interface interface {
+	SetLogger(*zap.SugaredLogger)
 	Validate(ctx context.Context, params *params.Run, event *info.Event) error
 	Detect(*http.Header, string, *zap.SugaredLogger) (bool, bool, *zap.SugaredLogger, error)
 	ParsePayload(context.Context, *params.Run, *http.Request, string) (*info.Event, error)

--- a/pkg/resolve/resolve.go
+++ b/pkg/resolve/resolve.go
@@ -108,8 +108,8 @@ type Opts struct {
 // Pipeline/PipelineRuns/Tasks and resolve them inline as a single PipelineRun
 // generateName can be set as True to set the name as a generateName + "-" for
 // unique pipelinerun
-func Resolve(ctx context.Context, cs *params.Run, providerintf provider.Interface, event *info.Event, data string, ropt *Opts) ([]*tektonv1beta1.PipelineRun, error) {
-	types := readTypes(cs.Clients.Log, data)
+func Resolve(ctx context.Context, cs *params.Run, logger *zap.SugaredLogger, providerintf provider.Interface, event *info.Event, data string, ropt *Opts) ([]*tektonv1beta1.PipelineRun, error) {
+	types := readTypes(logger, data)
 	if len(types.PipelineRuns) == 0 {
 		return []*tektonv1beta1.PipelineRun{}, errors.New("we need at least one pipelinerun to start with")
 	}
@@ -120,7 +120,7 @@ func Resolve(ctx context.Context, cs *params.Run, providerintf provider.Interfac
 			rt := matcher.RemoteTasks{
 				Run: cs,
 			}
-			remoteTasks, err := rt.GetTaskFromAnnotations(ctx, providerintf, event, pipelinerun.GetObjectMeta().GetAnnotations())
+			remoteTasks, err := rt.GetTaskFromAnnotations(ctx, logger, providerintf, event, pipelinerun.GetObjectMeta().GetAnnotations())
 			if err != nil {
 				return []*tektonv1beta1.PipelineRun{}, err
 			}

--- a/pkg/resolve/resolve_test.go
+++ b/pkg/resolve/resolve_test.go
@@ -42,10 +42,8 @@ func readTDfile(t *testing.T, testname string, generateName bool, remoteTasking 
 	observer, log := zapobserver.New(zap.InfoLevel)
 	logger := zap.New(observer).Sugar()
 	cs := &params.Run{
-		Clients: clients.Clients{
-			Log: logger,
-		},
-		Info: info.Info{},
+		Clients: clients.Clients{},
+		Info:    info.Info{},
 	}
 	ropt := &Opts{
 		GenerateName: generateName,
@@ -53,7 +51,7 @@ func readTDfile(t *testing.T, testname string, generateName bool, remoteTasking 
 	}
 	event := &info.Event{}
 	tprovider := &testprovider.TestProviderImp{}
-	resolved, err := Resolve(ctx, cs, tprovider, event, string(data), ropt)
+	resolved, err := Resolve(ctx, cs, logger, tprovider, event, string(data), ropt)
 	if err != nil {
 		return &tektonv1beta1.PipelineRun{}, nil, err
 	}

--- a/pkg/test/kubernetestint/kubernetesint.go
+++ b/pkg/test/kubernetestint/kubernetesint.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	tektonv1beta1client "github.com/tektoncd/pipeline/pkg/client/clientset/versioned/typed/pipeline/v1beta1"
+	"go.uber.org/zap"
 )
 
 type KinterfaceTest struct {
@@ -26,11 +27,11 @@ func (k *KinterfaceTest) GetConsoleUI(ctx context.Context, ns string, pr string)
 	return k.ConsoleURL, nil
 }
 
-func (k *KinterfaceTest) CreateBasicAuthSecret(ctx context.Context, runevent *info.Event, targetNamespace string) error {
+func (k *KinterfaceTest) CreateBasicAuthSecret(ctx context.Context, logger *zap.SugaredLogger, runevent *info.Event, targetNamespace string) error {
 	return nil
 }
 
-func (k *KinterfaceTest) DeleteBasicAuthSecret(ctx context.Context, runevent *info.Event, targetNamespace string) error {
+func (k *KinterfaceTest) DeleteBasicAuthSecret(ctx context.Context, logger *zap.SugaredLogger, runevent *info.Event, targetNamespace string) error {
 	return nil
 }
 
@@ -42,7 +43,7 @@ func (k *KinterfaceTest) WaitForPipelineRunSucceed(ctx context.Context, tektonbe
 	return nil
 }
 
-func (k *KinterfaceTest) CleanupPipelines(ctx context.Context, repo *v1alpha1.Repository, pr *v1beta1.PipelineRun, limitnumber int) error {
+func (k *KinterfaceTest) CleanupPipelines(ctx context.Context, logger *zap.SugaredLogger, repo *v1alpha1.Repository, pr *v1beta1.PipelineRun, limitnumber int) error {
 	if k.ExpectedNumberofCleanups != limitnumber {
 		return fmt.Errorf("we wanted %d and we got %d", k.ExpectedNumberofCleanups, limitnumber)
 	}

--- a/pkg/test/provider/testwebvcs.go
+++ b/pkg/test/provider/testwebvcs.go
@@ -19,9 +19,8 @@ type TestProviderImp struct {
 	FilesInsideRepo      map[string]string
 }
 
-// func (v *TestProviderImp) ParseEventType(request *http.Request, event *info.Event) error {
-//	return nil
-// }
+func (v *TestProviderImp) SetLogger(logger *zap.SugaredLogger) {
+}
 
 func (v *TestProviderImp) Validate(ctx context.Context, params *params.Run, event *info.Event) error {
 	return nil


### PR DESCRIPTION
controller now uses a separate logger with its event id while
processing each event so that we can filter out events by its
id.

Closes #553 


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
