### PR TITLE
add support for incoming webhook on bitbucket cloud

### DIFF
--- a/docs/content/docs/guide/incoming_webhook.md
+++ b/docs/content/docs/guide/incoming_webhook.md
@@ -18,6 +18,15 @@ you will need to have a git_provider spec to specify a token when using the
 github-apps method the same way we are doing for github-webhook method. Refer to
 the [github webhook documentation](/docs/install/github_webhook) for how to set
 this up.
+
+Additionally since we are not able to detect automatically the type of provider
+on URL. You will need to add it to the `git_provider.type` spec. Supported
+values are:
+
+- github
+- gitlab
+- bitbucket-cloud
+
 {{< /hint >}}
 
 Here is an example of a Repository CRD matching the target branch main:

--- a/pkg/provider/bitbucketcloud/bitbucket.go
+++ b/pkg/provider/bitbucketcloud/bitbucket.go
@@ -152,10 +152,14 @@ func (v *Provider) SetClient(_ context.Context, event *info.Event) error {
 }
 
 func (v *Provider) GetCommitInfo(_ context.Context, event *info.Event) error {
+	branchortag := event.SHA
+	if branchortag == "" {
+		branchortag = event.HeadBranch
+	}
 	response, err := v.Client.Repositories.Commits.GetCommits(&bitbucket.CommitsOptions{
 		Owner:       event.Organization,
 		RepoSlug:    event.Repository,
-		Branchortag: event.SHA,
+		Branchortag: branchortag,
 	})
 	if err != nil {
 		return err

--- a/pkg/provider/bitbucketcloud/bitbucket_test.go
+++ b/pkg/provider/bitbucketcloud/bitbucket_test.go
@@ -149,6 +149,28 @@ func TestGetCommitInfo(t *testing.T) {
 				Mainbranch: bitbucket.RepositoryBranch{Name: "branshe"},
 			},
 		},
+		{
+			name: "Get commit info no SHA",
+			event: bbcloudtest.MakeEvent(&info.Event{
+				Organization: "org",
+				Repository:   "repo",
+				HeadBranch:   "hello",
+				SHA:          "none",
+			}),
+			commitinfo: types.Commit{
+				Hash: "convertedcommit",
+				Links: types.Links{
+					HTML: types.HTMLLink{
+						HRef: "https://everywhereigo",
+					},
+				},
+				Message: "Das Commit",
+				Author:  types.Author{},
+			},
+			repoinfo: &bitbucket.Repository{
+				Mainbranch: bitbucket.RepositoryBranch{Name: "branshe"},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/provider/bitbucketcloud/test/bbcloudtest.go
+++ b/pkg/provider/bitbucketcloud/test/bbcloudtest.go
@@ -325,6 +325,9 @@ func MakeEvent(event *info.Event) *info.Event {
 	if rev.SHA == "" {
 		rev.SHA = "1234"
 	}
+	if rev.SHA == "none" {
+		rev.SHA = ""
+	}
 	if rev.Organization == "" {
 		rev.Organization = "owner"
 	}


### PR DESCRIPTION


# Changes

add support for incoming webhook on bitbucket cloud

Fixes #723

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
