### PR TITLE
Adds support for `/test <pipelinerun-name>` comment (Gitlab/Bitbucket Cloud/Server)

### DIFF
--- a/pkg/provider/bitbucketcloud/events.go
+++ b/pkg/provider/bitbucketcloud/events.go
@@ -137,6 +137,10 @@ func (v *Provider) ParsePayload(ctx context.Context, run *params.Run, request *h
 			} else if provider.IsOkToTestComment(e.Comment.Content.Raw) {
 				processedEvent.TriggerTarget = "pull_request"
 				processedEvent.EventType = "ok-to-test-comment"
+			} else if provider.IsTestComment(e.Comment.Content.Raw) {
+				processedEvent.TriggerTarget = "pull_request"
+				processedEvent.EventType = "test-comment"
+				processedEvent.TargetTestPipelineRun = provider.GetPipelineRunFromComment(e.Comment.Content.Raw)
 			}
 		}
 		processedEvent.Organization = e.Repository.Workspace.Slug
@@ -201,6 +205,9 @@ func (v *Provider) Detect(reqHeader *http.Header, payload string, logger *zap.Su
 				return setLoggerAndProceed(true, "", nil)
 			}
 			if provider.IsOkToTestComment(e.Comment.Content.Raw) {
+				return setLoggerAndProceed(true, "", nil)
+			}
+			if provider.IsTestComment(e.Comment.Content.Raw) {
 				return setLoggerAndProceed(true, "", nil)
 			}
 		}

--- a/pkg/provider/bitbucketcloud/events.go
+++ b/pkg/provider/bitbucketcloud/events.go
@@ -131,13 +131,14 @@ func (v *Provider) ParsePayload(ctx context.Context, run *params.Run, request *h
 			processedEvent.TriggerTarget = "pull_request"
 			processedEvent.EventType = "pull_request"
 		} else if provider.Valid(event, []string{"pullrequest:comment_created"}) {
-			if provider.IsRetestComment(e.Comment.Content.Raw) {
+			switch {
+			case provider.IsRetestComment(e.Comment.Content.Raw):
 				processedEvent.TriggerTarget = "pull_request"
 				processedEvent.EventType = "retest-comment"
-			} else if provider.IsOkToTestComment(e.Comment.Content.Raw) {
+			case provider.IsOkToTestComment(e.Comment.Content.Raw):
 				processedEvent.TriggerTarget = "pull_request"
 				processedEvent.EventType = "ok-to-test-comment"
-			} else if provider.IsTestComment(e.Comment.Content.Raw) {
+			case provider.IsTestComment(e.Comment.Content.Raw):
 				processedEvent.TriggerTarget = "pull_request"
 				processedEvent.EventType = "test-comment"
 				processedEvent.TargetTestPipelineRun = provider.GetPipelineRunFromComment(e.Comment.Content.Raw)

--- a/pkg/provider/bitbucketserver/events.go
+++ b/pkg/provider/bitbucketserver/events.go
@@ -52,13 +52,14 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 			processedEvent.TriggerTarget = "pull_request"
 			processedEvent.EventType = "pull_request"
 		} else if provider.Valid(eventType, []string{"pr:comment:added", "pr:comment:edited"}) {
-			if provider.IsRetestComment(e.Comment.Text) {
+			switch {
+			case provider.IsRetestComment(e.Comment.Text):
 				processedEvent.TriggerTarget = "pull_request"
 				processedEvent.EventType = "retest-comment"
-			} else if provider.IsOkToTestComment(e.Comment.Text) {
+			case provider.IsOkToTestComment(e.Comment.Text):
 				processedEvent.TriggerTarget = "pull_request"
 				processedEvent.EventType = "ok-to-test-comment"
-			} else if provider.IsTestComment(e.Comment.Text) {
+			case provider.IsTestComment(e.Comment.Text):
 				processedEvent.TriggerTarget = "pull_request"
 				processedEvent.EventType = "test-comment"
 				processedEvent.TargetTestPipelineRun = provider.GetPipelineRunFromComment(e.Comment.Text)

--- a/pkg/provider/bitbucketserver/events.go
+++ b/pkg/provider/bitbucketserver/events.go
@@ -58,6 +58,10 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 			} else if provider.IsOkToTestComment(e.Comment.Text) {
 				processedEvent.TriggerTarget = "pull_request"
 				processedEvent.EventType = "ok-to-test-comment"
+			} else if provider.IsTestComment(e.Comment.Text) {
+				processedEvent.TriggerTarget = "pull_request"
+				processedEvent.EventType = "test-comment"
+				processedEvent.TargetTestPipelineRun = provider.GetPipelineRunFromComment(e.Comment.Text)
 			}
 		}
 		// TODO: It's Really not an OWNER but a PROJECT
@@ -179,6 +183,9 @@ func (v *Provider) Detect(reqHeader *http.Header, payload string, logger *zap.Su
 				return setLoggerAndProceed(true, "", nil)
 			}
 			if provider.IsOkToTestComment(e.Comment.Text) {
+				return setLoggerAndProceed(true, "", nil)
+			}
+			if provider.IsTestComment(e.Comment.Text) {
 				return setLoggerAndProceed(true, "", nil)
 			}
 		}


### PR DESCRIPTION
Closes #660 #663

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
