### PR TITLE
Allow matching event to pipeline by modified files for GitHub push request

### DIFF
--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -278,8 +278,7 @@ func (v *Provider) getPullRequest(ctx context.Context, runevent *info.Event) (*i
 // GetFiles get a files from pull request
 func (v *Provider) GetFiles(ctx context.Context, runevent *info.Event) ([]string, error) {
 	if runevent.TriggerTarget == "pull_request" {
-		commitListOption := &github.ListOptions{}
-		repoCommit, _, err := v.Client.PullRequests.ListFiles(ctx, runevent.Organization, runevent.Repository, runevent.PullRequestNumber, commitListOption)
+		repoCommit, _, err := v.Client.PullRequests.ListFiles(ctx, runevent.Organization, runevent.Repository, runevent.PullRequestNumber, &github.ListOptions{})
 		if err != nil {
 			return []string{}, err
 		}

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -277,16 +277,31 @@ func (v *Provider) getPullRequest(ctx context.Context, runevent *info.Event) (*i
 
 // GetFiles get a files from pull request
 func (v *Provider) GetFiles(ctx context.Context, runevent *info.Event) ([]string, error) {
-	commitListOption := &github.ListOptions{}
-	repoCommit, _, err := v.Client.PullRequests.ListFiles(ctx, runevent.Organization, runevent.Repository, runevent.PullRequestNumber, commitListOption)
-	if err != nil {
-		return []string{}, err
+	if runevent.TriggerTarget == "pull_request" {
+		commitListOption := &github.ListOptions{}
+		repoCommit, _, err := v.Client.PullRequests.ListFiles(ctx, runevent.Organization, runevent.Repository, runevent.PullRequestNumber, commitListOption)
+		if err != nil {
+			return []string{}, err
+		}
+		result := []string{}
+		for j := range repoCommit {
+			result = append(result, *repoCommit[j].Filename)
+		}
+		return result, nil
 	}
-	result := []string{}
-	for j := range repoCommit {
-		result = append(result, *repoCommit[j].Filename)
+
+	if runevent.TriggerTarget == "push" {
+		result := []string{}
+		rC, _, err := v.Client.Repositories.GetCommit(ctx, runevent.Organization, runevent.Repository, runevent.SHA, &github.ListOptions{})
+		if err != nil {
+			return []string{}, err
+		}
+		for i := range rC.Files {
+			result = append(result, *rC.Files[i].Filename)
+		}
+		return result, nil
 	}
-	return result, nil
+	return []string{}, nil
 }
 
 // getObject Get an object from a repository

--- a/pkg/test/github/github.go
+++ b/pkg/test/github/github.go
@@ -25,7 +25,7 @@ const (
 	githubBaseURLPath = "/api/v3"
 )
 
-// SetupGH Setup a GitHUB httptest connexion, from go-github test-suit
+// SetupGH Setup a GitHUB httptest connection, from go-github test-suit
 func SetupGH() (client *github.Client, mux *http.ServeMux, serverURL string, teardown func()) {
 	// mux is the HTTP request multiplexer used with the test server.
 	mux = http.NewServeMux()


### PR DESCRIPTION
* Added changes to trigger pipelinerun for matched files using custom CEL functions for **GitHub Push** Request

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
