### PR TITLE
Adds event name in skipped event logs

### DIFF
--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -246,7 +246,7 @@ func (v *Provider) Detect(reqHeader *http.Header, payload string, logger *zap.Su
 		if gitEvent.GetAction() == "rerequested" && gitEvent.GetCheckRun() != nil {
 			return setLoggerAndProceed(true, "", nil)
 		}
-		return setLoggerAndProceed(false, fmt.Sprintf("unsupported action \"%s\"", gitEvent.GetAction()), nil)
+		return setLoggerAndProceed(false, fmt.Sprintf("check_run: unsupported action \"%s\"", gitEvent.GetAction()), nil)
 
 	case *github.IssueCommentEvent:
 		if gitEvent.GetAction() == "created" &&
@@ -260,18 +260,18 @@ func (v *Provider) Detect(reqHeader *http.Header, payload string, logger *zap.Su
 			}
 			return setLoggerAndProceed(false, "", nil)
 		}
-		return setLoggerAndProceed(false, "not a gitops pull request comment", nil)
+		return setLoggerAndProceed(false, "issue: not a gitops pull request comment", nil)
 	case *github.PushEvent:
 		if gitEvent.GetPusher() != nil {
 			return setLoggerAndProceed(true, "", nil)
 		}
-		return setLoggerAndProceed(false, "no push in event", nil)
+		return setLoggerAndProceed(false, "push: no pusher in event", nil)
 
 	case *github.PullRequestEvent:
 		if provider.Valid(gitEvent.GetAction(), []string{"opened", "synchronize", "reopened"}) {
 			return setLoggerAndProceed(true, "", nil)
 		}
-		return setLoggerAndProceed(false, fmt.Sprintf("unsupported action \"%s\"", gitEvent.GetAction()), nil)
+		return setLoggerAndProceed(false, fmt.Sprintf("pull_request: unsupported action \"%s\"", gitEvent.GetAction()), nil)
 
 	default:
 		return setLoggerAndProceed(false, fmt.Sprintf("github: event \"%v\" is not supported", event), nil)


### PR DESCRIPTION
this adds event name in skipped event logs to know which event it was
previous:-
  skipping event: unsupported action "completed"
now:-
  skipping event: check_run: unsupported action "completed"

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
