### PR TITLE
compress cache before uploading

### DIFF
--- a/.tekton/doc.yaml
+++ b/.tekton/doc.yaml
@@ -51,7 +51,7 @@ spec:
                 echo "Preview URL: https://preview-pipelines-as-code-ci.apps.paac.devcluster.openshift.com/docs/{{ pull_request_number }}"
             - name: upload-to-static-server
               # it has curl and we already pulled it
-              image: registry.redhat.io/rhel8/go-toolset:1.17.7
+              image: registry.redhat.io/rhel9/go-toolset:1.17.7
               workingDir: $(workspaces.source.path)
               env:
                 - name: HUB_TOKEN

--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -86,7 +86,7 @@ spec:
           workspaces:
             - name: source
           steps:
-            - image: registry.redhat.io/rhel8/go-toolset:1.17.7
+            - image: registry.redhat.io/rhel9/go-toolset:1.17.7
               env:
                 - name: GOCACHE
                   value: $(workspaces.source.path)/go-build-cache/cache
@@ -118,7 +118,7 @@ spec:
             - name: unittest
               # we get bumped out when usingh the official image with docker.io
               # ratelimit so workaround this.
-              image: registry.redhat.io/rhel8/go-toolset:1.17.7
+              image: registry.redhat.io/rhel9/go-toolset:1.17.7
               env:
                 - name: GOCACHE
                   value: $(workspaces.source.path)/go-build-cache/cache
@@ -202,7 +202,7 @@ spec:
           steps:
             - name: codecov-run
               # Has everything we need in there and we already fetched it!
-              image: registry.redhat.io/rhel8/go-toolset:1.17.7
+              image: registry.redhat.io/rhel9/go-toolset:1.17.7
               workingDir: $(workspaces.source.path)
               env:
                 - name: CODECOV_TOKEN

--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -107,14 +107,14 @@ spec:
                 mkdir -p ${GOCACHE} ${GOMODCACHE} ${GOLANGCILINT_CACHE}
                 cd $(dirname ${GOCACHE})
 
-                curl -fsI http://uploader:8080/golang-cache.tar || {
+                curl -fsI http://uploader:8080/golang-cache.tar.gz || {
                     echo "no cache found"
                     exit 0
                 }
 
                 echo "Getting cache"
-                curl -u ${UPLOADER_UPLOAD_CREDENTIALS} http://uploader:8080/golang-cache.tar|tar -x -f- || \
-                   curl -X DELETE -F "file=golang-cache.tar" http://uploader:8080/upload
+                curl -u ${UPLOADER_UPLOAD_CREDENTIALS} http://uploader:8080/golang-cache.tar.gz|tar -z -x -f- || \
+                   curl -X DELETE -F "file=golang-cache.tar.gz" http://uploader:8080/upload
             - name: unittest
               # we get bumped out when usingh the official image with docker.io
               # ratelimit so workaround this.
@@ -177,7 +177,7 @@ spec:
                     exit 0
                 }
 
-                lm="$(curl -fsI http://uploader:8080/golang-cache.tar|sed -n '/Last-Modified/ { s/Last-Modified: //;s/\r//; p}')"
+                lm="$(curl -fsI http://uploader:8080/golang-cache.tar.gz|sed -n '/Last-Modified/ { s/Last-Modified: //;s/\r//; p}')"
                 if [[ -n ${lm} ]];then
                     expired=$(python -c "import datetime, sys;print(datetime.datetime.now() > datetime.datetime.strptime(sys.argv[1], '%a, %d %b %Y %X %Z') + datetime.timedelta(days=1))" "${lm}")
                     [[ ${expired} == "False" ]] && {
@@ -187,8 +187,7 @@ spec:
                 fi
 
                 cd $(workspaces.source.path)/go-build-cache
-                tar cf - . |curl -u ${UPLOADER_UPLOAD_CREDENTIALS} \
-                    -# -L -f -F path=golang-cache.tar -X POST -F "file=@-" http://uploader:8080/upload
+                tar czf - . |curl -u ${UPLOADER_UPLOAD_CREDENTIALS} -# -L -f -F path=golang-cache.tar.gz -X POST -F "file=@-" http://uploader:8080/upload"
 
       - name: codecov
         runAfter:

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -55,13 +55,13 @@ spec:
                 set -ex
                 mkdir -p ${GOCACHE} ${GOMODCACHE} ${GOLANGCILINT_CACHE}
                 cd $(dirname ${GOCACHE})
-                curl -fsI http://uploader:8080/golang-cache.tar || {
+                curl -fsI http://uploader:8080/golang-cache.tar.gz || {
                     echo "no cache found"
                     exit 0
                 }
                 echo "Getting cache"
-                curl http://uploader:8080/golang-cache.tar|tar -x -f- || \
-                   curl -X DELETE -F "file=golang-cache.tar" http://uploader:8080/upload
+                curl http://uploader:8080/golang-cache.tar.gz|tar -z -x -f- || \
+                   curl -X DELETE -F "file=golang-cache.tar.gz" http://uploader:8080/upload
             - name: unittest
               image: registry.redhat.io/rhel9/go-toolset:1.17.7
               workingDir: $(workspaces.source.path)

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -40,7 +40,7 @@ spec:
           workspaces:
             - name: source
           steps:
-            - image: registry.redhat.io/rhel8/go-toolset:1.17.7
+            - image: registry.redhat.io/rhel9/go-toolset:1.17.7
               name: get-cache
               workingDir: $(workspaces.source.path)
               env:
@@ -63,7 +63,7 @@ spec:
                 curl http://uploader:8080/golang-cache.tar|tar -x -f- || \
                    curl -X DELETE -F "file=golang-cache.tar" http://uploader:8080/upload
             - name: unittest
-              image: registry.redhat.io/rhel8/go-toolset:1.17.7
+              image: registry.redhat.io/rhel9/go-toolset:1.17.7
               workingDir: $(workspaces.source.path)
               env:
                 - name: GOCACHE
@@ -86,7 +86,7 @@ spec:
           steps:
             - name: codecov-run
               # Has everything we need in there and we already fetched it!
-              image: registry.redhat.io/rhel8/go-toolset:1.17.7
+              image: registry.redhat.io/rhel9/go-toolset:1.17.7
               workingDir: $(workspaces.source.path)
               env:
                 - name: CODECOV_TOKEN


### PR DESCRIPTION
or curl will OOM, my guess there is some weird behaviour change between RHEL8 curl and RHEL9 and since we do some weird trick with curl to upload we may as well compress it.....

the file goes from ~1.5GB to 346MB compressed : 

```bash
sh-4.4$ du -sh golang-cache.tar.gz 
346M	golang-cache.tar.gz
```


Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com><!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
