### PR TITLE
Add Gitea Support

### DIFF
--- a/docs/content/dev/_index.md
+++ b/docs/content/dev/_index.md
@@ -60,6 +60,56 @@ override it you can set the `PAC_DIRS` environment variable.
   instead of ko. `-c` will only do the pac configuration (ie: creation of
   secrets/ingress etc..)
 
+## Gitea
+
+Gitea is "unofficially" supported. You just need to configure Gitea the same way
+you do for Github enteprise and Pipelines as Code will recognize it.
+
+Here is an example of a Gitea NS/CRD/Secret (set to empty):
+
+```yaml
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gitea
+
+---
+apiVersion: "pipelinesascode.tekton.dev/v1alpha1"
+kind: Repository
+metadata:
+  name: gitea
+  namespace: gitea
+spec:
+  url: "https://gitea.my.com/owner/repo"
+  git_provider:
+    user: "git"
+    url: "Your gitea installation URL, i.e: https://gitea.my.com/"
+    secret:
+      name: "secret"
+      key: token
+    webhook_secret:
+      name: "secret"
+      key: "webhook"
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gitea-home-chmouel
+  namespace: gitea
+type: Opaque
+stringData:
+  token: "your token has generated in gitea"
+  webhook: "" # make sure it's empty when you set this up on the interface and here
+```
+
+There is some gotchas with the webhook validation secret, Pipelines as Code
+detect a Gitea install and let the user set a empty webhook secret (by default
+it's enforced).
+
+Other than that YMMV, feel free to raise a bug if you find some.
+
 ## Debugging controller
 
 Create a [smee](https://smee.io) URL and point your app/webhook to it. Use
@@ -68,7 +118,7 @@ installed controller (this can be either run on your debugger or inside kind).
 
 An option of gosmee is to save the replay to a directory with `--saveDir
 /tmp/save`. If go to that directory a shell script will be created to replay
-the request that was sent directly to the controller without having to go via
+the request that was sent directly to the controller without having to go through
 another push.
 
 Use [snazy](https://github.com/chmouel/snazy) to watch the logs, it support pac

--- a/docs/content/docs/install/github_webhook.md
+++ b/docs/content/docs/install/github_webhook.md
@@ -14,18 +14,38 @@ API](https://docs.github.com/en/rest/guides/getting-started-with-the-checks-api)
 therefore the status of
 the tasks will be added as a Comment of the PR and not through the **Checks** Tab.
 
-After you have finished the [installation](/docs/install/installation) you can generate an app password for Pipelines-as-Code GitHub API operations.
+After you have finished the [installation](/docs/install/installation) you can
+generate an app password for Pipelines-as-Code GitHub API operations.
+
+## Generate a token for Pipelines as Code
 
 Follow this guide to create a personal token :
 
 <https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token>
 
-The only permission needed is the *repo* permission. You will have to note the generated token somewhere, or otherwise you will have to recreate it.
+The only permission needed is the *repo* permission. You will have to note the
+generated token somewhere, or otherwise you will have to recreate it.
 
-Now, you have 2 ways to configure webhook
+{{< hint danger >}}
+For best security practice you will probably want to have a short token
+expiration (like the rdefault 30 days). GitHub will send you a notification email
+if you token expires. When you have regenerated a new token you will need to
+update it on cluster. For example through the command line, you will want to replace
+`$NEW_TOKEN` and `$target_namespace` by their respective values:
 
-* You could use [`tkn pac repository create`](/docs/guide/cli) command which will create repository CR and configure webhook, or
-* You could follow [configuring webhook](#configure-webhook) to do it manually
+```shell
+kubectl -n $target_namespace patch secret githubwebhook -p "{\"data\": {\"foo\": \"$(echo -n $NEW_TOKEN|base64 -w0)\"}}"
+```
+
+{{< /hint >}}
+
+## Repository creation
+
+Now, you have 2 ways to configure the webhook:
+
+* You could use [`tkn pac repository create`](/docs/guide/cli) command which
+  will create repository CR and configure webhook, or
+* You could follow the [configuring webhook](#configure-webhook) guide to do it manually
 
 ## Configure webhook
 
@@ -65,7 +85,7 @@ follow below instruction to configure webhook manually
     --from-literal provider.token="TOKEN_AS_GENERATED_PREVIOUSLY" \
     --from-literal webhook.secret="SECRET_AS_SET_IN_WEBHOOK_CONFIGURATION"
   ```
-  
+
 * And now create Repository CRD referencing everything :
 
   ```yaml

--- a/docs/content/docs/install/gitlab.md
+++ b/docs/content/docs/install/gitlab.md
@@ -9,6 +9,8 @@ Pipelines-As-Code supports [Gitlab](https://www.gitlab.com) through a webhook.
 
 Follow the pipelines-as-code [installation](/docs/install/installation) according to your kubernetes cluster.
 
+## Generate a token for Pipelines as Code
+
 * You will have to generate a personal token as the manager of the Org or the Project,
   follow the steps here :
 
@@ -19,6 +21,29 @@ Follow the pipelines-as-code [installation](/docs/install/installation) accordin
   the MR come from, it will fail to do it with a project scoped token. We try
   to fallback nicely by showing the status of the pipeline directly as comment
   of the Merge Request.
+
+{{< hint danger >}}
+For best security practice you will probably want to have a short token
+expiration (like the default 30 days). Gitlab will send you a notification email
+if you token expires. When you have regenerated a new token you will need to
+update it on cluster. For example through the command line, you will want to replace
+`$NEW_TOKEN` and `$target_namespace` by their respective values:
+
+```shell
+kubectl -n $target_namespace patch secret gitlabwebhook -p "{\"data\": {\"foo\": \"$(echo -n $NEW_TOKEN|base64 -w0)\"}}"
+```
+
+{{< /hint >}}
+
+## Repository creation
+
+Now, you have 2 ways to configure the webhook:
+
+* You could use [`tkn pac repository create`](/docs/guide/cli) command which
+  will create repository CR and configure webhook, or
+* You could follow the [configuring webhook](#configure-webhook) guide to do it manually
+
+## Configure webhook
 
 * Go to your project and click on *Settings* and *"Webhooks"* from the sidebar on the left.
 
@@ -53,7 +78,7 @@ and another reference to a Kubernetes secret to validate the Webhook payload as 
     --from-literal provider.token="TOKEN_AS_GENERATED_PREVIOUSLY" \
     --from-literal webhook.secret="SECRET_AS_SET_IN_WEBHOOK_CONFIGURATION"
   ```
-  
+
 * And now create Repository CRD with the secret field referencing it.
 
 Here is an example of a Repository CRD :

--- a/pkg/cli/webhook/github.go
+++ b/pkg/cli/webhook/github.go
@@ -113,7 +113,7 @@ func (gh *gitHubConfig) askGHWebhookConfig(repoURL, controllerURL string) error 
 	// nolint:forbidigo
 	fmt.Println("ℹ ️You now need to create a GitHub personal token with scopes  `public_repo` & `admin:repo_hook`")
 	// nolint:forbidigo
-	fmt.Println("ℹ ️Go to this URL to generate one https://github.com/settings/tokens/new, see https://is.gd/BMgLH5 for documentation ")
+	fmt.Println("ℹ ️Go to this URL to generate a new token https://github.com/settings/tokens/new, see https://is.gd/G5gBFI for documentation ")
 	if err := prompt.SurveyAskOne(&survey.Password{
 		Message: "Please enter the GitHub access token: ",
 	}, &gh.personalAccessToken, survey.WithValidator(survey.Required)); err != nil {

--- a/pkg/cli/webhook/gitlab.go
+++ b/pkg/cli/webhook/gitlab.go
@@ -83,7 +83,7 @@ func (gl *gitLabConfig) askGLWebhookConfig(controllerURL string) error {
 	// nolint:forbidigo
 	fmt.Println("ℹ ️You now need to create a GitLab personal access token with `api` scope")
 	// nolint:forbidigo
-	fmt.Println("ℹ ️Go to this URL to generate one https://gitlab.com/-/profile/personal_access_tokens, see https://is.gd/WIXECN for documentation ")
+	fmt.Println("ℹ ️Go to this URL to generate one https://gitlab.com/-/profile/personal_access_tokens, see https://is.gd/rOEo9B for documentation ")
 	if err := prompt.SurveyAskOne(&survey.Password{
 		Message: "Please enter the GitLab access token: ",
 	}, &gl.personalAccessToken, survey.WithValidator(survey.Required)); err != nil {

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 
@@ -34,8 +35,20 @@ func (v *Provider) SetLogger(logger *zap.SugaredLogger) {
 
 func (v *Provider) Validate(ctx context.Context, cs *params.Run, event *info.Event) error {
 	signature := event.Request.Header.Get(github.SHA256SignatureHeader)
+
+	// detect if we run gitea and validate the signature
+	// there is currently an issue while validating the signature with gitea, so we are not enforcing the need webhook secret like we do for github.
+	if event.Request.Header.Get("X-Gitea-Event") != "" && event.Request.Header.Get("X-Gitea-Signature") == "" && event.Provider.WebhookSecret == "" {
+		v.Logger.Debug("no secret and signature found, skipping validation for gitea")
+		return nil
+	}
+
 	if signature == "" {
 		signature = event.Request.Header.Get(github.SHA1SignatureHeader)
+	}
+	if signature == "" || signature == "sha1=" {
+		// if no signature is present then don't validate, because user hasn't set one
+		return fmt.Errorf("no signature has been detected, for security reason we are not allowing webhooks that has no secret")
 	}
 	return github.ValidateSignature(signature, event.Request.Payload, []byte(event.Provider.WebhookSecret))
 }
@@ -45,6 +58,34 @@ func (v *Provider) GetConfig() *info.ProviderConfig {
 		TaskStatusTMPL: taskStatusTemplate,
 		APIURL:         apiPublicURL,
 	}
+}
+
+func (v *Provider) getGiteaClient(apiURL string, tc *http.Client) (*github.Client, error) {
+	// add /api/v1 to the base url
+	baseEndpoint, err := url.Parse(apiURL)
+	if err != nil {
+		return nil, err
+	}
+	if !strings.HasSuffix(baseEndpoint.Path, "/") {
+		baseEndpoint.Path += "/"
+	}
+	if !strings.HasSuffix(baseEndpoint.Path, "/api/v1/") && !strings.HasPrefix(baseEndpoint.Host, "api.") && !strings.Contains(baseEndpoint.Host, ".api.") {
+		baseEndpoint.Path += "api/v1/"
+	}
+	uploadURL, err := url.Parse(apiURL)
+	if err != nil {
+		return nil, err
+	}
+	if !strings.HasSuffix(uploadURL.Path, "/") {
+		uploadURL.Path += "/"
+	}
+	if !strings.HasSuffix(uploadURL.Path, "/api/v1/") && !strings.HasPrefix(uploadURL.Host, "api.") && !strings.Contains(uploadURL.Host, ".api.") {
+		uploadURL.Path += "api/v1/"
+	}
+	client := github.NewClient(tc)
+	client.BaseURL = baseEndpoint
+	client.UploadURL = uploadURL
+	return client, nil
 }
 
 func (v *Provider) SetClient(ctx context.Context, event *info.Event) error {
@@ -59,11 +100,21 @@ func (v *Provider) SetClient(ctx context.Context, event *info.Event) error {
 			apiURL = "https://" + apiURL
 		}
 	}
+
 	if apiURL != "" && apiURL != apiPublicURL {
 		client, _ = github.NewEnterpriseClient(apiURL, apiURL, tc)
 	} else {
 		client = github.NewClient(tc)
 		apiURL = client.BaseURL.String()
+	}
+
+	// if we have gitea events then do our own client thing
+	if event.Request != nil && event.Request.Header.Get("X-Gitea-Event") != "" {
+		var err error
+		client, err = v.getGiteaClient(apiURL, tc)
+		if err != nil {
+			return fmt.Errorf("cannot make a gitea client: %w", err)
+		}
 	}
 
 	// Make sure Client is not already set, so we don't override our fakeclient

--- a/pkg/provider/github/github_test.go
+++ b/pkg/provider/github/github_test.go
@@ -627,7 +627,8 @@ func TestValidate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			v := &Provider{}
+			logger := getLogger()
+			v := &Provider{Logger: logger}
 
 			hm := hmac.New(tt.hashFunc, []byte(tt.secret))
 			hm.Write([]byte(tt.payload))

--- a/samples/repository-secret.yaml
+++ b/samples/repository-secret.yaml
@@ -13,3 +13,6 @@ spec:
     secret:
       name: "github.enteprise.personal.access.token"
       key: "tokenkey"
+    webhook_secret:
+      name: "github-webhook-config"
+      key: "webhook.secret"


### PR DESCRIPTION
- Better documentation when creating webhook token
add (semi workish only for dev) support for Gitea

it workish, but there is some bugs which may be due of my Gitea install
(and not related to PAC).

webhook validation seems broken, so if we want to use it we need to make
sure it's empty.

Fixes #451

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
