### PR TITLE
Fix incoming webhook with github apps

### DIFF
--- a/pkg/params/info/events.go
+++ b/pkg/params/info/events.go
@@ -63,7 +63,6 @@ type Provider struct {
 	Token                 string
 	URL                   string
 	User                  string
-	InfoFromRepo          bool // whether the provider info come from the repository
 	WebhookSecret         string
 	WebhookSecretFromRepo bool
 }

--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -57,7 +57,7 @@ func (p *PacRun) matchRepoPR(ctx context.Context) ([]matcher.Match, *v1alpha1.Re
 	// allow webhook providers users to have a global webhook secret to be used,
 	// so instead of having to specify their in Repo each time, they use a
 	// shared one from pac.
-	if repo.Spec.GitProvider != nil {
+	if repo.Spec.GitProvider != nil && p.event.InstallationID <= 0 {
 		err := SecretFromRepository(ctx, p.run, p.k8int, p.vcx.GetConfig(), p.event, repo, p.logger)
 		if err != nil {
 			return nil, nil, err

--- a/pkg/pipelineascode/pipelinesascode_github_test.go
+++ b/pkg/pipelineascode/pipelinesascode_github_test.go
@@ -445,15 +445,20 @@ func TestRun(t *testing.T) {
 				Payload: payload,
 			}
 			tt.runevent.Provider = &info.Provider{
-				InfoFromRepo: tt.ProviderInfoFromRepo,
-				URL:          ghTestServerURL,
-				Token:        "NONE",
+				URL:   ghTestServerURL,
+				Token: "NONE",
 			}
 
 			k8int := &kitesthelper.KinterfaceTest{
 				ConsoleURL:               "https://console.url",
 				ExpectedNumberofCleanups: tt.expectedNumberofCleanups,
 				GetSecretResult:          secrets,
+			}
+
+			// InstallationID > 0 is used to detect if we are a GitHub APP
+			tt.runevent.InstallationID = 12345
+			if tt.ProviderInfoFromRepo {
+				tt.runevent.InstallationID = 0
 			}
 
 			vcx := &ghprovider.Provider{

--- a/pkg/pipelineascode/secret.go
+++ b/pkg/pipelineascode/secret.go
@@ -47,7 +47,6 @@ func SecretFromRepository(ctx context.Context, cs *params.Run, k8int kubeinterac
 	if event.Provider.Token == "" {
 		return nil
 	}
-	event.Provider.InfoFromRepo = true
 	event.Provider.User = repo.Spec.GitProvider.User
 
 	if repo.Spec.GitProvider.WebhookSecret == nil {

--- a/pkg/pipelineascode/secret_test.go
+++ b/pkg/pipelineascode/secret_test.go
@@ -123,7 +123,6 @@ func TestSecretFromRepository(t *testing.T) {
 			for key, value := range logs {
 				assert.Assert(t, tt.logmatch[key].MatchString(value.Message), "no match on logs %s => %s", tt.logmatch[key], value.Message)
 			}
-			assert.Assert(t, event.Provider.InfoFromRepo)
 			assert.Equal(t, tt.expectedSecret, event.Provider.Token)
 		})
 	}

--- a/pkg/provider/github/status.go
+++ b/pkg/provider/github/status.go
@@ -237,8 +237,11 @@ func (v *Provider) CreateStatus(ctx context.Context, tekton versioned.Interface,
 	}
 	statusOpts.Summary = fmt.Sprintf("%s%s %s", pacopts.ApplicationName, onPr, statusOpts.Summary)
 
-	if runevent.Provider.InfoFromRepo {
-		return v.createStatusCommit(ctx, runevent, pacopts, statusOpts)
+	// If we have an installationID which mean we have a github apps and we can use the checkRun API
+	if runevent.InstallationID > 0 {
+		return v.getOrUpdateCheckRunStatus(ctx, tekton, runevent, pacopts, statusOpts)
 	}
-	return v.getOrUpdateCheckRunStatus(ctx, tekton, runevent, pacopts, statusOpts)
+
+	// Otherwise use the update status commit API
+	return v.createStatusCommit(ctx, runevent, pacopts, statusOpts)
 }


### PR DESCRIPTION
When incoming webhook and github apps is set it will try to use the
webhook secret from the incoming webhook instead of the current
namespace.

Remove InfoFromRepo since we don't need and it's GH specific.

Closes #744

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [x] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [x] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [x] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [x] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
