### PR TITLE
fixes watcher failure due to missing env

### DIFF
--- a/config/500-watcher.yaml
+++ b/config/500-watcher.yaml
@@ -44,6 +44,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: METRICS_DOMAIN
+            value: tekton.dev/pipelinesascode
           ports:
           - name: probes
             containerPort: 8080


### PR DESCRIPTION
Error:
panic: The environment variable "METRICS_DOMAIN" is not set
If this is a process running on Kubernetes, then it should be specifying
this via:

  env:
  - name: METRICS_DOMAIN
    value: knative.dev/some-repository

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
