### PR TITLE
Replaces update with patch for adding checkrun label

### DIFF
--- a/config/201-controller-role.yaml
+++ b/config/201-controller-role.yaml
@@ -73,7 +73,7 @@ rules:
     verbs: ["create", "get", "list", "update"]
   - apiGroups: ["tekton.dev"]
     resources: ["pipelineruns"]
-    verbs: ["get", "delete", "list", "create", "watch", "update"]
+    verbs: ["get", "delete", "list", "create", "watch", "update", "patch"]
   - apiGroups: ["route.openshift.io"]
     resources: ["routes"]
     verbs: ["get"]


### PR DESCRIPTION
instead of doing multiple calls, we could just use patch to add
label on the pipelinerun.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
