### PR TITLE
Temporary fix to handle race condition occuring with updating check run label

### DIFF
--- a/config/201-controller-role.yaml
+++ b/config/201-controller-role.yaml
@@ -73,7 +73,7 @@ rules:
     verbs: ["create", "get", "list", "update"]
   - apiGroups: ["tekton.dev"]
     resources: ["pipelineruns"]
-    verbs: ["get", "delete", "list", "create", "watch", "update", "patch"]
+    verbs: ["get", "delete", "list", "create", "watch", "update"]
   - apiGroups: ["route.openshift.io"]
     resources: ["routes"]
     verbs: ["get"]

--- a/pkg/provider/github/status.go
+++ b/pkg/provider/github/status.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"strconv"
@@ -15,7 +14,6 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 const taskStatusTemplate = `
@@ -148,28 +146,22 @@ func (v *Provider) updatePipelineRunWithCheckRunID(ctx context.Context, tekton v
 	}
 	maxRun := 10
 	for i := 0; i < maxRun; i++ {
-		mergePatch := map[string]interface{}{
-			"metadata": map[string]interface{}{
-				"labels": map[string]string{
-					filepath.Join(apipac.GroupName, checkRunIDKey): strconv.FormatInt(*checkRunID, 10),
-				},
-			},
-		}
-		patch, err := json.Marshal(mergePatch)
+		pr, err := tekton.TektonV1beta1().PipelineRuns(pr.GetNamespace()).Get(ctx, pr.GetName(), v1.GetOptions{})
 		if err != nil {
 			return err
 		}
+		pr = pr.DeepCopy()
+		pr.GetLabels()[filepath.Join(apipac.GroupName, checkRunIDKey)] = strconv.FormatInt(*checkRunID, 10)
 
-		updatedPR, err := tekton.TektonV1beta1().PipelineRuns(pr.Namespace).Patch(ctx, pr.GetName(), types.MergePatchType, patch, v1.PatchOptions{})
+		pr, err = tekton.TektonV1beta1().PipelineRuns(pr.Namespace).Update(ctx, pr, v1.UpdateOptions{})
 		if err != nil {
-			v.Logger.Infof("Could not patch Pipelinerun with checkRunID, retrying %v/%v: %v", pr.GetNamespace(), pr.GetName(), err)
+			v.Logger.Infof("Could not update Pipelinerun with checkRunID, retrying %v/%v: %v", pr.GetNamespace(), pr.GetName(), err)
 			continue
 		}
-
-		v.Logger.Infof("PipelineRun %v/%v patched with checkRunID : %v", pr.GetNamespace(), pr.GetName(), updatedPR.Labels[filepath.Join(apipac.GroupName, checkRunIDKey)])
+		v.Logger.Infof("PipelineRun %v/%v updated with checkRunID", pr.GetNamespace(), pr.GetName())
 		return nil
 	}
-	return fmt.Errorf("cannot patch pipelineRun %v/%v with checkRunID", pr.GetNamespace(), pr.GetName())
+	return fmt.Errorf("cannot update pipelineRun %v/%v with checkRunID", pr.GetNamespace(), pr.GetName())
 }
 
 // createStatusCommit use the classic/old statuses API which is available when we


### PR DESCRIPTION
Revert "Replaces update with patch for adding checkrun label"

This reverts commit https://github.com/openshift-pipelines/pipelines-as-code/commit/1ffb14d776c67077d46d939e82ab4316b9ec0932.
this is a temporary fix to fix the race condition occuring during
adding the checkrunid label.

--- 

Wait for tekton.dev/pipeline label to add checkrun id label

this updates controller to wait for pipeline label in order to
avoid race condition.
this is a temporaray fix, we will update this with a proper fix soon.

this will not any performance change as pipelinerun is created and
started and waiting for adding label will not any effect on execution of
pipelinerun.

in case of concurreny, there may be delay of a few seconds in starting of
first pipelinerun from .tekton directory.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [x] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [x] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [x] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [x] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
