### PR TITLE
Add support for incoming webhook

### DIFF
--- a/cmd/pipelines-as-code-watcher/main.go
+++ b/cmd/pipelines-as-code-watcher/main.go
@@ -4,14 +4,21 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/reconciler"
 	"knative.dev/pkg/injection/sharedmain"
 )
 
-const probesPort = "8080"
+const globalProbesPort = "8080"
 
 func main() {
+	probesPort := globalProbesPort
+	envProbePort := os.Getenv("PAC_WATCHER_PORT")
+	if envProbePort != "" {
+		probesPort = envProbePort
+	}
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("/live", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)

--- a/config/300-repositories.yaml
+++ b/config/300-repositories.yaml
@@ -32,10 +32,10 @@ spec:
           type: string
         - name: Succeeded
           type: string
-          jsonPath: ".pipelinerun_status[-1].conditions[?(@.type==\"Succeeded\")].status"
+          jsonPath: '.pipelinerun_status[-1].conditions[?(@.type=="Succeeded")].status'
         - name: Reason
           type: string
-          jsonPath: ".pipelinerun_status[-1].conditions[?(@.type==\"Succeeded\")].reason"
+          jsonPath: '.pipelinerun_status[-1].conditions[?(@.type=="Succeeded")].reason'
         - name: StartTime
           type: date
           jsonPath: ".pipelinerun_status[-1].startTime"
@@ -50,14 +50,16 @@ spec:
           description: Schema for the repository API
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+              description:
+                "APIVersion defines the versioned schema of this representation
                 of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/  api-conventions.md#resources'
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/  api-conventions.md#resources"
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this
+              description:
+                "Kind is a string value representing the REST resource this
                 object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds"
               type: string
             metadata:
               type: object
@@ -67,6 +69,42 @@ spec:
                 url:
                   description: Repository URL
                   type: string
+                type:
+                  description: Git repository provider
+                  type: string
+                  enum:
+                    - github
+                    - gitea
+                    - bitbucket
+                    - gitlab
+                    - bitbucket-enteprise
+                incoming:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        description: Type of webhook
+                        type: string
+                        enum:
+                          - webhook-url
+                      targets:
+                        description: List of target branches or ref to trigger webhooks on
+                        type: array
+                        items:
+                          description: Branch name
+                          type: string
+                      secret:
+                        description: Secret to use for the webhook
+                        type: object
+                        properties:
+                          key:
+                            description: Key of the secret
+                            type: string
+                            default: "secret"
+                          name:
+                            description: Name of the secret
+                            type: string
                 git_provider:
                   type: object
                   properties:
@@ -75,6 +113,9 @@ spec:
                       type: string
                     user:
                       description: The Git provider api user
+                      type: string
+                    type:
+                      description: The Git provider type
                       type: string
                     secret:
                       type: object
@@ -105,4 +146,4 @@ spec:
     singular: repository
     kind: Repository
     shortNames:
-    - repo
+      - repo

--- a/docs/content/docs/guide/incoming_webhook.md
+++ b/docs/content/docs/guide/incoming_webhook.md
@@ -1,0 +1,76 @@
+---
+title: Incoming Webhook
+---
+# Incoming webhook
+
+Pipelines as Code support the concept of incoming webhook URL. Which let you
+start a PipelineRun in a Repository by a URL and a shared secret rather than
+having to generate a new code iteration.
+
+## Incoming Webhook URL
+
+You need to set your incoming match your Repository CRD, in your match you
+specify a reference Secret which will be used as a shared secret and the
+branches targetted by the incoming webhook.
+
+{{< hint danger >}}
+you will need to have a git_provider spec to specify a token when using the
+github-apps method the same way we are doing for github-webhook method. Refer to
+the [github webhook documentation](/docs/install/github_webhook) for how to set
+this up.
+{{< /hint >}}
+
+Here is an example of a Repository CRD matching the target branch main:
+
+```yaml
+---
+apiVersion: "pipelinesascode.tekton.dev/v1alpha1"
+kind: Repository
+metadata:
+  name: repo
+  namespace: ns
+spec:
+  url: "https://github.com/owner/repo"
+  git_provider:
+    type: github
+    secret:
+      name: "owner-token"
+  incoming:
+    - targets:
+      - main
+      secret:
+        name: repo-incoming-secret
+      type: webhook-url
+```
+
+a secret named `repo-incoming-secret` will have this value:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: repo-incoming-secret
+  namespace: ns
+type: Opaque
+stringData:
+  secret: very-secure-shared-secret
+```
+
+after setting this up, you will be able to trigger a PipelineRun called
+`pipelienrun1` which will be located in the `.tekton` directory of the Git repo
+`https://github.com/owner/repo`. As an example here is the full curl snippet:
+
+```shell
+curl -X POST https://control.pac.url/incoming?secret=very-secure-secret&repository=repo,branch=main
+```
+
+note two things the `"/incoming"` path to the controller URL and the `"POST"`
+method to the URL rather than a simple `"GET"`.
+
+Pipelines as Code when matched with act as this was a `"push"`, we will not have
+anywhere to report the status of the PipelineRuns
+
+In this case the best way to get a report or a notification is to add it directly
+with a finally task to your Pipeline or by inspecting the Repo CRD with the `tkn
+pac` CLI. See the [statuses documentation](/docs/guide/statuses) which has a few
+tips on how to do that.

--- a/pkg/adapter/adapter_test.go
+++ b/pkg/adapter/adapter_test.go
@@ -69,6 +69,12 @@ func TestHandleEvent(t *testing.T) {
 			statusCode:  400,
 		},
 		{
+			name:        "invalid json body only when payload has been set",
+			requestType: "POST",
+			event:       []byte(""),
+			statusCode:  200,
+		},
+		{
 			name:        "valid event",
 			requestType: "POST",
 			eventType:   "push",
@@ -137,7 +143,7 @@ func TestWhichProvider(t *testing.T) {
 			header: map[string][]string{
 				"foo": {"bar"},
 			},
-			event:         "interface",
+			event:         map[string]string{"foo": "bar"},
 			wantErrString: "no supported Git provider has been detected",
 		},
 	}
@@ -148,8 +154,11 @@ func TestWhichProvider(t *testing.T) {
 			if err != nil {
 				assert.NilError(t, err)
 			}
+			req := &http.Request{
+				Header: tt.header,
+			}
 
-			_, _, err = l.detectProvider(&tt.header, string(jeez))
+			_, _, err = l.detectProvider(req, string(jeez))
 			if tt.wantErrString != "" {
 				assert.ErrorContains(t, err, tt.wantErrString)
 				return

--- a/pkg/adapter/incoming.go
+++ b/pkg/adapter/incoming.go
@@ -1,0 +1,116 @@
+package adapter
+
+import (
+	"context"
+	"crypto/subtle"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/matcher"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketcloud"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketserver"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/github"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/gitlab"
+	"go.uber.org/zap"
+)
+
+func compareSecret(incomingSecret string, secretValue string) bool {
+	return subtle.ConstantTimeCompare([]byte(incomingSecret), []byte(secretValue)) != 0
+}
+
+func (l *listener) detectIncoming(ctx context.Context, req *http.Request, payload []byte) (bool, *v1alpha1.Repository, error) {
+	repository := req.URL.Query().Get("repository")
+	querySecret := req.URL.Query().Get("secret")
+	pipelineRun := req.URL.Query().Get("pipelinerun")
+	branch := req.URL.Query().Get("branch")
+	if req.URL.Path != "/incoming" {
+		return false, nil, nil
+	}
+	if repository == "" || querySecret == "" || branch == "" {
+		return false, nil, fmt.Errorf("missing query URL argument: branch, repository, secret: %+v",
+			req.URL.Query())
+	}
+
+	repo, err := matcher.GetRepo(ctx, l.run, repository)
+	if err != nil {
+		return false, nil, fmt.Errorf("error getting repo: %w", err)
+	}
+	if repo == nil {
+		return false, nil, fmt.Errorf("cannot find repository %s", repository)
+	}
+
+	if repo.Spec.Incomings == nil {
+		return false, nil, fmt.Errorf("you need to have incoming webhooks rules in your repo spec, repo: %s", repository)
+	}
+
+	hook := matcher.IncomingWebhookRule(branch, *repo.Spec.Incomings)
+	if hook == nil {
+		return false, nil, fmt.Errorf("branch '%s' has not matched any rules in repo incoming webhooks spec: %+v", branch, *repo.Spec.Incomings)
+	}
+
+	secretOpts := kubeinteraction.GetSecretOpt{
+		Namespace: repo.Namespace,
+		Name:      hook.Secret.Name,
+		Key:       hook.Secret.Key,
+	}
+	secretValue, err := l.kint.GetSecret(ctx, secretOpts)
+	if err != nil {
+		return false, nil, fmt.Errorf("error getting secret referenced in incoming-webhook: %w", err)
+	}
+
+	// TODO: move to somewhere common to share between gitlab and here
+	if !compareSecret(querySecret, secretValue) {
+		return false, nil, fmt.Errorf("secret passed to the webhook does not match incoming webhook secret in %s", hook.Secret.Name)
+	}
+
+	if repo.Spec.GitProvider.Type == "" {
+		return false, nil, fmt.Errorf("repo %s has no git provider type, you need to specify one, ie: github", repository)
+	}
+
+	// TODO: more than i think about it and more i think triggertarget should be
+	// eventType and vice versa, but keeping as is for now.
+	l.event.EventType = "incoming"
+	l.event.TriggerTarget = "push"
+	l.event.TargetPipelineRun = pipelineRun
+	l.event.HeadBranch = branch
+	l.event.BaseBranch = branch
+	l.event.Request.Header = req.Header
+	l.event.Request.Payload = payload
+	l.event.URL = repo.Spec.URL
+	l.event.Sender = "incoming"
+	return true, repo, nil
+}
+
+func (l *listener) processIncoming(targetRepo *v1alpha1.Repository) (provider.Interface, *zap.SugaredLogger, error) {
+	// can a git ssh URL be a Repo URL? I don't think this will even ever work
+	uparse, err := url.Parse(targetRepo.Spec.URL)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error parsing url: %w", err)
+	}
+	parts := strings.Split(uparse.Path, "/")
+	if len(parts) < 2 {
+		return nil, nil, fmt.Errorf("invalid repo url: %s", targetRepo.Spec.URL)
+	}
+	l.event.Organization = parts[len(parts)-2]
+	l.event.Repository = parts[len(parts)-1]
+
+	var provider provider.Interface
+	switch targetRepo.Spec.GitProvider.Type {
+	case "github":
+		provider = &github.Provider{}
+	case "gitlab":
+		provider = &gitlab.Provider{}
+	case "bitbucket-cloud":
+		provider = &bitbucketcloud.Provider{}
+	case "bitbucket-server":
+		provider = &bitbucketserver.Provider{}
+	default:
+		return l.processRes(false, nil, l.logger, "", fmt.Errorf("no supported Git provider has been detected"))
+	}
+	return l.processRes(true, provider, l.logger.With("provider", "incoming"), "", nil)
+}

--- a/pkg/adapter/incoming_test.go
+++ b/pkg/adapter/incoming_test.go
@@ -1,0 +1,538 @@
+package adapter
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketcloud"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketserver"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/github"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/gitlab"
+	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/test/kubernetestint"
+	"go.uber.org/zap"
+	zapobserver "go.uber.org/zap/zaptest/observer"
+	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	rtesting "knative.dev/pkg/reconciler/testing"
+)
+
+func Test_compareSecret(t *testing.T) {
+	type args struct {
+		incomingSecret string
+		secretValue    string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "good/secret comparaison",
+			args: args{
+				incomingSecret: "foo",
+				secretValue:    "foo",
+			},
+			want: true,
+		},
+		{
+			name: "bad/secret comparaison",
+			args: args{
+				incomingSecret: "foo",
+				secretValue:    "bar",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := compareSecret(tt.args.incomingSecret, tt.args.secretValue); got != tt.want {
+				t.Errorf("compareSecret() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_listener_detectIncoming(t *testing.T) {
+	const goodURL = "https://matched/by/incoming"
+	type args struct {
+		data             testclient.Data
+		method           string
+		queryURL         string
+		queryRepository  string
+		queryPipelineRun string
+		querySecret      string
+		queryBranch      string
+		secretResult     map[string]string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "good/incoming",
+			want: true,
+			args: args{
+				secretResult: map[string]string{"good-secret": "verysecrete"},
+				data: testclient.Data{
+					Repositories: []*v1alpha1.Repository{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "test-good",
+							},
+							Spec: v1alpha1.RepositorySpec{
+								URL: goodURL,
+								Incomings: &[]v1alpha1.Incoming{
+									{
+										Targets: []string{"main"},
+										Secret: v1alpha1.Secret{
+											Name: "good-secret",
+										},
+									},
+								},
+								GitProvider: &v1alpha1.GitProvider{
+									Type: "github",
+								},
+							},
+						},
+					},
+				},
+				method:           "GET",
+				queryURL:         "/incoming",
+				queryRepository:  "test-good",
+				querySecret:      "verysecrete",
+				queryPipelineRun: "pipelinerun1",
+				queryBranch:      "main",
+			},
+		},
+		{
+			name: "bad/noincomingurl",
+			args: args{
+				queryURL: "/nowhere",
+			},
+			want: false,
+		},
+		{
+			name: "bad/no repository in query",
+			args: args{
+				queryURL:         "/incoming",
+				querySecret:      "verysecrete",
+				queryPipelineRun: "pipelinerun1",
+				queryBranch:      "main",
+			},
+			wantErr: true,
+		},
+		{
+			name: "bad/no repository in query",
+			args: args{
+				queryURL:         "/incoming",
+				querySecret:      "verysecrete",
+				queryPipelineRun: "pipelinerun1",
+				queryBranch:      "main",
+				queryRepository:  "",
+			},
+			wantErr: true,
+		},
+		{
+			name: "bad/no secret in query",
+			args: args{
+				queryURL:         "/incoming",
+				queryRepository:  "repo",
+				queryPipelineRun: "pr",
+				querySecret:      "",
+				queryBranch:      "branch",
+			},
+			wantErr: true,
+		},
+		{
+			name: "bad/no pr in query",
+			args: args{
+				queryURL:         "/incoming",
+				queryRepository:  "repo",
+				queryPipelineRun: "",
+				querySecret:      "secret",
+				queryBranch:      "branch",
+			},
+			wantErr: true,
+		},
+		{
+			name: "bad/no branch in query",
+			args: args{
+				queryURL:         "/incoming",
+				queryRepository:  "repo",
+				queryPipelineRun: "pr",
+				querySecret:      "secret",
+				queryBranch:      "",
+			},
+			wantErr: true,
+		},
+		{
+			name: "bad/no matched repo",
+			args: args{
+				queryURL:         "/incoming",
+				queryRepository:  "repo",
+				queryPipelineRun: "pr",
+				querySecret:      "secret",
+				queryBranch:      "branch",
+			},
+			wantErr: true,
+		},
+		{
+			name: "bad/no incomings",
+			args: args{
+				queryURL:         "/incoming",
+				queryRepository:  "repo",
+				queryPipelineRun: "pr",
+				querySecret:      "secret",
+				queryBranch:      "main",
+				data: testclient.Data{
+					Repositories: []*v1alpha1.Repository{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "repo",
+							},
+							Spec: v1alpha1.RepositorySpec{
+								URL: goodURL,
+								Incomings: &[]v1alpha1.Incoming{
+									{
+										Targets: []string{"notmain"},
+										Secret: v1alpha1.Secret{
+											Name: "good-secret",
+										},
+									},
+								},
+								GitProvider: &v1alpha1.GitProvider{
+									Type: "github",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "bad/no matched branch in incoming",
+			args: args{
+				queryURL:         "/incoming",
+				queryRepository:  "test-good",
+				queryPipelineRun: "pr",
+				querySecret:      "secret",
+				queryBranch:      "branch",
+				data: testclient.Data{
+					Repositories: []*v1alpha1.Repository{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "test-good",
+							},
+							Spec: v1alpha1.RepositorySpec{
+								URL: goodURL,
+								GitProvider: &v1alpha1.GitProvider{
+									Type: "github",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "bad/not git provider type provided",
+			args: args{
+				queryURL:         "/incoming",
+				queryRepository:  "repo",
+				queryPipelineRun: "pr",
+				querySecret:      "secret",
+				queryBranch:      "main",
+				secretResult:     map[string]string{"secret": "secret"},
+				data: testclient.Data{
+					Repositories: []*v1alpha1.Repository{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "repo",
+							},
+							Spec: v1alpha1.RepositorySpec{
+								URL: goodURL,
+								Incomings: &[]v1alpha1.Incoming{
+									{
+										Targets: []string{"main"},
+										Secret: v1alpha1.Secret{
+											Name: "secret",
+										},
+									},
+								},
+								GitProvider: &v1alpha1.GitProvider{},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "bad/no matched secret",
+			args: args{
+				secretResult:     map[string]string{"secret": "verysecrete"},
+				queryURL:         "/incoming",
+				queryRepository:  "repo",
+				queryPipelineRun: "pr",
+				querySecret:      "secret",
+				queryBranch:      "main",
+				data: testclient.Data{
+					Repositories: []*v1alpha1.Repository{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "repo",
+							},
+							Spec: v1alpha1.RepositorySpec{
+								URL: goodURL,
+								Incomings: &[]v1alpha1.Incoming{
+									{
+										Targets: []string{"main"},
+										Secret: v1alpha1.Secret{
+											Name: "secret",
+										},
+									},
+								},
+								GitProvider: &v1alpha1.GitProvider{
+									Type: "github",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "bad/no matched secret",
+			args: args{
+				secretResult:     map[string]string{"secret": "verysecrete"},
+				queryURL:         "/incoming",
+				queryRepository:  "repo",
+				queryPipelineRun: "pr",
+				querySecret:      "secret",
+				queryBranch:      "main",
+				data: testclient.Data{
+					Repositories: []*v1alpha1.Repository{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "repo",
+							},
+							Spec: v1alpha1.RepositorySpec{
+								URL: goodURL,
+								Incomings: &[]v1alpha1.Incoming{
+									{
+										Targets: []string{"main"},
+										Secret: v1alpha1.Secret{
+											Name: "secret",
+										},
+									},
+								},
+								GitProvider: &v1alpha1.GitProvider{
+									Type: "github",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "bad/no git provider type",
+			args: args{
+				queryURL:         "/incoming",
+				queryRepository:  "repo",
+				queryPipelineRun: "pr",
+				querySecret:      "secret",
+				queryBranch:      "main",
+				data: testclient.Data{
+					Repositories: []*v1alpha1.Repository{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "repo",
+							},
+							Spec: v1alpha1.RepositorySpec{
+								URL: goodURL,
+								Incomings: &[]v1alpha1.Incoming{
+									{
+										Targets: []string{"main"},
+										Secret: v1alpha1.Secret{
+											Name: "secret",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			cs, _ := testclient.SeedTestData(t, ctx, tt.args.data)
+			client := &params.Run{
+				Clients: clients.Clients{PipelineAsCode: cs.PipelineAsCode},
+				Info:    info.Info{},
+			}
+			observer, _ := zapobserver.New(zap.InfoLevel)
+			logger := zap.New(observer).Sugar()
+			kint := &kubernetestint.KinterfaceTest{
+				GetSecretResult: tt.args.secretResult,
+			}
+
+			l := &listener{
+				run:    client,
+				logger: logger,
+				kint:   kint,
+				event:  info.NewEvent(),
+			}
+			// make a new request
+			req := httptest.NewRequest(tt.args.method,
+				fmt.Sprintf("http://localhost%s?repository=%s&secret=%s&pipelinerun=%s&branch=%s", tt.args.queryURL,
+					tt.args.queryRepository, tt.args.querySecret, tt.args.queryPipelineRun, tt.args.queryBranch),
+				strings.NewReader(""))
+			got, _, err := l.detectIncoming(ctx, req, []byte(""))
+			if tt.wantErr {
+				assert.Assert(t, err != nil)
+				return
+			}
+			assert.Equal(t, got, tt.want)
+			assert.Equal(t, l.event.TargetPipelineRun, tt.args.queryPipelineRun)
+		})
+	}
+}
+
+func Test_listener_processIncoming(t *testing.T) {
+	tests := []struct {
+		name       string
+		want       provider.Interface
+		wantErr    bool
+		targetRepo *v1alpha1.Repository
+		wantOrg    string
+		wantRepo   string
+	}{
+		{
+			name:     "process/github",
+			want:     &github.Provider{},
+			wantOrg:  "owner",
+			wantRepo: "repo",
+			targetRepo: &v1alpha1.Repository{
+				Spec: v1alpha1.RepositorySpec{
+					URL: "https://forge/owner/repo",
+					GitProvider: &v1alpha1.GitProvider{
+						Type: "github",
+					},
+				},
+			},
+		},
+		{
+			name:     "process/gitlab",
+			want:     &gitlab.Provider{},
+			wantOrg:  "owner",
+			wantRepo: "repo",
+			targetRepo: &v1alpha1.Repository{
+				Spec: v1alpha1.RepositorySpec{
+					URL: "https://forge/owner/repo",
+					GitProvider: &v1alpha1.GitProvider{
+						Type: "gitlab",
+					},
+				},
+			},
+		},
+		{
+			name:     "process/bitbucketcloud",
+			want:     &bitbucketcloud.Provider{},
+			wantOrg:  "owner",
+			wantRepo: "repo",
+			targetRepo: &v1alpha1.Repository{
+				Spec: v1alpha1.RepositorySpec{
+					URL: "https://forge/owner/repo",
+					GitProvider: &v1alpha1.GitProvider{
+						Type: "bitbucket-cloud",
+					},
+				},
+			},
+		},
+		{
+			name:     "process/bitbucketserver",
+			want:     &bitbucketserver.Provider{},
+			wantOrg:  "owner",
+			wantRepo: "repo",
+			targetRepo: &v1alpha1.Repository{
+				Spec: v1alpha1.RepositorySpec{
+					URL: "https://forge/owner/repo",
+					GitProvider: &v1alpha1.GitProvider{
+						Type: "bitbucket-server",
+					},
+				},
+			},
+		},
+		{
+			name:    "error/unknown provider",
+			wantErr: true,
+			targetRepo: &v1alpha1.Repository{
+				Spec: v1alpha1.RepositorySpec{
+					URL: "https://forge/owner/repo",
+					GitProvider: &v1alpha1.GitProvider{
+						Type: "unknown",
+					},
+				},
+			},
+		},
+		{
+			name:    "error/bad url",
+			wantErr: true,
+			targetRepo: &v1alpha1.Repository{
+				Spec: v1alpha1.RepositorySpec{
+					URL: "hellomoto",
+				},
+			},
+		},
+		{
+			name:    "error/not enough path in url",
+			wantErr: true,
+			targetRepo: &v1alpha1.Repository{
+				Spec: v1alpha1.RepositorySpec{
+					URL: "https://forge?owner=repo",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &params.Run{
+				Info: info.Info{},
+			}
+			kint := &kubernetestint.KinterfaceTest{}
+			observer, _ := zapobserver.New(zap.InfoLevel)
+			logger := zap.New(observer).Sugar()
+			l := &listener{
+				run: client, kint: kint, logger: logger, event: info.NewEvent(),
+			}
+			pintf, _, err := l.processIncoming(tt.targetRepo)
+			if tt.wantErr {
+				assert.Assert(t, err != nil)
+				return
+			}
+			assert.Assert(t, reflect.TypeOf(pintf).Elem() == reflect.TypeOf(tt.want).Elem())
+			assert.Assert(t, l.event.Organization == tt.wantOrg)
+			assert.Assert(t, l.event.Repository == tt.wantRepo)
+		})
+	}
+}

--- a/pkg/apis/pipelinesascode/v1alpha1/types.go
+++ b/pkg/apis/pipelinesascode/v1alpha1/types.go
@@ -61,16 +61,24 @@ type RepositoryRunStatus struct {
 type RepositorySpec struct {
 	URL         string       `json:"url"`
 	GitProvider *GitProvider `json:"git_provider,omitempty"`
+	Incomings   *[]Incoming  `json:"incoming,omitempty"`
+}
+
+type Incoming struct {
+	Type    string   `json:"type"`
+	Secret  Secret   `json:"secret"`
+	Targets []string `json:"targets,omitempty"`
 }
 
 type GitProvider struct {
-	URL           string             `json:"url,omitempty"`
-	User          string             `json:"user,omitempty"`
-	Secret        *GitProviderSecret `json:"secret,omitempty"`
-	WebhookSecret *GitProviderSecret `json:"webhook_secret,omitempty"`
+	URL           string  `json:"url,omitempty"`
+	User          string  `json:"user,omitempty"`
+	Secret        *Secret `json:"secret,omitempty"`
+	WebhookSecret *Secret `json:"webhook_secret,omitempty"`
+	Type          string  `json:"type,omitempty"`
 }
 
-type GitProviderSecret struct {
+type Secret struct {
 	Name string `json:"name"`
 	Key  string `json:"key"`
 }

--- a/pkg/cli/webhook/github.go
+++ b/pkg/cli/webhook/github.go
@@ -51,7 +51,7 @@ func (gh *gitHubConfig) Run(ctx context.Context, opts *Options) (*response, erro
 func (gh *gitHubConfig) askGHWebhookConfig(repoURL, controllerURL, apiURL string) error {
 	var defaultRepo string
 	if repoURL != "" {
-		defaultRepo, _ = formatting.GetRepoOwnerFromGHURL(repoURL)
+		defaultRepo, _ = formatting.GetRepoOwnerFromURL(repoURL)
 	}
 
 	if repoURL == "" || defaultRepo == "" {

--- a/pkg/cli/webhook/github_test.go
+++ b/pkg/cli/webhook/github_test.go
@@ -46,7 +46,7 @@ func TestAskGHWebhookConfig(t *testing.T) {
 				as.StubOne("webhook-secret")
 				as.StubOne("token")
 			},
-			repoURL:       "https:/github.com/pac/demo",
+			repoURL:       "https://github.com/pac/demo",
 			controllerURL: "https://test",
 			wantErrStr:    "",
 		},

--- a/pkg/cli/webhook/secret.go
+++ b/pkg/cli/webhook/secret.go
@@ -43,11 +43,11 @@ func (w *Options) updateRepositoryCR(ctx context.Context, res *response) error {
 		repo.Spec.GitProvider = &v1alpha1.GitProvider{}
 	}
 
-	repo.Spec.GitProvider.Secret = &v1alpha1.GitProviderSecret{
+	repo.Spec.GitProvider.Secret = &v1alpha1.Secret{
 		Name: w.RepositoryName,
 		Key:  providerTokenKey,
 	}
-	repo.Spec.GitProvider.WebhookSecret = &v1alpha1.GitProviderSecret{
+	repo.Spec.GitProvider.WebhookSecret = &v1alpha1.Secret{
 		Name: w.RepositoryName,
 		Key:  webhookSecretKey,
 	}

--- a/pkg/cmd/tknpac/repository/create.go
+++ b/pkg/cmd/tknpac/repository/create.go
@@ -223,7 +223,7 @@ func cleanupGitURL(rawURL string) (string, error) {
 }
 
 func createRepoCRD(ctx context.Context, opts *createOptions) error {
-	repoOwner, err := formatting.GetRepoOwnerFromGHURL(opts.event.URL)
+	repoOwner, err := formatting.GetRepoOwnerFromURL(opts.event.URL)
 	if err != nil {
 		return fmt.Errorf("invalid git URL: %s, it should be of format: https://gitprovider/project/repository", opts.event.URL)
 	}

--- a/pkg/cmd/tknpac/repository/describe.go
+++ b/pkg/cmd/tknpac/repository/describe.go
@@ -90,7 +90,7 @@ func askRepo(ctx context.Context, cs *params.Run, namespace string) (*v1alpha1.R
 
 	allRepositories := []string{}
 	for _, repository := range repositories.Items {
-		repoOwner, err := formatting.GetRepoOwnerFromGHURL(repository.Spec.URL)
+		repoOwner, err := formatting.GetRepoOwnerFromURL(repository.Spec.URL)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/tknpac/resolve/resolve.go
+++ b/pkg/cmd/tknpac/resolve/resolve.go
@@ -94,7 +94,7 @@ func Command(run *params.Run, streams *cli.IOStreams) *cobra.Command {
 			}
 
 			if _, ok := mapped["repo_owner"]; !ok && gitinfo.URL != "" {
-				repoOwner, err := formatting.GetRepoOwnerFromGHURL(gitinfo.URL)
+				repoOwner, err := formatting.GetRepoOwnerFromURL(gitinfo.URL)
 				if err != nil {
 					return err
 				}

--- a/pkg/formatting/vcs.go
+++ b/pkg/formatting/vcs.go
@@ -3,6 +3,7 @@ package formatting
 import (
 	"fmt"
 	"net/url"
+	"path/filepath"
 	"strings"
 
 	"golang.org/x/text/cases"
@@ -32,16 +33,26 @@ func ShortSHA(sha string) string {
 	return sha[0:shortShaLength]
 }
 
-func GetRepoOwnerFromGHURL(ghURL string) (string, error) {
-	u, err := url.Parse(ghURL)
+func GetRepoOwnerFromURL(ghURL string) (string, error) {
+	org, repo, err := GetRepoOwnerSplitted(ghURL)
 	if err != nil {
 		return "", err
 	}
-	sp := strings.Split(u.Path, "/")
-	if len(sp) == 1 {
-		return "", fmt.Errorf("not a URL with a REPO/OWNER at the end")
+	return strings.ToLower(fmt.Sprintf("%s/%s", org, repo)), nil
+}
+
+func GetRepoOwnerSplitted(u string) (string, string, error) {
+	uparse, err := url.Parse(u)
+	if err != nil {
+		return "", "", err
 	}
-	return fmt.Sprintf("%s/%s", strings.ToLower(sp[len(sp)-2]), strings.ToLower(sp[len(sp)-1])), nil
+	parts := strings.Split(uparse.Path, "/")
+	if len(parts) < 3 {
+		return "", "", fmt.Errorf("invalid repo url at least a organization/project and a repo needs to be specified: %s", u)
+	}
+	org := filepath.Join(parts[0 : len(parts)-1]...)
+	repo := parts[len(parts)-1]
+	return org, repo, nil
 }
 
 // CamelCasit pull_request > PullRequest

--- a/pkg/formatting/vcs_test.go
+++ b/pkg/formatting/vcs_test.go
@@ -33,6 +33,54 @@ func TestCamelCasit(t *testing.T) {
 	}
 }
 
+func TestGetRepoOwnerSplitted(t *testing.T) {
+	tests := []struct {
+		name    string
+		retOrg  string
+		retRepo string
+		wantErr bool
+		url     string
+	}{
+		{
+			name:    "good/parse url",
+			url:     "https://forge/owner/repo",
+			retOrg:  "owner",
+			retRepo: "repo",
+		},
+		{
+			name:    "good/parse url gitlab subpath",
+			url:     "https://forge/foo/bar/owner/repo",
+			retOrg:  "foo/bar/owner",
+			retRepo: "repo",
+		},
+		{
+			name:    "bad/no org/repo in url",
+			url:     "https://forge/repo",
+			wantErr: true,
+		},
+		{
+			name:    "bad/url",
+			url:     "hello/repo",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1, err := GetRepoOwnerSplitted(tt.url)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getOrgRepoURL() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.retOrg {
+				t.Errorf("getOrgRepoURL() got = %v, retOrg %v", got, tt.retOrg)
+			}
+			if got1 != tt.retRepo {
+				t.Errorf("getOrgRepoURL() got1 = %v, retOrg %v", got1, tt.retRepo)
+			}
+		})
+	}
+}
+
 func TestGetRepoOwnerFromGHURL(t *testing.T) {
 	type args struct {
 		ghURL string
@@ -69,7 +117,7 @@ func TestGetRepoOwnerFromGHURL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetRepoOwnerFromGHURL(tt.args.ghURL)
+			got, err := GetRepoOwnerFromURL(tt.args.ghURL)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetRepoOwnerFromGHURL() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/kubeinteraction/labels.go
+++ b/pkg/kubeinteraction/labels.go
@@ -37,6 +37,7 @@ func AddLabelsAndAnnotations(event *info.Event, pipelineRun *tektonv1beta1.Pipel
 	annotations := map[string]string{
 		filepath.Join(pipelinesascode.GroupName, "sha-title"): event.SHATitle,
 		filepath.Join(pipelinesascode.GroupName, "sha-url"):   event.SHAURL,
+		filepath.Join(pipelinesascode.GroupName, "repo-url"):  event.URL,
 	}
 
 	if event.PullRequestNumber != 0 {

--- a/pkg/matcher/annotation_matcher_test.go
+++ b/pkg/matcher/annotation_matcher_test.go
@@ -107,6 +107,34 @@ func TestMatchPipelinerunAnnotationAndRepositories(t *testing.T) {
 			},
 		},
 		{
+			name:    "match TargetPipelineRun",
+			wantErr: false,
+			args: args{
+				pruns: []*tektonv1beta1.PipelineRun{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							GenerateName: fmt.Sprintf("%s-", pipelineTargetNSName),
+						},
+					},
+				},
+				runevent: info.Event{
+					URL:               targetURL,
+					TargetPipelineRun: pipelineTargetNSName,
+				},
+				data: testclient.Data{
+					Repositories: []*v1alpha1.Repository{
+						testnewrepo.NewRepo(
+							testnewrepo.RepoTestcreationOpts{
+								Name:             "test-good",
+								URL:              targetURL,
+								InstallNamespace: targetNamespace,
+							},
+						),
+					},
+				},
+			},
+		},
+		{
 			name:    "bad CEL expresion",
 			wantErr: true,
 			args: args{

--- a/pkg/matcher/repo_runinfo_matcher.go
+++ b/pkg/matcher/repo_runinfo_matcher.go
@@ -24,3 +24,33 @@ func MatchEventURLRepo(ctx context.Context, cs *params.Run, event *info.Event, n
 
 	return nil, nil
 }
+
+// GetRepo get a repo by name anywhere on a cluster
+func GetRepo(ctx context.Context, cs *params.Run, repoName string) (*apipac.Repository, error) {
+	repositories, err := cs.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories("").List(
+		ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	for i := len(repositories.Items) - 1; i >= 0; i-- {
+		repo := repositories.Items[i]
+		if repo.GetName() == repoName {
+			return &repo, nil
+		}
+	}
+
+	return nil, nil
+}
+
+// IncomingWebhookRule will match a rule to an incoming rule, currently a rule is a target branch
+func IncomingWebhookRule(branch string, incomingWebhooks []apipac.Incoming) *apipac.Incoming {
+	// TODO: one day we will match the hook.Type here when we get something else than the dumb one (ie: slack)
+	for _, hook := range incomingWebhooks {
+		for _, v := range hook.Targets {
+			if v == branch {
+				return &hook
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/params/info/events.go
+++ b/pkg/params/info/events.go
@@ -9,6 +9,7 @@ type Event struct {
 	// EventType is what coming from the provider header, i.e:
 	// GitHub -> pull_request
 	// GitLab -> Merge Request Hook
+	// Incoming Webhook  -> incoming (always a push)
 	// Usually used for payload filtering passed from trigger directly
 	EventType string
 
@@ -19,6 +20,9 @@ type Event struct {
 	// others it would be always be pull_request we can rely on to know if it's
 	// a push or a pull_request
 	TriggerTarget string
+
+	// Target PipelineRun, the target PipelineRun user request. Used in incoming webhook
+	TargetPipelineRun string
 
 	BaseBranch        string // branch against where we are making the PR
 	DefaultBranch     string // master/main branches to know where things like the OWNERS file is located.
@@ -78,5 +82,6 @@ func (r *Event) DeepCopyInto(out *Event) {
 func NewEvent() *Event {
 	return &Event{
 		Provider: &Provider{},
+		Request:  &Request{},
 	}
 }

--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -135,7 +135,7 @@ is that what you want? make sure you use -n when generating the secret, eg: echo
 	if pipelineRuns == nil || err != nil {
 		msg := fmt.Sprintf("cannot locate templates in %s/ directory for this repository in %s", tektonDir, p.event.HeadBranch)
 		if err != nil {
-			msg += fmt.Sprintf("err: %s", err.Error())
+			msg += fmt.Sprintf(" err: %s", err.Error())
 		}
 		p.logger.Info(msg)
 		return nil, nil, nil
@@ -211,7 +211,7 @@ func changeSecret(prs []*tektonv1beta1.PipelineRun) error {
 
 // checkNeedUpdate using regexp, try to match some pattern for some issue in PR
 // to let the user know they need to update. or otherwise we will fail.
-// checks are depreacted/removed to n+1 release of OSP.
+// checks are deprecated/removed to n+1 release of OSP.
 // each check should give a good error message on how to update.
 func (p *PacRun) checkNeedUpdate(tmpl string) (string, bool) {
 	// nolint: gosec

--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -65,14 +65,19 @@ func (p *PacRun) matchRepoPR(ctx context.Context) ([]matcher.Match, *v1alpha1.Re
 	} else {
 		p.event.Provider.WebhookSecret, _ = GetCurrentNSWebhookSecret(ctx, p.k8int)
 	}
-	if err := p.vcx.Validate(ctx, p.run, p.event); err != nil {
-		// check that webhook secret has no /n or space into it
-		if strings.ContainsAny(p.event.Provider.WebhookSecret, "\n ") {
-			p.logger.Error(`we have failed to validate the payload with the webhook secret, 
+
+	// validate payload  for webhook secret
+	// we don't need to validate it in incoming since we already do this
+	if p.event.EventType != "incoming" {
+		if err := p.vcx.Validate(ctx, p.run, p.event); err != nil {
+			// check that webhook secret has no /n or space into it
+			if strings.ContainsAny(p.event.Provider.WebhookSecret, "\n ") {
+				p.logger.Error(`we have failed to validate the payload with the webhook secret, 
 it seems that we have detected a \n or a space at the end of your webhook secret, 
 is that what you want? make sure you use -n when generating the secret, eg: echo -n secret|base64`)
+			}
+			return nil, nil, fmt.Errorf("could not validate payload, check your webhook secret?: %w", err)
 		}
-		return nil, nil, fmt.Errorf("could not validate payload, check your webhook secret?: %w", err)
 	}
 
 	// Set the client, we should error out if there is a problem with
@@ -89,7 +94,7 @@ is that what you want? make sure you use -n when generating the secret, eg: echo
 	}
 
 	// Check if the submitter is allowed to run this.
-	if p.event.EventType != "push" {
+	if p.event.TriggerTarget != "push" {
 		allowed, err := p.vcx.IsAllowed(ctx, p.event)
 		if err != nil {
 			return nil, nil, err
@@ -136,8 +141,8 @@ is that what you want? make sure you use -n when generating the secret, eg: echo
 		return nil, nil, nil
 	}
 
-	// if /test or /retest command is used passing a pipelinerun then filter out the pipelinerun
-	pipelineRuns = filterPipelineRun(p.event.TargetTestPipelineRun, pipelineRuns)
+	// if /test command is used then filter out the pipelinerun
+	pipelineRuns = filterRunningPipelineRunOnTargetTest(p.event.TargetTestPipelineRun, pipelineRuns)
 	if pipelineRuns == nil {
 		p.logger.Info(fmt.Sprintf("cannot find pipelinerun %s in this repository", p.event.TargetTestPipelineRun))
 		return nil, nil, nil
@@ -147,6 +152,7 @@ is that what you want? make sure you use -n when generating the secret, eg: echo
 	if err != nil {
 		return nil, nil, err
 	}
+
 	// Match the PipelineRun with annotation
 	matchedPRs, err := matcher.MatchPipelinerunByAnnotation(ctx, p.logger, pipelineRuns, p.run, p.event)
 	if err != nil {
@@ -159,7 +165,7 @@ is that what you want? make sure you use -n when generating the secret, eg: echo
 	return matchedPRs, repo, nil
 }
 
-func filterPipelineRun(testPipeline string, prs []*tektonv1beta1.PipelineRun) []*tektonv1beta1.PipelineRun {
+func filterRunningPipelineRunOnTargetTest(testPipeline string, prs []*tektonv1beta1.PipelineRun) []*tektonv1beta1.PipelineRun {
 	if testPipeline == "" {
 		return prs
 	}
@@ -192,6 +198,10 @@ func changeSecret(prs []*tektonv1beta1.PipelineRun) error {
 		err = json.Unmarshal([]byte(processed), &np)
 		if err != nil {
 			return err
+		}
+		// don't crash when we don't have any annotations
+		if np.Annotations == nil {
+			np.Annotations = map[string]string{}
 		}
 		np.Annotations[gitAuthSecretAnnotation] = name
 		prs[k] = np

--- a/pkg/pipelineascode/secret.go
+++ b/pkg/pipelineascode/secret.go
@@ -33,6 +33,7 @@ func SecretFromRepository(ctx context.Context, cs *params.Run, k8int kubeinterac
 	if gitProviderSecretKey == "" {
 		gitProviderSecretKey = defaultGitProviderSecretKey
 	}
+
 	if event.Provider.Token, err = k8int.GetSecret(ctx, kubeinteraction.GetSecretOpt{
 		Namespace: repo.GetNamespace(),
 		Name:      repo.Spec.GitProvider.Secret.Name,
@@ -40,6 +41,7 @@ func SecretFromRepository(ctx context.Context, cs *params.Run, k8int kubeinterac
 	}); err != nil {
 		return err
 	}
+
 	// if we don't have a provider token in repo crd we won't be able to do much with it
 	// let it go and it will fail later on when doing SetClients or success if it was done from a github app
 	if event.Provider.Token == "" {

--- a/pkg/pipelineascode/secret_test.go
+++ b/pkg/pipelineascode/secret_test.go
@@ -36,10 +36,10 @@ func TestSecretFromRepository(t *testing.T) {
 			repo: &apipac.Repository{
 				Spec: apipac.RepositorySpec{
 					GitProvider: &apipac.GitProvider{
-						Secret: &apipac.GitProviderSecret{
+						Secret: &apipac.Secret{
 							Name: "repo-secret",
 						},
-						WebhookSecret: &apipac.GitProviderSecret{
+						WebhookSecret: &apipac.Secret{
 							Name: "repo-webhook-secret",
 						},
 					},
@@ -61,7 +61,7 @@ func TestSecretFromRepository(t *testing.T) {
 				Spec: apipac.RepositorySpec{
 					GitProvider: &apipac.GitProvider{
 						URL:    "https://dowant",
-						Secret: &apipac.GitProviderSecret{},
+						Secret: &apipac.Secret{},
 					},
 				},
 			},
@@ -77,7 +77,7 @@ func TestSecretFromRepository(t *testing.T) {
 				Spec: apipac.RepositorySpec{
 					GitProvider: &apipac.GitProvider{
 						User:   "userfoo",
-						Secret: &apipac.GitProviderSecret{},
+						Secret: &apipac.Secret{},
 					},
 				},
 			},
@@ -96,12 +96,12 @@ func TestSecretFromRepository(t *testing.T) {
 			if tt.repo.Spec.GitProvider.Secret != nil {
 				retsecret[tt.repo.Spec.GitProvider.Secret.Name] = tt.expectedSecret
 			} else {
-				tt.repo.Spec.GitProvider.Secret = &apipac.GitProviderSecret{}
+				tt.repo.Spec.GitProvider.Secret = &apipac.Secret{}
 			}
 			if tt.repo.Spec.GitProvider.WebhookSecret != nil {
 				retsecret[tt.repo.Spec.GitProvider.WebhookSecret.Name] = tt.expectedWebhookSecret
 			} else {
-				tt.repo.Spec.GitProvider.WebhookSecret = &apipac.GitProviderSecret{}
+				tt.repo.Spec.GitProvider.WebhookSecret = &apipac.Secret{}
 			}
 
 			k8int := &kitesthelper.KinterfaceTest{

--- a/pkg/provider/bitbucketcloud/bitbucket_test.go
+++ b/pkg/provider/bitbucketcloud/bitbucket_test.go
@@ -366,10 +366,10 @@ func TestProvider_Detect(t *testing.T) {
 				assert.NilError(t, err)
 			}
 
-			header := &http.Header{}
+			header := http.Header{}
 			header.Set("X-Event-Key", tt.eventType)
-
-			isBS, processReq, _, reason, err := bprovider.Detect(header, string(jeez), logger)
+			req := &http.Request{Header: header}
+			isBS, processReq, _, reason, err := bprovider.Detect(req, string(jeez), logger)
 			if tt.wantErrString != "" {
 				assert.ErrorContains(t, err, tt.wantErrString)
 				return

--- a/pkg/provider/bitbucketcloud/events.go
+++ b/pkg/provider/bitbucketcloud/events.go
@@ -171,10 +171,9 @@ func (v *Provider) ParsePayload(ctx context.Context, run *params.Run, request *h
 	return processedEvent, nil
 }
 
-func (v *Provider) Detect(reqHeader *http.Header, payload string, logger *zap.SugaredLogger) (bool, bool,
-	*zap.SugaredLogger, string, error,
-) {
+func (v *Provider) Detect(req *http.Request, payload string, logger *zap.SugaredLogger) (bool, bool, *zap.SugaredLogger, string, error) {
 	isBitCloud := false
+	reqHeader := req.Header
 	event := reqHeader.Get("X-Event-Key")
 	if event == "" {
 		return false, false, logger, "", nil

--- a/pkg/provider/bitbucketserver/bitbucketserver_test.go
+++ b/pkg/provider/bitbucketserver/bitbucketserver_test.go
@@ -430,10 +430,10 @@ func TestProvider_Detect(t *testing.T) {
 				assert.NilError(t, err)
 			}
 
-			header := &http.Header{}
+			header := http.Header{}
 			header.Set("X-Event-Key", tt.eventType)
-
-			isBS, processReq, _, reason, err := bprovider.Detect(header, string(jeez), logger)
+			req := &http.Request{Header: header}
+			isBS, processReq, _, reason, err := bprovider.Detect(req, string(jeez), logger)
 			if tt.wantErrString != "" {
 				assert.ErrorContains(t, err, tt.wantErrString)
 				return

--- a/pkg/provider/bitbucketserver/events.go
+++ b/pkg/provider/bitbucketserver/events.go
@@ -149,11 +149,9 @@ func parsePayloadType(event string) (interface{}, error) {
 
 // Detect processes event and detect if it is a bitbucket server event, whether to process or reject it
 // returns (if is a bitbucket server event, whether to process or reject, error if any occurred)
-func (v *Provider) Detect(reqHeader *http.Header, payload string, logger *zap.SugaredLogger) (bool, bool,
-	*zap.SugaredLogger, string, error,
-) {
+func (v *Provider) Detect(req *http.Request, payload string, logger *zap.SugaredLogger) (bool, bool, *zap.SugaredLogger, string, error) {
 	isBitServer := false
-	event := reqHeader.Get("X-Event-Key")
+	event := req.Header.Get("X-Event-Key")
 	if event == "" {
 		return false, false, logger, "", nil
 	}
@@ -169,7 +167,7 @@ func (v *Provider) Detect(reqHeader *http.Header, payload string, logger *zap.Su
 	setLoggerAndProceed := func(processEvent bool, reason string, err error) (bool, bool, *zap.SugaredLogger, string,
 		error,
 	) {
-		logger = logger.With("provider", "bitbucket-server", "event-id", reqHeader.Get("X-Request-Id"))
+		logger = logger.With("provider", "bitbucket-server", "event-id", req.Header.Get("X-Request-Id"))
 		return isBitServer, processEvent, logger, reason, err
 	}
 

--- a/pkg/provider/github/github_test.go
+++ b/pkg/provider/github/github_test.go
@@ -569,10 +569,11 @@ func TestProvider_Detect(t *testing.T) {
 				assert.NilError(t, err)
 			}
 
-			header := &http.Header{}
+			header := http.Header{}
 			header.Set("X-GitHub-Event", tt.eventType)
 
-			isGh, processReq, _, reason, err := gprovider.Detect(header, string(jeez), logger)
+			req := &http.Request{Header: header}
+			isGh, processReq, _, reason, err := gprovider.Detect(req, string(jeez), logger)
 			if tt.wantErrString != "" {
 				assert.ErrorContains(t, err, tt.wantErrString)
 				return

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -64,11 +64,9 @@ func (v *Provider) Validate(_ context.Context, _ *params.Run, event *info.Event)
 
 // Detect processes event and detect if it is a gitlab event, whether to process or reject it
 // returns (if is a GL event, whether to process or reject, logger with event metadata,, error if any occurred)
-func (v *Provider) Detect(reqHeader *http.Header, payload string, logger *zap.SugaredLogger) (bool, bool,
-	*zap.SugaredLogger, string, error,
-) {
+func (v *Provider) Detect(req *http.Request, payload string, logger *zap.SugaredLogger) (bool, bool, *zap.SugaredLogger, string, error) {
 	isGL := false
-	event := reqHeader.Get("X-Gitlab-Event")
+	event := req.Header.Get("X-Gitlab-Event")
 	if event == "" {
 		return false, false, logger, "no gitlab event", nil
 	}
@@ -79,7 +77,7 @@ func (v *Provider) Detect(reqHeader *http.Header, payload string, logger *zap.Su
 	setLoggerAndProceed := func(processEvent bool, reason string, err error) (bool, bool, *zap.SugaredLogger,
 		string, error,
 	) {
-		logger = logger.With("provider", "gitlab", "event-id", reqHeader.Get("X-Request-Id"))
+		logger = logger.With("provider", "gitlab", "event-id", req.Header.Get("X-Request-Id"))
 		return isGL, processEvent, logger, reason, err
 	}
 

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -236,26 +236,43 @@ func (v *Provider) GetConfig() *info.ProviderConfig {
 	}
 }
 
-func (v *Provider) SetClient(_ context.Context, event *info.Event) error {
+func (v *Provider) SetClient(_ context.Context, runevent *info.Event) error {
 	var err error
-	if event.Provider.Token == "" {
+	if runevent.Provider.Token == "" {
 		return fmt.Errorf("no git_provider.secret has been set in the repo crd")
 	}
 
 	// Try to detect automatically the API url if url is not coming from public
 	// gitlab. Unless user has set a spec.provider.url in its repo crd
 	apiURL := apiPublicURL
-	if event.Provider.URL != "" {
-		apiURL = event.Provider.URL
+	if runevent.Provider.URL != "" {
+		apiURL = runevent.Provider.URL
 	} else if !strings.HasPrefix(v.repoURL, apiPublicURL) {
 		apiURL = strings.ReplaceAll(v.repoURL, v.pathWithNamespace, "")
 	}
 
-	v.Client, err = gitlab.NewClient(event.Provider.Token, gitlab.WithBaseURL(apiURL))
+	v.Client, err = gitlab.NewClient(runevent.Provider.Token, gitlab.WithBaseURL(apiURL))
 	if err != nil {
 		return err
 	}
-	v.Token = &event.Provider.Token
+	v.Token = &runevent.Provider.Token
+
+	// if we don't have sourceProjectID (ie: incoming-webhook) then try to set
+	// it ASAP if we can.
+	if v.sourceProjectID == 0 && runevent.Organization != "" && runevent.Repository != "" {
+		projectSlug := filepath.Join(runevent.Organization, runevent.Repository)
+		projectinfo, _, err := v.Client.Projects.GetProject(projectSlug, &gitlab.GetProjectOptions{})
+		if err != nil {
+			return err
+		}
+		// TODO: we really need to move out the runevent.*ProjecTID to v.*ProjectID,
+		// I just spent half an hour debugging because i didn't realise it was there instead in v.*
+		v.sourceProjectID = projectinfo.ID
+		runevent.SourceProjectID = projectinfo.ID
+		runevent.TargetProjectID = projectinfo.ID
+		runevent.DefaultBranch = projectinfo.DefaultBranch
+	}
+
 	return nil
 }
 
@@ -310,12 +327,13 @@ func (v *Provider) CreateStatus(_ context.Context, _ versioned.Interface, event 
 	}
 	// nolint: dogsled
 	_, _, _ = v.Client.Commits.SetCommitStatus(event.SourceProjectID, event.SHA, opt)
-	if statusOpts.Conclusion != "running" {
-		opt := &gitlab.CreateMergeRequestNoteOptions{Body: gitlab.String(body)}
-		_, _, err := v.Client.Notes.CreateMergeRequestNote(event.TargetProjectID, event.PullRequestNumber, opt)
+
+	// only add a note when we are on a MR
+	if event.EventType == "pull_request" {
+		mopt := &gitlab.CreateMergeRequestNoteOptions{Body: gitlab.String(body)}
+		_, _, err := v.Client.Notes.CreateMergeRequestNote(event.TargetProjectID, event.PullRequestNumber, mopt)
 		return err
 	}
-
 	return nil
 }
 
@@ -385,10 +403,23 @@ func (v *Provider) GetFileInsideRepo(_ context.Context, runevent *info.Event, pa
 	return string(getobj), nil
 }
 
-func (v *Provider) GetCommitInfo(_ context.Context, _ *info.Event) error {
+func (v *Provider) GetCommitInfo(_ context.Context, runevent *info.Event) error {
 	if v.Client == nil {
 		return fmt.Errorf("no gitlab client has been initiliazed, " +
 			"exiting... (hint: did you forget setting a secret on your repo?)")
 	}
+
+	// if we don't have a SHA (ie: incoming-webhook) then get it from the branch
+	// and populate in the runevent.
+	if runevent.SHA == "" && runevent.HeadBranch != "" {
+		branchinfo, _, err := v.Client.Commits.GetCommit(v.sourceProjectID, runevent.HeadBranch)
+		if err != nil {
+			return err
+		}
+		runevent.SHA = branchinfo.ID
+		runevent.SHATitle = branchinfo.Title
+		runevent.SHAURL = branchinfo.WebURL
+	}
+
 	return nil
 }

--- a/pkg/provider/gitlab/gitlab_test.go
+++ b/pkg/provider/gitlab/gitlab_test.go
@@ -314,10 +314,10 @@ func TestGetCommitInfo(t *testing.T) {
 	v := &Provider{Client: client}
 
 	defer tearDown()
-	assert.NilError(t, v.GetCommitInfo(ctx, nil))
+	assert.NilError(t, v.GetCommitInfo(ctx, info.NewEvent()))
 
 	ncv := &Provider{}
-	assert.Assert(t, ncv.GetCommitInfo(ctx, nil) != nil)
+	assert.Assert(t, ncv.GetCommitInfo(ctx, info.NewEvent()) != nil)
 }
 
 func TestGetConfig(t *testing.T) {

--- a/pkg/provider/gitlab/gitlab_test.go
+++ b/pkg/provider/gitlab/gitlab_test.go
@@ -552,10 +552,10 @@ func TestProvider_Detect(t *testing.T) {
 			gprovider := Provider{}
 			logger := getLogger()
 
-			header := &http.Header{}
+			header := http.Header{}
 			header.Set("X-Gitlab-Event", string(tt.eventType))
-
-			isGL, processReq, _, reason, err := gprovider.Detect(header, tt.event, logger)
+			req := &http.Request{Header: header}
+			isGL, processReq, _, reason, err := gprovider.Detect(req, tt.event, logger)
 			if tt.wantErrString != "" {
 				assert.ErrorContains(t, err, tt.wantErrString)
 				return

--- a/pkg/provider/interface.go
+++ b/pkg/provider/interface.go
@@ -26,7 +26,7 @@ type StatusOpts struct {
 type Interface interface {
 	SetLogger(*zap.SugaredLogger)
 	Validate(ctx context.Context, params *params.Run, event *info.Event) error
-	Detect(*http.Header, string, *zap.SugaredLogger) (bool, bool, *zap.SugaredLogger, string, error)
+	Detect(*http.Request, string, *zap.SugaredLogger) (bool, bool, *zap.SugaredLogger, string, error)
 	ParsePayload(context.Context, *params.Run, *http.Request, string) (*info.Event, error)
 	IsAllowed(context.Context, *info.Event) (bool, error)
 	CreateStatus(context.Context, versioned.Interface, *info.Event, *info.PacOpts, StatusOpts) error

--- a/pkg/reconciler/status.go
+++ b/pkg/reconciler/status.go
@@ -91,6 +91,6 @@ func (r *Reconciler) postFinalStatus(ctx context.Context, logger *zap.SugaredLog
 	}
 
 	err = vcx.CreateStatus(ctx, r.run.Clients.Tekton, event, r.run.Info.Pac, status)
-	logger.Infof("pipelinerun %s has %s", pr.Name, status.Conclusion)
+	logger.Infof("pipelinerun %s has a status of '%s'", pr.Name, status.Conclusion)
 	return pr, err
 }

--- a/pkg/reconciler/testdata/test-failed-pipelinerun.yaml
+++ b/pkg/reconciler/testdata/test-failed-pipelinerun.yaml
@@ -10,6 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/pull-request: "28"
     pipelinesascode.tekton.dev/sha-title: fail it
     pipelinesascode.tekton.dev/sha-url: https://github.com/sm43/pac-app/commit/1e65fcc114bf71045c86c25dd204755735b28d09
+    pipelinesascode.tekton.dev/repo-url: https://github.com/sm43/pac-app
     pipelinesascode.tekton.dev/task: git-clone
   creationTimestamp: "2022-05-24T04:22:12Z"
   generateName: pac-app-pull-request-

--- a/pkg/reconciler/testdata/test-succeeded-pipelinerun.yaml
+++ b/pkg/reconciler/testdata/test-succeeded-pipelinerun.yaml
@@ -10,6 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/pull-request: "28"
     pipelinesascode.tekton.dev/sha-title: fail it
     pipelinesascode.tekton.dev/sha-url: https://github.com/sm43/pac-app/commit/1e65fcc114bf71045c86c25dd204755735b28d09
+    pipelinesascode.tekton.dev/repo-url: https://github.com/sm43/pac-app
     pipelinesascode.tekton.dev/task: git-clone
   creationTimestamp: "2022-05-24T04:22:12Z"
   generateName: pac-app-pull-request-1-

--- a/pkg/test/kubernetestint/kubernetesint.go
+++ b/pkg/test/kubernetestint/kubernetesint.go
@@ -20,28 +20,32 @@ type KinterfaceTest struct {
 
 var _ kubeinteraction.Interface = (*KinterfaceTest)(nil)
 
-func (k *KinterfaceTest) GetConsoleUI(ctx context.Context, ns string, pr string) (string, error) {
+func (k *KinterfaceTest) GetConsoleUI(_ context.Context, _ string, _ string) (string, error) {
 	if k.ConsoleURLErorring {
 		return "", fmt.Errorf("i want you to errit")
 	}
 	return k.ConsoleURL, nil
 }
 
-func (k *KinterfaceTest) CreateBasicAuthSecret(ctx context.Context, logger *zap.SugaredLogger, runevent *info.Event,
-	targetNamespace, secretName string,
-) error {
+func (k *KinterfaceTest) CreateBasicAuthSecret(context.Context, *zap.SugaredLogger, *info.Event, string, string) error {
 	return nil
 }
 
-func (k *KinterfaceTest) DeleteBasicAuthSecret(ctx context.Context, logger *zap.SugaredLogger, targetNamespace, secretName string) error {
+func (k *KinterfaceTest) DeleteBasicAuthSecret(_ context.Context, _ *zap.SugaredLogger, _, _ string) error {
 	return nil
 }
 
 func (k *KinterfaceTest) GetSecret(_ context.Context, secretopt kubeinteraction.GetSecretOpt) (string, error) {
+	// check if secret exist in k.GetSecretResult
+	if k.GetSecretResult[secretopt.Name] == "" {
+		return "", fmt.Errorf("secret %s does not exist", secretopt.Name)
+	}
 	return k.GetSecretResult[secretopt.Name], nil
 }
 
-func (k *KinterfaceTest) CleanupPipelines(ctx context.Context, logger *zap.SugaredLogger, repo *v1alpha1.Repository, pr *v1beta1.PipelineRun, limitnumber int) error {
+func (k *KinterfaceTest) CleanupPipelines(_ context.Context, _ *zap.SugaredLogger, _ *v1alpha1.Repository,
+	pr *v1beta1.PipelineRun, limitnumber int,
+) error {
 	if k.ExpectedNumberofCleanups != limitnumber {
 		return fmt.Errorf("we wanted %d and we got %d", k.ExpectedNumberofCleanups, limitnumber)
 	}

--- a/pkg/test/provider/testwebvcs.go
+++ b/pkg/test/provider/testwebvcs.go
@@ -27,9 +27,7 @@ func (v *TestProviderImp) Validate(ctx context.Context, params *params.Run, even
 	return nil
 }
 
-func (v *TestProviderImp) Detect(request *http.Header, body string, logger *zap.SugaredLogger) (bool, bool,
-	*zap.SugaredLogger, string, error,
-) {
+func (v *TestProviderImp) Detect(request *http.Request, body string, logger *zap.SugaredLogger) (bool, bool, *zap.SugaredLogger, string, error) {
 	return true, true, nil, "", nil
 }
 

--- a/pkg/test/repository/repository.go
+++ b/pkg/test/repository/repository.go
@@ -73,12 +73,12 @@ func NewRepo(opts RepoTestcreationOpts) *v1alpha1.Repository {
 
 	if opts.SecretName != "" || opts.ProviderURL != "" || opts.WebhookSecretName != "" {
 		repo.Spec.GitProvider = &v1alpha1.GitProvider{
-			Secret: &v1alpha1.GitProviderSecret{},
+			Secret: &v1alpha1.Secret{},
 		}
 	}
 
 	if opts.SecretName != "" {
-		repo.Spec.GitProvider.Secret = &v1alpha1.GitProviderSecret{
+		repo.Spec.GitProvider.Secret = &v1alpha1.Secret{
 			Name: opts.SecretName,
 		}
 	}
@@ -87,7 +87,7 @@ func NewRepo(opts RepoTestcreationOpts) *v1alpha1.Repository {
 	}
 
 	if opts.WebhookSecretName != "" {
-		repo.Spec.GitProvider.WebhookSecret = &v1alpha1.GitProviderSecret{
+		repo.Spec.GitProvider.WebhookSecret = &v1alpha1.Secret{
 			Name: opts.WebhookSecretName,
 		}
 	}

--- a/samples/repository-incoming-webhook.yml
+++ b/samples/repository-incoming-webhook.yml
@@ -1,0 +1,21 @@
+# Sample repository showing incoming webhook repository
+---
+apiVersion: "pipelinesascode.tekton.dev/v1alpha1"
+kind: Repository
+metadata:
+  name: sample-app
+  namespace: "sample-ci-webhook"
+spec:
+  # which URL this Repository handles
+  url: "https://forge.com/owner/sample-app"
+  incoming:
+    - type: webhook-url
+      targets:
+        - main
+      secret:
+        name: "webhook-secret"
+        key: "webhook.secret"
+  git_provider:
+    secret:
+      name: "provider.secret"
+      key: "tokenkey"

--- a/test/gitlab_incoming_webhook_test.go
+++ b/test/gitlab_incoming_webhook_test.go
@@ -1,0 +1,87 @@
+//go:build e2e
+// +build e2e
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	tgitlab "github.com/openshift-pipelines/pipelines-as-code/test/pkg/gitlab"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/secret"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
+	"github.com/tektoncd/pipeline/pkg/names"
+	"gotest.tools/v3/assert"
+)
+
+var (
+	incomingSecreteValue = "shhhh-secrete"
+	incomingSecretName   = "incoming-webhook-secret"
+)
+
+func TestGitlabIncomingWebhook(t *testing.T) {
+	randomedString := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
+	ctx := context.Background()
+	runcnx, opts, glprovider, err := tgitlab.Setup(ctx)
+	assert.NilError(t, err)
+	runcnx.Clients.Log.Info("Testing with Gitlab")
+	projectinfo, resp, err := glprovider.Client.Projects.GetProject(opts.ProjectID, nil)
+	assert.NilError(t, err)
+	if resp != nil && resp.Response.StatusCode == http.StatusNotFound {
+		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
+	}
+
+	incoming := &[]v1alpha1.Incoming{
+		{
+			Type: "webhook-url",
+			Secret: v1alpha1.Secret{
+				Name: incomingSecretName,
+				Key:  "incoming",
+			},
+			Targets: []string{randomedString},
+		},
+	}
+
+	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, randomedString, incoming)
+	assert.NilError(t, err)
+
+	err = secret.Create(ctx, runcnx, map[string]string{"incoming": incomingSecreteValue}, randomedString, incomingSecretName)
+	assert.NilError(t, err)
+
+	entries, err := payload.GetEntries([]string{
+		"testdata/pipelinerun.yaml", "testdata/pipelinerun-clone.yaml",
+	}, randomedString, randomedString, options.PushEvent)
+	assert.NilError(t, err)
+
+	title := "TestIncomingWebhook - " + randomedString
+	err = tgitlab.PushFilesToRef(glprovider.Client, title,
+		projectinfo.DefaultBranch,
+		randomedString,
+		opts.ProjectID,
+		entries, ".tekton/subdir/pr.yaml")
+	assert.NilError(t, err)
+	runcnx.Clients.Log.Infof("Branch %s has been created and pushed with files", randomedString)
+
+	url := fmt.Sprintf("%s/incoming?repository=%s&branch=%s&pipelinerun=%s&secret=%s", opts.ControllerURL,
+		randomedString, randomedString, "pipeline-clone", incomingSecreteValue)
+	client := &http.Client{}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
+	assert.NilError(t, err)
+	httpResp, err := client.Do(req)
+	assert.NilError(t, err)
+	defer httpResp.Body.Close()
+	runcnx.Clients.Log.Infof("Kicked off on incoming-webhook URL: %s", url)
+	assert.Assert(t, httpResp.StatusCode > 200 && httpResp.StatusCode < 300)
+	defer tgitlab.TearDown(ctx, t, runcnx, glprovider, -1, randomedString, randomedString, opts.ProjectID)
+
+	wait.Succeeded(ctx, t, runcnx, opts, "Merge_Request", randomedString, 2, "", title)
+}
+
+// Local Variables:
+// compile-command: "go test -tags=e2e -v -run TestGitlabIncomingWebhook$ ."
+// End:

--- a/test/gitlab_merge_request_test.go
+++ b/test/gitlab_merge_request_test.go
@@ -29,7 +29,7 @@ func TestGitlabMergeRequest(t *testing.T) {
 		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
 	}
 
-	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, targetNS)
+	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, targetNS, nil)
 	assert.NilError(t, err)
 
 	entries, err := payload.GetEntries([]string{

--- a/test/pkg/bitbucketcloud/crd.go
+++ b/test/pkg/bitbucketcloud/crd.go
@@ -48,7 +48,7 @@ func CreateCRD(ctx context.Context, t *testing.T, bprovider bitbucketcloud.Provi
 	repository.Spec.GitProvider = &v1alpha1.GitProvider{
 		URL:    apiURL,
 		User:   apiUser,
-		Secret: &v1alpha1.GitProviderSecret{Name: "webhook-token", Key: "token"},
+		Secret: &v1alpha1.Secret{Name: "webhook-token", Key: "token"},
 	}
 
 	err = pacrepo.CreateRepo(ctx, targetNS, run, repository)

--- a/test/pkg/github/crd.go
+++ b/test/pkg/github/crd.go
@@ -42,11 +42,11 @@ func CreateCRD(ctx context.Context, t *testing.T, repoinfo *ghlib.Repository, ru
 		assert.NilError(t, err)
 		repo.Spec.GitProvider = &v1alpha1.GitProvider{
 			URL: apiURL,
-			Secret: &v1alpha1.GitProviderSecret{
+			Secret: &v1alpha1.Secret{
 				Name: "webhook-token",
 				Key:  "token",
 			},
-			WebhookSecret: &v1alpha1.GitProviderSecret{
+			WebhookSecret: &v1alpha1.Secret{
 				Name: "webhook-token",
 				Key:  "webhook-secret",
 			},

--- a/test/pkg/gitlab/crd.go
+++ b/test/pkg/gitlab/crd.go
@@ -37,8 +37,8 @@ func CreateCRD(ctx context.Context, projectinfo *gitlab.Project, run *params.Run
 			URL: projectinfo.WebURL,
 			GitProvider: &v1alpha1.GitProvider{
 				URL:           apiURL,
-				Secret:        &v1alpha1.GitProviderSecret{Name: "webhook-token", Key: "token"},
-				WebhookSecret: &v1alpha1.GitProviderSecret{Name: "webhook-secret", Key: "secret"},
+				Secret:        &v1alpha1.Secret{Name: "webhook-token", Key: "token"},
+				WebhookSecret: &v1alpha1.Secret{Name: "webhook-secret", Key: "secret"},
 			},
 		},
 	}

--- a/test/pkg/gitlab/setup.go
+++ b/test/pkg/gitlab/setup.go
@@ -38,12 +38,18 @@ func Setup(ctx context.Context) (*params.Run, options.E2E, gitlab.Provider, erro
 		return nil, options.E2E{}, gitlab.Provider{}, fmt.Errorf("TEST_EL_WEBHOOK_SECRET env variable is required, cannot continue")
 	}
 
+	controllerURL := os.Getenv("TEST_EL_URL")
+	if controllerURL == "" {
+		return nil, options.E2E{}, gitlab.Provider{}, fmt.Errorf("TEST_EL_URL variable is required, cannot continue")
+	}
+
 	run := &params.Run{}
 	if err := run.Clients.NewClients(ctx, &run.Info); err != nil {
 		return nil, options.E2E{}, gitlab.Provider{}, err
 	}
 	e2eoptions := options.E2E{
-		ProjectID: gitlabPid,
+		ProjectID:     gitlabPid,
+		ControllerURL: controllerURL,
 	}
 	glprovider := gitlab.Provider{}
 	err = glprovider.SetClient(ctx,

--- a/test/pkg/options/options.go
+++ b/test/pkg/options/options.go
@@ -4,9 +4,11 @@ type E2E struct {
 	Repo, Organization string
 	DirectWebhook      bool
 	ProjectID          int
+	ControllerURL      string
 }
 
 var (
 	MainBranch       = "main"
 	PullRequestEvent = "pull_request"
+	PushEvent        = "push"
 )


### PR DESCRIPTION
let the user specify a shared secret and be able to target a
PipelineRun from a repo crd match.

We only let the user target what is explicitely targetted in the Repo
CRD, just in case you know for security being explicite is better to be
implicit.

There is room for improvement in the future. We currently do
webhook-url type which is not used anywhere, but we could have a slack
or other methods to be able to answer to slack if needed.

TODO: need to add an E2E test

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
