### PR TITLE
Add event sha, event type in logs to filter them easily

### DIFF
--- a/pkg/adapter/sinker.go
+++ b/pkg/adapter/sinker.go
@@ -28,6 +28,11 @@ func (s *sinker) processEvent(ctx context.Context, request *http.Request, payloa
 		s.logger.Errorf("failed to parse event: %v", err)
 		return err
 	}
+
+	// set logger with sha and event type
+	s.logger = s.logger.With("event-sha", s.event.SHA, "event-type", s.event.EventType)
+	s.vcx.SetLogger(s.logger)
+
 	s.event.Request = &info.Request{
 		Header:  request.Header,
 		Payload: bytes.TrimSpace(payload),

--- a/pkg/provider/bitbucketcloud/events.go
+++ b/pkg/provider/bitbucketcloud/events.go
@@ -191,7 +191,7 @@ func (v *Provider) Detect(reqHeader *http.Header, payload string, logger *zap.Su
 	setLoggerAndProceed := func(processEvent bool, reason string, err error) (bool, bool, *zap.SugaredLogger,
 		string, error,
 	) {
-		logger = logger.With("provider", "bitbucket-cloud", "event", reqHeader.Get("X-Request-Id"))
+		logger = logger.With("provider", "bitbucket-cloud", "event-id", reqHeader.Get("X-Request-Id"))
 		return isBitCloud, processEvent, logger, reason, err
 	}
 

--- a/pkg/provider/bitbucketserver/events.go
+++ b/pkg/provider/bitbucketserver/events.go
@@ -169,7 +169,7 @@ func (v *Provider) Detect(reqHeader *http.Header, payload string, logger *zap.Su
 	setLoggerAndProceed := func(processEvent bool, reason string, err error) (bool, bool, *zap.SugaredLogger, string,
 		error,
 	) {
-		logger = logger.With("provider", "bitbucket-server", "event", reqHeader.Get("X-Request-Id"))
+		logger = logger.With("provider", "bitbucket-server", "event-id", reqHeader.Get("X-Request-Id"))
 		return isBitServer, processEvent, logger, reason, err
 	}
 

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -292,7 +292,7 @@ func (v *Provider) Detect(reqHeader *http.Header, payload string, logger *zap.Su
 	setLoggerAndProceed := func(processEvent bool, reason string, err error) (bool, bool, *zap.SugaredLogger,
 		string, error,
 	) {
-		logger = logger.With("provider", "github", "event", reqHeader.Get("X-GitHub-Delivery"))
+		logger = logger.With("provider", "github", "event-id", reqHeader.Get("X-GitHub-Delivery"))
 		return isGH, processEvent, logger, reason, err
 	}
 

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -79,7 +79,7 @@ func (v *Provider) Detect(reqHeader *http.Header, payload string, logger *zap.Su
 	setLoggerAndProceed := func(processEvent bool, reason string, err error) (bool, bool, *zap.SugaredLogger,
 		string, error,
 	) {
-		logger = logger.With("provider", "gitlab", "event", reqHeader.Get("X-Request-Id"))
+		logger = logger.With("provider", "gitlab", "event-id", reqHeader.Get("X-Request-Id"))
 		return isGL, processEvent, logger, reason, err
 	}
 


### PR DESCRIPTION
Why?
- event sha is easy to get compared to event id (which is found in app/webhook) 
- there may be multiple events on same sha, so event type help
-  event -> event id is helpful for skipped events 

Closes #710 
# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
