### PR TITLE
Allow multiple providers by CLI

### DIFF
--- a/pkg/cli/webhook/github.go
+++ b/pkg/cli/webhook/github.go
@@ -82,6 +82,8 @@ func (gh *gitHubConfig) askGHWebhookConfig(repoURL, controllerURL string) error 
 		}, &gh.controllerURL, survey.WithValidator(survey.Required)); err != nil {
 			return err
 		}
+	} else {
+		gh.controllerURL = controllerURL
 	}
 
 	if err := prompt.SurveyAskOne(&survey.Password{

--- a/pkg/cli/webhook/webhook.go
+++ b/pkg/cli/webhook/webhook.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli/prompt"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cmd/tknpac/bootstrap"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 )
 
 type Interface interface {
@@ -56,6 +57,14 @@ func (w *Options) Install(ctx context.Context) error {
 	// TODO: if couldn't detect then ask user providing a list
 	if webhookProvider == nil {
 		return nil
+	}
+
+	if !w.GitHubWebhook {
+		if webhookProvider.GetName() == provider.ProviderGitHubWebhook && pacInfo.Provider == provider.ProviderGitHubApp {
+			fmt.Printf("✓ Skips configuring GitHub Webhook as GitHub App is already configured." +
+				" Please pass --github-webhook flag to still configure it")
+			return nil
+		}
 	}
 
 	msg := fmt.Sprintf("Would you like me to configure a %s Webhook for your repository? ",

--- a/pkg/cli/webhook/webhook.go
+++ b/pkg/cli/webhook/webhook.go
@@ -61,6 +61,7 @@ func (w *Options) Install(ctx context.Context) error {
 
 	if !w.GitHubWebhook {
 		if webhookProvider.GetName() == provider.ProviderGitHubWebhook && pacInfo.Provider == provider.ProviderGitHubApp {
+			// nolint
 			fmt.Printf("✓ Skips configuring GitHub Webhook as GitHub App is already configured." +
 				" Please pass --github-webhook flag to still configure it")
 			return nil

--- a/pkg/cmd/tknpac/bootstrap/bootstrap.go
+++ b/pkg/cmd/tknpac/bootstrap/bootstrap.go
@@ -35,7 +35,6 @@ type bootstrapOpts struct {
 	cliOpts         *cli.PacCliOpts
 	ioStreams       *cli.IOStreams
 	targetNamespace string
-	recreateSecret  bool
 
 	RouteName              string
 	GithubAPIURL           string
@@ -93,7 +92,6 @@ func install(ctx context.Context, run *params.Run, opts *bootstrapOpts) error {
 
 func createSecret(ctx context.Context, run *params.Run, opts *bootstrapOpts) error {
 	var err error
-	opts.recreateSecret = checkSecret(ctx, run, opts)
 
 	if opts.RouteName == "" {
 		opts.RouteName, _ = DetectOpenShiftRoute(ctx, run, opts.targetNamespace)
@@ -102,7 +100,7 @@ func createSecret(ctx context.Context, run *params.Run, opts *bootstrapOpts) err
 		return err
 	}
 
-	if opts.recreateSecret {
+	if opts.forceGitHubApp {
 		if err := deleteSecret(ctx, run, opts); err != nil {
 			return err
 		}
@@ -145,7 +143,9 @@ func Command(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
 
 			if !opts.forceGitHubApp {
 				if pacInfo.Provider == provider.ProviderGitHubApp {
-					return fmt.Errorf("skipping bootstraping GitHub App, as it is already configured. Please pass --force to override existing")
+					// nolint
+					fmt.Printf("👌 Skips bootstrapping GitHub App, as one is already configured. Please pass --force-configure to override existing\n")
+					return nil
 				}
 			}
 
@@ -202,7 +202,9 @@ func GithubApp(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
 
 			if !opts.forceGitHubApp {
 				if pacInfo.Provider == provider.ProviderGitHubApp {
-					return fmt.Errorf("skipping bootstraping GitHub App, as it is already configured. Please pass --override-app to override existing")
+					// nolint
+					fmt.Printf("👌 Skips bootstrapping GitHub App, as one is already configured. Please pass --force-configure to override existing\n")
+					return nil
 				}
 			}
 

--- a/pkg/cmd/tknpac/bootstrap/kubestuff.go
+++ b/pkg/cmd/tknpac/bootstrap/kubestuff.go
@@ -39,12 +39,6 @@ func createPacSecret(ctx context.Context, run *params.Run, opts *bootstrapOpts, 
 	return nil
 }
 
-// checkSecret checks if the secret exists
-func checkSecret(ctx context.Context, run *params.Run, opts *bootstrapOpts) bool {
-	_, err := run.Clients.Kube.CoreV1().Secrets(opts.targetNamespace).Get(ctx, secretName, metav1.GetOptions{})
-	return err == nil
-}
-
 // check if we have the namespace created
 func checkNS(ctx context.Context, run *params.Run, targetNamespace string) (bool, error) {
 	ns, err := run.Clients.Kube.CoreV1().Namespaces().Get(ctx, targetNamespace, metav1.GetOptions{})

--- a/pkg/cmd/tknpac/bootstrap/questions.go
+++ b/pkg/cmd/tknpac/bootstrap/questions.go
@@ -27,18 +27,6 @@ func askYN(deflt bool, title, question string) (bool, error) {
 func askQuestions(opts *bootstrapOpts) error {
 	var qs []*survey.Question
 
-	if opts.recreateSecret {
-		answer, err := askYN(false,
-			fmt.Sprintf("👀 A secret named %s in %s namespace has been detected.", secretName, opts.targetNamespace),
-			"Do you want me to override the secret?")
-		if err != nil {
-			return err
-		}
-		if !answer {
-			return fmt.Errorf("not overriding the secret")
-		}
-	}
-
 	if opts.GithubAPIURL == "" {
 		if opts.providerType == "github-enteprise-app" {
 			prompt := "Enter your Github enteprise API URL: "


### PR DESCRIPTION
Allow configuring webhook even if github app is configured
need to pass --github-webhook to configure webhook if app is already
need to pass --force-configure to override existing gh app


# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
