### PR TITLE
Updates Repo CRD & fixes generated pipelinerun

### DIFF
--- a/config/300-repositories.yaml
+++ b/config/300-repositories.yaml
@@ -82,7 +82,7 @@ spec:
                         key:
                           type: string
                           description: "Key inside the secret"
-                          default: "token"
+                          default: "provider.token"
                         name:
                           type: string
                           description: "The secret name"
@@ -92,7 +92,7 @@ spec:
                         key:
                           type: string
                           description: "Key inside the secret"
-                          default: "secret"
+                          default: "webhook.secret"
                         name:
                           type: string
                           description: "The secret name"

--- a/pkg/cmd/tknpac/generate/template.go
+++ b/pkg/cmd/tknpac/generate/template.go
@@ -91,9 +91,13 @@ func (o *Opts) genTmpl() (bytes.Buffer, error) {
 	// can't figure out how ParseFS works, so doing this manually..
 	t := template.Must(template.New("PipelineRun").Delims("<<", ">>").Parse(string(tmplB)))
 
-	prName := fmt.Sprintf("%s-%s",
-		filepath.Base(o.GitInfo.URL),
-		strings.ReplaceAll(o.Event.EventType, "_", "-"))
+	prName := filepath.Base(o.GitInfo.URL)
+
+	// if eventType has both the events [push, pull_request] then skip
+	// adding it to pipelinerun name
+	if !strings.Contains(o.Event.EventType, ",") {
+		prName = prName + "-" + strings.ReplaceAll(o.Event.EventType, "_", "-")
+	}
 
 	lang, err := o.detectLanguage()
 	if err != nil {


### PR DESCRIPTION
 Updates Repository CRD for updated secret keys

this updates the CRD with the updated keys which
are used for webhook secret, those were changed in the last release.

---
 fix generate cmd for pipelinerun name

skips adding event type to pipelinerun name if both the events are
configured which happens in repo create cmd and the pr fails to create
PipelineRun.tekton.dev "pac-webhook-[pull-request, push]-2v4fb" is invalid

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [x] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [x] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [x] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [x] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
