### PR TITLE
Use Pipelinerun templates in pac generate command

### DIFF
--- a/pkg/cmd/tknpac/generate/templates/generic.yaml
+++ b/pkg/cmd/tknpac/generate/templates/generic.yaml
@@ -2,37 +2,27 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: << .prName >>
+  name: pipelinerun-generic
   annotations:
     # The event we are targeting as seen from the webhook payload
     # this can be an array too, i.e: [pull_request, push]
-    pipelinesascode.tekton.dev/on-event: "<< .event.EventType >>"
+    pipelinesascode.tekton.dev/on-event: "pull_request"
 
     # The branch or tag we are targeting (ie: main, refs/tags/*)
-    pipelinesascode.tekton.dev/on-target-branch: "<< .event.BaseBranch >>"
-    << if .use_cluster_task >>
-    # If we want to use the git-clone task from hub we could specify the
-    # annotation `pipelinesascode.tekton.dev/task annotation` and reference it
-    # in the taskRef. Pipelines as Code when it sees this will grab it from hub
-    # and automatically use the latest version. right now by default we will
-    # use the `git-clone` ClusterTasks as shipped on this cluster.
-    #
-    # pipelinesascode.tekton.dev/task: "git-clone"
+    pipelinesascode.tekton.dev/on-target-branch: "main"
 
-    <<- else >>
     # Fetch the git-clone task from hub, we are able to reference later on it
     # with taskRef and it will automatically be embedded into our pipeline.
     pipelinesascode.tekton.dev/task: "git-clone"
-    << end >>
-    <<- if .extra_task.AnnotationTask >>
 
-    # Task for <<.extra_task.Language >>
-    pipelinesascode.tekton.dev/task-1: "[<< .extra_task.AnnotationTask >>]"
-    << end >>
+    # Use maven task from hub
+    pipelinesascode.tekton.dev/task-1: "[maven]"
+
     # You can add more tasks in here to reuse, browse the one you like from here
     # https://hub.tekton.dev/
     # example:
     # pipelinesascode.tekton.dev/task-2: "[maven, buildah]"
+
 
     # How many runs we want to keep attached to this event
     pipelinesascode.tekton.dev/max-keep-runs: "5"
@@ -55,9 +45,7 @@ spec:
       - name: fetch-repository
         taskRef:
           name: git-clone
-          <<- if .use_cluster_task >>
           kind: ClusterTask
-          <<- end >>
         workspaces:
           - name: output
             workspace: source
@@ -68,9 +56,6 @@ spec:
             value: $(params.repo_url)
           - name: revision
             value: $(params.revision)
-      <<- if .extra_task.Task>>
-      << .extra_task.Task >>
-      <<- end >>
       # Customize this task if you like, or just do a taskRef
       # to one of the hub task.
       - name: noop-task

--- a/pkg/cmd/tknpac/generate/templates/go.yaml
+++ b/pkg/cmd/tknpac/generate/templates/go.yaml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: go-template
+  name: pipelinerun-go
   annotations:
     # The event we are targeting as seen from the webhook payload
     # this can be an array too, i.e: [pull_request, push]
@@ -14,7 +14,6 @@ metadata:
     # Fetch the git-clone task from hub, we are able to reference later on it
     # with taskRef and it will automatically be embedded into our pipeline.
     pipelinesascode.tekton.dev/task: "git-clone"
-
 
     # Task for Golang
     pipelinesascode.tekton.dev/task-1: "[golangci-lint]"

--- a/pkg/cmd/tknpac/generate/templates/java.yaml
+++ b/pkg/cmd/tknpac/generate/templates/java.yaml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: nodejs-template
+  name: pipelinerun-java
   annotations:
     # The event we are targeting as seen from the webhook payload
     # this can be an array too, i.e: [pull_request, push]
@@ -14,10 +14,6 @@ metadata:
     # Fetch the git-clone task from hub, we are able to reference later on it
     # with taskRef and it will automatically be embedded into our pipeline.
     pipelinesascode.tekton.dev/task: "git-clone"
-
-
-    # Task for Nodejs
-    pipelinesascode.tekton.dev/task-1: "[npm]"
 
     # You can add more tasks in here to reuse, browse the one you like from here
     # https://hub.tekton.dev/
@@ -38,6 +34,7 @@ spec:
     params:
       - name: repo_url
       - name: revision
+      - name: image_name
     workspaces:
       - name: source
       - name: basic-auth
@@ -55,19 +52,18 @@ spec:
             value: $(params.repo_url)
           - name: revision
             value: $(params.revision)
-      - name: run-test
+      - name: maven-test
         taskRef:
-          name: npm
+          name: maven
+        runAfter:
+          - fetch-repository
+        params:
+          - name: GOALS
+            value:
+              - test
         workspaces:
           - name: source
             workspace: source
-        params:
-          - name: ARGS
-            value:
-              - test
-        runAfter:
-          - fetch-repository
-
   workspaces:
     - name: source
       volumeClaimTemplate:

--- a/pkg/cmd/tknpac/generate/templates/nodejs.yaml
+++ b/pkg/cmd/tknpac/generate/templates/nodejs.yaml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: python-template
+  name: pipelinerun-nodejs
   annotations:
     # The event we are targeting as seen from the webhook payload
     # this can be an array too, i.e: [pull_request, push]
@@ -15,9 +15,8 @@ metadata:
     # with taskRef and it will automatically be embedded into our pipeline.
     pipelinesascode.tekton.dev/task: "git-clone"
 
-
-    # Task for Python
-    pipelinesascode.tekton.dev/task-1: "[pylint]"
+    # Task for Nodejs
+    pipelinesascode.tekton.dev/task-1: "[npm]"
 
     # You can add more tasks in here to reuse, browse the one you like from here
     # https://hub.tekton.dev/
@@ -55,14 +54,18 @@ spec:
             value: $(params.repo_url)
           - name: revision
             value: $(params.revision)
-      - name: pylint
+      - name: run-test
         taskRef:
-          name: pylint
-        runAfter:
-          - fetch-repository
+          name: npm
         workspaces:
           - name: source
             workspace: source
+        params:
+          - name: ARGS
+            value:
+              - test
+        runAfter:
+          - fetch-repository
 
   workspaces:
     - name: source

--- a/pkg/cmd/tknpac/generate/templates/python.yaml
+++ b/pkg/cmd/tknpac/generate/templates/python.yaml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: java-template
+  name: pipelinerun-python
   annotations:
     # The event we are targeting as seen from the webhook payload
     # this can be an array too, i.e: [pull_request, push]
@@ -14,6 +14,9 @@ metadata:
     # Fetch the git-clone task from hub, we are able to reference later on it
     # with taskRef and it will automatically be embedded into our pipeline.
     pipelinesascode.tekton.dev/task: "git-clone"
+
+    # Task for Python
+    pipelinesascode.tekton.dev/task-1: "[pylint]"
 
     # You can add more tasks in here to reuse, browse the one you like from here
     # https://hub.tekton.dev/
@@ -30,22 +33,10 @@ spec:
       value: "{{ repo_url }}"
     - name: revision
       value: "{{ revision }}"
-    - name: image_name
-      value: ""
-    - name: app_name
-      value: ""
-    - name: path_context
-      value: ""
-    - name: version
-      value: ""
   pipelineSpec:
     params:
       - name: repo_url
       - name: revision
-      - name: image_name
-      - name: app_name
-      - name: path_context
-      - name: version
     workspaces:
       - name: source
       - name: basic-auth
@@ -63,35 +54,13 @@ spec:
             value: $(params.repo_url)
           - name: revision
             value: $(params.revision)
-      - name: build
-        params:
-          - name: IMAGE
-            value: $(params.image_name)
-          - name: TLSVERIFY
-            value: "false"
-          - name: PATH_CONTEXT
-            value: $(params.path_context)
-          - name: VERSION
-            value: $(params.version)
+      - name: pylint
+        taskRef:
+          name: pylint
         runAfter:
           - fetch-repository
-        taskRef:
-          kind: ClusterTask
-          name: s2i-java
         workspaces:
           - name: source
-            workspace: source
-      - name: deploy
-        params:
-          - name: SCRIPT
-            value: oc rollout status deploy/$(params.app_name)
-        runAfter:
-          - build
-        taskRef:
-          kind: ClusterTask
-          name: openshift-client
-        workspaces:
-          - name: workspace
             workspace: source
 
   workspaces:


### PR DESCRIPTION
Use builtin pipelinerun templates as shipped to the one for the console.
Don't use templating since we want to give it as raw to the console so
use string substitions.
Make java template use maven and not deploy

Closes #737

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
