### PR TITLE
Update gitlab-webhook command

### DIFF
--- a/pkg/cli/webhook/gitlab_test.go
+++ b/pkg/cli/webhook/gitlab_test.go
@@ -21,10 +21,12 @@ func TestAskGLWebhookConfig(t *testing.T) {
 		askStubs      func(*prompt.AskStubber)
 		providerURL   string
 		controllerURL string
+		repoURL       string
 	}{
 		{
 			name: "ask all details no defaults",
 			askStubs: func(as *prompt.AskStubber) {
+				as.StubOne("https://gitlab.com/pac/test")
 				as.StubOne("id")
 				as.StubOne("https://test")
 				as.StubOne("webhook-secret")
@@ -41,6 +43,7 @@ func TestAskGLWebhookConfig(t *testing.T) {
 				as.StubOne("webhook-secret")
 				as.StubOne("token")
 			},
+			repoURL:       "https://gitlab.com/pac/demo",
 			controllerURL: "https://test",
 			providerURL:   "https://gl.pac.test",
 			wantErrStr:    "",
@@ -55,7 +58,7 @@ func TestAskGLWebhookConfig(t *testing.T) {
 				tt.askStubs(as)
 			}
 			gl := gitLabConfig{IOStream: io}
-			err := gl.askGLWebhookConfig(tt.controllerURL, tt.providerURL)
+			err := gl.askGLWebhookConfig(tt.repoURL, tt.controllerURL, tt.providerURL)
 			if tt.wantErrStr != "" {
 				assert.Equal(t, err.Error(), tt.wantErrStr)
 				return


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
1. Update gitlab-webhook command to show default Repository info
2. Added check to not ask `Please enter your GitLab API URL::` for `https://gitlab.com` to make behavior similar to GitHub and Bitbucket
3. Modified message `Please enter your GitLab API URL::` -> `Please enter your GitLab enterprise API URL::`

Changes:

**Before:**
```
$ tkn pac setup gitlab-webhook

? Please enter the project ID for the repository you want to be configured,
  project ID refers to an unique ID shown at the top of your GitLab project : 17103
? Please enter your controller public route URL:  https://smee.io/kIVoOfQotuoc1Ca
ℹ ️You now need to create a GitLab personal access token with `api` scope
ℹ ️Go to this URL to generate one https://gitlab.com/-/profile/personal_access_tokens, see https://is.gd/rOEo9B for documentation
? Please enter the GitLab access token:  **************************
? Please enter your GitLab API URL::  https://gitlab.com/
✓ Webhook has been created on your repository
...
```

**After:**
```
$ ./tkn-pac setup gitlab-webhook

✓ Setting up GitLab Webhook for Repository https://gitlab.com/savitaashture/gitlabpushtestpac
? Please enter the project ID for the repository you want to be configured, 
  project ID refers to an unique ID shown at the top of your GitLab project : 17103
? Please enter your controller public route URL:  https://smee.io/kIVoOfQotuoc1Ca
ℹ ️You now need to create a GitLab personal access token with `api` scope
ℹ ️Go to this URL to generate one https://gitlab.com/-/profile/personal_access_tokens, see https://is.gd/rOEo9B for documentation 
? Please enter the GitLab access token:  **************************
✓ Webhook has been created on your repository
...
```

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
