### PR TITLE
Add tkn pac logs to show logs of a repo directly

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -132,7 +132,7 @@ spec:
                 make test
 
             - name: lint
-              image: quay.io/app-sre/golangci-lint:v1.46.0
+              image: quay.io/app-sre/golangci-lint:v1.46.2
               workingDir: $(workspaces.source.path)
               env:
                 - name: GOCACHE

--- a/docs/content/docs/guide/cli.md
+++ b/docs/content/docs/guide/cli.md
@@ -11,6 +11,7 @@ Pipelines as Code provide a powerful CLI designed to work with tkn plug-in.  `tk
 * `delete`: delete an existing Pipelines as Code Repository definition.
 * `generate`: generate a simple pipelinerun to get you started with Pipelines as Code.
 * `list`: list Pipelines as Code Repositories.
+* `logs`: show the logs of a PipelineRun form a Repository CRD.
 * `describe`: describe a Pipelines as Code Repository and the runs associated with it.
 * `resolve`: Resolve a pipelinerun as if it were executed by pipelines as code on service.
 * `setup`: Setup a Git provider app or webhook with pipelines as code service.
@@ -165,6 +166,21 @@ to the UI URL to see the Pipelinerun associated with it.
 {{< /details >}}
 
 {{< details "tkn pac generate" >}}
+
+### Logs
+
+`tkn pac logs` -- will show the logs attached to a Repository.
+
+If you don't specify a repository on the command line it will as for one or auto
+select it if there is only one.
+
+This will show the latest pipelinerun to a repo unless you specify the flag `-s`
+which *shift* the pipelinerun status. So for example :
+
+`tkn pac logs -s 2` will show the logs of the second latest pipelinerun.
+
+[`tkn`](https://github.com/tektoncd/cli) binary needs to be installed to show
+the logs.
 
 ### Generate
 

--- a/pkg/cli/prompt/select_repo.go
+++ b/pkg/cli/prompt/select_repo.go
@@ -1,0 +1,60 @@
+package prompt
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func SelectRepo(ctx context.Context, cs *params.Run, namespace string) (*v1alpha1.Repository, error) {
+	repositories, err := cs.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(repositories.Items) == 0 {
+		return nil, fmt.Errorf("no repo found")
+	}
+	if len(repositories.Items) == 1 {
+		return &repositories.Items[0], nil
+	}
+
+	allRepositories := []string{}
+	for _, repository := range repositories.Items {
+		repoOwner, err := formatting.GetRepoOwnerFromURL(repository.Spec.URL)
+		if err != nil {
+			return nil, err
+		}
+		allRepositories = append(allRepositories,
+			fmt.Sprintf("%s - %s",
+				repository.GetName(),
+				repoOwner))
+	}
+
+	var replyString string
+	if err := SurveyAskOne(&survey.Select{
+		Message: "Select a repository",
+		Options: allRepositories,
+	}, &replyString); err != nil {
+		return nil, err
+	}
+
+	if replyString == "" {
+		return nil, fmt.Errorf("you need to choose a repository")
+	}
+	replyName := strings.Fields(replyString)[0]
+
+	for _, repository := range repositories.Items {
+		if repository.GetName() == replyName {
+			return &repository, nil
+		}
+	}
+
+	return nil, fmt.Errorf("cannot match repository")
+}

--- a/pkg/cmd/tknpac/describe/describe_test.go
+++ b/pkg/cmd/tknpac/describe/describe_test.go
@@ -1,9 +1,7 @@
 package describe
 
 import (
-	"bytes"
 	"fmt"
-	"io/ioutil"
 	"strings"
 	"testing"
 	"time"
@@ -16,6 +14,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	tcli "github.com/openshift-pipelines/pipelines-as-code/pkg/test/cli"
 	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
 	tektontest "github.com/openshift-pipelines/pipelines-as-code/pkg/test/tekton"
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -26,17 +25,6 @@ import (
 	"knative.dev/pkg/apis/duck/v1beta1"
 	rtesting "knative.dev/pkg/reconciler/testing"
 )
-
-func newIOStream() (*cli.IOStreams, *bytes.Buffer) {
-	in := &bytes.Buffer{}
-	out := &bytes.Buffer{}
-	errOut := &bytes.Buffer{}
-	return &cli.IOStreams{
-		In:     ioutil.NopCloser(in),
-		Out:    out,
-		ErrOut: errOut,
-	}, out
-}
 
 func TestDescribe(t *testing.T) {
 	cw := clockwork.NewFakeClock()
@@ -249,7 +237,7 @@ func TestDescribe(t *testing.T) {
 				Info: info.Info{Kube: info.KubeOpts{Namespace: tt.args.currentNamespace}},
 			}
 
-			io, out := newIOStream()
+			io, out := tcli.NewIOStream()
 			if err := describe(
 				ctx, cs, cw, tt.args.opts, io,
 				tt.args.repoName); (err != nil) != tt.wantErr {

--- a/pkg/cmd/tknpac/logs/logs.go
+++ b/pkg/cmd/tknpac/logs/logs.go
@@ -158,6 +158,7 @@ func log(ctx context.Context, lo *logOption) error {
 	fmt.Fprintf(lo.ioStreams.Out, "Showing logs from Repository: %s PR: %s\n", repository.GetName(), prName)
 
 	// if we have found the plugin then sysexec it by replacing current process.
+	// nolint: gosec
 	if err := syscall.Exec(lo.tknPath, []string{lo.tknPath, "pr", "logs", "-n", lo.cs.Info.Kube.Namespace, pr.GetName()}, os.Environ()); err != nil {
 		fmt.Fprintf(os.Stderr, "Command finished with error: %v", err)
 		os.Exit(127)

--- a/pkg/cmd/tknpac/logs/logs.go
+++ b/pkg/cmd/tknpac/logs/logs.go
@@ -1,0 +1,138 @@
+package logs
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli/prompt"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/cmd/tknpac/completion"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/consoleui"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/spf13/cobra"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const longhelp = `
+
+logs - show the PipelineRun logs attached to a Repository
+
+tkn pac logs will get the logs of a PipelineRun belonging to a Repository.
+
+the PipelineRun needs to exist on the kubernetes cluster to be able to display the logs.`
+
+var (
+	namespaceFlag = "namespace"
+	shiftFlag     = "shift"
+)
+
+func Command(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "logs",
+		Long:  longhelp,
+		Short: "Display the PipelineRun logs from a Repository",
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
+		ValidArgsFunction: completion.ParentCompletion,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var err error
+			var repoName string
+			opts := cli.NewCliOptions(cmd)
+
+			opts.Namespace, err = cmd.Flags().GetString(namespaceFlag)
+			if err != nil {
+				return err
+			}
+
+			if len(args) > 0 {
+				repoName = args[0]
+			}
+
+			ctx := context.Background()
+			err = run.Clients.NewClients(ctx, &run.Info)
+			if err != nil {
+				return err
+			}
+
+			// The only way to know the tekton dashboard url is if the user specify it because we are not supposed to have access to the configmap.
+			// so let the user specify a env variable to implicitly set tekton dashboard
+			if os.Getenv("TEKTON_DASHBOARD_URL") != "" {
+				run.Clients.ConsoleUI = &consoleui.TektonDashboard{BaseURL: os.Getenv("TEKTON_DASHBOARD_URL")}
+			}
+
+			shift, err := cmd.Flags().GetInt(shiftFlag)
+			if err != nil {
+				return err
+			}
+
+			return log(ctx, run, opts, ioStreams, repoName, shift)
+		},
+	}
+
+	cmd.Flags().StringP(
+		namespaceFlag, "n", "", "If present, the namespace scope for this CLI request")
+
+	cmd.Flags().IntP(
+		shiftFlag, "s", 1, "Show the last N number of Repository if it exist")
+
+	return cmd
+}
+
+func getTknPath() (string, error) {
+	fname, err := exec.LookPath("tkn")
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Abs(fname)
+}
+
+func log(ctx context.Context, cs *params.Run, opts *cli.PacCliOpts, ioStreams *cli.IOStreams, repoName string, shift int) error {
+	var repository *v1alpha1.Repository
+	var err error
+
+	if opts.Namespace != "" {
+		cs.Info.Kube.Namespace = opts.Namespace
+	}
+
+	if repoName != "" {
+		repository, err = cs.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(cs.Info.Kube.Namespace).Get(ctx,
+			repoName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+	} else {
+		repository, err = prompt.SelectRepo(ctx, cs, cs.Info.Kube.Namespace)
+		if err != nil {
+			return err
+		}
+	}
+
+	tknpac, err := getTknPath()
+	if err != nil {
+		return err
+	}
+	if len(repository.Status) == 0 {
+		return fmt.Errorf("no status on repository")
+	}
+	prName := repository.Status[len(repository.Status)-shift].PipelineRunName
+	pr, err := cs.Clients.Tekton.TektonV1beta1().PipelineRuns(cs.Info.Kube.Namespace).Get(ctx, prName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(ioStreams.Out, "Showing logs from Repository: %s PR: %s\n", repository.GetName(), prName)
+
+	// if we have found the plugin then sysexec it by replacing current process.
+	if err := syscall.Exec(tknpac, []string{tknpac, "pr", "logs", "-n", cs.Info.Kube.Namespace, pr.GetName()}, os.Environ()); err != nil {
+		fmt.Fprintf(os.Stderr, "Command finished with error: %v", err)
+		os.Exit(127)
+	}
+	return nil
+}

--- a/pkg/cmd/tknpac/logs/logs_test.go
+++ b/pkg/cmd/tknpac/logs/logs_test.go
@@ -1,0 +1,133 @@
+package logs
+
+import (
+	"testing"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/consoleui"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	tcli "github.com/openshift-pipelines/pipelines-as-code/pkg/test/cli"
+	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
+	tektontest "github.com/openshift-pipelines/pipelines-as-code/pkg/test/tekton"
+	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	rtesting "knative.dev/pkg/reconciler/testing"
+)
+
+func TestLogs(t *testing.T) {
+	cw := clockwork.NewFakeClock()
+	ns := "ns"
+	completed := tektonv1beta1.PipelineRunReasonCompleted.String()
+
+	tests := []struct {
+		name             string
+		wantErr          bool
+		repoName         string
+		currentNamespace string
+		statuses         []v1alpha1.RepositoryRunStatus
+		shift            int
+		pruns            []*tektonv1beta1.PipelineRun
+	}{
+		{
+			name:             "good/show logs",
+			wantErr:          false,
+			repoName:         "test",
+			currentNamespace: ns,
+			shift:            1,
+			statuses: []v1alpha1.RepositoryRunStatus{
+				{
+					PipelineRunName: "test-pipeline",
+				},
+			},
+			pruns: []*tektonv1beta1.PipelineRun{
+				tektontest.MakePRCompletion(cw, "test-pipeline", ns, completed, map[string]string{}, 30),
+			},
+		},
+		{
+			name:             "bad/shift",
+			wantErr:          true,
+			repoName:         "test",
+			currentNamespace: ns,
+			shift:            2,
+			statuses: []v1alpha1.RepositoryRunStatus{
+				{
+					PipelineRunName: "test-pipeline",
+				},
+			},
+			pruns: []*tektonv1beta1.PipelineRun{
+				tektontest.MakePRCompletion(cw, "test-pipeline", ns, completed, map[string]string{}, 30),
+			},
+		},
+		{
+			name:             "bad/no status",
+			wantErr:          true,
+			repoName:         "test",
+			currentNamespace: ns,
+			shift:            2,
+			pruns: []*tektonv1beta1.PipelineRun{
+				tektontest.MakePRCompletion(cw, "test-pipeline", ns, completed, map[string]string{}, 30),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repositories := []*v1alpha1.Repository{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      tt.repoName,
+						Namespace: tt.currentNamespace,
+					},
+					Spec: v1alpha1.RepositorySpec{
+						URL: "https://anurl.com",
+					},
+					Status: tt.statuses,
+				},
+			}
+			tdata := testclient.Data{
+				Namespaces: []*corev1.Namespace{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: tt.currentNamespace,
+						},
+					},
+				},
+				PipelineRuns: tt.pruns,
+				Repositories: repositories,
+			}
+
+			ctx, _ := rtesting.SetupFakeContext(t)
+			stdata, _ := testclient.SeedTestData(t, ctx, tdata)
+			cs := &params.Run{
+				Clients: clients.Clients{
+					PipelineAsCode: stdata.PipelineAsCode,
+					Tekton:         stdata.Pipeline,
+					ConsoleUI:      consoleui.FallBackConsole{},
+				},
+				Info: info.Info{Kube: info.KubeOpts{Namespace: tt.currentNamespace}},
+			}
+			io, _ := tcli.NewIOStream()
+			lopts := &logOption{
+				cs: cs,
+				opts: &cli.PacCliOpts{
+					Namespace: tt.currentNamespace,
+				},
+				repoName:  tt.repoName,
+				shift:     tt.shift,
+				tknPath:   "/bin/true",
+				ioStreams: io,
+			}
+
+			err := log(ctx, lopts)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("log() wantError is true but no error has been set")
+				}
+			}
+		})
+	}
+}

--- a/pkg/cmd/tknpac/root.go
+++ b/pkg/cmd/tknpac/root.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cmd/tknpac/describe"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cmd/tknpac/generate"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cmd/tknpac/list"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/cmd/tknpac/logs"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cmd/tknpac/resolve"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cmd/tknpac/setup"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cmd/tknpac/version"
@@ -35,6 +36,7 @@ func Root(clients *params.Run) *cobra.Command {
 	cmd.AddCommand(list.Root(clients, ioStreams))
 	cmd.AddCommand(deleterepo.Root(clients, ioStreams))
 	cmd.AddCommand(describe.Root(clients, ioStreams))
+	cmd.AddCommand(logs.Command(clients, ioStreams))
 	cmd.AddCommand(resolve.Command(clients, ioStreams))
 	cmd.AddCommand(completion.Command())
 	cmd.AddCommand(bootstrap.Command(clients, ioStreams))

--- a/pkg/test/cli/iostreams.go
+++ b/pkg/test/cli/iostreams.go
@@ -1,0 +1,20 @@
+package cli
+
+import (
+	"bytes"
+	"io/ioutil"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
+)
+
+// NewIOStream return a fake iostreams
+func NewIOStream() (*cli.IOStreams, *bytes.Buffer) {
+	in := &bytes.Buffer{}
+	out := &bytes.Buffer{}
+	errOut := &bytes.Buffer{}
+	return &cli.IOStreams{
+		In:     ioutil.NopCloser(in),
+		Out:    out,
+		ErrOut: errOut,
+	}, out
+}


### PR DESCRIPTION
Simple at first, show only logs from completed PR,  not live. but we can expand in the future. i'd like one day to be able to show logs from somewhere else than live PipelineRun and this may a good place for that, cluster-logging or something else,

Fixes #175 


Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
