### PR TITLE
Adds support for /test comment to run a specific pipelinerun

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -30,7 +30,7 @@ of the execution when triggered by a `Pull Request` or a `Push`.
 
 <--->
 
-- Pull-request actions in comments such as `/retest`
+- Pull-request "*GitOps*" actions through comments with  `/retest`, `/test <pipeline-name>` and so on.
 
 - Automatic Task resolution in Pipelines (local Tasks, Tekton Hub, and remote URLs)
 

--- a/docs/content/docs/guide/statuses.md
+++ b/docs/content/docs/guide/statuses.md
@@ -23,6 +23,17 @@ failure is not with your PR but seems to be an infra issue.
 /retest
 ```
 
+Note that `/retest` runs every `PipelineRun` matching the Pull Request. If you want to retest an individual `PipelineRun`
+you can run it again by adding a comment with `/test <pipelinerun-name>`.
+
+Example:
+
+```yaml
+/test <pipelineRun-name>
+```
+
+NOTE: `/test` is currently supported only on GitHub Apps.
+
 ## CRD
 
 Status of your pipeline execution is stored inside the Repo CustomResource :

--- a/pkg/params/info/events.go
+++ b/pkg/params/info/events.go
@@ -29,6 +29,8 @@ type Event struct {
 	SHATitle          string // commit title for UIs
 	PullRequestNumber int    // Pull or Merge Request number
 
+	TestPipelineRun string // PipelineRun name to run
+
 	// TODO: move forge specifics to each driver
 	// Github
 	Organization string

--- a/pkg/params/info/events.go
+++ b/pkg/params/info/events.go
@@ -3,6 +3,7 @@ package info
 import "net/http"
 
 type Event struct {
+	State
 	Event interface{}
 
 	// EventType is what coming from the provider header, i.e:
@@ -29,8 +30,6 @@ type Event struct {
 	SHATitle          string // commit title for UIs
 	PullRequestNumber int    // Pull or Merge Request number
 
-	TestPipelineRun string // PipelineRun name to run
-
 	// TODO: move forge specifics to each driver
 	// Github
 	Organization string
@@ -44,6 +43,10 @@ type Event struct {
 	// Bitbucket Server
 	CloneURL string // bitbucket server has a different url for cloning the repo than normal public html url
 	Provider *Provider
+}
+
+type State struct {
+	TargetTestPipelineRun string // PipelineRun name to run
 }
 
 type Provider struct {

--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -129,9 +129,9 @@ func (p *PacRun) matchRepoPR(ctx context.Context) ([]matcher.Match, *v1alpha1.Re
 	}
 
 	// if /test command is used then filter out the pipelinerun
-	pipelineRuns = filterPipelineRun(p.event.TestPipelineRun, pipelineRuns)
+	pipelineRuns = filterPipelineRun(p.event.TargetTestPipelineRun, pipelineRuns)
 	if pipelineRuns == nil {
-		p.logger.Info(fmt.Sprintf("cannot find pipelinerun %s in this repository", p.event.TestPipelineRun))
+		p.logger.Info(fmt.Sprintf("cannot find pipelinerun %s in this repository", p.event.TargetTestPipelineRun))
 		return nil, nil, nil
 	}
 

--- a/pkg/provider/github/events.go
+++ b/pkg/provider/github/events.go
@@ -249,7 +249,7 @@ func (v *Provider) handleIssueCommentEvent(ctx context.Context, event *github.Is
 
 	// if it is a /test comment figure out the pipelinerun name
 	if provider.IsTestComment(event.GetComment().GetBody()) {
-		runevent.TestPipelineRun = getPipelineRunFromComment(event.GetComment().GetBody())
+		runevent.TargetTestPipelineRun = provider.GetPipelineRunFromComment(event.GetComment().GetBody())
 	}
 
 	// We are getting the full URL so we have to get the last part to get the PR number,
@@ -263,13 +263,4 @@ func (v *Provider) handleIssueCommentEvent(ctx context.Context, event *github.Is
 
 	v.Logger.Infof("PR recheck from issue commment on %s/%s#%d has been requested", runevent.Organization, runevent.Repository, runevent.PullRequestNumber)
 	return v.getPullRequest(ctx, runevent)
-}
-
-func getPipelineRunFromComment(comment string) string {
-	// get string after /test command
-	splitTest := strings.Split(comment, "/test")
-	// now get the first line
-	getFirstLine := strings.Split(splitTest[1], "\n")
-	// trim spaces
-	return strings.TrimSpace(getFirstLine[0])
 }

--- a/pkg/provider/github/events_test.go
+++ b/pkg/provider/github/events_test.go
@@ -427,3 +427,39 @@ func TestAppTokenGeneration(t *testing.T) {
 		})
 	}
 }
+
+func TestTestComment(t *testing.T) {
+	tests := []struct {
+		name    string
+		comment string
+		want    string
+	}{
+		{
+			name:    "test a pipeline",
+			comment: "/test abc-01-pr",
+			want:    "abc-01-pr",
+		},
+		{
+			name:    "string before test command",
+			comment: "abc \n /test abc-01-pr",
+			want:    "abc-01-pr",
+		},
+		{
+			name:    "string after test command",
+			comment: "/test abc-01-pr \n abc",
+			want:    "abc-01-pr",
+		},
+		{
+			name:    "string before and after test command",
+			comment: "before \n /test abc-01-pr \n after",
+			want:    "abc-01-pr",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getPipelineRunFromComment(tt.comment)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/provider/github/events_test.go
+++ b/pkg/provider/github/events_test.go
@@ -427,39 +427,3 @@ func TestAppTokenGeneration(t *testing.T) {
 		})
 	}
 }
-
-func TestTestComment(t *testing.T) {
-	tests := []struct {
-		name    string
-		comment string
-		want    string
-	}{
-		{
-			name:    "test a pipeline",
-			comment: "/test abc-01-pr",
-			want:    "abc-01-pr",
-		},
-		{
-			name:    "string before test command",
-			comment: "abc \n /test abc-01-pr",
-			want:    "abc-01-pr",
-		},
-		{
-			name:    "string after test command",
-			comment: "/test abc-01-pr \n abc",
-			want:    "abc-01-pr",
-		},
-		{
-			name:    "string before and after test command",
-			comment: "before \n /test abc-01-pr \n after",
-			want:    "abc-01-pr",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := getPipelineRunFromComment(tt.comment)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -258,6 +258,9 @@ func (v *Provider) Detect(reqHeader *http.Header, payload string, logger *zap.Su
 			if provider.IsOkToTestComment(gitEvent.GetComment().GetBody()) {
 				return setLoggerAndProceed(true, "", nil)
 			}
+			if provider.IsTestComment(gitEvent.GetComment().GetBody()) {
+				return setLoggerAndProceed(true, "", nil)
+			}
 			return setLoggerAndProceed(false, "", nil)
 		}
 		return setLoggerAndProceed(false, "issue: not a gitops pull request comment", nil)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -7,6 +7,7 @@ import (
 var (
 	retestRegex   = regexp.MustCompile(`(?m)^/retest\s*$`)
 	oktotestRegex = regexp.MustCompile(`(?m)^/ok-to-test\s*$`)
+	testRegex     = regexp.MustCompile(`(?m)^/test[ \t]+\S+`)
 )
 
 const (
@@ -30,4 +31,8 @@ func IsRetestComment(comment string) bool {
 
 func IsOkToTestComment(comment string) bool {
 	return oktotestRegex.MatchString(comment)
+}
+
+func IsTestComment(comment string) bool {
+	return testRegex.MatchString(comment)
 }

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"regexp"
+	"strings"
 )
 
 var (
@@ -35,4 +36,13 @@ func IsOkToTestComment(comment string) bool {
 
 func IsTestComment(comment string) bool {
 	return testRegex.MatchString(comment)
+}
+
+func GetPipelineRunFromComment(comment string) string {
+	// get string after /test command
+	splitTest := strings.Split(comment, "/test")
+	// now get the first line
+	getFirstLine := strings.Split(splitTest[1], "\n")
+	// trim spaces
+	return strings.TrimSpace(getFirstLine[0])
 }

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -97,3 +97,44 @@ func TestIsRetestComment(t *testing.T) {
 		})
 	}
 }
+
+func TestTestComment(t *testing.T) {
+	tests := []struct {
+		name    string
+		comment string
+		want    bool
+	}{
+		{
+			name:    "invalid need an input",
+			comment: "/test",
+			want:    false,
+		},
+		{
+			name:    "invalid comment",
+			comment: "/test-all",
+			want:    false,
+		},
+		{
+			name:    "run a specific pipeline",
+			comment: "/test abc-01-pr",
+			want:    true,
+		},
+		{
+			name:    "valid with some string before",
+			comment: "/lgtm \n/test abc",
+			want:    true,
+		},
+		{
+			name:    "valid with some string before and after",
+			comment: "hi, trigger the pipeline abc ci \n/test abc \n then report the status back",
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsTestComment(tt.comment)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -138,3 +138,39 @@ func TestTestComment(t *testing.T) {
 		})
 	}
 }
+
+func TestGetPipelineRunFromComment(t *testing.T) {
+	tests := []struct {
+		name    string
+		comment string
+		want    string
+	}{
+		{
+			name:    "test a pipeline",
+			comment: "/test abc-01-pr",
+			want:    "abc-01-pr",
+		},
+		{
+			name:    "string before test command",
+			comment: "abc \n /test abc-01-pr",
+			want:    "abc-01-pr",
+		},
+		{
+			name:    "string after test command",
+			comment: "/test abc-01-pr \n abc",
+			want:    "abc-01-pr",
+		},
+		{
+			name:    "string before and after test command",
+			comment: "before \n /test abc-01-pr \n after",
+			want:    "abc-01-pr",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetPipelineRunFromComment(tt.comment)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/resolve/resolve.go
+++ b/pkg/resolve/resolve.go
@@ -99,8 +99,8 @@ func inlineTasks(tasks []tektonv1beta1.PipelineTask, ropt *Opts, types Types) ([
 }
 
 type Opts struct {
-	GenerateName bool     // wether to GenerateName
-	RemoteTasks  bool     // wether to parse annotation to fetch tasks from remote
+	GenerateName bool     // whether to GenerateName
+	RemoteTasks  bool     // whether to parse annotation to fetch tasks from remote
 	SkipInlining []string // task to skip inlining
 }
 

--- a/test/github_pullrequest_test_comment_test.go
+++ b/test/github_pullrequest_test_comment_test.go
@@ -1,0 +1,46 @@
+//go:build e2e
+// +build e2e
+
+package test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-github/v43/github"
+	tgithub "github.com/openshift-pipelines/pipelines-as-code/test/pkg/github"
+	twait "github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGithubPullRequestTest(t *testing.T) {
+	ctx := context.TODO()
+	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, sha := tgithub.RunPullRequest(ctx, t, "Github test comment",
+		[]string{"testdata/pipelinerun.yaml", "testdata/pipelinerun-clone.yaml"}, false)
+	defer tgithub.TearDown(ctx, t, runcnx, ghcnx, prNumber, targetRefName, targetNS, opts)
+
+	runcnx.Clients.Log.Infof("Creating /test in PullRequest")
+	_, _, err := ghcnx.Client.Issues.CreateComment(ctx,
+		opts.Organization,
+		opts.Repo, prNumber,
+		&github.IssueComment{Body: github.String("/test pipeline")})
+	assert.NilError(t, err)
+
+	runcnx.Clients.Log.Infof("Wait for the second repository update to be updated")
+	waitOpts := twait.Opts{
+		RepoName:        targetNS,
+		Namespace:       targetNS,
+		MinNumberStatus: 1,
+		PollTimeout:     twait.DefaultTimeout,
+		TargetSHA:       sha,
+	}
+	err = twait.UntilRepositoryUpdated(ctx, runcnx.Clients, waitOpts)
+	assert.NilError(t, err)
+
+	runcnx.Clients.Log.Infof("Check if we have the repository set as succeeded")
+	repo, err := runcnx.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(targetNS).Get(ctx, targetNS, metav1.GetOptions{})
+	assert.NilError(t, err)
+	assert.Assert(t, repo.Status[len(repo.Status)-1].Conditions[0].Status == corev1.ConditionTrue)
+}


### PR DESCRIPTION
When having multiple pipelinerun in repostiory
user can now run any specific pr using /test comment

eg
```
/test <pipelinerun-name>
```
![test-pr](https://user-images.githubusercontent.com/55777192/167544764-18fc7535-326a-4da4-8486-3400854ddb40.gif)

Fixes #637 


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
