### PR TITLE
gitlab: .tekton/ subtree support

### DIFF
--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -314,8 +314,9 @@ func (v *Provider) GetTektonDir(_ context.Context, event *info.Event, path strin
 	}
 
 	opt := &gitlab.ListTreeOptions{
-		Path: gitlab.String(path),
-		Ref:  gitlab.String(event.HeadBranch),
+		Path:      gitlab.String(path),
+		Ref:       gitlab.String(event.HeadBranch),
+		Recursive: gitlab.Bool(true),
 	}
 
 	objects, resp, err := v.Client.Repositories.ListTree(v.sourceProjectID, opt)

--- a/pkg/provider/gitlab/gitlab_test.go
+++ b/pkg/provider/gitlab/gitlab_test.go
@@ -457,7 +457,7 @@ func TestGetFileInsideRepo(t *testing.T) {
 		Client:          client,
 	}
 	thelp.MuxListTektonDir(t, mux, v.sourceProjectID, event.HeadBranch, content)
-	got, err := v.GetFileInsideRepo(ctx, event, ".tekton/pr.yaml", "")
+	got, err := v.GetFileInsideRepo(ctx, event, ".tekton/subtree/pr.yaml", "")
 	assert.NilError(t, err)
 	assert.Equal(t, content, got)
 

--- a/pkg/provider/gitlab/test/test.go
+++ b/pkg/provider/gitlab/test/test.go
@@ -64,13 +64,13 @@ func MuxListTektonDir(t *testing.T, mux *http.ServeMux, pid int, ref, prs string
 	mux.HandleFunc(fmt.Sprintf("/projects/%d/repository/tree", pid), func(rw http.ResponseWriter, r *http.Request) {
 		if r.URL.Query().Get("ref") == ref {
 			fmt.Fprintf(rw, `[
-			{"name": "pac.yaml", "path": ".tekton/pr.yaml"},
+			{"name": "pac.yaml", "path": ".tekton/subtree/pr.yaml"},
 			{"name": "random.yaml", "path": ".tekton/random.yaml"}
 			]`)
 		}
 	})
 
-	MuxGetFile(t, mux, pid, ".tekton/pr.yaml", prs)
+	MuxGetFile(t, mux, pid, ".tekton/subtree/pr.yaml", prs)
 	MuxGetFile(t, mux, pid, ".tekton/random.yaml", `foo:bar`)
 }
 

--- a/test/gitlab_merge_request_test.go
+++ b/test/gitlab_merge_request_test.go
@@ -32,7 +32,9 @@ func TestGitlabMergeRequest(t *testing.T) {
 	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, targetNS)
 	assert.NilError(t, err)
 
-	entries, err := payload.GetEntries([]string{"testdata/pipelinerun.yaml", "testdata/pipelinerun-clone.yaml"}, targetNS, projectinfo.DefaultBranch,
+	entries, err := payload.GetEntries([]string{
+		"testdata/pipelinerun.yaml", "testdata/pipelinerun-clone.yaml",
+	}, targetNS, projectinfo.DefaultBranch,
 		options.PullRequestEvent)
 	assert.NilError(t, err)
 
@@ -42,7 +44,7 @@ func TestGitlabMergeRequest(t *testing.T) {
 		projectinfo.DefaultBranch,
 		targetRefName,
 		opts.ProjectID,
-		entries)
+		entries, ".tekton/subdir/pr.yaml")
 	assert.NilError(t, err)
 	runcnx.Clients.Log.Infof("Branch %s has been created and pushed with files", targetRefName)
 	mrID, err := tgitlab.CreateMR(glprovider.Client, opts.ProjectID, targetRefName, projectinfo.DefaultBranch, title)

--- a/test/pkg/gitlab/test.go
+++ b/test/pkg/gitlab/test.go
@@ -9,13 +9,13 @@ var (
 	commitEmail  = "e2e-pipelines@redhat.com"
 )
 
-func PushFilesToRef(client *ghlib.Client, commitMessage, baseBranch, targetRef string, pid int, files map[string]string) error {
+func PushFilesToRef(client *ghlib.Client, commitMessage, baseBranch, targetRef string, pid int, files map[string]string, targetFile string) error {
 	fullYaml := ""
 	for _, content := range files {
 		fullYaml += "---\n"
 		fullYaml += content
 	}
-	_, _, err := client.RepositoryFiles.CreateFile(pid, ".tekton/pr.yaml", &ghlib.CreateFileOptions{
+	_, _, err := client.RepositoryFiles.CreateFile(pid, targetFile, &ghlib.CreateFileOptions{
 		Branch:        ghlib.String(targetRef),
 		StartBranch:   ghlib.String(baseBranch),
 		AuthorEmail:   ghlib.String(commitEmail),


### PR DESCRIPTION
pretty easy since just a flag to the gitlab api to get recursive calls.
changed e2e/unittest to use subdirs

Closes #583

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [x] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [x] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [x] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [x] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
