### PR TITLE
Add s390x and ppc64le when releasing binary

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,6 +15,8 @@ builds:
     goarch:
       - amd64
       - arm64
+      - s390x
+      - ppc64le
     ldflags:
       - -w
       - -s

--- a/pkg/cmd/tknpac/logs/logs_test.go
+++ b/pkg/cmd/tknpac/logs/logs_test.go
@@ -1,6 +1,7 @@
 package logs
 
 import (
+	"os/exec"
 	"testing"
 
 	"github.com/jonboulle/clockwork"
@@ -14,6 +15,7 @@ import (
 	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
 	tektontest "github.com/openshift-pipelines/pipelines-as-code/pkg/test/tekton"
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"gotest.tools/v3/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	rtesting "knative.dev/pkg/reconciler/testing"
@@ -22,6 +24,7 @@ import (
 func TestLogs(t *testing.T) {
 	cw := clockwork.NewFakeClock()
 	ns := "ns"
+
 	completed := tektonv1beta1.PipelineRunReasonCompleted.String()
 
 	tests := []struct {
@@ -110,6 +113,9 @@ func TestLogs(t *testing.T) {
 				},
 				Info: info.Info{Kube: info.KubeOpts{Namespace: tt.currentNamespace}},
 			}
+
+			tknPath, err := exec.LookPath("true")
+			assert.NilError(t, err)
 			io, _ := tcli.NewIOStream()
 			lopts := &logOption{
 				cs: cs,
@@ -118,11 +124,11 @@ func TestLogs(t *testing.T) {
 				},
 				repoName:  tt.repoName,
 				shift:     tt.shift,
-				tknPath:   "/bin/true",
+				tknPath:   tknPath,
 				ioStreams: io,
 			}
 
-			err := log(ctx, lopts)
+			err = log(ctx, lopts)
 			if tt.wantErr {
 				if err == nil {
 					t.Errorf("log() wantError is true but no error has been set")


### PR DESCRIPTION
and fixes #746 to be able to run unittest on osx along the way

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
