### PR TITLE
Adds setup github-webhook command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Pipelines as Code -- An opinionated CI based on OpenShift Pipelines / Tekton.
 
 Full documentation for the stable version is available from <https://pipelinesascode.com>
-Documentation for the developement branch is available [here](https://nightly.pipelines-as-code.pages.dev/) 
+Documentation for the developement branch is available [here](https://nightly.pipelines-as-code.pages.dev/)
 
 ## Introduction
 

--- a/docs/content/docs/guide/cli.md
+++ b/docs/content/docs/guide/cli.md
@@ -13,6 +13,7 @@ Pipelines as Code provide a powerful CLI designed to work with tkn plug-in.  `tk
 * `list`: list Pipelines as Code Repositories.
 * `describe`: describe a Pipelines as Code Repository and the runs associated with it.
 * `resolve`: Resolve a pipelinerun as if it were executed by pipelines as code on service.
+* `setup`: Setup a Git provider app or webhook with pipelines as code service.
 
 ## Install
 
@@ -216,6 +217,17 @@ to push it first before using `tkn pac resolve|kubectl apply`.
 
 Compared with running directly on CI, you need to explicitly specify the list of
 filenames or directory where you have the templates.
+{{< /details >}}
+
+{{< details "tkn pac setup github-app" >}}
+
+### Setup GitHub Webhook
+
+`tkn-pac setup github-webhook`: will allow you to set up a GitHub webhook with pipelines
+as code service.
+
+After setting up webhook, it will provide an option to create Repository and configure it with
+required secrets.
 {{< /details >}}
 
 ## Screenshot

--- a/pkg/cli/webhook/github.go
+++ b/pkg/cli/webhook/github.go
@@ -12,7 +12,6 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli/prompt"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	"golang.org/x/oauth2"
 )
 
@@ -27,10 +26,6 @@ type gitHubConfig struct {
 	webhookSecret       string
 	personalAccessToken string
 	APIURL              string
-}
-
-func (gh *gitHubConfig) GetName() string {
-	return provider.ProviderGitHubWebhook
 }
 
 func (gh *gitHubConfig) Run(ctx context.Context, opts *Options) (*response, error) {
@@ -58,7 +53,10 @@ func (gh *gitHubConfig) askGHWebhookConfig(repoURL, controllerURL, apiURL string
 		fmt.Fprintf(gh.IOStream.Out, "✓ Setting up GitHub Webhook for Repository %s\n", repoURL)
 	}
 
-	defaultRepo, _ := formatting.GetRepoOwnerFromURL(repoURL)
+	defaultRepo, err := formatting.GetRepoOwnerFromURL(repoURL)
+	if err != nil {
+		return err
+	}
 
 	repoArr := strings.Split(defaultRepo, "/")
 	if len(repoArr) != 2 {
@@ -108,7 +106,7 @@ func (gh *gitHubConfig) askGHWebhookConfig(repoURL, controllerURL, apiURL string
 		return err
 	}
 
-	if apiURL == "" && !strings.Contains(repoURL, "https://github.com") {
+	if apiURL == "" && !strings.HasPrefix(repoURL, "https://github.com") {
 		if err := prompt.SurveyAskOne(&survey.Input{
 			Message: "Please enter your GitHub enterprise API URL:: ",
 		}, &gh.APIURL, survey.WithValidator(survey.Required)); err != nil {

--- a/pkg/cli/webhook/github_test.go
+++ b/pkg/cli/webhook/github_test.go
@@ -27,7 +27,7 @@ func TestAskGHWebhookConfig(t *testing.T) {
 			askStubs: func(as *prompt.AskStubber) {
 				as.StubOne("invalid-repo")
 			},
-			wantErrStr: "invalid repository, needs to be of format 'org-name/repo-name'",
+			wantErrStr: "invalid repo url at least a organization/project and a repo needs to be specified: invalid-repo",
 		},
 		{
 			name: "ask all details no defaults",

--- a/pkg/cli/webhook/github_test.go
+++ b/pkg/cli/webhook/github_test.go
@@ -32,8 +32,8 @@ func TestAskGHWebhookConfig(t *testing.T) {
 		{
 			name: "ask all details no defaults",
 			askStubs: func(as *prompt.AskStubber) {
-				as.StubOne("pac/demo")
-				as.StubOne("https://test")
+				as.StubOne("https://github.com/pac/test")
+				as.StubOne("https://controller.url")
 				as.StubOne("webhook-secret")
 				as.StubOne("token")
 			},

--- a/pkg/cli/webhook/secret.go
+++ b/pkg/cli/webhook/secret.go
@@ -15,9 +15,9 @@ const (
 )
 
 func (w *Options) createWebhookSecret(ctx context.Context, response *response) error {
-	_, err := w.Run.Clients.Kube.CoreV1().Secrets(w.RepositoryNamespace).Create(ctx, &corev1.Secret{
+	_, err := w.Run.Clients.Kube.CoreV1().Secrets(w.repositoryNamespace).Create(ctx, &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: w.RepositoryName,
+			Name: w.repositoryName,
 		},
 		Data: map[string][]byte{
 			providerTokenKey: []byte(response.PersonalAccessToken),
@@ -28,13 +28,13 @@ func (w *Options) createWebhookSecret(ctx context.Context, response *response) e
 		return err
 	}
 
-	fmt.Fprintf(w.IOStreams.Out, "🔑 Webhook Secret %s has been created in the %s namespace.\n", w.RepositoryName, w.RepositoryNamespace)
+	fmt.Fprintf(w.IOStreams.Out, "🔑 Webhook Secret %s has been created in the %s namespace.\n", w.repositoryName, w.repositoryNamespace)
 	return nil
 }
 
 func (w *Options) updateRepositoryCR(ctx context.Context, res *response) error {
-	repo, err := w.Run.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(w.RepositoryNamespace).
-		Get(ctx, w.RepositoryName, metav1.GetOptions{})
+	repo, err := w.Run.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(w.repositoryNamespace).
+		Get(ctx, w.repositoryName, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -44,11 +44,11 @@ func (w *Options) updateRepositoryCR(ctx context.Context, res *response) error {
 	}
 
 	repo.Spec.GitProvider.Secret = &v1alpha1.Secret{
-		Name: w.RepositoryName,
+		Name: w.repositoryName,
 		Key:  providerTokenKey,
 	}
 	repo.Spec.GitProvider.WebhookSecret = &v1alpha1.Secret{
-		Name: w.RepositoryName,
+		Name: w.repositoryName,
 		Key:  webhookSecretKey,
 	}
 
@@ -56,12 +56,12 @@ func (w *Options) updateRepositoryCR(ctx context.Context, res *response) error {
 		repo.Spec.GitProvider.URL = res.APIURL
 	}
 
-	_, err = w.Run.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(w.RepositoryNamespace).
+	_, err = w.Run.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(w.repositoryNamespace).
 		Update(ctx, repo, metav1.UpdateOptions{})
 	if err != nil {
 		return err
 	}
 
-	fmt.Fprintf(w.IOStreams.Out, "🔑 Repository CR %s has been updated with webhook secret in the %s namespace\n", w.RepositoryName, w.RepositoryNamespace)
+	fmt.Fprintf(w.IOStreams.Out, "🔑 Repository CR %s has been updated with webhook secret in the %s namespace\n", w.repositoryName, w.repositoryNamespace)
 	return nil
 }

--- a/pkg/cli/webhook/webhook.go
+++ b/pkg/cli/webhook/webhook.go
@@ -22,7 +22,6 @@ type ProviderType string
 const ProviderTypeGitHub ProviderType = "GitHub"
 
 type Interface interface {
-	GetName() string
 	Run(context.Context, *Options) (*response, error)
 }
 
@@ -88,8 +87,8 @@ func (w *Options) Install(ctx context.Context, providerType ProviderType) error 
 		return err
 	}
 	if !createRepo {
-		fmt.Fprintln(w.IOStreams.Out, "✓ Skips creating Repository CR")
-		fmt.Fprintln(w.IOStreams.Out, "💡 Don't forget to create a secret with webhook secret and provider token & attaching in Repository CR.")
+		fmt.Fprintln(w.IOStreams.Out, "✓ Skipping Repository creation")
+		fmt.Fprintln(w.IOStreams.Out, "💡 Don't forget to create a secret with webhook secret and provider token & attaching in Repository.")
 		return nil
 	}
 

--- a/pkg/cli/webhook/webhook.go
+++ b/pkg/cli/webhook/webhook.go
@@ -3,16 +3,23 @@ package webhook
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
+	apipac "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli/prompt"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cmd/tknpac/bootstrap"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/cmd/tknpac/create"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/git"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
+	pacinfo "github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+type ProviderType string
+
+const ProviderTypeGitHub ProviderType = "GitHub"
 
 type Interface interface {
 	GetName() string
@@ -23,15 +30,11 @@ type Options struct {
 	Run                 *params.Run
 	IOStreams           *cli.IOStreams
 	PACNamespace        string
-	ControllerURL       string
 	RepositoryURL       string
 	ProviderAPIURL      string
-	RepositoryName      string
-	RepositoryNamespace string
-
-	// github specific flag
-	// allows configuring webhook if app is already configured
-	GitHubWebhook bool
+	ControllerURL       string
+	repositoryName      string
+	repositoryNamespace string
 }
 
 type response struct {
@@ -41,7 +44,15 @@ type response struct {
 	APIURL              string
 }
 
-func (w *Options) Install(ctx context.Context) error {
+func (w *Options) Install(ctx context.Context, providerType ProviderType) error {
+	if w.RepositoryURL == "" {
+		q := "Please enter the Git repository url containing the pipelines: "
+		if err := prompt.SurveyAskOne(&survey.Input{Message: q}, &w.RepositoryURL,
+			survey.WithValidator(survey.Required)); err != nil {
+			return err
+		}
+	}
+
 	// figure out pac installation namespace
 	installationNS, err := bootstrap.DetectPacInstallation(ctx, w.PACNamespace, w.Run)
 	if err != nil {
@@ -54,44 +65,16 @@ func (w *Options) Install(ctx context.Context) error {
 		return err
 	}
 
-	// figure out which git provider from the Repo URL
-	webhookProvider := detectProvider(w.RepositoryURL, w.IOStreams)
-
-	if !w.GitHubWebhook && webhookProvider != nil {
-		if webhookProvider.GetName() == provider.ProviderGitHubWebhook && pacInfo.Provider == provider.ProviderGitHubApp {
-			fmt.Fprintln(w.IOStreams.Out, "✓ Skips configuring GitHub Webhook as GitHub App is already configured."+
-				" Please pass --github-webhook flag to still configure it")
-			return nil
-		}
-	}
-
-	var msg string
-	if webhookProvider != nil {
-		msg = fmt.Sprintf("Would you like me to configure a %s Webhook for your repository? ",
-			strings.TrimSuffix(webhookProvider.GetName(), "Webhook"))
-	} else {
-		msg = "Would you like me to configure a Webhook for your repository?"
-	}
-
-	var configureWebhook bool
-	if err := prompt.SurveyAskOne(&survey.Confirm{Message: msg, Default: true}, &configureWebhook); err != nil {
-		return err
-	}
-	if !configureWebhook {
-		return nil
-	}
-
-	if webhookProvider == nil {
-		if webhookProvider, err = askProvider(w.IOStreams); webhookProvider == nil || err != nil {
-			return err
-		}
-	}
-
-	// check if info configmap has url then use that otherwise try to detec
+	// check if info configmap has url then use that otherwise try to detect
 	if pacInfo.ControllerURL != "" && w.ControllerURL == "" {
 		w.ControllerURL = pacInfo.ControllerURL
 	} else {
 		w.ControllerURL, _ = bootstrap.DetectOpenShiftRoute(ctx, w.Run, w.PACNamespace)
+	}
+
+	var webhookProvider Interface
+	if providerType == ProviderTypeGitHub {
+		webhookProvider = &gitHubConfig{IOStream: w.IOStreams}
 	}
 
 	response, err := webhookProvider.Run(ctx, w)
@@ -99,7 +82,31 @@ func (w *Options) Install(ctx context.Context) error {
 		return err
 	}
 
-	if err := w.askRepositoryCRDetails(); err != nil {
+	msg := "Would you like me to create the Repository CR for your git repository?"
+	var createRepo bool
+	if err := prompt.SurveyAskOne(&survey.Confirm{Message: msg, Default: true}, &createRepo); err != nil {
+		return err
+	}
+	if !createRepo {
+		fmt.Fprintln(w.IOStreams.Out, "✓ Skips creating Repository CR")
+		fmt.Fprintln(w.IOStreams.Out, "💡 Don't forget to create a secret with webhook secret and provider token & attaching in Repository CR.")
+		return nil
+	}
+
+	repo := create.RepoOptions{
+		Run: w.Run,
+		Event: &pacinfo.Event{
+			URL: w.RepositoryURL,
+		},
+		GitInfo: &git.Info{URL: w.RepositoryURL},
+		Repository: &apipac.Repository{
+			ObjectMeta: v1.ObjectMeta{},
+		},
+		IoStreams: w.IOStreams,
+	}
+
+	w.repositoryName, w.repositoryNamespace, err = repo.Create(ctx)
+	if err != nil {
 		return err
 	}
 
@@ -110,49 +117,4 @@ func (w *Options) Install(ctx context.Context) error {
 
 	// update repo cr with webhook secret
 	return w.updateRepositoryCR(ctx, response)
-}
-
-func askProvider(ioStreams *cli.IOStreams) (Interface, error) {
-	var answer string
-	if err := survey.AskOne(&survey.Select{
-		Message: "Please select the provider you wish to configure with your repository:",
-		Options: []string{"GitHub", "GitLab"},
-	}, &answer, survey.WithValidator(survey.Required)); err != nil {
-		return nil, err
-	}
-
-	if answer == "GitHub" {
-		return &gitHubConfig{Hosted: true, IOStream: ioStreams}, nil
-	} else if answer == "GitLab" {
-		return &gitLabConfig{Hosted: true, IOStream: ioStreams}, nil
-	}
-	return nil, nil
-}
-
-func detectProvider(url string, ioStreams *cli.IOStreams) Interface {
-	if strings.Contains(url, "https://github.com") {
-		return &gitHubConfig{IOStream: ioStreams}
-	} else if strings.Contains(url, "https://gitlab.com") {
-		return &gitLabConfig{IOStream: ioStreams}
-	}
-	return nil
-}
-
-func (w *Options) askRepositoryCRDetails() error {
-	if w.RepositoryName == "" {
-		if err := prompt.SurveyAskOne(&survey.Input{
-			Message: "Please enter the Repository CR Name to configure with webhook: ",
-		}, &w.RepositoryName, survey.WithValidator(survey.Required)); err != nil {
-			return err
-		}
-	}
-
-	if w.RepositoryNamespace == "" {
-		if err := prompt.SurveyAskOne(&survey.Input{
-			Message: "Please enter the Repository CR Namespace to configure with webhook: ",
-		}, &w.RepositoryNamespace, survey.WithValidator(survey.Required)); err != nil {
-			return err
-		}
-	}
-	return nil
 }

--- a/pkg/cmd/tknpac/create/repository.go
+++ b/pkg/cmd/tknpac/create/repository.go
@@ -84,7 +84,7 @@ func repositoryCommand(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command
 				return err
 			}
 
-			fmt.Fprintln(ioStreams.Out, "🚀 You can use \"tkn pac setup\" command to setup a webhook with your repository")
+			fmt.Fprintln(ioStreams.Out, "🚀 You can use the command \"tkn pac setup\" to setup a repository with webhook")
 			return nil
 		},
 		Annotations: map[string]string{

--- a/pkg/cmd/tknpac/create/repository.go
+++ b/pkg/cmd/tknpac/create/repository.go
@@ -26,22 +26,22 @@ const (
 	noColorFlag = "no-color"
 )
 
-type repoOptions struct {
-	event        *info.Event
-	repository   *apipac.Repository
-	run          *params.Run
-	gitInfo      *git.Info
+type RepoOptions struct {
+	Event        *info.Event
+	Repository   *apipac.Repository
+	Run          *params.Run
+	GitInfo      *git.Info
 	pacNamespace string
 
-	ioStreams *cli.IOStreams
+	IoStreams *cli.IOStreams
 	cliOpts   *cli.PacCliOpts
 }
 
 func repositoryCommand(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
-	createOpts := &repoOptions{
-		event:      info.NewEvent(),
-		repository: &apipac.Repository{},
-		run:        run,
+	createOpts := &RepoOptions{
+		Event:      info.NewEvent(),
+		Repository: &apipac.Repository{},
+		Run:        run,
 	}
 	cmd := &cobra.Command{
 		Use:     "repository",
@@ -50,15 +50,15 @@ func repositoryCommand(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			ctx := context.Background()
-			createOpts.ioStreams = ioStreams
+			createOpts.IoStreams = ioStreams
 			createOpts.cliOpts = cli.NewCliOptions(cmd)
-			createOpts.ioStreams.SetColorEnabled(!createOpts.cliOpts.NoColoring)
+			createOpts.IoStreams.SetColorEnabled(!createOpts.cliOpts.NoColoring)
 
 			cwd, err := os.Getwd()
 			if err != nil {
 				return err
 			}
-			createOpts.gitInfo = git.GetGitInfo(cwd)
+			createOpts.GitInfo = git.GetGitInfo(cwd)
 			if err := run.Clients.NewClients(ctx, &run.Info); err != nil {
 				return err
 			}
@@ -67,17 +67,13 @@ func repositoryCommand(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command
 				return err
 			}
 
-			if err := getOrCreateNamespace(ctx, createOpts); err != nil {
-				return err
-			}
-
-			if err := createRepoCRD(ctx, createOpts); err != nil {
+			if _, _, err := createOpts.Create(ctx); err != nil {
 				return err
 			}
 
 			gopt := generate.MakeOpts()
-			gopt.GitInfo = createOpts.gitInfo
-			gopt.IOStreams = createOpts.ioStreams
+			gopt.GitInfo = createOpts.GitInfo
+			gopt.IOStreams = createOpts.IoStreams
 			gopt.CLIOpts = createOpts.cliOpts
 
 			// defaulting the values for repo create command
@@ -97,29 +93,41 @@ func repositoryCommand(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command
 	}
 
 	cmd.PersistentFlags().BoolP(noColorFlag, "C", !ioStreams.ColorEnabled(), "Disable coloring")
-	cmd.PersistentFlags().StringVar(&createOpts.repository.Name, "name", "", "Repository name")
-	cmd.PersistentFlags().StringVar(&createOpts.event.URL, "url", "", "Repository URL")
-	cmd.PersistentFlags().StringVarP(&createOpts.repository.Namespace, "namespace", "n", "",
+	cmd.PersistentFlags().StringVar(&createOpts.Repository.Name, "name", "", "Repository name")
+	cmd.PersistentFlags().StringVar(&createOpts.Event.URL, "url", "", "Repository URL")
+	cmd.PersistentFlags().StringVarP(&createOpts.Repository.Namespace, "namespace", "n", "",
 		"The target namespace where the runs will be created")
 	cmd.PersistentFlags().StringVarP(&createOpts.pacNamespace, "pac-namespace",
 		"", "", "The namespace where pac is installed")
 	return cmd
 }
 
+func (r *RepoOptions) Create(ctx context.Context) (string, string, error) {
+	if err := getOrCreateNamespace(ctx, r); err != nil {
+		return "", "", err
+	}
+
+	repoName, repoNamespace, err := createRepoCRD(ctx, r)
+	if err != nil {
+		return "", "", err
+	}
+	return repoName, repoNamespace, err
+}
+
 // getOrCreateNamespace ask and create namespace or use the default one
-func getOrCreateNamespace(ctx context.Context, opts *repoOptions) error {
-	if opts.repository.Namespace != "" {
+func getOrCreateNamespace(ctx context.Context, opts *RepoOptions) error {
+	if opts.Repository.Namespace != "" {
 		return nil
 	}
 
 	// by default, use the current namespace unless it's default or
 	// pipelines-as-code and then propose some meaningful namespace based on the
 	// git url.
-	autoNS := opts.run.Info.Kube.Namespace
+	autoNS := opts.Run.Info.Kube.Namespace
 
 	if (autoNS == "default" || autoNS == "pipelines-as-code") &&
-		opts.gitInfo.URL != "" {
-		autoNS = filepath.Base(opts.gitInfo.URL) + "-pipelines"
+		opts.GitInfo.URL != "" {
+		autoNS = filepath.Base(opts.GitInfo.URL) + "-pipelines"
 	}
 
 	var chosenNS string
@@ -133,14 +141,14 @@ func getOrCreateNamespace(ctx context.Context, opts *repoOptions) error {
 		chosenNS = autoNS
 	}
 	// check if the namespace exists if it does just exit
-	_, err := opts.run.Clients.Kube.CoreV1().Namespaces().Get(ctx, chosenNS, metav1.GetOptions{})
+	_, err := opts.Run.Clients.Kube.CoreV1().Namespaces().Get(ctx, chosenNS, metav1.GetOptions{})
 	if err == nil {
-		opts.repository.Namespace = chosenNS
+		opts.Repository.Namespace = chosenNS
 		return nil
 	}
 
-	fmt.Fprintf(opts.ioStreams.Out, "%s Namespace %s is not found\n",
-		opts.ioStreams.ColorScheme().WarningIcon(),
+	fmt.Fprintf(opts.IoStreams.Out, "%s Namespace %s is not found\n",
+		opts.IoStreams.ColorScheme().WarningIcon(),
 		chosenNS,
 	)
 	msg = fmt.Sprintf("Would you like me to create the namespace %s?", chosenNS)
@@ -152,41 +160,41 @@ func getOrCreateNamespace(ctx context.Context, opts *repoOptions) error {
 		return fmt.Errorf("you need to create the target namespace first")
 	}
 
-	_, err = opts.run.Clients.Kube.CoreV1().Namespaces().Create(ctx,
+	_, err = opts.Run.Clients.Kube.CoreV1().Namespaces().Create(ctx,
 		&v1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: chosenNS,
 			},
 		},
 		metav1.CreateOptions{})
-	opts.repository.Namespace = chosenNS
+	opts.Repository.Namespace = chosenNS
 	return err
 }
 
 // getRepoURL get the repository URL from the user using the git url as default.
-func getRepoURL(opts *repoOptions) error {
-	if opts.event.URL != "" {
+func getRepoURL(opts *RepoOptions) error {
+	if opts.Event.URL != "" {
 		return nil
 	}
 
 	q := "Enter the Git repository url containing the pipelines "
 	var err error
-	if opts.gitInfo.URL != "" {
-		opts.gitInfo.URL, err = cleanupGitURL(opts.gitInfo.URL)
+	if opts.GitInfo.URL != "" {
+		opts.GitInfo.URL, err = cleanupGitURL(opts.GitInfo.URL)
 		if err != nil {
 			return err
 		}
-		q += fmt.Sprintf("(default: %s)", opts.gitInfo.URL)
+		q += fmt.Sprintf("(default: %s)", opts.GitInfo.URL)
 	}
 	q += ": "
-	if err := prompt.SurveyAskOne(&survey.Input{Message: q}, &opts.event.URL); err != nil {
+	if err := prompt.SurveyAskOne(&survey.Input{Message: q}, &opts.Event.URL); err != nil {
 		return err
 	}
-	if opts.event.URL != "" {
+	if opts.Event.URL != "" {
 		return nil
 	}
-	if opts.event.URL == "" && opts.gitInfo.URL != "" {
-		opts.event.URL = opts.gitInfo.URL
+	if opts.Event.URL == "" && opts.GitInfo.URL != "" {
+		opts.Event.URL = opts.GitInfo.URL
 		return nil
 	}
 
@@ -201,31 +209,31 @@ func cleanupGitURL(rawURL string) (string, error) {
 	return fmt.Sprintf("%s://%s%s", parsedURL.Scheme, parsedURL.Host, parsedURL.Path), nil
 }
 
-func createRepoCRD(ctx context.Context, opts *repoOptions) error {
-	repoOwner, err := formatting.GetRepoOwnerFromURL(opts.event.URL)
+func createRepoCRD(ctx context.Context, opts *RepoOptions) (string, string, error) {
+	repoOwner, err := formatting.GetRepoOwnerFromURL(opts.Event.URL)
 	if err != nil {
-		return fmt.Errorf("invalid git URL: %s, it should be of format: https://gitprovider/project/repository", opts.event.URL)
+		return "", "", fmt.Errorf("invalid git URL: %s, it should be of format: https://gitprovider/project/repository", opts.Event.URL)
 	}
 	repositoryName := strings.ReplaceAll(repoOwner, "/", "-")
-	opts.repository, err = opts.run.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(opts.repository.Namespace).Create(
+	opts.Repository, err = opts.Run.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(opts.Repository.Namespace).Create(
 		ctx,
 		&apipac.Repository{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: repositoryName,
 			},
 			Spec: apipac.RepositorySpec{
-				URL: opts.event.URL,
+				URL: opts.Event.URL,
 			},
 		},
 		metav1.CreateOptions{})
 	if err != nil {
-		return err
+		return "", "", err
 	}
-	cs := opts.ioStreams.ColorScheme()
-	fmt.Fprintf(opts.ioStreams.Out, "%s Repository %s has been created in %s namespace\n",
+	cs := opts.IoStreams.ColorScheme()
+	fmt.Fprintf(opts.IoStreams.Out, "%s Repository %s has been created in %s namespace\n",
 		cs.SuccessIconWithColor(cs.Green),
 		repositoryName,
-		opts.repository.Namespace,
+		opts.Repository.Namespace,
 	)
-	return nil
+	return opts.Repository.Name, opts.Repository.Namespace, nil
 }

--- a/pkg/cmd/tknpac/create/repository_test.go
+++ b/pkg/cmd/tknpac/create/repository_test.go
@@ -77,13 +77,13 @@ func TestGetRepoURL(t *testing.T) {
 				tt.askStubs(as)
 			}
 			io, _, _, _ := cli.IOTest()
-			err := getRepoURL(&repoOptions{
-				event:      &tt.event,
-				repository: &tt.repo,
-				gitInfo:    &tt.gitinfo,
-				ioStreams:  io,
+			err := getRepoURL(&RepoOptions{
+				Event:      &tt.event,
+				Repository: &tt.repo,
+				GitInfo:    &tt.gitinfo,
+				IoStreams:  io,
 				cliOpts:    &cli.PacCliOpts{},
-				run: &params.Run{
+				Run: &params.Run{
 					Clients: clients.Clients{
 						Kube: stdata.Kube,
 					},
@@ -189,13 +189,13 @@ func TestGetNamespace(t *testing.T) {
 				tt.askStubs(as)
 			}
 			io, _, stdout, _ := cli.IOTest()
-			err := getOrCreateNamespace(ctx, &repoOptions{
-				event:      info.NewEvent(),
-				repository: &tt.repo,
-				gitInfo:    &tt.gitinfo,
-				ioStreams:  io,
+			err := getOrCreateNamespace(ctx, &RepoOptions{
+				Event:      info.NewEvent(),
+				Repository: &tt.repo,
+				GitInfo:    &tt.gitinfo,
+				IoStreams:  io,
 				cliOpts:    &cli.PacCliOpts{},
-				run: &params.Run{
+				Run: &params.Run{
 					Clients: clients.Clients{
 						Kube: stdata.Kube,
 					},

--- a/pkg/cmd/tknpac/root.go
+++ b/pkg/cmd/tknpac/root.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cmd/tknpac/generate"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cmd/tknpac/list"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cmd/tknpac/resolve"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/cmd/tknpac/setup"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cmd/tknpac/version"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/spf13/cobra"
@@ -38,5 +39,6 @@ func Root(clients *params.Run) *cobra.Command {
 	cmd.AddCommand(completion.Command())
 	cmd.AddCommand(bootstrap.Command(clients, ioStreams))
 	cmd.AddCommand(generate.Command(clients, ioStreams))
+	cmd.AddCommand(setup.Root(clients, ioStreams))
 	return cmd
 }

--- a/pkg/cmd/tknpac/setup/github-webhook.go
+++ b/pkg/cmd/tknpac/setup/github-webhook.go
@@ -1,0 +1,52 @@
+package setup
+
+import (
+	"os"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli/webhook"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/git"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/spf13/cobra"
+)
+
+func githubWebhookCommand(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
+	var githubURLForWebhook, pacNamespace string
+	cmd := &cobra.Command{
+		Use:     "github-webhook",
+		Aliases: []string{""},
+		Short:   "Setup GitHub Webhook with Pipelines As Code",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			cwd, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			gitInfo := git.GetGitInfo(cwd)
+			if err := run.Clients.NewClients(ctx, &run.Info); err != nil {
+				return err
+			}
+
+			if err := run.Clients.NewClients(ctx, &run.Info); err != nil {
+				return err
+			}
+
+			config := &webhook.Options{
+				Run:            run,
+				PACNamespace:   pacNamespace,
+				RepositoryURL:  gitInfo.URL,
+				ProviderAPIURL: githubURLForWebhook,
+				IOStreams:      ioStreams,
+			}
+
+			return config.Install(ctx, webhook.ProviderTypeGitHub)
+		},
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
+	}
+	cmd.PersistentFlags().StringVarP(&pacNamespace, "pac-namespace", "", "", "The namespace where pac is installed")
+	cmd.PersistentFlags().StringVarP(&githubURLForWebhook, "github-api-url", "", "", "GitHub Enterprise API URL")
+	return cmd
+}

--- a/pkg/cmd/tknpac/setup/root.go
+++ b/pkg/cmd/tknpac/setup/root.go
@@ -1,0 +1,23 @@
+package setup
+
+import (
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/spf13/cobra"
+)
+
+func Root(clients *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "setup",
+		Aliases:      []string{},
+		Short:        "Setup provider app or webhook",
+		Long:         `Setup provider app or webhook with pipelines as code`,
+		SilenceUsage: true,
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
+	}
+
+	cmd.AddCommand(githubWebhookCommand(clients, ioStreams))
+	return cmd
+}


### PR DESCRIPTION
part of refactoring

adds a new `setup github-webhook` command

-  update create repo command to just suggest using setup command for webhook instead of actually doing it
- setup github-webhook configures webhook and ask if user want to create repository cr
- and then attaches webhook secret to repository cr

![image (1)](https://user-images.githubusercontent.com/55777192/172627839-e9a1f7d3-255c-4a64-a227-a77b34dabfeb.png)



# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
