### PR TITLE
Build tkn-pac docker image to its own

### DIFF
--- a/.github/workflows/ghcr.yaml
+++ b/.github/workflows/ghcr.yaml
@@ -4,8 +4,9 @@ on: ["push"]
 
 env:
   REGISTRY: ghcr.io
-  CONTROLLER_IMAGE_NAME: ${{ github.repository }}
+  CONTROLLER_IMAGE_NAME: ${{ github.repository }}-controller
   WATCHER_IMAGE_NAME: ${{ github.repository }}-watcher
+  TKN_PAC_IMAGE_NAME: tkn-pac
 
 jobs:
   build-and-push-image:
@@ -36,7 +37,7 @@ jobs:
         with:
           context: .
           build-args: |
-            COMPONENT=controller
+            BINARY_NAME=pipelines-as-code-controller
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -52,7 +53,23 @@ jobs:
         with:
           context: .
           build-args: |
-            COMPONENT=watcher
+            BINARY_NAME=pipelines-as-code-watcher
+          push: true
+          tags: ${{ steps.meta-watcher.outputs.tags }}
+          labels: ${{ steps.meta-watcher.outputs.labels }}
+
+      - name: Extract metadata (tags, labels) for tkn-pac
+        id: meta-watcher
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.TKN_PAC_IMAGE_NAME }}
+
+      - name: Build and push watcher docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          build-args: |
+            BINARY_NAME=tkn-pac
           push: true
           tags: ${{ steps.meta-watcher.outputs.tags }}
           labels: ${{ steps.meta-watcher.outputs.labels }}

--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -177,9 +177,9 @@ spec:
                     exit 0
                 }
 
-                lm="$(curl -fsI http://uploader:8080/golang-cache.tar.gz|sed -n '/Last-Modified/ { s/Last-Modified: //;s/\r//; p}')"
+                lm="$(curl -fsI http://uploader:8080/golang-cache.tar.gz|sed -En '/Last-Modified/ { s/Last-Modified:\s*//;p;}')"
                 if [[ -n ${lm} ]];then
-                    expired=$(python -c "import datetime, sys;print(datetime.datetime.now() > datetime.datetime.strptime(sys.argv[1], '%a, %d %b %Y %X %Z') + datetime.timedelta(days=1))" "${lm}")
+                    expired=$(python -c "import datetime, sys;print(datetime.datetime.now() > datetime.datetime.strptime(sys.argv[1].strip(), '%a, %d %b %Y %X %Z') + datetime.timedelta(days=1))" "${lm}")
                     [[ ${expired} == "False" ]] && {
                       echo "Cache is younger than a day"
                       exit
@@ -187,7 +187,7 @@ spec:
                 fi
 
                 cd $(workspaces.source.path)/go-build-cache
-                tar czf - . |curl -u ${UPLOADER_UPLOAD_CREDENTIALS} -# -L -f -F path=golang-cache.tar.gz -X POST -F "file=@-" http://uploader:8080/upload"
+                tar czf - . |curl -u ${UPLOADER_UPLOAD_CREDENTIALS} -# -L -f -F path=golang-cache.tar.gz -X POST -F "file=@-" http://uploader:8080/upload
 
       - name: codecov
         runAfter:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,20 @@
 FROM registry.access.redhat.com/ubi9/go-toolset AS builder
 
-ARG COMPONENT=controller
+ARG BINARY_NAME=pipelines-as-code-controller
 COPY . /src
 WORKDIR /src
 RUN \
-    make /tmp/tkn-pac /tmp/pipelines-as-code-${COMPONENT} LDFLAGS="-s -w" OUTPUT_DIR=/tmp
+    make /tmp/${BINARY_NAME} LDFLAGS="-s -w" OUTPUT_DIR=/tmp
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal
 
-ARG COMPONENT=controller
-LABEL com.redhat.component=pipelines-as-code-${COMPONENT} \
-    name=openshift-pipelines/pipelines-as-code-${COMPONENT} \
+ARG BINARY_NAME=pipelines-as-code-controller
+LABEL com.redhat.component=${BINARY_NAME} \
+    name=openshift-pipelines/${BINARY_NAME} \
     maintainer=pipelines@redhat.com \
-    summary="This image is to run Pipelines as Code ${COMPONENT} component"
+    summary="This image is to run Pipelines as Code ${BINARY_NAME} component"
 
-COPY --from=builder /tmp/pipelines-as-code-${COMPONENT} /usr/bin/pipelines-as-code-${COMPONENT}
-COPY --from=builder /tmp/tkn-pac /usr/bin/tkn-pac
+COPY --from=builder /tmp/${BINARY_NAME} /usr/bin/${BINARY_NAME}
 
-ENV RUN_COMPONENT=$COMPONENT
-CMD /usr/bin/pipelines-as-code-${RUN_COMPONENT}
+ENV RUN_BINARY_NAME=$BINARY_NAME
+CMD /usr/bin/${RUN_BINARY_NAME}

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
 TARGET_NAMESPACE=pipelines-as-code
-QUAY_REPOSITORY=quay.io/openshift-pipeline/pipelines-as-code
-QUAY_REPOSITORY_BRANCH=main
 GOLANGCI_LINT=golangci-lint
 GOFUMPT=gofumpt
 LDFLAGS=
@@ -30,18 +28,6 @@ vendor:
 
 $(OUTPUT_DIR)/%: cmd/% FORCE
 	go build -mod=vendor $(FLAGS)  -v -o $@ ./$<
-
-.PHONY: releaseyaml
-releaseyaml: ## Generate release.yaml, use it like this `make releaseyaml|kubectl apply -f-`
-	@env TARGET_REPO=$(QUAY_REPOSITORY) TARGET_BRANCH=$(QUAY_REPOSITORY_BRANCH) TARGET_NAMESPACE=$(TARGET_NAMESPACE) \
-		PAC_VERSION=$(PAC_VERSION) \
-		./hack/generate-releaseyaml.sh
-
-.PHONY: releaseko
-releaseko: ## Generate release.yaml with ko but changing the target_namespace and branch if needed
-	@env TARGET_BRANCH=$(QUAY_REPOSITORY_BRANCH) TARGET_NAMESPACE=$(TARGET_NAMESPACE) \
-		PAC_VERSION=$(PAC_VERSION) \
-		./hack/generate-releaseyaml.sh ko
 
 check: lint test
 

--- a/docs/content/docs/guide/cli.md
+++ b/docs/content/docs/guide/cli.md
@@ -53,7 +53,7 @@ brew upgrade openshift-pipelines/pipelines-as-code/tektoncd-pac
 ```shell
 # use docker
 podman run -e KUBECONFIG=/tmp/kube/config -v ${HOME}/.kube:/tmp/kube \
-     -it  ghcr.io/openshift-pipelines/pipelines-as-code:stable tkn-pac help
+     -it  ghcr.io/openshift-pipelines/tkn-pac:stable tkn-pac help
 ```
 
 {{< /tab >}}

--- a/hack/generate-releaseyaml.sh
+++ b/hack/generate-releaseyaml.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euf
 
-export TARGET_REPO=${TARGET_REPO:-ghcr.io/openshift-pipelines/pipelines-as-code}
+export TARGET_REPO_CONTROLLER=${TARGET_REPO_CONTROLLER:-ghcr.io/openshift-pipelines/pipelines-as-code-controller}
 export TARGET_REPO_WATCHER=${TARGET_REPO_WATCHER:-ghcr.io/openshift-pipelines/pipelines-as-code-watcher}
 export TARGET_BRANCH=${TARGET_BRANCH:-main}
 export TARGET_NAMESPACE=${TARGET_NAMESPACE:-pipelines-as-code}
@@ -32,7 +32,7 @@ fi
 
 for file in ${files};do
     head -1 ${file} | grep -q -- "---" || echo "---"
-    sed -r -e "s,(.*image:.*)ko://github.com/openshift-pipelines/pipelines-as-code/cmd/pipelines-as-code-controller.*,\1${TARGET_REPO}:${TARGET_BRANCH}\"," \
+    sed -r -e "s,(.*image:.*)ko://github.com/openshift-pipelines/pipelines-as-code/cmd/pipelines-as-code-controller.*,\1${TARGET_REPO_CONTROLLER}:${TARGET_BRANCH}\"," \
         -r -e "s,(.*image:.*)ko://github.com/openshift-pipelines/pipelines-as-code/cmd/pipelines-as-code-watcher.*,\1${TARGET_REPO_WATCHER}:${TARGET_BRANCH}\"," \
         -e "s/(namespace: )\w+.*/\1${TARGET_NAMESPACE}/g" \
         -e "s,app.kubernetes.io/version:.*,app.kubernetes.io/version: \"${TARGET_PAC_VERSION}\"," \


### PR DESCRIPTION
Don't build tkn-pac inside the controller image, build it in its own.
call controller image -controller as it should be.
remove make releaseyaml from Dockerfile since not used anywhere
maybe we can add it again another day...

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com><!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
