### PR TITLE
tkn-pac: Get pr names from cluster instead of repo status so we can get the live ones

### DIFF
--- a/docs/content/docs/guide/cli.md
+++ b/docs/content/docs/guide/cli.md
@@ -171,13 +171,10 @@ to the UI URL to see the Pipelinerun associated with it.
 
 `tkn pac logs` -- will show the logs attached to a Repository.
 
-If you don't specify a repository on the command line it will as for one or auto
+If you don't specify a repository on the command line it will ask you to choose one or auto
 select it if there is only one.
 
-This will show the latest pipelinerun to a repo unless you specify the flag `-s`
-which *shift* the pipelinerun status. So for example :
-
-`tkn pac logs -s 2` will show the logs of the second latest pipelinerun.
+IF you add the "-w" flag it will directly open the console URL to the log.
 
 [`tkn`](https://github.com/tektoncd/cli) binary needs to be installed to show
 the logs.

--- a/pkg/cli/browser/browser.go
+++ b/pkg/cli/browser/browser.go
@@ -1,0 +1,23 @@
+package browser
+
+import (
+	"os/exec"
+	"runtime"
+)
+
+// OpenWebBrowser opens the specified URL in the default browser of the user.
+func OpenWebBrowser(url string) error {
+	var cmd string
+	var args []string
+	switch runtime.GOOS {
+	case "windows":
+		cmd = "cmd"
+		args = []string{"/c", "start"}
+	case "darwin":
+		cmd = "open"
+	default: // "linux", "freebsd", "openbsd", "netbsd"
+		cmd = "xdg-open"
+	}
+	args = append(args, url)
+	return exec.Command(cmd, args...).Start()
+}

--- a/pkg/cli/prompt/prompt.go
+++ b/pkg/cli/prompt/prompt.go
@@ -2,7 +2,7 @@ package prompt
 
 import "github.com/AlecAivazis/survey/v2"
 
-// SurveyAskOne ask one question tbe stubbed later
+// SurveyAskOne ask one question to be stubbed later
 var SurveyAskOne = func(p survey.Prompt, response interface{}, opts ...survey.AskOpt) error {
 	return survey.AskOne(p, response, opts...)
 }

--- a/pkg/cmd/tknpac/bootstrap/web.go
+++ b/pkg/cmd/tknpac/bootstrap/web.go
@@ -6,32 +6,13 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"os/exec"
 	"path/filepath"
-	"runtime"
 
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli/browser"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 )
-
-// openWebBrowser opens the specified URL in the default browser of the user.
-func openWebBrowser(url string) error {
-	var cmd string
-	var args []string
-
-	switch runtime.GOOS {
-	case "windows":
-		cmd = "cmd"
-		args = []string{"/c", "start"}
-	case "darwin":
-		cmd = "open"
-	default: // "linux", "freebsd", "openbsd", "netbsd"
-		cmd = "xdg-open"
-	}
-	args = append(args, url)
-	return exec.Command(cmd, args...).Start()
-}
 
 // startWebServer starts a webserver that will redirect the user to the github app creation page.
 func startWebServer(ctx context.Context, opts *bootstrapOpts, run *params.Run, jeez string) error {
@@ -56,7 +37,7 @@ func startWebServer(ctx context.Context, opts *bootstrapOpts, run *params.Run, j
 		url := fmt.Sprintf("http://localhost:%d", opts.webserverPort)
 		fmt.Fprintf(opts.ioStreams.Out, "🌍 Starting a web browser on %s, click on the button to create your GitHub APP\n", url)
 		// nolint:errcheck
-		go openWebBrowser(url)
+		go browser.OpenWebBrowser(url)
 		if err := s.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.Fatal(err)
 		}

--- a/pkg/sort/pipelinerun.go
+++ b/pkg/sort/pipelinerun.go
@@ -25,3 +25,21 @@ func PipelineRunSortByCompletionTime(items []v1beta1.PipelineRun) []v1beta1.Pipe
 	sort.Sort(prSortByCompletionTime(items))
 	return items
 }
+
+func PipelineRunSortByStartTime(prs []v1beta1.PipelineRun) {
+	sort.Sort(byStartTime(prs))
+}
+
+type byStartTime []v1beta1.PipelineRun
+
+func (prs byStartTime) Len() int      { return len(prs) }
+func (prs byStartTime) Swap(i, j int) { prs[i], prs[j] = prs[j], prs[i] }
+func (prs byStartTime) Less(i, j int) bool {
+	if prs[j].Status.StartTime == nil {
+		return false
+	}
+	if prs[i].Status.StartTime == nil {
+		return true
+	}
+	return prs[j].Status.StartTime.Before(prs[i].Status.StartTime)
+}


### PR DESCRIPTION
So we can get the live prs too to show the logs for.
add -w to open the console url instead of using 
 

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
