### PR TITLE
readd GO_TEST_FLAGS to make coverage working

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -128,7 +128,8 @@ spec:
               script: |
                 #!/usr/bin/env bash
                 set -eux
-                make test GO_TEST_FLAGS="-v -race -coverprofile=coverage.txt -covermode=atomic"
+                export GO_TEST_FLAGS="-v -race -coverprofile=coverage.txt -covermode=atomic"
+                make test
 
             - name: lint
               image: quay.io/app-sre/golangci-lint:v1.46.0

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ LDFLAGS=
 OUTPUT_DIR=bin
 GO           = go
 TIMEOUT_UNIT = 5m
+GO_TEST_FLAGS +=
 
 
 PY_FILES := $(shell find . -type f -regex ".*py" -print)
@@ -61,7 +62,7 @@ test: test-clean test-unit ## Run test-unit
 test-unit: ## Run unit tests
 	@echo "Running unit tests..."
 	@set -o pipefail ; \
-		$(GO) test -timeout $(TIMEOUT_UNIT) $(ARGS) ./... | { grep -v 'no test files'; true; }
+		$(GO) test $(GO_TEST_FLAGS) -timeout $(TIMEOUT_UNIT) $(ARGS) ./... | { grep -v 'no test files'; true; }
 
 .PHONY: test-e2e-cleanup
 test-e2e-cleanup: ## cleanup test e2e namespace/pr left open


### PR DESCRIPTION
for whatever reason i had this "cleaned" up but that broke coverage generation

Closes #668

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
