### PR TITLE
Fixes status report when pipelinerun fails

### DIFF
--- a/pkg/sort/task_status.go
+++ b/pkg/sort/task_status.go
@@ -9,8 +9,6 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/consoleui"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	corev1 "k8s.io/api/core/v1"
-	knativeapi "knative.dev/pkg/apis"
 )
 
 type tkr struct {
@@ -42,10 +40,6 @@ func (trs taskrunList) Less(i, j int) bool {
 func TaskStatusTmpl(pr *tektonv1beta1.PipelineRun, console consoleui.Interface, statusTemplate string) (string, error) {
 	trl := taskrunList{}
 	outputBuffer := bytes.Buffer{}
-	c := pr.GetStatusCondition().GetCondition(knativeapi.ConditionSucceeded)
-	if c != nil && c.Status != corev1.ConditionTrue {
-		return fmt.Sprintf("PipelineRun has failed to be created: %s", c.Message), nil
-	}
 
 	if len(pr.Status.TaskRuns) == 0 {
 		return "PipelineRun has no taskruns", nil

--- a/pkg/sort/task_status_test.go
+++ b/pkg/sort/task_status_test.go
@@ -8,9 +8,6 @@ import (
 	tektontest "github.com/openshift-pipelines/pipelines-as-code/pkg/test/tekton"
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"gotest.tools/v3/assert"
-	corev1 "k8s.io/api/core/v1"
-	knativeapi "knative.dev/pkg/apis"
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 )
 
 func TestStatusTmpl(t *testing.T) {
@@ -57,20 +54,6 @@ func TestStatusTmpl(t *testing.T) {
 			name:       "test sorted status nada",
 			wantRegexp: regexp.MustCompile("PipelineRun has no taskruns"),
 			pr:         tektontest.MakePR("nada", "ns", nil, nil),
-		},
-		{
-			name:       "pipelinerun no apply",
-			wantRegexp: regexp.MustCompile("PipelineRun has failed to be created: looozeuuur"),
-			pr: tektontest.MakePR("pr1", "looz", map[string]*tektonv1beta1.PipelineRunTaskRunStatus{},
-				&duckv1beta1.Status{
-					Conditions: duckv1beta1.Conditions{
-						{
-							Status:  corev1.ConditionFalse,
-							Type:    knativeapi.ConditionSucceeded,
-							Message: "looozeuuur",
-						},
-					},
-				}),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
if pipelinerun fails it checks the suceeded.status for true and if not
then report as pipelinerun was not created.
but when pipleinrun fails the succeded.status is false.
this fixes it.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
