### PR TITLE
Update `/test` and `/retest` comment

### DIFF
--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -136,7 +136,7 @@ is that what you want? make sure you use -n when generating the secret, eg: echo
 		return nil, nil, nil
 	}
 
-	// if /test command is used then filter out the pipelinerun
+	// if /test or /retest command is used passing a pipelinerun then filter out the pipelinerun
 	pipelineRuns = filterPipelineRun(p.event.TargetTestPipelineRun, pipelineRuns)
 	if pipelineRuns == nil {
 		p.logger.Info(fmt.Sprintf("cannot find pipelinerun %s in this repository", p.event.TargetTestPipelineRun))

--- a/pkg/provider/github/events.go
+++ b/pkg/provider/github/events.go
@@ -250,8 +250,8 @@ func (v *Provider) handleIssueCommentEvent(ctx context.Context, event *github.Is
 		return info.NewEvent(), fmt.Errorf("issue comment is not coming from a pull_request")
 	}
 
-	// if it is a /test comment figure out the pipelinerun name
-	if provider.IsTestComment(event.GetComment().GetBody()) {
+	// if it is a /test or /retest comment with pipelinerun name figure out the pipelinerun name
+	if provider.IsTestRetestComment(event.GetComment().GetBody()) {
 		runevent.TargetTestPipelineRun = provider.GetPipelineRunFromComment(event.GetComment().GetBody())
 	}
 

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -314,13 +314,10 @@ func (v *Provider) Detect(reqHeader *http.Header, payload string, logger *zap.Su
 		if gitEvent.GetAction() == "created" &&
 			gitEvent.GetIssue().IsPullRequest() &&
 			gitEvent.GetIssue().GetState() == "open" {
-			if provider.IsRetestComment(gitEvent.GetComment().GetBody()) {
+			if provider.IsTestRetestComment(gitEvent.GetComment().GetBody()) {
 				return setLoggerAndProceed(true, "", nil)
 			}
 			if provider.IsOkToTestComment(gitEvent.GetComment().GetBody()) {
-				return setLoggerAndProceed(true, "", nil)
-			}
-			if provider.IsTestComment(gitEvent.GetComment().GetBody()) {
 				return setLoggerAndProceed(true, "", nil)
 			}
 			return setLoggerAndProceed(false, "", nil)

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -100,13 +100,10 @@ func (v *Provider) Detect(reqHeader *http.Header, payload string, logger *zap.Su
 		return setLoggerAndProceed(true, "", nil)
 	case *gitlab.MergeCommentEvent:
 		if gitEvent.MergeRequest.State == "opened" {
-			if provider.IsRetestComment(gitEvent.ObjectAttributes.Note) {
+			if provider.IsTestRetestComment(gitEvent.ObjectAttributes.Note) {
 				return setLoggerAndProceed(true, "", nil)
 			}
 			if provider.IsOkToTestComment(gitEvent.ObjectAttributes.Note) {
-				return setLoggerAndProceed(true, "", nil)
-			}
-			if provider.IsTestComment(gitEvent.ObjectAttributes.Note) {
 				return setLoggerAndProceed(true, "", nil)
 			}
 		}
@@ -203,8 +200,8 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 		processedEvent.SHATitle = gitEvent.MergeRequest.LastCommit.Message
 		processedEvent.BaseBranch = gitEvent.MergeRequest.TargetBranch
 		processedEvent.HeadBranch = gitEvent.MergeRequest.SourceBranch
-		// if it is a /test comment figure out the pipelineRun name
-		if provider.IsTestComment(gitEvent.ObjectAttributes.Note) {
+		// if it is a /test or /retest comment with pipelinerun name figure out the pipelineRun name
+		if provider.IsTestRetestComment(gitEvent.ObjectAttributes.Note) {
 			processedEvent.TargetTestPipelineRun = provider.GetPipelineRunFromComment(gitEvent.ObjectAttributes.Note)
 		}
 

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -6,9 +6,9 @@ import (
 )
 
 var (
-	retestRegex   = regexp.MustCompile(`(?m)^/retest\s*$`)
-	oktotestRegex = regexp.MustCompile(`(?m)^/ok-to-test\s*$`)
-	testRegex     = regexp.MustCompile(`(?m)^/test[ \t]+\S+`)
+	testRetestAllRegex    = regexp.MustCompile(`(?m)^(/retest|/test)\s*$`)
+	testRetestSingleRegex = regexp.MustCompile(`(?m)^(/test|/retest)[ \t]+\S+`)
+	oktotestRegex         = regexp.MustCompile(`(?m)^/ok-to-test\s*$`)
 )
 
 const (
@@ -26,21 +26,21 @@ func Valid(value string, validValues []string) bool {
 	return false
 }
 
-func IsRetestComment(comment string) bool {
-	return retestRegex.MatchString(comment)
+func IsTestRetestComment(comment string) bool {
+	return testRetestSingleRegex.MatchString(comment) || testRetestAllRegex.MatchString(comment)
 }
 
 func IsOkToTestComment(comment string) bool {
 	return oktotestRegex.MatchString(comment)
 }
 
-func IsTestComment(comment string) bool {
-	return testRegex.MatchString(comment)
-}
-
 func GetPipelineRunFromComment(comment string) string {
-	// get string after /test command
-	splitTest := strings.Split(comment, "/test")
+	var splitTest []string
+	if strings.Contains(comment, "/test") {
+		splitTest = strings.Split(comment, "/test")
+	} else {
+		splitTest = strings.Split(comment, "/retest")
+	}
 	// now get the first line
 	getFirstLine := strings.Split(splitTest[1], "\n")
 	// trim spaces

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -52,25 +52,40 @@ func TestIsOkToTestComment(t *testing.T) {
 	}
 }
 
-func TestIsRetestComment(t *testing.T) {
+func TestIsTestRetestComment(t *testing.T) {
 	tests := []struct {
 		name    string
 		comment string
 		want    bool
 	}{
 		{
-			name:    "valid",
+			name:    "valid retest",
 			comment: "/retest",
 			want:    true,
 		},
 		{
-			name:    "valid with some string before",
+			name:    "valid test",
+			comment: "/test",
+			want:    true,
+		},
+		{
+			name:    "valid retest with some string before",
 			comment: "/lgtm \n/retest",
+			want:    true,
+		},
+		{
+			name:    "valid test with some string before",
+			comment: "/lgtm \n/test",
 			want:    true,
 		},
 		{
 			name:    "valid with some string before and after",
 			comment: "hi, trigger the ci \n/retest \n then report the status back",
+			want:    true,
+		},
+		{
+			name:    "test valid with some string before and after",
+			comment: "hi, trigger the ci \n/test \n then report the status back",
 			want:    true,
 		},
 		{
@@ -84,56 +99,25 @@ func TestIsRetestComment(t *testing.T) {
 			want:    false,
 		},
 		{
-			name:    "invalid comment",
+			name:    "retest trigger single pr",
 			comment: "/retest abc",
+			want:    true,
+		},
+		{
+			name:    "test trigger single pr",
+			comment: "/test abc",
+			want:    true,
+		},
+		{
+			name:    "invalid",
+			comment: "test abc",
 			want:    false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := IsRetestComment(tt.comment)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}
-
-func TestTestComment(t *testing.T) {
-	tests := []struct {
-		name    string
-		comment string
-		want    bool
-	}{
-		{
-			name:    "invalid need an input",
-			comment: "/test",
-			want:    false,
-		},
-		{
-			name:    "invalid comment",
-			comment: "/test-all",
-			want:    false,
-		},
-		{
-			name:    "run a specific pipeline",
-			comment: "/test abc-01-pr",
-			want:    true,
-		},
-		{
-			name:    "valid with some string before",
-			comment: "/lgtm \n/test abc",
-			want:    true,
-		},
-		{
-			name:    "valid with some string before and after",
-			comment: "hi, trigger the pipeline abc ci \n/test abc \n then report the status back",
-			want:    true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := IsTestComment(tt.comment)
+			got := IsTestRetestComment(tt.comment)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -145,6 +129,16 @@ func TestGetPipelineRunFromComment(t *testing.T) {
 		comment string
 		want    string
 	}{
+		{
+			name:    "test no pipelinerun",
+			comment: "/test",
+			want:    "",
+		},
+		{
+			name:    "retest no pipelinerun",
+			comment: "/retest",
+			want:    "",
+		},
 		{
 			name:    "test a pipeline",
 			comment: "/test abc-01-pr",
@@ -163,6 +157,26 @@ func TestGetPipelineRunFromComment(t *testing.T) {
 		{
 			name:    "string before and after test command",
 			comment: "before \n /test abc-01-pr \n after",
+			want:    "abc-01-pr",
+		},
+		{
+			name:    "retest a pipeline",
+			comment: "/retest abc-01-pr",
+			want:    "abc-01-pr",
+		},
+		{
+			name:    "string before retest command",
+			comment: "abc \n /retest abc-01-pr",
+			want:    "abc-01-pr",
+		},
+		{
+			name:    "string after retest command",
+			comment: "/retest abc-01-pr \n abc",
+			want:    "abc-01-pr",
+		},
+		{
+			name:    "string before and after retest command",
+			comment: "before \n /retest abc-01-pr \n after",
 			want:    "abc-01-pr",
 		},
 	}


### PR DESCRIPTION
Now,
/test , /retest works similar
both trigger all pipelineruns.
but if passed with a pipelinerun name then trigger a specific
`/test <pipelinerun>` or `/retest <pipelinerun>`

Closes #661 
Closes #662 

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
