### PR TITLE
Prevent re installation of pac from cli

### DIFF
--- a/pkg/cmd/tknpac/bootstrap/kubestuff.go
+++ b/pkg/cmd/tknpac/bootstrap/kubestuff.go
@@ -37,24 +37,6 @@ func createPacSecret(ctx context.Context, run *params.Run, opts *bootstrapOpts, 
 	return nil
 }
 
-// check if we have the namespace created
-func checkNS(ctx context.Context, run *params.Run, targetNamespace string) (bool, error) {
-	ns, err := run.Clients.Kube.CoreV1().Namespaces().Get(ctx, targetNamespace, metav1.GetOptions{})
-	if err != nil {
-		return false, err
-	}
-
-	// check if there is a configmap with the pipelines-as-code label in targetNamespace
-	cms, err := run.Clients.Kube.CoreV1().ConfigMaps(ns.GetName()).List(ctx, metav1.ListOptions{LabelSelector: configMapPacLabel})
-	if err != nil {
-		return false, err
-	}
-	if cms.Items == nil || len(cms.Items) == 0 {
-		return false, nil
-	}
-	return true, nil
-}
-
 func checkPipelinesInstalled(run *params.Run) (bool, error) {
 	return checkGroupInstalled(run, "tekton.dev")
 }


### PR DESCRIPTION
CLI now checks Repository CRD to check installation of pac then look for info configmap 
to check where pac is installed.

this is improvement to previous logic where we used to look in only 2 namespaces

Closes #538 

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
