### PR TITLE
Skip inlining Custom Task

### DIFF
--- a/docs/content/docs/guide/resolver.md
+++ b/docs/content/docs/guide/resolver.md
@@ -22,12 +22,13 @@ If you have a taskRef to a task located in any directory or subdirectories of th
 `.tekton/` directory it will be automatically embedded even if it's not in the
 annotations.
 
-If you have a reference to a
-[`ClusterTask`](https://github.com/tektoncd/pipeline/blob/main/docs/tasks.md#task-vs-clustertask)
-or a
-[`Bundle`](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#tekton-bundles)
-(`Task` or `Pipeline`) the resolver will just use them as is and would not try
-to do anything with it.
+The resolver will skip resolving if he sees these type of tasks:
+
+* a reference to a [`ClusterTask`](https://github.com/tektoncd/pipeline/blob/main/docs/tasks.md#task-vs-clustertask)
+* a `Task` or `Pipeline` [`Bundle`](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#tekton-bundles)
+* or a [Custom Task](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#using-custom-tasks) with an apiVersion that doesn't have a `tekton.dev/` prefix.
+
+It just use them "as is" and will not try to do anything with it.
 
 If pipelines as code cannot resolve the referenced tasks in the `Pipeline` or
 `PipelineSpec`, the run will fail before applying the pipelinerun onto the

--- a/pkg/resolve/resolve.go
+++ b/pkg/resolve/resolve.go
@@ -80,10 +80,15 @@ func skippingTask(taskName string, skippedTasks []string) bool {
 	return false
 }
 
+func isTektonAPIVersion(apiVersion string) bool {
+	return strings.HasPrefix(apiVersion, "tekton.dev/") || apiVersion == ""
+}
+
 func inlineTasks(tasks []tektonv1beta1.PipelineTask, ropt *Opts, types Types) ([]tektonv1beta1.PipelineTask, error) {
 	pipelineTasks := []tektonv1beta1.PipelineTask{}
 	for _, task := range tasks {
 		if task.TaskRef != nil && task.TaskRef.Bundle == "" &&
+			isTektonAPIVersion(task.TaskRef.APIVersion) &&
 			string(task.TaskRef.Kind) != "ClusterTask" &&
 			!skippingTask(task.TaskRef.Name, ropt.SkipInlining) {
 			taskResolved, err := getTaskByName(task.TaskRef.Name, types.Tasks)

--- a/pkg/resolve/resolve_test.go
+++ b/pkg/resolve/resolve_test.go
@@ -34,6 +34,7 @@ func setup() {
 
 // Not sure how to get testParams fixtures working
 func readTDfile(t *testing.T, testname string, generateName bool, remoteTasking bool) (*tektonv1beta1.PipelineRun, *zapobserver.ObservedLogs, error) {
+	t.Helper()
 	ctx, _ := rtesting.SetupFakeContext(t)
 	data, err := ioutil.ReadFile("testdata/" + testname + ".yaml")
 	if err != nil {
@@ -95,6 +96,14 @@ func TestClusterTasksSkipped(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, resolved.Spec.PipelineSpec.Tasks[0].Name, "clustertask")
 	assert.Equal(t, string(resolved.Spec.PipelineSpec.Tasks[0].TaskRef.Kind), "ClusterTask")
+}
+
+func TestCustomTasksSkipped(t *testing.T) {
+	resolved, _, err := readTDfile(t, "pipelinerun-with-a-customtask", false, true)
+	assert.NilError(t, err)
+	assert.Equal(t, resolved.Spec.PipelineSpec.Tasks[0].Name, "shipwright")
+	assert.Equal(t, string(resolved.Spec.PipelineSpec.Tasks[0].TaskRef.APIVersion), "shipwright.io/v1alpha1")
+	assert.Equal(t, string(resolved.Spec.PipelineSpec.Tasks[0].TaskRef.Kind), "Build")
 }
 
 func TestPipelineRunPipelineSpecTaskSpec(t *testing.T) {

--- a/pkg/resolve/testdata/pipelinerun-with-a-customtask.yaml
+++ b/pkg/resolve/testdata/pipelinerun-with-a-customtask.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: pr-test1
+spec:
+  pipelineRef:
+    name: pipeline-test1
+  params:
+    - name: key
+      value: "{{value}}"
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: pipeline-test1
+spec:
+  params:
+    - name: repo_url
+    - name: revision
+  tasks:
+  - name: shipwright
+    taskRef:
+      apiVersion: shipwright.io/v1alpha1
+      kind: Build
+      name: nodejs-ex


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

If a Custom Task is used in `PipelineRun` or `Pipeline`, the resolver
won't try to inline it. We detect Custom Task from their `apiVersion`
being not empty and not starting with `tekton.dev/`.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>


# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [x] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [x] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [x] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [x] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
