### PR TITLE
make sure the e2e createrepo admission webhook err

### DIFF
--- a/test/repository_webhook_test.go
+++ b/test/repository_webhook_test.go
@@ -43,5 +43,6 @@ func TestRepositoryCreation(t *testing.T) {
 	err = repository.CreateNS(ctx, targetNsNew, runcnx)
 	assert.NilError(t, err)
 	err = repository.CreateRepo(ctx, targetNsNew, runcnx, repo)
+	assert.Assert(t, err != nil)
 	assert.Equal(t, err.Error(), "admission webhook \"validation.pipelinesascode.tekton.dev\" denied the request: repository already exist with url: https://pac.test/pac/app")
 }


### PR DESCRIPTION
We were not checking it and we would get :

```
 goroutine 859 [running]:
testing.tRunner.func1.2({0x239f1a0, 0x37f7070})
	/opt/hostedtoolcache/go/1.17.12/x64/src/testing/testing.go:1209 +0x36c
testing.tRunner.func1()
	/opt/hostedtoolcache/go/1.17.12/x64/src/testing/testing.go:1212 +0x3b6
panic({0x239f1a0, 0x37f7070})
	/opt/hostedtoolcache/go/1.17.12/x64/src/runtime/panic.go:1047 +0x266
github.com/openshift-pipelines/pipelines-as-code/test.TestRepositoryCreation(0xc000641860)
	/home/runner/work/pipelines-as-code/pipelines-as-code/test/repository_webhook_test.go:46 +0x4a5
testing.tRunner(0xc000641860, 0x26cae98)
	/opt/hostedtoolcache/go/1.17.12/x64/src/testing/testing.go:1259 +0x230
created by testing.(*T).Run
	/opt/hostedtoolcache/go/1.17.12/x64/src/testing/testing.go:1306
        +0x727i
```

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
