### PR TITLE
Adds check for pipelinerun completed state in reconciler

### DIFF
--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -34,6 +34,13 @@ var gitAuthSecretAnnotation = filepath.Join(pipelinesascode.GroupName, "git-auth
 
 func (r *Reconciler) ReconcileKind(ctx context.Context, pr *v1beta1.PipelineRun) pkgreconciler.Event {
 	logger := logging.FromContext(ctx)
+
+	// if pipelineRun is in completed state then return
+	state, exist := pr.GetLabels()[filepath.Join(pipelinesascode.GroupName, "state")]
+	if exist && state == kubeinteraction.StateCompleted {
+		return nil
+	}
+
 	if pr.IsDone() {
 		logger = logger.With(
 			"pipeline-run", pr.GetName(),


### PR DESCRIPTION
if watcher pod restarts then it seems all pipelineruns are processed
regardless of out filter for state, this adds a check for state in
reconciler and returns if its completed.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
