### PR TITLE
Fix configmap read issue for watcher

### DIFF
--- a/pkg/reconciler/controller.go
+++ b/pkg/reconciler/controller.go
@@ -30,6 +30,10 @@ func NewController() func(context.Context, configmap.Watcher) *controller.Impl {
 			log.Fatal("failed to init kinit client : ", err)
 		}
 
+		if err := run.GetConfigFromConfigMap(ctx); err != nil {
+			log.Fatal("failed to get defaults : ", err)
+		}
+
 		run.Info.Pac.LogURL = run.Clients.ConsoleUI.URL()
 
 		pipelineRunInformer := pipelineruninformer.Get(ctx)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
* Added changes to read values from configmap

**Fixes:**
This PR fixes reading values from configmap to clean secret when `SecretAutoCreation` is enabled during final status report.

**Verification:**
Watcher pod logs

```
{"severity":"INFO","timestamp":"2022-08-03T07:57:11.031181472Z","logger":"pac-watcher","caller":"kubeinteraction/secrets.go:115","message":"Secret pac-gitauth-geag has been deleted in namespace article-pipelines","knative.dev/controller":"github.com.openshift-pipelines.pipelines-as-code.pkg.reconciler.Reconciler","knative.dev/kind":"tekton.dev.PipelineRun","knative.dev/traceid":"94968bce-2b74-4128-9d56-f46dbebcbf49","knative.dev/key":"article-pipelines/article-bzx9l","pipeline-run":"article-bzx9l","event-sha":"25d3c47ed775e97e2ebbd893890ea88a5af905f7"}
{"severity":"INFO","timestamp":"2022-08-03T07:57:11.352380687Z","logger":"pac-watcher","caller":"reconciler/status.go:94","message":"pipelinerun article-bzx9l has a status of 'success'","knative.dev/controller":"github.com.openshift-pipelines.pipelines-as-code.pkg.reconciler.Reconciler","knative.dev/kind":"tekton.dev.PipelineRun","knative.dev/traceid":"94968bce-2b74-4128-9d56-f46dbebcbf49","knative.dev/key":"article-pipelines/article-bzx9l","pipeline-run":"article-bzx9l","event-sha":"25d3c47ed775e97e2ebbd893890ea88a5af905f7"}

``` 

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
