### PR TITLE
gitlab: use subtle constant time comparaison

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -131,7 +131,7 @@ spec:
                 make test GO_TEST_FLAGS="-v -race -coverprofile=coverage.txt -covermode=atomic"
 
             - name: lint
-              image: quay.io/app-sre/golangci-lint:v1.45.0
+              image: quay.io/app-sre/golangci-lint:v1.46.0
               workingDir: $(workspaces.source.path)
               env:
                 - name: GOCACHE

--- a/pkg/kubeinteraction/secrets_test.go
+++ b/pkg/kubeinteraction/secrets_test.go
@@ -1,7 +1,6 @@
 package kubeinteraction
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -121,7 +120,7 @@ func TestCreateBasicAuthSecret(t *testing.T) {
 				}
 			}
 			if !found {
-				t.Fatal(fmt.Sprintf("we could not find the secret %s out of secrets created: %+v", tt.expectedStartSecretName, slist.Items))
+				t.Fatalf("we could not find the secret %s out of secrets created: %+v", tt.expectedStartSecretName, slist.Items)
 			}
 		})
 	}

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -2,6 +2,7 @@ package gitlab
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -53,7 +54,8 @@ func (v *Provider) Validate(_ context.Context, _ *params.Run, event *info.Event)
 	if event.Provider.WebhookSecret == "" && token != "" {
 		return fmt.Errorf("gitlab failed validaton: failed to find webhook secret")
 	}
-	if event.Provider.WebhookSecret != token {
+
+	if subtle.ConstantTimeCompare([]byte(event.Provider.WebhookSecret), []byte(token)) == 0 {
 		return fmt.Errorf("gitlab failed validaton: event's secret doesn't match with webhook secret")
 	}
 	return nil

--- a/pkg/test/http/http.go
+++ b/pkg/test/http/http.go
@@ -30,9 +30,6 @@ func MakeHTTPTestClient(t *testing.T, config map[string]map[string]string) *http
 				}
 			}
 		}
-		if resp == nil {
-			t.Fatalf("No url matching config: %v", config)
-		}
 		return resp
 	})
 }


### PR DESCRIPTION
when comparing webhook secret with subtle.ConstantTimeCompare to not be
open timing attack. https://en.wikipedia.org/wiki/Timing_attack

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com><!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
