### PR TITLE
Increasing QPS limit to 50 for handling multiple pipelinerun

### DIFF
--- a/pkg/params/clients/clients.go
+++ b/pkg/params/clients/clients.go
@@ -129,6 +129,8 @@ func (c *Clients) NewClients(ctx context.Context, info *info.Info) error {
 	if err != nil {
 		return err
 	}
+	config.QPS = 50
+	config.Burst = 50
 
 	c.Kube, err = c.kubeClient(config)
 	if err != nil {


### PR DESCRIPTION
by default QPS is 5, but if there are multiple pipelineruns then
logs show were are rate limiting, because we create secret as well as
pipelineruns, hence increasing.

error logs:
```
I0801 05:23:58.002715       1 request.go:665] Waited for 1.143543855s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/apis/tekton.dev/v1beta1/namespaces/pac-app-pipelines/pipelineruns/pac-app-7-q6rfl

```

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
