### PR TITLE
add provider type to the labels

### DIFF
--- a/pkg/kubeinteraction/labels.go
+++ b/pkg/kubeinteraction/labels.go
@@ -11,7 +11,7 @@ import (
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 )
 
-func AddLabelsAndAnnotations(event *info.Event, pipelineRun *tektonv1beta1.PipelineRun, repo *apipac.Repository) {
+func AddLabelsAndAnnotations(event *info.Event, pipelineRun *tektonv1beta1.PipelineRun, repo *apipac.Repository, providerinfo *info.ProviderConfig) {
 	// Add labels on the soon to be created pipelinerun so UI/CLI can easily
 	// query them.
 	labels := map[string]string{
@@ -24,6 +24,7 @@ func AddLabelsAndAnnotations(event *info.Event, pipelineRun *tektonv1beta1.Pipel
 		filepath.Join(pipelinesascode.GroupName, "event-type"):     formatting.K8LabelsCleanup(event.EventType),
 		filepath.Join(pipelinesascode.GroupName, "branch"):         formatting.K8LabelsCleanup(event.BaseBranch),
 		filepath.Join(pipelinesascode.GroupName, "repository"):     formatting.K8LabelsCleanup(repo.GetName()),
+		filepath.Join(pipelinesascode.GroupName, "git-provider"):   providerinfo.Name,
 	}
 
 	annotations := map[string]string{

--- a/pkg/kubeinteraction/labels_test.go
+++ b/pkg/kubeinteraction/labels_test.go
@@ -51,7 +51,7 @@ func TestAddLabelsAndAnnotations(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			AddLabelsAndAnnotations(tt.args.event, tt.args.pipelineRun, tt.args.repo)
+			AddLabelsAndAnnotations(tt.args.event, tt.args.pipelineRun, tt.args.repo, &info.ProviderConfig{})
 			assert.Assert(t, tt.args.pipelineRun.Labels[filepath.Join(pipelinesascode.GroupName, "url-org")] == tt.args.event.Organization, "'%s' != %s",
 				tt.args.pipelineRun.Labels[filepath.Join(pipelinesascode.GroupName, "url-org")], tt.args.event.Organization)
 			assert.Assert(t, tt.args.pipelineRun.Annotations[filepath.Join(pipelinesascode.GroupName,

--- a/pkg/params/info/vcsconfig.go
+++ b/pkg/params/info/vcsconfig.go
@@ -3,4 +3,5 @@ package info
 type ProviderConfig struct {
 	TaskStatusTMPL string
 	APIURL         string
+	Name           string
 }

--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -91,7 +91,7 @@ func (p *PacRun) startPR(ctx context.Context, match matcher.Match) error {
 	}
 
 	// Add labels and annotations to pipelinerun
-	kubeinteraction.AddLabelsAndAnnotations(p.event, match.PipelineRun, match.Repo)
+	kubeinteraction.AddLabelsAndAnnotations(p.event, match.PipelineRun, match.Repo, p.vcx.GetConfig())
 
 	// Create the actual pipeline
 	pr, err := p.run.Clients.Tekton.TektonV1beta1().PipelineRuns(match.Repo.GetNamespace()).Create(ctx,

--- a/pkg/provider/bitbucketcloud/bitbucket.go
+++ b/pkg/provider/bitbucketcloud/bitbucket.go
@@ -38,6 +38,7 @@ func (v *Provider) GetConfig() *info.ProviderConfig {
 	return &info.ProviderConfig{
 		TaskStatusTMPL: taskStatusTemplate,
 		APIURL:         bitbucket.DEFAULT_BITBUCKET_API_BASE_URL,
+		Name:           "bitbucket-cloud",
 	}
 }
 

--- a/pkg/provider/bitbucketserver/bitbucketserver.go
+++ b/pkg/provider/bitbucketserver/bitbucketserver.go
@@ -243,5 +243,6 @@ func (v *Provider) GetCommitInfo(ctx context.Context, event *info.Event) error {
 func (v *Provider) GetConfig() *info.ProviderConfig {
 	return &info.ProviderConfig{
 		TaskStatusTMPL: taskStatusTemplate,
+		Name:           "bitbucket-server",
 	}
 }

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -27,6 +27,8 @@ type Provider struct {
 	ApplicationID *int64
 
 	CheckRunIDS *sync.Map
+
+	providerName string
 }
 
 func (v *Provider) SetLogger(logger *zap.SugaredLogger) {
@@ -57,6 +59,7 @@ func (v *Provider) GetConfig() *info.ProviderConfig {
 	return &info.ProviderConfig{
 		TaskStatusTMPL: taskStatusTemplate,
 		APIURL:         apiPublicURL,
+		Name:           v.providerName,
 	}
 }
 
@@ -101,7 +104,9 @@ func (v *Provider) SetClient(ctx context.Context, event *info.Event) error {
 		}
 	}
 
+	v.providerName = "github"
 	if apiURL != "" && apiURL != apiPublicURL {
+		v.providerName = "github-enteprise"
 		client, _ = github.NewEnterpriseClient(apiURL, apiURL, tc)
 	} else {
 		client = github.NewClient(tc)
@@ -115,6 +120,7 @@ func (v *Provider) SetClient(ctx context.Context, event *info.Event) error {
 		if err != nil {
 			return fmt.Errorf("cannot make a gitea client: %w", err)
 		}
+		v.providerName = "gitea"
 	}
 
 	// Make sure Client is not already set, so we don't override our fakeclient

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -223,6 +223,7 @@ func (v *Provider) GetConfig() *info.ProviderConfig {
 	return &info.ProviderConfig{
 		TaskStatusTMPL: taskStatusTemplate,
 		APIURL:         apiPublicURL,
+		Name:           "gitlab",
 	}
 }
 


### PR DESCRIPTION
we add a label with the provider type.
we don't put it in the repostatus since it doesn't make sense.
I wanted to update the cli/describe to show it, but that may be more
difficult since we rely on repostatus for it. may need a new struct and
new trickery

Fixes #653 

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
