### PR TITLE
Add clusterrole for nonadmin user to access repository

### DIFF
--- a/config/200-role.yaml
+++ b/config/200-role.yaml
@@ -17,6 +17,7 @@ metadata:
   name: pipelines-as-code-info
   namespace: pipelines-as-code
   labels:
+    app.kubernetes.io/version: "devel"
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: pipelines-as-code
 rules:
@@ -35,6 +36,7 @@ metadata:
   name: pipelines-as-code-info
   namespace: pipelines-as-code
   labels:
+    app.kubernetes.io/version: "devel"
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: pipelines-as-code
 subjects:
@@ -45,3 +47,28 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: pipelines-as-code-info
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pipelines-as-code-aggregate
+  labels:
+    app.kubernetes.io/version: "devel"
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: pipelines-as-code
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+  - apiGroups:
+      - pipelinesascode.tekton.dev
+    resources:
+      - repositories
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch

--- a/config/400-controller.yaml
+++ b/config/400-controller.yaml
@@ -17,6 +17,9 @@ kind: Deployment
 metadata:
   name: pipelines-as-code-controller
   namespace: pipelines-as-code
+  labels:
+    app.kubernetes.io/version: "devel"
+    app.kubernetes.io/part-of: pipelines-as-code
 spec:
   replicas: 1
   selector:

--- a/config/401-controller-service.yaml
+++ b/config/401-controller-service.yaml
@@ -17,6 +17,9 @@ kind: Service
 metadata:
   name: pipelines-as-code-controller
   namespace: pipelines-as-code
+  labels:
+    app.kubernetes.io/version: "devel"
+    app.kubernetes.io/part-of: pipelines-as-code
 spec:
   ports:
   - name: http-listener

--- a/config/500-watcher.yaml
+++ b/config/500-watcher.yaml
@@ -17,6 +17,9 @@ kind: Deployment
 metadata:
   name: pipelines-as-code-watcher
   namespace: pipelines-as-code
+  labels:
+    app.kubernetes.io/version: "devel"
+    app.kubernetes.io/part-of: pipelines-as-code
 spec:
   replicas: 1
   selector:

--- a/config/600-webhook.yaml
+++ b/config/600-webhook.yaml
@@ -17,6 +17,9 @@ kind: Deployment
 metadata:
   name: pipelines-as-code-webhook
   namespace: pipelines-as-code
+  labels:
+    app.kubernetes.io/version: "devel"
+    app.kubernetes.io/part-of: pipelines-as-code
 spec:
   replicas: 1
   selector:

--- a/config/601-webhook-service.yaml
+++ b/config/601-webhook-service.yaml
@@ -18,8 +18,8 @@ metadata:
   name: pipelines-as-code-webhook
   namespace: pipelines-as-code
   labels:
-    name: pipelines-as-code-webhook
-    app: pipelines-as-code
+    app.kubernetes.io/version: "devel"
+    app.kubernetes.io/part-of: pipelines-as-code
 spec:
   ports:
     - name: https-webhook


### PR DESCRIPTION
this adds clusterrole so that non admin users can do CRUD operation
on repository cr in their namespaces.
also common labels to all resources of pac.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
