### PR TITLE
add GO_TEST_FLAGS to make e2e-test

### DIFF
--- a/.github/workflows/kind-e2e-tests.yaml
+++ b/.github/workflows/kind-e2e-tests.yaml
@@ -13,6 +13,15 @@ on:
       - '*.*'
     branches:
       - main
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "**.go"
+      - "Makefile"
+      - "go.mod"
+      - "go.sum"
+      - "!docs/**"
+
 jobs:
   e2e-tests:
     name: e2e tests

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ test-e2e-cleanup: ## cleanup test e2e namespace/pr left open
 
 .PHONY: test-e2e
 test-e2e:  test-e2e-cleanup ## run e2e tests
-	@go test -failfast -count=1 -tags=e2e $(GO_TEST_FLAGS) ./test
+	@go test $(GO_TEST_FLAGS) -failfast -count=1 -tags=e2e $(GO_TEST_FLAGS) ./test
 
 .PHONY: lint
 lint: lint-go lint-yaml lint-md ## run all linters


### PR DESCRIPTION
so we can see the live test running in e2e github action log

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
