### PR TITLE
Configure Gitlab webhook by cli

### DIFF
--- a/pkg/cli/webhook/github.go
+++ b/pkg/cli/webhook/github.go
@@ -32,15 +32,6 @@ func (gh *gitHubConfig) GetName() string {
 }
 
 func (gh *gitHubConfig) Run(ctx context.Context, opts *Options) (*response, error) {
-	msg := "Would you like me to configure a GitHub Webhook for your repository? "
-	var configureWebhook bool
-	if err := prompt.SurveyAskOne(&survey.Confirm{Message: msg, Default: true}, &configureWebhook); err != nil {
-		return nil, err
-	}
-	if !configureWebhook {
-		return &response{UserDeclined: true}, nil
-	}
-
 	err := gh.askGHWebhookConfig(opts.RepositoryURL, opts.ControllerURL)
 	if err != nil {
 		return nil, err
@@ -48,7 +39,6 @@ func (gh *gitHubConfig) Run(ctx context.Context, opts *Options) (*response, erro
 	gh.APIURL = opts.ProviderAPIURL
 
 	return &response{
-		UserDeclined:        false,
 		ControllerURL:       gh.controllerURL,
 		PersonalAccessToken: gh.personalAccessToken,
 		WebhookSecret:       gh.webhookSecret,

--- a/pkg/cli/webhook/github_test.go
+++ b/pkg/cli/webhook/github_test.go
@@ -11,42 +11,6 @@ import (
 	rtesting "knative.dev/pkg/reconciler/testing"
 )
 
-func TestGithubWebhook(t *testing.T) {
-	tests := []struct {
-		name       string
-		wantErrStr string
-		askStubs   func(*prompt.AskStubber)
-		response   response
-	}{
-		{
-			name: "declined by user",
-			askStubs: func(as *prompt.AskStubber) {
-				as.StubOne("n")
-			},
-			response: response{UserDeclined: true},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctx, _ := rtesting.SetupFakeContext(t)
-			as, teardown := prompt.InitAskStubber()
-			defer teardown()
-			if tt.askStubs != nil {
-				tt.askStubs(as)
-			}
-			gh := gitHubConfig{}
-			res, err := gh.Run(ctx, &Options{})
-			if tt.wantErrStr != "" {
-				assert.Equal(t, err.Error(), tt.wantErrStr)
-				return
-			}
-			assert.NilError(t, err)
-			assert.Equal(t, res.UserDeclined, tt.response.UserDeclined)
-		})
-	}
-}
-
 func TestAskGHWebhookConfig(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/pkg/cli/webhook/gitlab.go
+++ b/pkg/cli/webhook/gitlab.go
@@ -26,15 +26,6 @@ func (gl *gitLabConfig) GetName() string {
 }
 
 func (gl *gitLabConfig) Run(ctx context.Context, opts *Options) (*response, error) {
-	msg := "Would you like me to configure a GitLab Webhook for your repository? "
-	var configureWebhook bool
-	if err := prompt.SurveyAskOne(&survey.Confirm{Message: msg, Default: true}, &configureWebhook); err != nil {
-		return nil, err
-	}
-	if !configureWebhook {
-		return &response{UserDeclined: true}, nil
-	}
-
 	err := gl.askGLWebhookConfig(opts.ControllerURL)
 	if err != nil {
 		return nil, err
@@ -42,7 +33,6 @@ func (gl *gitLabConfig) Run(ctx context.Context, opts *Options) (*response, erro
 	gl.APIURL = opts.ProviderAPIURL
 
 	return &response{
-		UserDeclined:        false,
 		ControllerURL:       gl.controllerURL,
 		PersonalAccessToken: gl.personalAccessToken,
 		WebhookSecret:       gl.webhookSecret,

--- a/pkg/cli/webhook/gitlab.go
+++ b/pkg/cli/webhook/gitlab.go
@@ -1,0 +1,126 @@
+package webhook
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli/prompt"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
+	"github.com/xanzy/go-gitlab"
+)
+
+type gitLabConfig struct {
+	Client              *gitlab.Client
+	controllerURL       string
+	projectID           string
+	webhookSecret       string
+	personalAccessToken string
+	APIURL              string
+}
+
+func (gl *gitLabConfig) GetName() string {
+	return provider.ProviderGitLabWebhook
+}
+
+func (gl *gitLabConfig) Run(ctx context.Context, opts *Options) (*response, error) {
+	msg := "Would you like me to configure a GitLab Webhook for your repository? "
+	var configureWebhook bool
+	if err := prompt.SurveyAskOne(&survey.Confirm{Message: msg, Default: true}, &configureWebhook); err != nil {
+		return nil, err
+	}
+	if !configureWebhook {
+		return &response{UserDeclined: true}, nil
+	}
+
+	err := gl.askGLWebhookConfig(opts.ControllerURL)
+	if err != nil {
+		return nil, err
+	}
+	gl.APIURL = opts.ProviderAPIURL
+
+	return &response{
+		UserDeclined:        false,
+		ControllerURL:       gl.controllerURL,
+		PersonalAccessToken: gl.personalAccessToken,
+		WebhookSecret:       gl.webhookSecret,
+	}, gl.create(ctx)
+}
+
+func (gl *gitLabConfig) askGLWebhookConfig(controllerURL string) error {
+	msg := fmt.Sprintf("Please enter project ID for the repository you want to be configured :")
+	if err := prompt.SurveyAskOne(&survey.Input{Message: msg}, &gl.projectID,
+		survey.WithValidator(survey.Required)); err != nil {
+		return err
+	}
+
+	if controllerURL == "" {
+		if err := prompt.SurveyAskOne(&survey.Input{
+			Message: "Please enter your controller public route URL: ",
+		}, &gl.controllerURL, survey.WithValidator(survey.Required)); err != nil {
+			return err
+		}
+	}
+
+	if err := prompt.SurveyAskOne(&survey.Password{
+		Message: "Please enter the secret to configure the webhook for payload validation: ",
+	}, &gl.webhookSecret, survey.WithValidator(survey.Required)); err != nil {
+		return err
+	}
+
+	// nolint:forbidigo
+	fmt.Println("ℹ ️You now need to create a GitLab personal access token with `api` scope")
+	// nolint:forbidigo
+	fmt.Println("ℹ ️Go to this URL to generate one https://gitlab.com/-/profile/personal_access_tokens, see https://is.gd/WIXECN for documentation ")
+	if err := prompt.SurveyAskOne(&survey.Password{
+		Message: "Please enter the GitLab access token: ",
+	}, &gl.personalAccessToken, survey.WithValidator(survey.Required)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (gl *gitLabConfig) create(ctx context.Context) error {
+	glClient, err := gl.newClient()
+	if err != nil {
+		return err
+	}
+
+	hookOpts := &gitlab.AddProjectHookOptions{
+		EnableSSLVerification: gitlab.Bool(true),
+		MergeRequestsEvents:   gitlab.Bool(true),
+		NoteEvents:            gitlab.Bool(true),
+		PushEvents:            gitlab.Bool(true),
+		Token:                 gitlab.String(gl.webhookSecret),
+		URL:                   gitlab.String(gl.controllerURL),
+	}
+
+	_, resp, err := glClient.Projects.AddProjectHook(gl.projectID, hookOpts)
+	if err != nil {
+
+	}
+
+	if resp.Response.StatusCode != http.StatusCreated {
+		payload, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("failed to read response body: %v", err)
+		}
+		return fmt.Errorf("failed to create webhook, status code: %v, error : %v",
+			resp.Response.StatusCode, payload)
+	}
+
+	// nolint:forbidigo
+	fmt.Printf("✓ Webhook has been created on your repository\n")
+	return nil
+}
+
+func (gl *gitLabConfig) newClient() (*gitlab.Client, error) {
+	if gl.Client != nil {
+		return gl.Client, nil
+	}
+
+	return gitlab.NewClient(gl.personalAccessToken, gitlab.WithBaseURL(gl.APIURL))
+}

--- a/pkg/cli/webhook/gitlab.go
+++ b/pkg/cli/webhook/gitlab.go
@@ -25,7 +25,7 @@ func (gl *gitLabConfig) GetName() string {
 	return provider.ProviderGitLabWebhook
 }
 
-func (gl *gitLabConfig) Run(ctx context.Context, opts *Options) (*response, error) {
+func (gl *gitLabConfig) Run(_ context.Context, opts *Options) (*response, error) {
 	err := gl.askGLWebhookConfig(opts.ControllerURL)
 	if err != nil {
 		return nil, err
@@ -36,11 +36,11 @@ func (gl *gitLabConfig) Run(ctx context.Context, opts *Options) (*response, erro
 		ControllerURL:       gl.controllerURL,
 		PersonalAccessToken: gl.personalAccessToken,
 		WebhookSecret:       gl.webhookSecret,
-	}, gl.create(ctx)
+	}, gl.create()
 }
 
 func (gl *gitLabConfig) askGLWebhookConfig(controllerURL string) error {
-	msg := fmt.Sprintf("Please enter project ID for the repository you want to be configured :")
+	msg := "Please enter project ID for the repository you want to be configured :"
 	if err := prompt.SurveyAskOne(&survey.Input{Message: msg}, &gl.projectID,
 		survey.WithValidator(survey.Required)); err != nil {
 		return err
@@ -73,7 +73,7 @@ func (gl *gitLabConfig) askGLWebhookConfig(controllerURL string) error {
 	return nil
 }
 
-func (gl *gitLabConfig) create(ctx context.Context) error {
+func (gl *gitLabConfig) create() error {
 	glClient, err := gl.newClient()
 	if err != nil {
 		return err
@@ -90,13 +90,13 @@ func (gl *gitLabConfig) create(ctx context.Context) error {
 
 	_, resp, err := glClient.Projects.AddProjectHook(gl.projectID, hookOpts)
 	if err != nil {
-
+		return err
 	}
 
 	if resp.Response.StatusCode != http.StatusCreated {
 		payload, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return fmt.Errorf("failed to read response body: %v", err)
+			return fmt.Errorf("failed to read response body: %w", err)
 		}
 		return fmt.Errorf("failed to create webhook, status code: %v, error : %v",
 			resp.Response.StatusCode, payload)

--- a/pkg/cli/webhook/gitlab.go
+++ b/pkg/cli/webhook/gitlab.go
@@ -40,7 +40,7 @@ func (gl *gitLabConfig) Run(_ context.Context, opts *Options) (*response, error)
 }
 
 func (gl *gitLabConfig) askGLWebhookConfig(controllerURL string) error {
-	msg := "Please enter project ID for the repository you want to be configured :"
+	msg := "Please enter the project ID for the repository you want to be configured :"
 	if err := prompt.SurveyAskOne(&survey.Input{Message: msg}, &gl.projectID,
 		survey.WithValidator(survey.Required)); err != nil {
 		return err

--- a/pkg/cli/webhook/gitlab_test.go
+++ b/pkg/cli/webhook/gitlab_test.go
@@ -1,0 +1,107 @@
+package webhook
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli/prompt"
+	thelp "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/gitlab/test"
+	"gotest.tools/v3/assert"
+	rtesting "knative.dev/pkg/reconciler/testing"
+)
+
+func TestAskGLWebhookConfig(t *testing.T) {
+	tests := []struct {
+		name          string
+		wantErrStr    string
+		askStubs      func(*prompt.AskStubber)
+		controllerURL string
+	}{
+		{
+			name: "ask all details no defaults",
+			askStubs: func(as *prompt.AskStubber) {
+				as.StubOne("id")
+				as.StubOne("https://test")
+				as.StubOne("webhook-secret")
+				as.StubOne("token")
+			},
+			wantErrStr: "",
+		},
+		{
+			name: "with defaults",
+			askStubs: func(as *prompt.AskStubber) {
+				as.StubOne("id")
+				as.StubOne("webhook-secret")
+				as.StubOne("token")
+			},
+			controllerURL: "https://test",
+			wantErrStr:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			as, teardown := prompt.InitAskStubber()
+			defer teardown()
+			if tt.askStubs != nil {
+				tt.askStubs(as)
+			}
+			gl := gitLabConfig{}
+			err := gl.askGLWebhookConfig(tt.controllerURL)
+			if tt.wantErrStr != "" {
+				assert.Equal(t, err.Error(), tt.wantErrStr)
+				return
+			}
+			assert.NilError(t, err)
+		})
+	}
+}
+
+func TestGLCreate(t *testing.T) {
+	ctx, _ := rtesting.SetupFakeContext(t)
+	fakeclient, mux, teardown := thelp.Setup(ctx, t)
+	defer teardown()
+
+	// webhook created
+	mux.HandleFunc("/projects/11/hooks", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(201)
+	})
+
+	// webhook failed
+	mux.HandleFunc("/projects/13/hooks", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(403)
+		_, _ = fmt.Fprint(w, `{"status": "forbidden"}`)
+	})
+
+	tests := []struct {
+		name      string
+		projectID string
+		wantErr   bool
+	}{
+		{
+			name:      "webhook created",
+			projectID: "11",
+			wantErr:   false,
+		},
+		{
+			name:      "webhook failed",
+			projectID: "13",
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			gl := gitLabConfig{
+				Client:    fakeclient,
+				projectID: tt.projectID,
+			}
+			err := gl.create(ctx)
+			if !tt.wantErr {
+				assert.NilError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/cli/webhook/gitlab_test.go
+++ b/pkg/cli/webhook/gitlab_test.go
@@ -66,6 +66,7 @@ func TestGLCreate(t *testing.T) {
 	// webhook created
 	mux.HandleFunc("/projects/11/hooks", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(201)
+		_, _ = fmt.Fprint(w, `{"status": "ok"}`)
 	})
 
 	// webhook failed
@@ -93,12 +94,11 @@ func TestGLCreate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx, _ := rtesting.SetupFakeContext(t)
 			gl := gitLabConfig{
 				Client:    fakeclient,
 				projectID: tt.projectID,
 			}
-			err := gl.create(ctx)
+			err := gl.create()
 			if !tt.wantErr {
 				assert.NilError(t, err)
 			}

--- a/pkg/cli/webhook/secret.go
+++ b/pkg/cli/webhook/secret.go
@@ -16,6 +16,7 @@ const (
 
 	// nolint
 	githubWebhookSecretName = "github-webhook-secret"
+	// nolint
 	gitlabWebhookSecretName = "gitlab-webhook-secret"
 )
 

--- a/pkg/cli/webhook/secret.go
+++ b/pkg/cli/webhook/secret.go
@@ -16,6 +16,7 @@ const (
 
 	// nolint
 	githubWebhookSecretName = "github-webhook-secret"
+	gitlabWebhookSecretName = "gitlab-webhook-secret"
 )
 
 func (w *Options) createWebhookSecret(ctx context.Context, provider string, response *response) error {
@@ -71,8 +72,12 @@ func (w *Options) updateRepositoryCR(ctx context.Context, provider string) error
 }
 
 func getSecretName(providerName string) string {
-	if providerName == provider.ProviderGitHubWebhook {
+	switch providerName {
+	case provider.ProviderGitHubWebhook:
 		return githubWebhookSecretName
+	case provider.ProviderGitLabWebhook:
+		return gitlabWebhookSecretName
+	default:
+		return ""
 	}
-	return ""
 }

--- a/pkg/cli/webhook/webhook.go
+++ b/pkg/cli/webhook/webhook.go
@@ -121,6 +121,8 @@ func (w *Options) proceed(alreadyConfigured, toConfigure string) bool {
 func detectProvider(url string) Interface {
 	if strings.Contains(url, "github.com") {
 		return &gitHubConfig{}
+	} else if strings.Contains(url, "gitlab.com") {
+		return &gitLabConfig{}
 	}
 	return nil
 }

--- a/pkg/cli/webhook/webhook.go
+++ b/pkg/cli/webhook/webhook.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -32,7 +33,6 @@ type Options struct {
 }
 
 type response struct {
-	UserDeclined        bool
 	ControllerURL       string
 	WebhookSecret       string
 	PersonalAccessToken string
@@ -65,6 +65,16 @@ func (w *Options) Install(ctx context.Context) error {
 		return nil
 	}
 
+	msg := fmt.Sprintf("Would you like me to configure a %s Webhook for your repository? ",
+		strings.TrimSuffix(webhookProvider.GetName(), "Webhook"))
+	var configureWebhook bool
+	if err := prompt.SurveyAskOne(&survey.Confirm{Message: msg, Default: true}, &configureWebhook); err != nil {
+		return err
+	}
+	if !configureWebhook {
+		return nil
+	}
+
 	// check if info configmap has url then use that otherwise try to detec
 	if pacInfo.ControllerURL != "" && w.ControllerURL == "" {
 		w.ControllerURL = pacInfo.ControllerURL
@@ -73,7 +83,7 @@ func (w *Options) Install(ctx context.Context) error {
 	}
 
 	response, err := webhookProvider.Run(ctx, w)
-	if err != nil || response.UserDeclined {
+	if err != nil {
 		return err
 	}
 

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -12,6 +12,7 @@ var (
 const (
 	ProviderGitHubApp     = "GitHubApp"
 	ProviderGitHubWebhook = "GitHubWebhook"
+	ProviderGitLabWebhook = "GitLabWebhook"
 )
 
 func Valid(value string, validValues []string) bool {


### PR DESCRIPTION
this adds feature in repo create cmd to provider
user option to configure webhook, it detect if the repo
url is of gitlab and ask user if you would like to
configure webhook.
Closes #607 

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
