### PR TITLE
Adds setup bitbucket-cloud-webhook command

### DIFF
--- a/docs/content/docs/install/github_webhook.md
+++ b/docs/content/docs/install/github_webhook.md
@@ -43,7 +43,7 @@ NOTE: If you are going to configure webhook through CLI, you will need to also a
 
 Now, you have 2 ways to set up the repository and configure the webhook:
 
-You could use [`tkn pac repository create`](/docs/guide/cli) command which
+You could use [`tkn pac setup github-webhook`](/docs/guide/cli) command which
   will create set up your repository and configure webhook.
 
   You need to have a personal access token created with `admin:repo_hook` scope. tkn-pac will use this token to configure the

--- a/docs/content/docs/install/gitlab.md
+++ b/docs/content/docs/install/gitlab.md
@@ -9,7 +9,7 @@ Pipelines-As-Code supports [Gitlab](https://www.gitlab.com) through a webhook.
 
 Follow the pipelines-as-code [installation](/docs/install/installation) according to your kubernetes cluster.
 
-## Create GitHub Personal Access Token
+## Create GitLab Personal Access Token
 
 * You will have to generate a personal token as the manager of the Org or the Project,
   follow the steps here :
@@ -26,7 +26,7 @@ Follow the pipelines-as-code [installation](/docs/install/installation) accordin
 
 Now, you have 2 ways to set up the repository and configure the webhook:
 
-You could use [`tkn pac repository create`](/docs/guide/cli) command which
+You could use [`tkn pac setup gitlab-webhook`](/docs/guide/cli) command which
   will create repository CR and configure webhook.
 
   You need to have a personal access token created with `admin:repo_hook` scope. tkn-pac will use this token to configure the

--- a/pkg/cli/webhook/bitbucket_cloud.go
+++ b/pkg/cli/webhook/bitbucket_cloud.go
@@ -1,0 +1,150 @@
+package webhook
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/ktrysmt/go-bitbucket"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli/prompt"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
+)
+
+type bitbucketCloudConfig struct {
+	Client              *bitbucket.Client
+	IOStream            *cli.IOStreams
+	controllerURL       string
+	repoOwner           string
+	repoName            string
+	personalAccessToken string
+	username            string
+	APIURL              string
+}
+
+func (bb *bitbucketCloudConfig) Run(_ context.Context, opts *Options) (*response, error) {
+	err := bb.askBBWebhookConfig(opts.RepositoryURL, opts.ControllerURL, opts.ProviderAPIURL)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response{
+		ControllerURL:       bb.controllerURL,
+		PersonalAccessToken: bb.personalAccessToken,
+		WebhookSecret:       "",
+		APIURL:              bb.APIURL,
+		UserName:            bb.username,
+	}, bb.create()
+}
+
+// nolint: duplicate
+func (bb *bitbucketCloudConfig) askBBWebhookConfig(repositoryURL, controllerURL, apiURL string) error {
+	if repositoryURL == "" {
+		msg := "Please enter the git repository url you want to be configured: "
+		if err := prompt.SurveyAskOne(&survey.Input{Message: msg}, &repositoryURL,
+			survey.WithValidator(survey.Required)); err != nil {
+			return err
+		}
+	} else {
+		fmt.Fprintf(bb.IOStream.Out, "✓ Setting up Bitbucket Webhook for Repository %s\n", repositoryURL)
+	}
+
+	defaultRepo, err := formatting.GetRepoOwnerFromURL(repositoryURL)
+	if err != nil {
+		return err
+	}
+
+	repoArr := strings.Split(defaultRepo, "/")
+	if len(repoArr) != 2 {
+		return fmt.Errorf("invalid repository, needs to be of format 'org-name/repo-name'")
+	}
+	bb.repoOwner = repoArr[0]
+	bb.repoName = repoArr[1]
+
+	if err := prompt.SurveyAskOne(&survey.Input{
+		Message: "Please enter your bitbucket cloud username: ",
+	}, &bb.username, survey.WithValidator(survey.Required)); err != nil {
+		return err
+	}
+
+	fmt.Fprintln(bb.IOStream.Out, "ℹ ️You now need to create a Bitbucket Cloud app password, please checkout the docs at https://is.gd/fqMHiJ for the required permissions")
+	if err := prompt.SurveyAskOne(&survey.Password{
+		Message: "Please enter the Bitbucket Cloud app password: ",
+	}, &bb.personalAccessToken, survey.WithValidator(survey.Required)); err != nil {
+		return err
+	}
+
+	bb.controllerURL = controllerURL
+
+	// confirm whether to use the detected url
+	if bb.controllerURL != "" {
+		var answer bool
+		fmt.Fprintf(bb.IOStream.Out, "👀 I have detected a controller url: %s\n", bb.controllerURL)
+		err := prompt.SurveyAskOne(&survey.Confirm{
+			Message: "Do you want me to use it?",
+			Default: true,
+		}, &answer)
+		if err != nil {
+			return err
+		}
+		if !answer {
+			bb.controllerURL = ""
+		}
+	}
+
+	if bb.controllerURL == "" {
+		if err := prompt.SurveyAskOne(&survey.Input{
+			Message: "Please enter your controller public route URL: ",
+		}, &bb.controllerURL, survey.WithValidator(survey.Required)); err != nil {
+			return err
+		}
+	}
+
+	if apiURL == "" && !strings.HasPrefix(repositoryURL, "https://bitbucket.org") {
+		if err := prompt.SurveyAskOne(&survey.Input{
+			Message: "Please enter your Bitbucket enterprise API URL:: ",
+		}, &bb.APIURL, survey.WithValidator(survey.Required)); err != nil {
+			return err
+		}
+	} else {
+		bb.APIURL = apiURL
+	}
+
+	return nil
+}
+
+func (bb *bitbucketCloudConfig) create() error {
+	if bb.Client == nil {
+		bb.Client = bitbucket.NewBasicAuth(bb.repoOwner, bb.personalAccessToken)
+	}
+	if bb.APIURL != "" {
+		parsedURL, err := url.Parse(bb.APIURL)
+		if err != nil {
+			return err
+		}
+		bb.Client.SetApiBaseURL(*parsedURL)
+	}
+
+	opts := &bitbucket.WebhooksOptions{
+		Owner:    bb.repoOwner,
+		RepoSlug: bb.repoName,
+		Url:      bb.controllerURL,
+		Active:   true,
+		Events: []string{
+			"repo:push",
+			"pullrequest:created",
+			"pullrequest:updated",
+			"pullrequest:comment_created",
+		},
+	}
+
+	_, err := bb.Client.Repositories.Webhooks.Create(opts)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(bb.IOStream.Out, "✓ Webhook has been created on repository %v/%v\n", bb.repoOwner, bb.repoName)
+	return nil
+}

--- a/pkg/cli/webhook/bitbucket_cloud_test.go
+++ b/pkg/cli/webhook/bitbucket_cloud_test.go
@@ -1,0 +1,129 @@
+package webhook
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli/prompt"
+	bbcloudtest "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketcloud/test"
+	"gotest.tools/v3/assert"
+)
+
+func TestAskBBWebhookConfig(t *testing.T) {
+	// nolint
+	io, _, _, _ := cli.IOTest()
+	tests := []struct {
+		name          string
+		wantErrStr    string
+		askStubs      func(*prompt.AskStubber)
+		repoURL       string
+		controllerURL string
+	}{
+		{
+			name: "invalid repo format",
+			askStubs: func(as *prompt.AskStubber) {
+				as.StubOne("invalid-repo")
+			},
+			wantErrStr: "invalid repo url at least a organization/project and a repo needs to be specified: invalid-repo",
+		},
+		{
+			name: "ask all details no defaults",
+			askStubs: func(as *prompt.AskStubber) {
+				as.StubOne("https://bitbucket.org/pac/test")
+				as.StubOne("https://controller.url")
+				as.StubOne("user")
+				as.StubOne("token")
+			},
+			wantErrStr: "",
+		},
+		{
+			name: "with defaults",
+			askStubs: func(as *prompt.AskStubber) {
+				as.StubOne(true)
+				as.StubOne("webhook-secret")
+				as.StubOne("user")
+				as.StubOne("token")
+				as.StubOne("")
+			},
+			repoURL:       "https://bitbucket.org/pac/demo",
+			controllerURL: "https://test",
+			wantErrStr:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			as, teardown := prompt.InitAskStubber()
+			defer teardown()
+			if tt.askStubs != nil {
+				tt.askStubs(as)
+			}
+			bb := bitbucketCloudConfig{IOStream: io}
+			err := bb.askBBWebhookConfig(tt.repoURL, tt.controllerURL, "")
+			if tt.wantErrStr != "" {
+				assert.Equal(t, err.Error(), tt.wantErrStr)
+				return
+			}
+			assert.NilError(t, err)
+		})
+	}
+}
+
+func TestBBCreate(t *testing.T) {
+	bbclient, mux, tearDown := bbcloudtest.SetupBBCloudClient(t)
+	defer tearDown()
+	// nolint
+	io, _, _, _ := cli.IOTest()
+
+	// webhook created for repo pac/repo
+	mux.HandleFunc("/repositories/pac/repo/hooks", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(201)
+		_, _ = fmt.Fprint(w, `{"type": "ok"}`)
+	})
+
+	// webhook failed for repo pac/invalid
+	mux.HandleFunc("/repositories/pac/invalid/hooks", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(403)
+		_, _ = fmt.Fprint(w, `{"type": "error"}`)
+	})
+
+	tests := []struct {
+		name      string
+		wantErr   bool
+		repoName  string
+		repoOwner string
+		apiURL    string
+	}{
+		{
+			name:      "webhook created",
+			repoOwner: "pac",
+			repoName:  "repo",
+		},
+		{
+			name:      "webhook failed",
+			repoOwner: "pac",
+			repoName:  "invalid",
+			wantErr:   true,
+			apiURL:    "https://api.bitbucket.org/2.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bb := bitbucketCloudConfig{
+				IOStream:      io,
+				Client:        bbclient,
+				repoOwner:     tt.repoOwner,
+				repoName:      tt.repoName,
+				APIURL:        tt.apiURL,
+				controllerURL: "https://bb.pac.test",
+			}
+			err := bb.create()
+			if !tt.wantErr {
+				assert.NilError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/cli/webhook/secret.go
+++ b/pkg/cli/webhook/secret.go
@@ -52,6 +52,10 @@ func (w *Options) updateRepositoryCR(ctx context.Context, res *response) error {
 		Key:  webhookSecretKey,
 	}
 
+	if res.UserName != "" {
+		repo.Spec.GitProvider.User = res.UserName
+	}
+
 	if res.APIURL != "" {
 		repo.Spec.GitProvider.URL = res.APIURL
 	}

--- a/pkg/cli/webhook/webhook.go
+++ b/pkg/cli/webhook/webhook.go
@@ -33,6 +33,7 @@ type Options struct {
 }
 
 type response struct {
+	UserName            string
 	ControllerURL       string
 	WebhookSecret       string
 	PersonalAccessToken string
@@ -73,6 +74,8 @@ func (w *Options) Install(ctx context.Context, providerType string) error {
 		webhookProvider = &gitHubConfig{IOStream: w.IOStreams}
 	case "gitlab":
 		webhookProvider = &gitLabConfig{IOStream: w.IOStreams}
+	case "bitbucket-cloud":
+		webhookProvider = &bitbucketCloudConfig{IOStream: w.IOStreams}
 	default:
 		return fmt.Errorf("invalid webhook provider")
 	}

--- a/pkg/cmd/tknpac/setup/bitbucket-cloud-webhook.go
+++ b/pkg/cmd/tknpac/setup/bitbucket-cloud-webhook.go
@@ -1,0 +1,11 @@
+package setup
+
+import (
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/spf13/cobra"
+)
+
+func bitbucketCloudWebhookCommand(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
+	return buildProviderCommand(run, ioStreams, "bitbucket-cloud")
+}

--- a/pkg/cmd/tknpac/setup/root.go
+++ b/pkg/cmd/tknpac/setup/root.go
@@ -26,6 +26,7 @@ func Root(clients *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
 
 	cmd.AddCommand(githubWebhookCommand(clients, ioStreams))
 	cmd.AddCommand(gitlabWebhookCommand(clients, ioStreams))
+	cmd.AddCommand(bitbucketCloudWebhookCommand(clients, ioStreams))
 	return cmd
 }
 


### PR DESCRIPTION
```
 > ~/go/src/github.com/openshift-pipelines/bitc-pac (sm) > tkn pac setup bitbucket-cloud-webhook
✓ Setting up Bitbucket Webhook for Repository https://bitbucket.org/smukhade/pac-e2e-test
? Please enter your bitbucket cloud username:  smukhade
ℹ ️You now need to create a Bitbucket Cloud app password, please checkout the docs at https://is.gd/fqMHiJ for the required permissions
? Please enter the Bitbucket Cloud app password:  ********************
👀 I have detected a controller url: https://smee.io/RfJSeRjNXRA25A
? Do you want me to use it? Yes
✓ Webhook has been created on repository smukhade/pac-e2e-test
? Would you like me to create the Repository CR for your git repository? Yes
? Please enter the namespace where the pipeline should run (default: pac-e2e-test-pipelines): 
! Namespace pac-e2e-test-pipelines is not found
? Would you like me to create the namespace pac-e2e-test-pipelines? Yes
✓ Repository smukhade-pac-e2e-test has been created in pac-e2e-test-pipelines namespace
🔑 Webhook Secret smukhade-pac-e2e-test has been created in the pac-e2e-test-pipelines namespace.
🔑 Repository CR smukhade-pac-e2e-test has been updated with webhook secret in the pac-e2e-test-pipelines namespace
```

Closes #624 
Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
