### PR TITLE
Remove unused configuration and code snippet

### DIFF
--- a/config/302-pac-configmap.yaml
+++ b/config/302-pac-configmap.yaml
@@ -14,9 +14,6 @@
 
 apiVersion: v1
 data:
-  # The number of days kept for pipelinerun inside pipelines-as-code namespace
-  max-keep-days: "5"
-
   # The application name, you can customize this label
   application-name: "Pipelines as Code CI"
 

--- a/docs/content/docs/install/settings.md
+++ b/docs/content/docs/install/settings.md
@@ -13,18 +13,6 @@ There is a few things you can configure through the configmap
   The name of the application showing for example in the GitHub Checks
   labels. Default to `Pipelines as Code CI`
 
-* `max-keep-days`
-
-  The number of the day to keep the PipelineRuns runs in the `pipelines-as-code`
-  namespace. We install by default a cronjob that cleans up the PipelineRuns
-  generated on events in pipelines-as-code namespace. Note that these
-  PipelineRuns are internal to Pipelines-as-code are separate from the
-  PipelineRuns that exist in the user's GitHub repository. The cronjob runs
-  every hour and by default cleanups PipelineRuns over a day. This configmap
-  setting doesn't affect the cleanups of the user's PipelineRuns which are
-  controlled by the [annotations on the PipelineRun definition in the user's
-  GitHub repository](/docs/guide/cleanups).
-
 * `secret-auto-create`
 
   Whether to auto create a secret with the token generated through the GitHub
@@ -40,3 +28,21 @@ There is a few things you can configure through the configmap
 
   The base URL for the [tekton hub](https://github.com/tektoncd/hub/)
   API. default to the [public hub](https://hub.tekton.dev/): <https://api.hub.tekton.dev/v1>
+
+* `bitbucket-cloud-check-source-ip`
+
+  Public bitbucket doesn't have the concept of Secret, we need to be
+  able to secure the request by querying
+  [atlassian ip ranges](https://ip-ranges.atlassian.com/),
+  this only happen for public bitbucket (ie: when provider URL is not set in
+  repository spec). If you want to override this, you need to bear in mind
+  this could be a security issue, a malicious user can send a PR to your repo
+  with a modification to your PipelineRun that would grab secrets, tunnel or
+  others and then send a malicious webhook payload to the controller which
+  look like a authorized owner has send the PR to run it.
+  This feature is enabled by default.
+
+* `bitbucket-cloud-additional-source-ip`
+
+  This will provide us to give extra IPS (ie: 127.0.0.1) or networks (127.0.0.0/16)
+  separated by commas.

--- a/pkg/params/info/defaults.go
+++ b/pkg/params/info/defaults.go
@@ -1,10 +1,7 @@
 package info
 
-import "time"
-
 const (
-	PACConfigmapName          = "pipelines-as-code"
-	PACApplicationName        = "Pipelines as Code CI"
-	HubURL                    = "https://api.hub.tekton.dev/v1"
-	DefaultPipelineRunTimeout = 2 * time.Hour
+	PACConfigmapName   = "pipelines-as-code"
+	PACApplicationName = "Pipelines as Code CI"
+	HubURL             = "https://api.hub.tekton.dev/v1"
 )

--- a/pkg/params/info/pac.go
+++ b/pkg/params/info/pac.go
@@ -3,21 +3,19 @@ package info
 import (
 	"os"
 	"strings"
-	"time"
 
 	"github.com/spf13/cobra"
 )
 
 type PacOpts struct {
-	LogURL                    string
-	ApplicationName           string // the Application Name for example "Pipelines as Code"
-	SecretAutoCreation        bool   // secret auto creation in target namespace
-	WebhookType               string
-	PayloadFile               string
-	TektonDashboardURL        string
-	HubURL                    string
-	RemoteTasks               bool
-	DefaultPipelineRunTimeout *time.Duration
+	LogURL             string
+	ApplicationName    string // the Application Name for example "Pipelines as Code"
+	SecretAutoCreation bool   // secret auto creation in target namespace
+	WebhookType        string
+	PayloadFile        string
+	TektonDashboardURL string
+	HubURL             string
+	RemoteTasks        bool
 
 	// bitbucket cloud specific fields
 	BitbucketCloudCheckSourceIP      bool

--- a/pkg/params/run.go
+++ b/pkg/params/run.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/consoleui"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
@@ -110,15 +109,6 @@ func (r *Run) UpdatePACInfo(ctx context.Context) error {
 
 	if remoteTask, ok := cfg.Data["remote-tasks"]; ok {
 		r.Info.Pac.RemoteTasks = StringToBool(remoteTask)
-	}
-
-	if timeout, ok := cfg.Data["default-pipelinerun-timeout"]; ok {
-		parsedTimeout, err := time.ParseDuration(timeout)
-		if err != nil {
-			r.Clients.Log.Errorf("failed to parse default-pipelinerun-timeout: %s", cfg.Data["default-pipelinerun-timeout"])
-		} else {
-			r.Info.Pac.DefaultPipelineRunTimeout = &parsedTimeout
-		}
 	}
 
 	if check, ok := cfg.Data["bitbucket-cloud-check-source-ip"]; ok {

--- a/pkg/pipelineascode/pipelinesascode_github_test.go
+++ b/pkg/pipelineascode/pipelinesascode_github_test.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/google/go-github/v45/github"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
@@ -416,7 +415,6 @@ func TestRun(t *testing.T) {
 			stdata, _ := testclient.SeedTestData(t, ctx, tdata)
 			tdc := testDynamic.Options{}
 			dc, _ := tdc.Client()
-			duration, _ := time.ParseDuration("0h0m5s")
 			cs := &params.Run{
 				Clients: clients.Clients{
 					PipelineAsCode: stdata.PipelineAsCode,
@@ -428,8 +426,7 @@ func TestRun(t *testing.T) {
 				},
 				Info: info.Info{
 					Pac: &info.PacOpts{
-						SecretAutoCreation:        true,
-						DefaultPipelineRunTimeout: &duration,
+						SecretAutoCreation: true,
 					},
 				},
 			}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

* Removed `max-keep-days` configuration as its handled by PipelineRun spec directly
* Added bitbucket related configuration information to doc
* Removed unused code snippet for `default-pipelinerun-timeout`


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
