### PR TITLE
Adds setup gitlab-webhook command

### DIFF
--- a/docs/content/docs/guide/cli.md
+++ b/docs/content/docs/guide/cli.md
@@ -219,15 +219,22 @@ Compared with running directly on CI, you need to explicitly specify the list of
 filenames or directory where you have the templates.
 {{< /details >}}
 
-{{< details "tkn pac setup github-app" >}}
+{{< details "tkn pac setup github-webhook" >}}
 
 ### Setup GitHub Webhook
 
-`tkn-pac setup github-webhook`: will allow you to set up a GitHub webhook with pipelines
-as code service.
+`tkn-pac setup github-webhook`: will let you set up a GitHub webhook to interact with Pipelines as Code
 
-After setting up webhook, it will provide an option to create Repository and configure it with
-required secrets.
+It will let you provide an option to create a Repository and configure it with the required secrets.
+{{< /details >}}
+
+{{< details "tkn pac setup gitlab-webhook" >}}
+
+### Setup GitLab Webhook
+
+`tkn-pac setup gitlab-webhook`: will let you set up a GitLab webhook to interact with Pipelines as Code.
+
+It will let you provide an option to create a Repository and configure it with the required secrets.
 {{< /details >}}
 
 ## Screenshot

--- a/pkg/cli/webhook/gitlab.go
+++ b/pkg/cli/webhook/gitlab.go
@@ -21,7 +21,6 @@ type gitLabConfig struct {
 	webhookSecret       string
 	personalAccessToken string
 	APIURL              string
-	Hosted              bool
 }
 
 func (gl *gitLabConfig) GetName() string {
@@ -90,7 +89,7 @@ func (gl *gitLabConfig) askGLWebhookConfig(controllerURL, apiURL string) error {
 		return err
 	}
 
-	if apiURL == "" && gl.Hosted {
+	if apiURL == "" {
 		if err := prompt.SurveyAskOne(&survey.Input{
 			Message: "Please enter your GitLab API URL:: ",
 		}, &gl.APIURL, survey.WithValidator(survey.Required)); err != nil {

--- a/pkg/cli/webhook/gitlab_test.go
+++ b/pkg/cli/webhook/gitlab_test.go
@@ -19,6 +19,7 @@ func TestAskGLWebhookConfig(t *testing.T) {
 		name          string
 		wantErrStr    string
 		askStubs      func(*prompt.AskStubber)
+		providerURL   string
 		controllerURL string
 	}{
 		{
@@ -28,6 +29,7 @@ func TestAskGLWebhookConfig(t *testing.T) {
 				as.StubOne("https://test")
 				as.StubOne("webhook-secret")
 				as.StubOne("token")
+				as.StubOne("https://gl.pac.test")
 			},
 			wantErrStr: "",
 		},
@@ -40,6 +42,7 @@ func TestAskGLWebhookConfig(t *testing.T) {
 				as.StubOne("token")
 			},
 			controllerURL: "https://test",
+			providerURL:   "https://gl.pac.test",
 			wantErrStr:    "",
 		},
 	}
@@ -52,7 +55,7 @@ func TestAskGLWebhookConfig(t *testing.T) {
 				tt.askStubs(as)
 			}
 			gl := gitLabConfig{IOStream: io}
-			err := gl.askGLWebhookConfig(tt.controllerURL, "")
+			err := gl.askGLWebhookConfig(tt.controllerURL, tt.providerURL)
 			if tt.wantErrStr != "" {
 				assert.Equal(t, err.Error(), tt.wantErrStr)
 				return

--- a/pkg/cmd/tknpac/setup/gitlab-webhook.go
+++ b/pkg/cmd/tknpac/setup/gitlab-webhook.go
@@ -6,6 +6,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func githubWebhookCommand(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
-	return buildProviderCommand(run, ioStreams, "github")
+func gitlabWebhookCommand(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
+	return buildProviderCommand(run, ioStreams, "gitlab")
 }

--- a/pkg/cmd/tknpac/setup/root.go
+++ b/pkg/cmd/tknpac/setup/root.go
@@ -1,7 +1,13 @@
 package setup
 
 import (
+	"fmt"
+	"os"
+	"strings"
+
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli/webhook"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/git"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/spf13/cobra"
 )
@@ -19,5 +25,49 @@ func Root(clients *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
 	}
 
 	cmd.AddCommand(githubWebhookCommand(clients, ioStreams))
+	cmd.AddCommand(gitlabWebhookCommand(clients, ioStreams))
+	return cmd
+}
+
+func buildProviderCommand(run *params.Run, ioStreams *cli.IOStreams, provider string) *cobra.Command {
+	var providerURL, pacNamespace string
+	cmd := &cobra.Command{
+		Use:     fmt.Sprintf("%s-webhook", provider),
+		Aliases: []string{""},
+		Short:   fmt.Sprintf("Setup %s Webhook with Pipelines As Code", strings.ToTitle(provider)),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			cwd, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			gitInfo := git.GetGitInfo(cwd)
+			if err := run.Clients.NewClients(ctx, &run.Info); err != nil {
+				return err
+			}
+
+			if err := run.Clients.NewClients(ctx, &run.Info); err != nil {
+				return err
+			}
+
+			config := &webhook.Options{
+				Run:            run,
+				PACNamespace:   pacNamespace,
+				RepositoryURL:  gitInfo.URL,
+				ProviderAPIURL: providerURL,
+				IOStreams:      ioStreams,
+			}
+
+			return config.Install(ctx, provider)
+		},
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
+	}
+	cmd.PersistentFlags().StringVarP(&pacNamespace, "pac-namespace", "", "", "The namespace where pac is installed")
+	cmd.PersistentFlags().StringVarP(&providerURL, fmt.Sprintf("%s-api-url", provider),
+		"", "", fmt.Sprintf("%s Enterprise API URL", strings.ToTitle(provider)))
+
 	return cmd
 }


### PR DESCRIPTION
Part of CLI redesign
- now repo create command doesn't have webhook configuration step
- but cli provides separate cmd to configure webhook

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
