### PR TITLE
add some tests for kubeinteraction and wait

### DIFF
--- a/pkg/kubeinteraction/kubeinteraction_test.go
+++ b/pkg/kubeinteraction/kubeinteraction_test.go
@@ -1,0 +1,13 @@
+package kubeinteraction
+
+import (
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"gotest.tools/v3/assert"
+)
+
+func TestNewKubernetesInteraction(t *testing.T) {
+	_, err := NewKubernetesInteraction(params.New())
+	assert.NilError(t, err)
+}

--- a/pkg/kubeinteraction/wait_test.go
+++ b/pkg/kubeinteraction/wait_test.go
@@ -1,0 +1,46 @@
+package kubeinteraction
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	rtesting "knative.dev/pkg/reconciler/testing"
+)
+
+func TestPollImmediateWithContext(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr bool
+		fn      func() (bool, error)
+	}{
+		{
+			name: "test true",
+			fn: func() (bool, error) {
+				return true, nil
+			},
+		},
+		{
+			name: "test false",
+			fn: func() (bool, error) {
+				return true, fmt.Errorf("error me")
+			},
+			wantErr: true,
+		},
+		{
+			name: "timeout",
+			fn: func() (bool, error) {
+				return false, nil
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			if err := PollImmediateWithContext(ctx, 1*time.Millisecond, tt.fn); (err != nil) != tt.wantErr {
+				t.Errorf("PollImmediateWithContext() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
sneakily want to test if e2e jobs is fixed by adding (kinda useless but look good on coverage) test

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
