### PR TITLE
Generate git auth secret randomly to a variable

### DIFF
--- a/docs/content/docs/guide/privaterepo.md
+++ b/docs/content/docs/guide/privaterepo.md
@@ -10,11 +10,11 @@ in the target namespace with the user token for the
 to use and be able to clone private repositories.
 
 Whenever Pipelines as Code create a new PipelineRun in the target namespace it
-will create or update a secret called :
+will create or update a secret called:
 
-`pac-git-basic-auth-REPOSITORY_OWNER-REPOSITORY_NAME`
+`pac-gitauth-REPOSITORY_OWNER-REPOSITORY_NAME-RANDOM_STRING`
 
-The secret contains a `.gitconfig` and a Git credentials `.git-credentials` with
+The secret contains a `.gitconfig` and Git credentials `.git-credentials` with
 the https URL using the token it discovered from the GitHub application or
 attached to the secret.
 
@@ -22,7 +22,7 @@ As documented :
 
 <https://github.com/tektoncd/catalog/blob/main/task/git-clone/0.4/README.md>
 
-the secret needs to be referenced inside your PipelineRun and Pipeline as a
+The secret needs to be referenced inside your PipelineRun and Pipeline as a
 workspace called basic-auth to be passed to the `git-clone` task.
 
 For example in your PipelineRun you will add the workspace referencing the
@@ -32,10 +32,10 @@ Secret :
   workspace:
   - name: basic-auth
     secret:
-      secretName: "pac-git-basic-auth-{{repo_owner}}-{{repo_name}}"
+      secretName: "{{ git_auth_secret }}"
 ```
 
-And inside your pipeline, you are referencing them for the `git-clone` to reuse  :
+And inside your pipeline, you are referencing them for the `git-clone` to reuse:
 
 ```yaml
 […]

--- a/pkg/cmd/tknpac/generate/templates/pipelinerun.yaml.tmpl
+++ b/pkg/cmd/tknpac/generate/templates/pipelinerun.yaml.tmpl
@@ -101,4 +101,4 @@ spec:
   # checkout the private repositories
   - name: basic-auth
     secret:
-      secretName: "pac-git-basic-auth-{{repo_owner}}-{{repo_name}}"
+      secretName: "{{ git_auth_secret }}"

--- a/pkg/kubeinteraction/kubeinteraction.go
+++ b/pkg/kubeinteraction/kubeinteraction.go
@@ -22,8 +22,8 @@ type GetSecretOpt struct {
 type Interface interface {
 	WaitForPipelineRunSucceed(context.Context, tektonv1beta1client.TektonV1beta1Interface, *v1beta1.PipelineRun, time.Duration) error
 	CleanupPipelines(context.Context, *zap.SugaredLogger, *v1alpha1.Repository, *v1beta1.PipelineRun, int) error
-	CreateBasicAuthSecret(context.Context, *zap.SugaredLogger, *info.Event, string) error
-	DeleteBasicAuthSecret(context.Context, *zap.SugaredLogger, *info.Event, string) error
+	CreateBasicAuthSecret(context.Context, *zap.SugaredLogger, *info.Event, string) (string, error)
+	DeleteBasicAuthSecret(context.Context, *zap.SugaredLogger, string, string) error
 	GetSecret(context.Context, GetSecretOpt) (string, error)
 }
 

--- a/pkg/kubeinteraction/kubeinteraction.go
+++ b/pkg/kubeinteraction/kubeinteraction.go
@@ -22,7 +22,7 @@ type GetSecretOpt struct {
 type Interface interface {
 	WaitForPipelineRunSucceed(context.Context, tektonv1beta1client.TektonV1beta1Interface, *v1beta1.PipelineRun, time.Duration) error
 	CleanupPipelines(context.Context, *zap.SugaredLogger, *v1alpha1.Repository, *v1beta1.PipelineRun, int) error
-	CreateBasicAuthSecret(context.Context, *zap.SugaredLogger, *info.Event, string) (string, error)
+	CreateBasicAuthSecret(context.Context, *zap.SugaredLogger, *info.Event, string, string) error
 	DeleteBasicAuthSecret(context.Context, *zap.SugaredLogger, string, string) error
 	GetSecret(context.Context, GetSecretOpt) (string, error)
 }
@@ -30,6 +30,9 @@ type Interface interface {
 type Interaction struct {
 	Run *params.Run
 }
+
+// validate the interface implementation
+var _ Interface = (*Interaction)(nil)
 
 func NewKubernetesInteraction(c *params.Run) (*Interaction, error) {
 	return &Interaction{

--- a/pkg/kubeinteraction/secrets_test.go
+++ b/pkg/kubeinteraction/secrets_test.go
@@ -107,7 +107,7 @@ func TestCreateBasicAuthSecret(t *testing.T) {
 				},
 			}
 			tt.event.Provider.Token = secrete
-			_, err := kint.CreateBasicAuthSecret(ctx, fakelogger, tt.event, tt.targetNS)
+			err := kint.CreateBasicAuthSecret(ctx, fakelogger, tt.event, tt.targetNS, tt.expectedStartSecretName)
 			assert.NilError(t, err)
 
 			slist, err := kint.Run.Clients.Kube.CoreV1().Secrets(tt.targetNS).List(ctx, metav1.ListOptions{})
@@ -150,31 +150,18 @@ func TestDeleteBasicAuthSecret(t *testing.T) {
 			},
 		},
 	}
-	event := info.Event{
-		Organization: "owner",
-		Repository:   "repo",
-		URL:          "https://forge/owner/repo",
-	}
-	event2 := info.Event{
-		Organization: "owner2",
-		Repository:   "repo2",
-		URL:          "https://forge/owner/repo2",
-	}
 
 	tests := []struct {
 		name     string
 		targetNS string
-		event    info.Event
 	}{
 		{
 			name:     "auth basic secret there",
 			targetNS: nsthere,
-			event:    event,
 		},
 		{
 			name:     "auth basic secret not there",
 			targetNS: nsthere,
-			event:    event2,
 		},
 	}
 	for _, tt := range tests {
@@ -197,7 +184,7 @@ func TestDeleteBasicAuthSecret(t *testing.T) {
 			assert.NilError(t, err)
 
 			found := false
-			secretName := GetBasicAuthSecretName(&tt.event)
+			secretName := GetBasicAuthSecretName()
 			for _, s := range slist.Items {
 				if s.Name == secretName {
 					found = true
@@ -211,7 +198,7 @@ func TestDeleteBasicAuthSecret(t *testing.T) {
 }
 
 func TestGetBasicAuthSecret(t *testing.T) {
-	t1 := GetBasicAuthSecretName(&info.Event{})
-	t2 := GetBasicAuthSecretName(&info.Event{})
+	t1 := GetBasicAuthSecretName()
+	t2 := GetBasicAuthSecretName()
 	assert.Assert(t, t1 != t2)
 }

--- a/pkg/kubeinteraction/secrets_test.go
+++ b/pkg/kubeinteraction/secrets_test.go
@@ -1,6 +1,8 @@
 package kubeinteraction
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
@@ -62,32 +64,33 @@ func TestCreateBasicAuthSecret(t *testing.T) {
 	lowercaseEvent.URL = "https://forge/UPPER/CASE"
 
 	tests := []struct {
-		name                   string
-		targetNS               string
-		event                  *info.Event
-		expectedGitCredentials string
-		expectedSecretName     string
+		name                    string
+		targetNS                string
+		event                   *info.Event
+		expectedGitCredentials  string
+		expectedStartSecretName string
+		expectedError           bool
 	}{
 		{
-			name:                   "Target secret not there",
-			targetNS:               nsNotThere,
-			event:                  event,
-			expectedGitCredentials: "https://git:verysecrete@forge/owner/repo",
-			expectedSecretName:     "pac-git-basic-auth-owner-repo",
+			name:                    "Target secret not there",
+			targetNS:                nsNotThere,
+			event:                   event,
+			expectedGitCredentials:  "https://git:verysecrete@forge/owner/repo",
+			expectedStartSecretName: "pac-gitauth-owner-repo",
 		},
 		{
-			name:                   "Target secret already there",
-			targetNS:               nsthere,
-			event:                  event,
-			expectedGitCredentials: "https://git:verysecrete@forge/owner/repo",
-			expectedSecretName:     "pac-git-basic-auth-owner-repo",
+			name:                    "Target secret already there",
+			targetNS:                nsthere,
+			event:                   event,
+			expectedGitCredentials:  "https://git:verysecrete@forge/owner/repo",
+			expectedStartSecretName: "pac-gitauth-owner-repo",
 		},
 		{
-			name:                   "Lowercase secrets",
-			targetNS:               nsthere,
-			event:                  lowercaseEvent,
-			expectedGitCredentials: "https://git:verysecrete@forge/UPPER/CASE",
-			expectedSecretName:     "pac-git-basic-auth-upper-case",
+			name:                    "Lowercase secrets",
+			targetNS:                nsthere,
+			event:                   lowercaseEvent,
+			expectedGitCredentials:  "https://git:verysecrete@forge/UPPER/CASE",
+			expectedStartSecretName: "pac-gitauth-upper-case",
 		},
 	}
 	for _, tt := range tests {
@@ -104,7 +107,7 @@ func TestCreateBasicAuthSecret(t *testing.T) {
 				},
 			}
 			tt.event.Provider.Token = secrete
-			err := kint.CreateBasicAuthSecret(ctx, fakelogger, tt.event, tt.targetNS)
+			_, err := kint.CreateBasicAuthSecret(ctx, fakelogger, tt.event, tt.targetNS)
 			assert.NilError(t, err)
 
 			slist, err := kint.Run.Clients.Kube.CoreV1().Secrets(tt.targetNS).List(ctx, metav1.ListOptions{})
@@ -113,12 +116,12 @@ func TestCreateBasicAuthSecret(t *testing.T) {
 
 			found := false
 			for _, s := range slist.Items {
-				if s.Name == tt.expectedSecretName && s.StringData[".git-credentials"] == tt.expectedGitCredentials {
+				if strings.HasPrefix(s.GetName(), tt.expectedStartSecretName) && s.StringData[".git-credentials"] == tt.expectedGitCredentials {
 					found = true
 				}
 			}
 			if !found {
-				t.Fatal("failed to create secret ", tt.expectedSecretName)
+				t.Fatal(fmt.Sprintf("we could not find the secret %s out of secrets created: %+v", tt.expectedStartSecretName, slist.Items))
 			}
 		})
 	}
@@ -187,14 +190,14 @@ func TestDeleteBasicAuthSecret(t *testing.T) {
 					},
 				},
 			}
-			err := kint.DeleteBasicAuthSecret(ctx, fakelogger, &tt.event, tt.targetNS)
+			err := kint.DeleteBasicAuthSecret(ctx, fakelogger, "", tt.targetNS)
 			assert.NilError(t, err)
 
 			slist, err := kint.Run.Clients.Kube.CoreV1().Secrets(tt.targetNS).List(ctx, metav1.ListOptions{})
 			assert.NilError(t, err)
 
 			found := false
-			secretName := getBasicAuthSecretName(&tt.event)
+			secretName := GetBasicAuthSecretName(&tt.event)
 			for _, s := range slist.Items {
 				if s.Name == secretName {
 					found = true
@@ -205,4 +208,10 @@ func TestDeleteBasicAuthSecret(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetBasicAuthSecret(t *testing.T) {
+	t1 := GetBasicAuthSecretName(&info.Event{})
+	t2 := GetBasicAuthSecretName(&info.Event{})
+	assert.Assert(t, t1 != t2)
 }

--- a/pkg/matcher/repo_runinfo_matcher_test.go
+++ b/pkg/matcher/repo_runinfo_matcher_test.go
@@ -135,7 +135,7 @@ func Test_getRepoByCR(t *testing.T) {
 				t.Errorf("GetRepoByCR() got = '%v', want '%v'", got.GetNamespace(), tt.wantTargetNS)
 			}
 			if tt.wantTargetNS != "" && got == nil {
-				t.Errorf("GetRepoByCR() got = '%v', want '%v'", got.GetNamespace(), tt.wantTargetNS)
+				t.Errorf("GetRepoByCR() want nil got '%v'", tt.wantTargetNS)
 			}
 
 			if tt.wantTargetNS != "" && tt.wantTargetNS != got.GetNamespace() {

--- a/pkg/params/info/events.go
+++ b/pkg/params/info/events.go
@@ -34,9 +34,11 @@ type Event struct {
 	Organization string
 	Repository   string
 
+	// TODO: move out inside the provider
 	// Bitbucket Cloud
 	AccountID string
 
+	// TODO: move out inside the provider
 	// Bitbucket Server
 	CloneURL string // bitbucket server has a different url for cloning the repo than normal public html url
 	Provider *Provider

--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -1,0 +1,140 @@
+package pipelineascode
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/matcher"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/resolve"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/templates"
+	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+)
+
+// matchRepoPR matches the repo and the PRs from the event
+func (p *PacRun) matchRepoPR(ctx context.Context) ([]matcher.Match, *v1alpha1.Repository, error) {
+	// Match the Event URL to a Repository URL,
+	repo, err := matcher.MatchEventURLRepo(ctx, p.run, p.event, "")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if repo == nil {
+		if p.event.Provider.Token == "" {
+			p.logger.Warn("cannot set status since no token has been set")
+			return nil, nil, nil
+		}
+		msg := fmt.Sprintf("cannot find a namespace match for %s", p.event.URL)
+		p.logger.Warn(msg)
+
+		status := provider.StatusOpts{
+			Status:     "completed",
+			Conclusion: "skipped",
+			Text:       msg,
+			DetailsURL: "https://tenor.com/search/sad-cat-gifs",
+		}
+		if err := p.vcx.CreateStatus(ctx, p.event, p.run.Info.Pac, status); err != nil {
+			return nil, nil, fmt.Errorf("failed to run create status on repo not found: %w", err)
+		}
+		return nil, nil, nil
+	}
+
+	// If we have a git_provider field in repository spec, then get all the
+	// information from there, including the webhook secret.
+	// otherwise get the secret from the current ns (i.e: pipelines-as-code/openshift-pipelines.)
+	//
+	// TODO: there is going to be some improvements later we may want to do if
+	// they are use cases for it :
+	// allow webhook providers users to have a global webhook secret to be used,
+	// so instead of having to specify their in Repo each time, they use a
+	// shared one from pac.
+	if repo.Spec.GitProvider != nil {
+		err := secretFromRepository(ctx, p.run, p.k8int, p.vcx.GetConfig(), p.event, repo, p.logger)
+		if err != nil {
+			return nil, nil, err
+		}
+	} else {
+		p.event.Provider.WebhookSecret, _ = getCurrentNSWebhookSecret(ctx, p.k8int)
+	}
+	if err := p.vcx.Validate(ctx, p.run, p.event); err != nil {
+		return nil, nil, fmt.Errorf("could not validate payload, check your webhook secret?: %w", err)
+	}
+
+	// Set the client, we should error out if there is a problem with
+	// token or secret or we won't be able to do much.
+	err = p.vcx.SetClient(ctx, p.event)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Get the SHA commit info, we want to get the URL and commit title
+	err = p.vcx.GetCommitInfo(ctx, p.event)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Check if the submitter is allowed to run this.
+	allowed, err := p.vcx.IsAllowed(ctx, p.event)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if !allowed {
+		msg := fmt.Sprintf("User %s is not allowed to run CI on this repo.", p.event.Sender)
+		p.logger.Info(msg)
+		if p.event.AccountID != "" {
+			msg = fmt.Sprintf("User: %s AccountID: %s is not allowed to run CI on this repo.", p.event.Sender, p.event.AccountID)
+		}
+		status := provider.StatusOpts{
+			Status:     "completed",
+			Conclusion: "skipped",
+			Text:       msg,
+			DetailsURL: "https://tenor.com/search/police-cat-gifs",
+		}
+		if err := p.vcx.CreateStatus(ctx, p.event, p.run.Info.Pac, status); err != nil {
+			return nil, nil, fmt.Errorf("failed to run create status, user is not allowed to run: %w", err)
+		}
+		return nil, nil, nil
+	}
+
+	pipelineRuns, err := p.getAllPipelineRuns(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if pipelineRuns == nil {
+		msg := fmt.Sprintf("cannot locate templates in %s/ directory for this repository in %s", tektonDir, p.event.HeadBranch)
+		p.logger.Info(msg)
+		return nil, nil, nil
+	}
+
+	// Match the PipelineRun with annotation
+	matchedPRs, err := matcher.MatchPipelinerunByAnnotation(ctx, p.logger, pipelineRuns, p.run, p.event)
+	if err != nil {
+		// Don't fail when you don't have a match between pipeline and annotations
+		// TODO: better reporting
+		p.logger.Warn(err.Error())
+		return nil, nil, nil
+	}
+
+	return matchedPRs, repo, nil
+}
+
+func (p *PacRun) getAllPipelineRuns(ctx context.Context) ([]*tektonv1beta1.PipelineRun, error) {
+	// Get everything in tekton directory
+	allTemplates, err := p.vcx.GetTektonDir(ctx, p.event, tektonDir)
+	if allTemplates == "" || err != nil {
+		// nolint: nilerr
+		return nil, nil
+	}
+
+	// Replace those {{var}} placeholders user has in her template to the run.Info variable
+	allTemplates = templates.Process(p.event, allTemplates)
+
+	// Merge everything (i.e: tasks/pipeline etc..) as a single pipelinerun
+	return resolve.Resolve(ctx, p.run, p.logger, p.vcx, p.event, allTemplates, &resolve.Opts{
+		GenerateName: true,
+		RemoteTasks:  p.run.Info.Pac.RemoteTasks,
+	})
+}

--- a/pkg/pipelineascode/match_test.go
+++ b/pkg/pipelineascode/match_test.go
@@ -1,0 +1,39 @@
+package pipelineascode
+
+import (
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestPacRun_checkNeedUpdate(t *testing.T) {
+	tests := []struct {
+		name                 string
+		tmpl                 string
+		upgradeMessageSubstr string
+		needupdate           bool
+	}{
+		{
+			name: "old secrets",
+			tmpl: `		  secretName: "pac-git-basic-auth-{{repo_owner}}-{{repo_name}}"`,
+			upgradeMessageSubstr: "old basic auth secret name",
+			needupdate:           true,
+		},
+		{
+			name:       "no need",
+			tmpl:       ` secretName: "foo-bar-foo"`,
+			needupdate: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewPacs(nil, nil, nil, nil, nil)
+			got, needupdate := p.checkNeedUpdate(tt.tmpl)
+			if tt.upgradeMessageSubstr != "" {
+				assert.Assert(t, strings.Contains(got, tt.upgradeMessageSubstr))
+			}
+			assert.Assert(t, needupdate == tt.needupdate)
+		})
+	}
+}

--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -9,16 +9,12 @@ import (
 	"time"
 
 	apipac "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/matcher"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/resolve"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/templates"
-	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -42,115 +38,6 @@ type PacRun struct {
 
 func NewPacs(event *info.Event, vcx provider.Interface, run *params.Run, k8int kubeinteraction.Interface, logger *zap.SugaredLogger) PacRun {
 	return PacRun{event: event, run: run, vcx: vcx, k8int: k8int, logger: logger}
-}
-
-// matchRepoPR matches the repo and the PRs from the event
-func (p *PacRun) matchRepoPR(ctx context.Context) ([]matcher.Match, *v1alpha1.Repository, error) {
-	// Match the Event URL to a Repository URL,
-	repo, err := matcher.MatchEventURLRepo(ctx, p.run, p.event, "")
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if repo == nil {
-		if p.event.Provider.Token == "" {
-			p.logger.Warn("cannot set status since no token has been set")
-			return nil, nil, nil
-		}
-		msg := fmt.Sprintf("cannot find a namespace match for %s", p.event.URL)
-		p.logger.Warn(msg)
-
-		status := provider.StatusOpts{
-			Status:     "completed",
-			Conclusion: "skipped",
-			Text:       msg,
-			DetailsURL: "https://tenor.com/search/sad-cat-gifs",
-		}
-		if err := p.vcx.CreateStatus(ctx, p.event, p.run.Info.Pac, status); err != nil {
-			return nil, nil, fmt.Errorf("failed to run create status on repo not found: %w", err)
-		}
-		return nil, nil, nil
-	}
-
-	// If we have a git_provider field in repository spec, then get all the
-	// information from there, including the webhook secret.
-	// otherwise get the secret from the current ns (i.e: pipelines-as-code/openshift-pipelines.)
-	//
-	// TODO: there is going to be some improvements later we may want to do if
-	// they are use cases for it :
-	// allow webhook providers users to have a global webhook secret to be used,
-	// so instead of having to specify their in Repo each time, they use a
-	// shared one from pac.
-	if repo.Spec.GitProvider != nil {
-		err := secretFromRepository(ctx, p.run, p.k8int, p.vcx.GetConfig(), p.event, repo, p.logger)
-		if err != nil {
-			return nil, nil, err
-		}
-	} else {
-		p.event.Provider.WebhookSecret, _ = getCurrentNSWebhookSecret(ctx, p.k8int)
-	}
-	if err := p.vcx.Validate(ctx, p.run, p.event); err != nil {
-		return nil, nil, fmt.Errorf("could not validate payload, check your webhook secret?: %w", err)
-	}
-
-	// Set the client, we should error out if there is a problem with
-	// token or secret or we won't be able to do much.
-	err = p.vcx.SetClient(ctx, p.event)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Get the SHA commit info, we want to get the URL and commit title
-	err = p.vcx.GetCommitInfo(ctx, p.event)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Check if the submitter is allowed to run this.
-	allowed, err := p.vcx.IsAllowed(ctx, p.event)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if !allowed {
-		msg := fmt.Sprintf("User %s is not allowed to run CI on this repo.", p.event.Sender)
-		p.logger.Info(msg)
-		if p.event.AccountID != "" {
-			msg = fmt.Sprintf("User: %s AccountID: %s is not allowed to run CI on this repo.", p.event.Sender, p.event.AccountID)
-		}
-		status := provider.StatusOpts{
-			Status:     "completed",
-			Conclusion: "skipped",
-			Text:       msg,
-			DetailsURL: "https://tenor.com/search/police-cat-gifs",
-		}
-		if err := p.vcx.CreateStatus(ctx, p.event, p.run.Info.Pac, status); err != nil {
-			return nil, nil, fmt.Errorf("failed to run create status, user is not allowed to run: %w", err)
-		}
-		return nil, nil, nil
-	}
-
-	pipelineRuns, err := getAllPipelineRuns(ctx, p.logger, p.run, p.vcx, p.event)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if pipelineRuns == nil {
-		msg := fmt.Sprintf("cannot locate templates in %s/ directory for this repository in %s", tektonDir, p.event.HeadBranch)
-		p.logger.Info(msg)
-		return nil, nil, nil
-	}
-
-	// Match the PipelineRun with annotation
-	matchedPRs, err := matcher.MatchPipelinerunByAnnotation(ctx, p.logger, pipelineRuns, p.run, p.event)
-	if err != nil {
-		// Don't fail when you don't have a match between pipeline and annotations
-		// TODO: better reporting
-		p.logger.Warn(err.Error())
-		return nil, nil, nil
-	}
-
-	return matchedPRs, repo, nil
 }
 
 func (p *PacRun) Run(ctx context.Context) error {
@@ -272,22 +159,4 @@ func (p *PacRun) startPR(ctx context.Context, match matcher.Match) error {
 	}
 
 	return p.updateRepoRunStatus(ctx, newPr, match.Repo)
-}
-
-func getAllPipelineRuns(ctx context.Context, logger *zap.SugaredLogger, cs *params.Run, providerintf provider.Interface, event *info.Event) ([]*tektonv1beta1.PipelineRun, error) {
-	// Get everything in tekton directory
-	allTemplates, err := providerintf.GetTektonDir(ctx, event, tektonDir)
-	if allTemplates == "" || err != nil {
-		// nolint: nilerr
-		return nil, nil
-	}
-
-	// Replace those {{var}} placeholders user has in her template to the run.Info variable
-	allTemplates = templates.Process(event, allTemplates)
-
-	// Merge everything (i.e: tasks/pipeline etc..) as a single pipelinerun
-	return resolve.Resolve(ctx, cs, logger, providerintf, event, allTemplates, &resolve.Opts{
-		GenerateName: true,
-		RemoteTasks:  cs.Info.Pac.RemoteTasks,
-	})
 }

--- a/pkg/pipelineascode/pipelinesascode_github_test.go
+++ b/pkg/pipelineascode/pipelinesascode_github_test.go
@@ -82,7 +82,7 @@ func testSetupCommonGhReplies(t *testing.T, mux *http.ServeMux, runevent info.Ev
 			// We created multiple status but the last one should be completed.
 			// TODO: we could maybe refine this test
 			if created.GetStatus() == "completed" {
-				assert.Equal(t, created.GetConclusion(), finalStatus)
+				assert.Equal(t, created.GetConclusion(), finalStatus, "we got the status `%s` but we should have get the status `%s`", created.GetConclusion(), finalStatus)
 				assert.Assert(t, strings.Contains(created.GetOutput().GetText(), finalStatusText),
 					"GetStatus/CheckRun %s != %s", created.GetOutput().GetText(), finalStatusText)
 			}

--- a/pkg/pipelineascode/status.go
+++ b/pkg/pipelineascode/status.go
@@ -51,10 +51,8 @@ func (p *PacRun) updateRepoRunStatus(ctx context.Context, pr *tektonv1beta1.Pipe
 		nrepo, err := p.run.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(lastrepo.Namespace).Update(
 			ctx, lastrepo, metav1.UpdateOptions{})
 		if err != nil {
-			if err != nil {
-				p.logger.Infof("Could not update repo %s, retrying %d/%d: %s", lastrepo.Namespace, i, maxRun, err.Error())
-				continue
-			}
+			p.logger.Infof("Could not update repo %s, retrying %d/%d: %s", lastrepo.Namespace, i, maxRun, err.Error())
+			continue
 		}
 		p.logger.Infof("Repository status of %s has been updated", nrepo.Name)
 		return nil

--- a/pkg/random/random.go
+++ b/pkg/random/random.go
@@ -1,0 +1,36 @@
+package random
+
+import (
+	"crypto/rand"
+)
+
+const (
+	letterBytes   = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ" // 52 possibilities
+	letterIdxBits = 6                                                      // 6 bits to represent 64 possibilities / indexes
+	letterIdxMask = 1<<letterIdxBits - 1                                   // All 1-bits, as many as letterIdxBits
+)
+
+// AlphaString returns a random alphanumeric string of the requested length
+// https://stackoverflow.com/a/35615565/145125
+func AlphaString(length int) string {
+	result := make([]byte, length)
+	bufferSize := int(float64(length) * 1.3)
+	for i, j, randomBytes := 0, 0, []byte{}; i < length; j++ {
+		if j%bufferSize == 0 {
+			randomBytes = secureRandomBytes(bufferSize)
+		}
+		if idx := int(randomBytes[j%length] & letterIdxMask); idx < len(letterBytes) {
+			result[i] = letterBytes[idx]
+			i++
+		}
+	}
+
+	return string(result)
+}
+
+// secureRandomBytes returns the requested number of bytes using crypto/rand
+func secureRandomBytes(length int) []byte {
+	randomBytes := make([]byte, length)
+	_, _ = rand.Read(randomBytes)
+	return randomBytes
+}

--- a/pkg/random/random_test.go
+++ b/pkg/random/random_test.go
@@ -1,0 +1,17 @@
+package random
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestRandomAlphaString(t *testing.T) {
+	// statichcek SA4000 error if we inline on the same line :\
+	f := AlphaString(4)
+	assert.Assert(t, f != AlphaString(4))
+}
+
+func TestRandomAlphaStringLength(t *testing.T) {
+	assert.Assert(t, len(AlphaString(10)) == 10)
+}

--- a/pkg/templates/templating.go
+++ b/pkg/templates/templating.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 )
 
@@ -33,13 +34,14 @@ func Process(event *info.Event, template string) string {
 	}
 
 	maptemplate := map[string]string{
-		"revision":      event.SHA,
-		"repo_url":      repoURL,
-		"repo_owner":    strings.ToLower(event.Organization),
-		"repo_name":     strings.ToLower(event.Repository),
-		"target_branch": formatting.SanitizeBranch(event.BaseBranch),
-		"source_branch": formatting.SanitizeBranch(event.HeadBranch),
-		"sender":        strings.ToLower(event.Sender),
+		"revision":        event.SHA,
+		"repo_url":        repoURL,
+		"repo_owner":      strings.ToLower(event.Organization),
+		"repo_name":       strings.ToLower(event.Repository),
+		"target_branch":   formatting.SanitizeBranch(event.BaseBranch),
+		"source_branch":   formatting.SanitizeBranch(event.HeadBranch),
+		"sender":          strings.ToLower(event.Sender),
+		"git_auth_secret": kubeinteraction.GetBasicAuthSecretName(event),
 	}
 	// we don't want to get a 0 replaced
 	if event.PullRequestNumber != 0 {

--- a/pkg/templates/templating.go
+++ b/pkg/templates/templating.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 )
 
@@ -34,14 +33,13 @@ func Process(event *info.Event, template string) string {
 	}
 
 	maptemplate := map[string]string{
-		"revision":        event.SHA,
-		"repo_url":        repoURL,
-		"repo_owner":      strings.ToLower(event.Organization),
-		"repo_name":       strings.ToLower(event.Repository),
-		"target_branch":   formatting.SanitizeBranch(event.BaseBranch),
-		"source_branch":   formatting.SanitizeBranch(event.HeadBranch),
-		"sender":          strings.ToLower(event.Sender),
-		"git_auth_secret": kubeinteraction.GetBasicAuthSecretName(event),
+		"revision":      event.SHA,
+		"repo_url":      repoURL,
+		"repo_owner":    strings.ToLower(event.Organization),
+		"repo_name":     strings.ToLower(event.Repository),
+		"target_branch": formatting.SanitizeBranch(event.BaseBranch),
+		"source_branch": formatting.SanitizeBranch(event.HeadBranch),
+		"sender":        strings.ToLower(event.Sender),
 	}
 	// we don't want to get a 0 replaced
 	if event.PullRequestNumber != 0 {

--- a/pkg/test/kubernetestint/kubernetesint.go
+++ b/pkg/test/kubernetestint/kubernetesint.go
@@ -27,11 +27,11 @@ func (k *KinterfaceTest) GetConsoleUI(ctx context.Context, ns string, pr string)
 	return k.ConsoleURL, nil
 }
 
-func (k *KinterfaceTest) CreateBasicAuthSecret(ctx context.Context, logger *zap.SugaredLogger, runevent *info.Event, targetNamespace string) error {
-	return nil
+func (k *KinterfaceTest) CreateBasicAuthSecret(ctx context.Context, logger *zap.SugaredLogger, runevent *info.Event, targetNamespace string) (string, error) {
+	return "", nil
 }
 
-func (k *KinterfaceTest) DeleteBasicAuthSecret(ctx context.Context, logger *zap.SugaredLogger, runevent *info.Event, targetNamespace string) error {
+func (k *KinterfaceTest) DeleteBasicAuthSecret(ctx context.Context, logger *zap.SugaredLogger, targetNamespace, secretName string) error {
 	return nil
 }
 

--- a/pkg/test/kubernetestint/kubernetesint.go
+++ b/pkg/test/kubernetestint/kubernetesint.go
@@ -20,6 +20,8 @@ type KinterfaceTest struct {
 	GetSecretResult          map[string]string
 }
 
+var _ kubeinteraction.Interface = (*KinterfaceTest)(nil)
+
 func (k *KinterfaceTest) GetConsoleUI(ctx context.Context, ns string, pr string) (string, error) {
 	if k.ConsoleURLErorring {
 		return "", fmt.Errorf("i want you to errit")
@@ -27,15 +29,17 @@ func (k *KinterfaceTest) GetConsoleUI(ctx context.Context, ns string, pr string)
 	return k.ConsoleURL, nil
 }
 
-func (k *KinterfaceTest) CreateBasicAuthSecret(ctx context.Context, logger *zap.SugaredLogger, runevent *info.Event, targetNamespace string) (string, error) {
-	return "", nil
+func (k *KinterfaceTest) CreateBasicAuthSecret(ctx context.Context, logger *zap.SugaredLogger, runevent *info.Event,
+	targetNamespace, secretName string,
+) error {
+	return nil
 }
 
 func (k *KinterfaceTest) DeleteBasicAuthSecret(ctx context.Context, logger *zap.SugaredLogger, targetNamespace, secretName string) error {
 	return nil
 }
 
-func (k *KinterfaceTest) GetSecret(ctx context.Context, secretopt kubeinteraction.GetSecretOpt) (string, error) {
+func (k *KinterfaceTest) GetSecret(_ context.Context, secretopt kubeinteraction.GetSecretOpt) (string, error) {
 	return k.GetSecretResult[secretopt.Name], nil
 }
 

--- a/test/testdata/pipelinerun_git_clone_private.yaml
+++ b/test/testdata/pipelinerun_git_clone_private.yaml
@@ -20,7 +20,7 @@ spec:
               storage: 1Gi
     - name: basic-auth
       secret:
-        secretName: "pac-git-basic-auth-{{repo_owner}}-{{repo_name}}"
+        secretName: "{{ git_auth_secret }}"
   params:
     - name: repo_url
       value: "{{repo_url}}"


### PR DESCRIPTION
We now generate random chars at the end of the generated secret.
We expose a new variable :

{{ git_auth_secret }}

The way it works is : 

- get all pipelinesruns in a string
- replace all templates variable in string (but not the git_auth_secret one
- resolve the string as PipelineRuns object
- go over all pipelineruns
- encode them as json
- replace git_auth_secret with a random one (we used to have the whole repo-name/owner in the name but we could get into limit of the secret name so now just simple random)
- we store in annotations the git auth name, we don't need it but in case there is a failure we could easily cleanup them if needed
- we create the secret with extra annotations to which url/sha it belongs
- we delete that secret at the end.


which can be generated in template.

- [x] We need to figure out about migration and how to have old PipelineRun working, since this is a breaking change (even tho it's a good one). 
- [x] Docs
- [x] Update CLI default template.
- [x] reEnable secret creation for multiplue pipeline
- [x] Fix E2E secret creation..

Closes #543

Migration: 

~1. Analyze pipelinerun and see if  we can detect:~

```yaml		
secretName: "pac-git-basic-auth-{{repo_owner}}-{{repo_name}}"
```
~and if present use the old one until user migrate it.~

~2. Create two auth secrets (beurk)~

3. Just deal with it ! since we are in TP For OSP we may as well just break things...

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [x] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [x] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [x] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [x] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
