### PR TITLE
Concurrency in pac ⚔️

### DIFF
--- a/config/202-watcher-role.yaml
+++ b/config/202-watcher-role.yaml
@@ -70,13 +70,16 @@ rules:
     verbs: ["get", "delete"]
   - apiGroups: ["pipelinesascode.tekton.dev"]
     resources: ["repositories"]
-    verbs: ["get", "update"]
+    verbs: ["get", "update", "list"]
   - apiGroups: ["tekton.dev"]
     resources: ["pipelineruns"]
-    verbs: ["get", "delete", "list", "create", "watch", "update"]
+    verbs: ["get", "delete", "list", "create", "watch", "update", "patch"]
   - apiGroups: ["route.openshift.io"]
     resources: ["routes"]
     verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "update", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/config/300-repositories.yaml
+++ b/config/300-repositories.yaml
@@ -66,6 +66,9 @@ spec:
             spec:
               description: Spec defines the desired state of Repository
               properties:
+                concurrency_limit:
+                  description: Number of maximum pipelinerun running at any moment
+                  type: integer
                 url:
                   description: Repository URL
                   type: string

--- a/docs/content/docs/guide/repositorycrd.md
+++ b/docs/content/docs/guide/repositorycrd.md
@@ -56,3 +56,17 @@ pipelinesascode.tekton.dev/target-namespace: "mynamespace"
 
 and Pipelines as Code will only match the repository in the mynamespace
 Namespace rather than trying to match it from all available repository on cluster.
+
+## Concurrency
+
+`concurrency_limit` allows you to define the maximum number of PipelineRuns running at any time for a Repository.
+
+```yaml
+spec:
+  concurrency_limit: <number> 
+```
+
+Example:
+Lets say you have 3 pipelines in `.tekton` directory, and you create a pull request with `concurrency_limit` defined as 1 in
+Repository CR. Then all the pipelineruns will run one after the another, at any time only one pipelinerun would be in running
+state and rest of them will be queued.

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/xanzy/go-gitlab v0.68.2
 	go.uber.org/zap v1.21.0
 	golang.org/x/oauth2 v0.0.0-20220622183110-fd043fe589d2
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/text v0.3.7
 	gotest.tools/v3 v3.3.0
 	k8s.io/api v0.23.5
@@ -111,7 +112,6 @@ require (
 	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d // indirect
 	golang.org/x/mod v0.5.1 // indirect
 	golang.org/x/net v0.0.0-20220624214902-1bab6f366d9e // indirect
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b // indirect
 	golang.org/x/term v0.0.0-20220526004731-065cf7ba2467 // indirect
 	golang.org/x/time v0.0.0-20220609170525-579cf78fd858 // indirect

--- a/pkg/apis/pipelinesascode/v1alpha1/types.go
+++ b/pkg/apis/pipelinesascode/v1alpha1/types.go
@@ -59,9 +59,10 @@ type RepositoryRunStatus struct {
 
 // RepositorySpec is the spec of a repo
 type RepositorySpec struct {
-	URL         string       `json:"url"`
-	GitProvider *GitProvider `json:"git_provider,omitempty"`
-	Incomings   *[]Incoming  `json:"incoming,omitempty"`
+	ConcurrencyLimit *int         `json:"concurrency_limit,omitempty"`
+	URL              string       `json:"url"`
+	GitProvider      *GitProvider `json:"git_provider,omitempty"`
+	Incomings        *[]Incoming  `json:"incoming,omitempty"`
 }
 
 type Incoming struct {

--- a/pkg/kubeinteraction/labels.go
+++ b/pkg/kubeinteraction/labels.go
@@ -14,6 +14,7 @@ import (
 
 const (
 	StateStarted   = "started"
+	StateQueued    = "queued"
 	StateCompleted = "completed"
 )
 

--- a/pkg/reconciler/cleanup.go
+++ b/pkg/reconciler/cleanup.go
@@ -1,0 +1,46 @@
+package reconciler
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strconv"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"go.uber.org/zap"
+)
+
+var gitAuthSecretAnnotation = filepath.Join(pipelinesascode.GroupName, "git-auth-secret")
+
+func (r *Reconciler) cleanupSecrets(ctx context.Context, logger *zap.SugaredLogger, repo *v1alpha1.Repository, pr *v1beta1.PipelineRun) error {
+	var gitAuthSecretName string
+	if annotation, ok := pr.Annotations[gitAuthSecretAnnotation]; ok {
+		gitAuthSecretName = annotation
+	} else {
+		return fmt.Errorf("cannot get annotation %s as set on PR", gitAuthSecretAnnotation)
+	}
+
+	err := r.kinteract.DeleteBasicAuthSecret(ctx, logger, repo.GetNamespace(), gitAuthSecretName)
+	if err != nil {
+		return fmt.Errorf("deleting basic auth secret has failed: %w ", err)
+	}
+	return nil
+}
+
+func (r *Reconciler) cleanupPipelineRuns(ctx context.Context, logger *zap.SugaredLogger, repo *v1alpha1.Repository, pr *v1beta1.PipelineRun) error {
+	keepMaxPipeline, ok := pr.Annotations[filepath.Join(pipelinesascode.GroupName, "max-keep-runs")]
+	if ok {
+		max, err := strconv.Atoi(keepMaxPipeline)
+		if err != nil {
+			return err
+		}
+
+		err = r.kinteract.CleanupPipelines(ctx, logger, repo, pr, max)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/reconciler/event.go
+++ b/pkg/reconciler/event.go
@@ -74,8 +74,8 @@ func buildEventFromPipelineRun(pr *v1beta1.PipelineRun) *info.Event {
 	}
 
 	// GitHub
-	if prNumber, ok := prAnno[filepath.Join(pipelinesascode.GroupName, "installation-id")]; ok {
-		id, _ := strconv.Atoi(prNumber)
+	if installationID, ok := prAnno[filepath.Join(pipelinesascode.GroupName, "installation-id")]; ok {
+		id, _ := strconv.Atoi(installationID)
 		event.InstallationID = int64(id)
 	}
 	if gheURL, ok := prAnno[filepath.Join(pipelinesascode.GroupName, "ghe-url")]; ok {

--- a/pkg/reconciler/finalizer.go
+++ b/pkg/reconciler/finalizer.go
@@ -1,0 +1,49 @@
+package reconciler
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/logging"
+	pkgreconciler "knative.dev/pkg/reconciler"
+)
+
+func (r *Reconciler) FinalizeKind(ctx context.Context, pr *v1beta1.PipelineRun) pkgreconciler.Event {
+	logger := logging.FromContext(ctx)
+	state, exist := pr.GetLabels()[filepath.Join(pipelinesascode.GroupName, "state")]
+	if !exist || state == kubeinteraction.StateCompleted {
+		return nil
+	}
+
+	if state == kubeinteraction.StateQueued || state == kubeinteraction.StateStarted {
+		repoName, ok := pr.GetLabels()[filepath.Join(pipelinesascode.GroupName, "repository")]
+		if !ok {
+			return nil
+		}
+		repo, err := r.run.Clients.PipelineAsCode.PipelinesascodeV1alpha1().
+			Repositories(pr.Namespace).Get(ctx, repoName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		next := r.qm.RemoveFromQueue(repo, pr)
+		if next != "" {
+			key := strings.Split(next, "/")
+			pr, err := r.run.Clients.Tekton.TektonV1beta1().PipelineRuns(key[0]).Get(ctx, key[1], metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			if err := r.updatePipelineRunToInProgress(ctx, logger, repo, pr); err != nil {
+				logger.Error("failed to update status: ", err)
+				return err
+			}
+			return nil
+		}
+	}
+	return nil
+}

--- a/pkg/sync/common.go
+++ b/pkg/sync/common.go
@@ -1,0 +1,19 @@
+package sync
+
+import (
+	"time"
+)
+
+type Semaphore interface {
+	acquire(string) bool
+	acquireLatest() string
+	tryAcquire(string) (bool, string)
+	release(string) bool
+	resize(int) bool
+	addToQueue(string, time.Time)
+	removeFromQueue(string)
+	getName() string
+	getLimit() int
+	getCurrentRunning() []string
+	getCurrentPending() []string
+}

--- a/pkg/sync/priority_queue.go
+++ b/pkg/sync/priority_queue.go
@@ -1,0 +1,77 @@
+package sync
+
+import (
+	"container/heap"
+)
+
+type (
+	key = string
+)
+
+type item struct {
+	key      string
+	priority int64
+	index    int
+}
+
+type priorityQueue struct {
+	items     []*item
+	itemByKey map[string]*item
+}
+
+func (pq *priorityQueue) add(key key, priority int64) {
+	if res, ok := pq.itemByKey[key]; ok {
+		if res.priority != priority {
+			res.priority = priority
+			heap.Fix(pq, res.index)
+		}
+	} else {
+		heap.Push(pq, &item{key: key, priority: priority})
+	}
+}
+
+func (pq *priorityQueue) remove(key key) {
+	if item, ok := pq.itemByKey[key]; ok {
+		heap.Remove(pq, item.index)
+		delete(pq.itemByKey, key)
+	}
+}
+
+func (pq *priorityQueue) pop() *item {
+	item, _ := heap.Pop(pq).(*item)
+	return item
+}
+
+func (pq *priorityQueue) peek() *item {
+	return pq.items[0]
+}
+
+func (pq priorityQueue) Len() int { return len(pq.items) }
+
+func (pq priorityQueue) Less(i, j int) bool {
+	return pq.items[i].priority < pq.items[j].priority
+}
+
+func (pq priorityQueue) Swap(i, j int) {
+	pq.items[i], pq.items[j] = pq.items[j], pq.items[i]
+	pq.items[i].index = i
+	pq.items[j].index = j
+}
+
+func (pq *priorityQueue) Push(x interface{}) {
+	n := len(pq.items)
+	item, _ := x.(*item)
+	item.index = n
+	pq.items = append(pq.items, item)
+	pq.itemByKey[item.key] = item
+}
+
+func (pq *priorityQueue) Pop() interface{} {
+	old := pq.items
+	n := len(old)
+	item := old[n-1]
+	item.index = -1
+	pq.items = old[0 : n-1]
+	delete(pq.itemByKey, item.key)
+	return item
+}

--- a/pkg/sync/priority_queue_test.go
+++ b/pkg/sync/priority_queue_test.go
@@ -1,0 +1,53 @@
+package sync
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestPriorityQueue(t *testing.T) {
+	// create new priority queue
+	pq := &priorityQueue{itemByKey: make(map[string]*item)}
+
+	// Priority Wise
+	// item-d > item-b > item-c > item-a
+	// 2 > 3 > 7 > 13
+	// less priority number means early to execute
+
+	// adding items with random priorities
+	// priority is creation time hence the item with less priority number
+	// will be on top of Queue
+	pq.add("item-a", 13)
+	pq.add("item-b", 3)
+	pq.add("item-c", 7)
+	pq.add("item-d", 2)
+
+	// number of items
+	assert.Equal(t, pq.Len(), 4)
+	assert.Equal(t, pq.peek().key, "item-d")
+
+	// pop from the queue
+	i := pq.pop()
+	assert.Equal(t, i.key, "item-d")
+
+	// check the top most
+	assert.Equal(t, pq.peek().key, "item-b")
+
+	// items remaining
+	assert.Equal(t, pq.Len(), 3)
+
+	pq.remove("item-b")
+
+	// check the top most
+	assert.Equal(t, pq.peek().key, "item-c")
+
+	// items remaining
+	assert.Equal(t, pq.Len(), 2)
+
+	// changing priority
+	pq.add("item-a", 1)
+
+	// check the top most
+	assert.Equal(t, pq.peek().key, "item-a")
+}

--- a/pkg/sync/queue_manager.go
+++ b/pkg/sync/queue_manager.go
@@ -1,0 +1,177 @@
+package sync
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/generated/clientset/versioned"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	versioned2 "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	"go.uber.org/zap"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type QueueManager struct {
+	queueMap map[string]Semaphore
+	lock     *sync.Mutex
+	logger   *zap.SugaredLogger
+}
+
+func NewQueueManager(logger *zap.SugaredLogger) *QueueManager {
+	return &QueueManager{
+		queueMap: make(map[string]Semaphore),
+		lock:     &sync.Mutex{},
+		logger:   logger,
+	}
+}
+
+// getSemaphore returns existing semaphore created for repository or create
+// a new one with limit provided in repository
+// Semaphore: nothing but a waiting and a running queue for a repository
+// with limit deciding how many should be running at a time
+func (qm *QueueManager) getSemaphore(repo *v1alpha1.Repository) (Semaphore, error) {
+	repoKey := repoKey(repo)
+
+	if sema, found := qm.queueMap[repoKey]; found {
+		if err := qm.checkAndUpdateSemaphoreSize(repo, sema); err != nil {
+			return nil, err
+		}
+		return sema, nil
+	}
+
+	// create a new semaphore
+	qm.queueMap[repoKey] = newSemaphore(repoKey, *repo.Spec.ConcurrencyLimit)
+
+	return qm.queueMap[repoKey], nil
+}
+
+func repoKey(repo *v1alpha1.Repository) string {
+	return fmt.Sprintf("%s/%s", repo.Namespace, repo.Name)
+}
+
+func (qm *QueueManager) checkAndUpdateSemaphoreSize(repo *v1alpha1.Repository, semaphore Semaphore) error {
+	limit := *repo.Spec.ConcurrencyLimit
+	if limit != semaphore.getLimit() {
+		if semaphore.resize(limit) {
+			return nil
+		}
+		return fmt.Errorf("failed to resize semaphore")
+	}
+	return nil
+}
+
+// AddToQueue adds the pipelineRun to the waiting queue of the repository
+// and if it is at the top and ready to run which means currently running pipelineRun < limit
+// then move it to running queue
+func (qm *QueueManager) AddToQueue(repo *v1alpha1.Repository, run *v1beta1.PipelineRun) (bool, string, error) {
+	qm.lock.Lock()
+	defer qm.lock.Unlock()
+
+	sema, err := qm.getSemaphore(repo)
+	if err != nil {
+		return false, "", err
+	}
+
+	qKey := getQueueKey(run)
+	sema.addToQueue(qKey, run.CreationTimestamp.Time)
+
+	qm.logger.Infof("added pipelineRun (%s) to queue for repository (%s)", qKey, repoKey(repo))
+
+	acquired, msg := sema.tryAcquire(qKey)
+	if acquired {
+		qm.logger.Infof("moved (%s) to running for repository (%s)", qKey, repoKey(repo))
+	}
+	return acquired, msg, nil
+}
+
+// RemoveFromQueue removes the pipelineRun from the queues of the repository
+// It also start the next one which is on top of the waiting queue and return its name
+// if started or returns ""
+func (qm *QueueManager) RemoveFromQueue(repo *v1alpha1.Repository, run *v1beta1.PipelineRun) string {
+	qm.lock.Lock()
+	defer qm.lock.Unlock()
+
+	repoKey := repoKey(repo)
+	sema, found := qm.queueMap[repoKey]
+	if !found {
+		return ""
+	}
+
+	qKey := getQueueKey(run)
+	sema.release(qKey)
+	sema.removeFromQueue(qKey)
+	qm.logger.Infof("removed (%s) for repository (%s)", qKey, repoKey)
+
+	if next := sema.acquireLatest(); next != "" {
+		qm.logger.Infof("moved (%s) to running for repository (%s)", qKey, repoKey)
+		return next
+	}
+	return ""
+}
+
+func getQueueKey(run *v1beta1.PipelineRun) string {
+	return fmt.Sprintf("%s/%s", run.Namespace, run.Name)
+}
+
+// InitQueues rebuild all the queues for all repository if concurrency is defined before
+// reconciler started reconciling them
+func (qm *QueueManager) InitQueues(ctx context.Context, tekton versioned2.Interface, pac versioned.Interface) error {
+	// fetch all repos
+	repos, err := pac.PipelinesascodeV1alpha1().Repositories("").List(ctx, v1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	// pipelineRuns from the namespace where repository is present
+	// those are required for creating queues
+	for _, repo := range repos.Items {
+		repo := repo
+		if repo.Spec.ConcurrencyLimit == nil || *repo.Spec.ConcurrencyLimit == 0 {
+			continue
+		}
+
+		// add all pipelineRuns in queued state to pending queue
+		prs, err := tekton.TektonV1beta1().PipelineRuns(repo.Namespace).
+			List(ctx, v1.ListOptions{
+				LabelSelector: fmt.Sprintf("%s/%s=%s", pipelinesascode.GroupName, "state", kubeinteraction.StateQueued),
+			})
+		if err != nil {
+			return err
+		}
+
+		for _, pr := range prs.Items {
+			pr := pr
+			sema, err := qm.getSemaphore(&repo)
+			if err != nil {
+				return err
+			}
+
+			qKey := getQueueKey(&pr)
+			sema.addToQueue(qKey, pr.CreationTimestamp.Time)
+		}
+
+		// now fetch all started pipelineRun and update the running queue
+		prs, err = tekton.TektonV1beta1().PipelineRuns(repo.Namespace).
+			List(ctx, v1.ListOptions{
+				LabelSelector: fmt.Sprintf("%s/%s=%s", pipelinesascode.GroupName, "state", kubeinteraction.StateStarted),
+			})
+		if err != nil {
+			return err
+		}
+
+		for _, pr := range prs.Items {
+			pr := pr
+			sema, err := qm.getSemaphore(&repo)
+			if err != nil {
+				return err
+			}
+			sema.acquire(getQueueKey(&pr))
+		}
+	}
+
+	return nil
+}

--- a/pkg/sync/queue_manager_test.go
+++ b/pkg/sync/queue_manager_test.go
@@ -1,0 +1,148 @@
+package sync
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
+	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"go.uber.org/zap"
+	zapobserver "go.uber.org/zap/zaptest/observer"
+	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	rtesting "knative.dev/pkg/reconciler/testing"
+)
+
+func TestNewQueueManager(t *testing.T) {
+	observer, _ := zapobserver.New(zap.InfoLevel)
+	logger := zap.New(observer).Sugar()
+	cw := clockwork.NewFakeClock()
+
+	qm := NewQueueManager(logger)
+
+	// repository for which pipelineRun are created
+	repo := newTestRepo("test", 1)
+
+	// first pipelineRun
+	prFirst := newTestPR("first", cw.Now(), nil)
+
+	// added to queue, as there is only one should start
+	started, _, err := qm.AddToQueue(repo, prFirst)
+	assert.NilError(t, err)
+	assert.Equal(t, started, true)
+
+	// adding another pipelineRun, limit is 1 so this will be added to pending queue
+	prSecond := newTestPR("second", cw.Now().Add(1*time.Second), nil)
+
+	started, msg, err := qm.AddToQueue(repo, prSecond)
+	assert.NilError(t, err)
+	assert.Equal(t, started, false)
+	assert.Equal(t, msg, "Waiting for test-ns/test lock. Available queue status: 0/1")
+
+	// removing first pr from running
+	qm.RemoveFromQueue(repo, prFirst)
+
+	// first is removed so the pending should be moved to running
+	sema := qm.queueMap[repoKey(repo)]
+	assert.Equal(t, sema.getCurrentRunning()[0], getQueueKey(prSecond))
+
+	// updating concurrency to 2
+	repo.Spec.ConcurrencyLimit = intPtr(2)
+
+	prThird := newTestPR("third", cw.Now().Add(7*time.Second), nil)
+	prFourth := newTestPR("fourth", cw.Now().Add(5*time.Second), nil)
+	prFifth := newTestPR("fifth", cw.Now().Add(4*time.Second), nil)
+
+	// Second is still running now, when third is added it should get started
+	started, _, err = qm.AddToQueue(repo, prThird)
+	assert.NilError(t, err)
+	assert.Equal(t, started, true)
+
+	started, _, err = qm.AddToQueue(repo, prFourth)
+	assert.NilError(t, err)
+	assert.Equal(t, started, false)
+
+	started, _, err = qm.AddToQueue(repo, prFifth)
+	assert.NilError(t, err)
+	assert.Equal(t, started, false)
+
+	// now if second is finished then next fifth should be started
+	// as its priority i.e creation time is before fourth
+	next := qm.RemoveFromQueue(repo, prSecond)
+	assert.Equal(t, next, getQueueKey(prFifth))
+}
+
+func newTestRepo(name string, limit int) *v1alpha1.Repository {
+	return &v1alpha1.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "test-ns",
+		},
+		Spec: v1alpha1.RepositorySpec{
+			ConcurrencyLimit: intPtr(limit),
+		},
+	}
+}
+
+var intPtr = func(val int) *int { return &val }
+
+func newTestPR(name string, time time.Time, labels map[string]string) *v1beta1.PipelineRun {
+	return &v1beta1.PipelineRun{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         "test-ns",
+			CreationTimestamp: metav1.Time{Time: time},
+			Labels:            labels,
+		},
+		Spec:   v1beta1.PipelineRunSpec{},
+		Status: v1beta1.PipelineRunStatus{},
+	}
+}
+
+func TestQueueManager_InitQueues(t *testing.T) {
+	ctx, _ := rtesting.SetupFakeContext(t)
+	observer, _ := zapobserver.New(zap.InfoLevel)
+	logger := zap.New(observer).Sugar()
+	cw := clockwork.NewFakeClock()
+
+	startedLabel := map[string]string{
+		fmt.Sprintf("%s/%s", pipelinesascode.GroupName, "state"): kubeinteraction.StateStarted,
+	}
+	queuedLabel := map[string]string{
+		fmt.Sprintf("%s/%s", pipelinesascode.GroupName, "state"): kubeinteraction.StateQueued,
+	}
+
+	repo := newTestRepo("test", 1)
+
+	firstPR := newTestPR("first", cw.Now(), startedLabel)
+	secondPR := newTestPR("second", cw.Now().Add(5*time.Second), queuedLabel)
+	thirdPR := newTestPR("third", cw.Now().Add(3*time.Second), queuedLabel)
+
+	tdata := testclient.Data{
+		Repositories: []*v1alpha1.Repository{repo},
+		PipelineRuns: []*v1beta1.PipelineRun{firstPR, secondPR, thirdPR},
+	}
+	stdata, _ := testclient.SeedTestData(t, ctx, tdata)
+
+	qm := NewQueueManager(logger)
+
+	err := qm.InitQueues(ctx, stdata.Pipeline, stdata.PipelineAsCode)
+	assert.NilError(t, err)
+
+	// queues are built
+	sema := qm.queueMap[repoKey(repo)]
+	assert.Equal(t, len(sema.getCurrentPending()), 2)
+	assert.Equal(t, len(sema.getCurrentRunning()), 1)
+
+	// now if first is completed and removed from running queue
+	// then third must start as it was created before second
+	qm.RemoveFromQueue(repo, firstPR)
+	assert.Equal(t, sema.getCurrentRunning()[0], getQueueKey(thirdPR))
+	assert.Equal(t, sema.getCurrentPending()[0], getQueueKey(secondPR))
+}

--- a/pkg/sync/semaphore.go
+++ b/pkg/sync/semaphore.go
@@ -1,0 +1,165 @@
+package sync
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	sema "golang.org/x/sync/semaphore"
+)
+
+type prioritySemaphore struct {
+	name      string
+	limit     int
+	pending   *priorityQueue
+	running   map[string]bool
+	semaphore *sema.Weighted
+	lock      *sync.Mutex
+}
+
+var _ Semaphore = &prioritySemaphore{}
+
+func newSemaphore(name string, limit int) *prioritySemaphore {
+	return &prioritySemaphore{
+		name:      name,
+		limit:     limit,
+		pending:   &priorityQueue{itemByKey: make(map[string]*item)},
+		semaphore: sema.NewWeighted(int64(limit)),
+		running:   make(map[string]bool),
+		lock:      &sync.Mutex{},
+	}
+}
+
+func (s *prioritySemaphore) getName() string {
+	return s.name
+}
+
+func (s *prioritySemaphore) getLimit() int {
+	return s.limit
+}
+
+func (s *prioritySemaphore) getCurrentPending() []string {
+	keys := []string{}
+	for _, item := range s.pending.items {
+		keys = append(keys, item.key)
+	}
+	return keys
+}
+
+func (s *prioritySemaphore) getCurrentRunning() []string {
+	keys := []string{}
+	for k := range s.running {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+func (s *prioritySemaphore) resize(n int) bool {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	cur := len(s.running)
+	// downward case, acquired n locks
+	if cur > n {
+		cur = n
+	}
+
+	semaphore := sema.NewWeighted(int64(n))
+	status := semaphore.TryAcquire(int64(cur))
+	if status {
+		s.semaphore = semaphore
+		s.limit = n
+	}
+	return status
+}
+
+func (s *prioritySemaphore) removeFromQueue(key string) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	s.pending.remove(key)
+}
+
+func (s *prioritySemaphore) acquireLatest() string {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if s.pending.Len() == 0 {
+		return ""
+	}
+
+	ready := s.pending.peek()
+
+	if s.semaphore.TryAcquire(1) {
+		_ = s.pending.pop()
+		s.running[ready.key] = true
+		return ready.key
+	}
+	return ""
+}
+
+func (s *prioritySemaphore) release(key string) bool {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if _, ok := s.running[key]; ok {
+		delete(s.running, key)
+
+		// When semaphore resized downward
+		// Remove the excess holders from map once the done.
+		if len(s.running) >= s.limit {
+			return true
+		}
+
+		s.semaphore.Release(1)
+	}
+	return true
+}
+
+func (s *prioritySemaphore) addToQueue(key string, creationTime time.Time) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if _, ok := s.running[key]; ok {
+		return
+	}
+	s.pending.add(key, creationTime.Unix())
+}
+
+func (s *prioritySemaphore) tryAcquire(key string) (bool, string) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if _, ok := s.running[key]; ok {
+		return true, ""
+	}
+
+	waitingMsg := fmt.Sprintf("Waiting for %s lock. Available queue status: %d/%d", s.name, s.limit-len(s.running), s.limit)
+
+	// Check whether requested key is in front of priority queue.
+	// If it is in front position, it will allow to acquire lock.
+	// If it is not a front key, it needs to wait for its turn.
+	var nextKey string
+	if s.pending.Len() > 0 {
+		item := s.pending.peek()
+		nextKey = fmt.Sprintf("%v", item.key)
+		if key != nextKey {
+			return false, waitingMsg
+		}
+	}
+
+	if s.acquire(nextKey) {
+		s.pending.pop()
+		return true, ""
+	}
+
+	return false, waitingMsg
+}
+
+func (s *prioritySemaphore) acquire(key string) bool {
+	if s.semaphore.TryAcquire(1) {
+		s.running[key] = true
+		return true
+	}
+	return false
+}

--- a/pkg/sync/semaphore_test.go
+++ b/pkg/sync/semaphore_test.go
@@ -1,0 +1,110 @@
+package sync
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"gotest.tools/v3/assert"
+)
+
+func TestNewSemaphore(t *testing.T) {
+	repo := newSemaphore("test", 1)
+	cw := clockwork.NewFakeClock()
+
+	assert.Equal(t, repo.getName(), "test")
+	assert.Equal(t, repo.getLimit(), 1)
+
+	// add elements
+	// randomly adding elements, the element with the less priority
+	// must execute first
+	repo.addToQueue("C", cw.Now().Add(5*time.Second))
+	repo.addToQueue("A", cw.Now())
+	repo.addToQueue("B", cw.Now().Add(1*time.Second))
+
+	// start the topmost, which would be A
+	acquired, msg := repo.tryAcquire("A")
+	assert.Equal(t, acquired, true)
+	assert.Equal(t, msg, "")
+
+	// hit again
+	acquired, _ = repo.tryAcquire("A")
+	assert.Equal(t, acquired, true)
+
+	// try acquiring B, but limit is 1 so should fail
+	acquired, _ = repo.tryAcquire("B")
+	assert.Equal(t, acquired, false)
+
+	// C is back in the queue should also fail
+	acquired, _ = repo.tryAcquire("C")
+	assert.Equal(t, acquired, false)
+
+	assert.Equal(t, len(repo.getCurrentRunning()), 1)
+	assert.Equal(t, len(repo.getCurrentPending()), 2)
+
+	// adding element to Queue which is running
+	// nothing should happen
+	repo.addToQueue("A", cw.Now().Add(5*time.Second))
+
+	// A is done
+	repo.release("A")
+	repo.removeFromQueue("A")
+
+	assert.Equal(t, len(repo.getCurrentRunning()), 0)
+	assert.Equal(t, len(repo.getCurrentPending()), 2)
+
+	// start the next
+	assert.Equal(t, repo.acquireLatest(), "B")
+
+	assert.Equal(t, len(repo.getCurrentRunning()), 1)
+	assert.Equal(t, len(repo.getCurrentPending()), 1)
+
+	// B is done
+	repo.release("B")
+	repo.removeFromQueue("B")
+
+	// resize to 2
+	repo.resize(2)
+
+	// now add new elements
+	repo.addToQueue("D", cw.Now().Add(8*time.Second))
+	repo.addToQueue("E", cw.Now().Add(6*time.Second))
+	repo.addToQueue("F", cw.Now().Add(7*time.Second))
+
+	// queue already have C in it
+	// now the queue must have C > E > F > D
+	// C being on the top
+
+	// start the next
+	assert.Equal(t, repo.acquireLatest(), "C")
+	assert.Equal(t, repo.acquireLatest(), "E")
+
+	// size is 2 now if we try to acquire again it will return empty
+	assert.Equal(t, repo.acquireLatest(), "")
+
+	// resize back to 1
+	repo.resize(1)
+	assert.Equal(t, repo.getLimit(), 1)
+
+	assert.Equal(t, len(repo.getCurrentRunning()), 2)
+	assert.Equal(t, len(repo.getCurrentPending()), 2)
+
+	// try to start next but it shouldn't as 2 are still running
+	assert.Equal(t, repo.acquireLatest(), "")
+
+	repo.release("C")
+	repo.removeFromQueue("C")
+
+	// try again to start next but it shouldn't as 1 is
+	// still running
+	assert.Equal(t, repo.acquireLatest(), "")
+
+	repo.release("E")
+	repo.removeFromQueue("E")
+
+	// empty the pending Queue
+	repo.removeFromQueue("F")
+	repo.removeFromQueue("D")
+
+	assert.Equal(t, repo.acquireLatest(), "")
+}

--- a/pkg/webhook/validation.go
+++ b/pkg/webhook/validation.go
@@ -37,6 +37,10 @@ func (ac *reconciler) Admit(_ context.Context, request *v1.AdmissionRequest) *v1
 		return webhook.MakeErrorStatus(fmt.Sprintf("repository already exist with url: %s", repo.Spec.URL))
 	}
 
+	if repo.Spec.ConcurrencyLimit != nil && *repo.Spec.ConcurrencyLimit == 0 {
+		return webhook.MakeErrorStatus("concurrency limit must be greater than 0")
+	}
+
 	return &v1.AdmissionResponse{Allowed: true}
 }
 

--- a/test/github_pullrequest_concurrency_test.go
+++ b/test/github_pullrequest_concurrency_test.go
@@ -1,0 +1,94 @@
+//go:build e2e
+// +build e2e
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	tgithub "github.com/openshift-pipelines/pipelines-as-code/test/pkg/github"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
+	"github.com/tektoncd/pipeline/pkg/names"
+	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGithubPullRequestConcurrency(t *testing.T) {
+	ctx := context.Background()
+	label := "Github PullRequest Concurrent"
+
+	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
+	runcnx, opts, ghcnx, err := tgithub.Setup(ctx, false)
+	assert.NilError(t, err)
+
+	logmsg := fmt.Sprintf("Testing %s with Github APPS integration on %s", label, targetNS)
+	runcnx.Clients.Log.Info(logmsg)
+
+	repoinfo, resp, err := ghcnx.Client.Repositories.Get(ctx, opts.Organization, opts.Repo)
+	assert.NilError(t, err)
+	if resp != nil && resp.Response.StatusCode == http.StatusNotFound {
+		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
+	}
+
+	// set concurrency
+	opts.Concurrency = 1
+
+	err = tgithub.CreateCRD(ctx, t, repoinfo, runcnx, opts, targetNS)
+	assert.NilError(t, err)
+
+	yamlFiles := []string{"testdata/pipelinerun_long_running.yaml", "testdata/pipelinerun_long_running_another.yaml"}
+	entries, err := payload.GetEntries(yamlFiles, targetNS, options.MainBranch, options.PullRequestEvent)
+	assert.NilError(t, err)
+
+	targetRefName := fmt.Sprintf("refs/heads/%s",
+		names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test"))
+
+	sha, err := tgithub.PushFilesToRef(ctx, ghcnx.Client, logmsg, repoinfo.GetDefaultBranch(), targetRefName,
+		opts.Organization, opts.Repo, entries)
+	assert.NilError(t, err)
+	runcnx.Clients.Log.Infof("Commit %s has been created and pushed to %s", sha, targetRefName)
+
+	prNumber, err := tgithub.PRCreate(ctx, runcnx, ghcnx, opts.Organization,
+		opts.Repo, targetRefName, repoinfo.GetDefaultBranch(), logmsg)
+	assert.NilError(t, err)
+
+	runcnx.Clients.Log.Info("waiting to let controller process the event")
+	time.Sleep(5 * time.Second)
+
+	allPR, err := runcnx.Clients.Tekton.TektonV1beta1().PipelineRuns(targetNS).List(ctx, metav1.ListOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, len(allPR.Items), 2)
+
+	var pending, running bool
+	for _, pr := range allPR.Items {
+		if pr.Spec.Status == "" {
+			running = true
+		} else {
+			pending = true
+		}
+	}
+	if !(pending && running) {
+		runcnx.Clients.Log.Fatal("one pipelineRun must be in running state and one in pending")
+	}
+
+	wait.Succeeded(ctx, t, runcnx, opts, options.PullRequestEvent, targetNS, len(yamlFiles), sha, logmsg)
+
+	runcnx.Clients.Log.Infof("Waiting for Repository to be updated for second pipelineRun")
+	waitOpts := wait.Opts{
+		RepoName:        targetNS,
+		Namespace:       targetNS,
+		MinNumberStatus: 1,
+		PollTimeout:     wait.DefaultTimeout,
+		TargetSHA:       sha,
+	}
+	err = wait.UntilRepositoryUpdated(ctx, runcnx.Clients, waitOpts)
+	assert.NilError(t, err)
+
+	defer tgithub.TearDown(ctx, t, runcnx, ghcnx, prNumber, targetRefName, targetNS, opts)
+}

--- a/test/pkg/github/crd.go
+++ b/test/pkg/github/crd.go
@@ -25,6 +25,10 @@ func CreateCRD(ctx context.Context, t *testing.T, repoinfo *ghlib.Repository, ru
 		},
 	}
 
+	if opts.Concurrency != 0 {
+		repo.Spec.ConcurrencyLimit = intPtr(opts.Concurrency)
+	}
+
 	err := repository.CreateNS(ctx, targetNS, run)
 	assert.NilError(t, err)
 
@@ -57,3 +61,5 @@ func CreateCRD(ctx context.Context, t *testing.T, repoinfo *ghlib.Repository, ru
 	assert.NilError(t, err)
 	return err
 }
+
+var intPtr = func(val int) *int { return &val }

--- a/test/pkg/options/options.go
+++ b/test/pkg/options/options.go
@@ -5,6 +5,7 @@ type E2E struct {
 	DirectWebhook      bool
 	ProjectID          int
 	ControllerURL      string
+	Concurrency        int
 }
 
 var (

--- a/test/testdata/pipelinerun_long_running.yaml
+++ b/test/testdata/pipelinerun_long_running.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: pipeline-long-running
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "%s"
+    pipelinesascode.tekton.dev/on-target-branch: "[%s]"
+    pipelinesascode.tekton.dev/on-event: "[%s]"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: task
+        taskSpec:
+          steps:
+            - name: task
+              image: registry.access.redhat.com/ubi9/ubi-micro
+              script: |
+                echo "hello pipeline"
+                sleep 10
+                exit 0

--- a/test/testdata/pipelinerun_long_running_another.yaml
+++ b/test/testdata/pipelinerun_long_running_another.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: pipeline-long-running-another
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "%s"
+    pipelinesascode.tekton.dev/on-target-branch: "[%s]"
+    pipelinesascode.tekton.dev/on-event: "[%s]"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: task
+        taskSpec:
+          steps:
+            - name: task
+              image: registry.access.redhat.com/ubi9/ubi-micro
+              script: |
+                echo "hello pipeline"
+                sleep 10
+                exit 0


### PR DESCRIPTION
This enable configuring concurrency 
Repository CR
```
spec
  concurrency_limit: 1
```
Controller:
- will work as it is for cases where concurreny is not defined, create pr with label `state=started` 
- if concurrency is defined then mark pipelinerun status as `pending` and label `state=queued`
- report status back to provider as `queued` or `in_progress` depending on concurrency

Watcher:
-  reconciler pipelineruns with state = queued or started
- if state is queued, then
  - create a semaphore/queue for the repository for which it is triggered
  - add it in the pending queue 
  - if running < limit, the immediately start it
- if state is started, then work as previous
  - wait for pipelinerun to be done
  - then report status to provider 
  - and remove it from the queue   


The implementation is inspired by ArgoCD Workflows
https://github.com/argoproj/argo-workflows/blob/master/workflow/sync/sync_manager.go


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
