### PR TITLE
Remove kind ClusterTask from generic template

### DIFF
--- a/pkg/cmd/tknpac/generate/templates/generic.yaml
+++ b/pkg/cmd/tknpac/generate/templates/generic.yaml
@@ -45,7 +45,6 @@ spec:
       - name: fetch-repository
         taskRef:
           name: git-clone
-          kind: ClusterTask
         workspaces:
           - name: output
             workspace: source


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Issue
`tkn-pac generate` uses generic template and it used to have `kind: ClusterTask` so when we push those changes Pipelinerun use to fail with error `CouldNotGetTask`
```
  Warning  Failed           25s (x2 over 25s)  PipelineRun             Pipeline article-pipelines/article-pull-request-qjpsq can't be Run; it contains Tasks that don't exist: Couldn't retrieve Task "git-clone": clustertasks.tekton.dev "git-clone" not found
  Normal   FinalizerUpdate  25s                pipelinerun-controller  Updated "article-pull-request-qjpsq" finalizers
  Warning  Error            25s                PipelineRun             Operation cannot be fulfilled on pipelineruns.tekton.dev "article-pull-request-qjpsq": the object has been modified; please apply your changes to the latest version and try again
  Warning  InternalError    25s                PipelineRun             2 errors occurred:
           * Couldn't retrieve Task "git-clone": clustertasks.tekton.dev "git-clone" not found
           * Operation cannot be fulfilled on pipelineruns.tekton.dev "article-pull-request-qjpsq": the object has been modified; please apply your changes to the latest version and try again
  Warning  InternalError  25s  PipelineRun  1 error occurred:
           * Couldn't retrieve Task "git-clone": clustertasks.tekton.dev "git-clone" not found
```
# Changes
* Removed `kind: ClusterTask` from generic.yaml

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
