### PR TITLE
Get SHA from Before if head_commit is not passed.

### DIFF
--- a/pkg/provider/github/events.go
+++ b/pkg/provider/github/events.go
@@ -171,6 +171,10 @@ func (v *Provider) processEvent(ctx context.Context, event *info.Event, eventInt
 		processedEvent.DefaultBranch = gitEvent.GetRepo().GetDefaultBranch()
 		processedEvent.URL = gitEvent.GetRepo().GetHTMLURL()
 		processedEvent.SHA = gitEvent.GetHeadCommit().GetID()
+		// on push event we may not get a head commit but only
+		if processedEvent.SHA == "" {
+			processedEvent.SHA = gitEvent.GetBefore()
+		}
 		processedEvent.SHAURL = gitEvent.GetHeadCommit().GetURL()
 		processedEvent.SHATitle = gitEvent.GetHeadCommit().GetMessage()
 		processedEvent.Sender = gitEvent.GetSender().GetLogin()


### PR DESCRIPTION
So at least we could set the status on commit properly on webhook

it now would properly update the SHA via the status API for webhook when success/failure : 

![image](https://user-images.githubusercontent.com/98980/165492456-538c52ce-ba60-48a8-a8dc-0d9d1bca2189.png)

Closes #618 

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
