### PR TITLE
Operator needs same container name nomencolature everywhere

### DIFF
--- a/config/600-webhook.yaml
+++ b/config/600-webhook.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       serviceAccountName: pipelines-as-code-webhook
       containers:
-        - name: pipelines-as-code-webhook
+        - name: pac-webhook
           image: "ko://github.com/openshift-pipelines/pipelines-as-code/cmd/pipelines-as-code-webhook"
           env:
             - name: SYSTEM_NAMESPACE


### PR DESCRIPTION
so modifying pipelines-as-code-webhook to pac-webhook to match the other
controllers images

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
