### PR TITLE
Update to golangci-lint 1.49.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,7 +17,6 @@ linters:
     - dogsled
     - durationcheck
     - exhaustive
-    # - exhaustivestruct
     - exportloopref
     - forbidigo
     - forcetypeassert
@@ -30,11 +29,9 @@ linters:
     - gosec
     - gocritic
     - misspell
-    - deadcode
     - gosec
     - gosimple
     - govet
-    - ifshort
     - importas
     - makezero
     - nakedret

--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -132,7 +132,8 @@ spec:
                 make test
 
             - name: lint
-              image: quay.io/app-sre/golangci-lint:v1.47.2
+              # golangci-lint has not tagged their image for 1.40.0 yet so using latest for now until we can pin it
+              image: mirror.gcr.io/golangci/golangci-lint:latest
               workingDir: $(workspaces.source.path)
               env:
                 - name: GOCACHE

--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"time"
@@ -76,7 +76,7 @@ func (l *listener) Start(_ context.Context) error {
 
 	mux.HandleFunc("/", l.handleEvent())
 
-	// nolint: gosec
+	//nolint: gosec
 	srv := &http.Server{
 		Addr: ":" + adapterPort,
 		Handler: http.TimeoutHandler(mux,
@@ -105,8 +105,10 @@ func (l listener) handleEvent() http.HandlerFunc {
 			return
 		}
 
+		// read request Body
+
 		// event body
-		payload, err := ioutil.ReadAll(request.Body)
+		payload, err := io.ReadAll(request.Body)
 		if err != nil {
 			l.logger.Errorf("failed to read body : %v", err)
 			response.WriteHeader(http.StatusInternalServerError)

--- a/pkg/cli/iostreams.go
+++ b/pkg/cli/iostreams.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	surveyCore "github.com/AlecAivazis/survey/v2/core"
@@ -117,7 +116,7 @@ func IOTest() (*IOStreams, *bytes.Buffer, *bytes.Buffer, *bytes.Buffer) {
 	out := &bytes.Buffer{}
 	errOut := &bytes.Buffer{}
 	return &IOStreams{
-		In:     ioutil.NopCloser(in),
+		In:     io.NopCloser(in),
 		Out:    out,
 		ErrOut: errOut,
 	}, in, out, errOut

--- a/pkg/cli/webhook/bitbucket_cloud.go
+++ b/pkg/cli/webhook/bitbucket_cloud.go
@@ -39,7 +39,6 @@ func (bb *bitbucketCloudConfig) Run(_ context.Context, opts *Options) (*response
 	}, bb.create()
 }
 
-// nolint: duplicate
 func (bb *bitbucketCloudConfig) askBBWebhookConfig(repositoryURL, controllerURL, apiURL string) error {
 	if repositoryURL == "" {
 		msg := "Please enter the git repository url you want to be configured: "

--- a/pkg/cli/webhook/bitbucket_cloud_test.go
+++ b/pkg/cli/webhook/bitbucket_cloud_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAskBBWebhookConfig(t *testing.T) {
-	// nolint
+	//nolint
 	io, _, _, _ := cli.IOTest()
 	tests := []struct {
 		name          string
@@ -74,7 +74,7 @@ func TestAskBBWebhookConfig(t *testing.T) {
 func TestBBCreate(t *testing.T) {
 	bbclient, mux, tearDown := bbcloudtest.SetupBBCloudClient(t)
 	defer tearDown()
-	// nolint
+	//nolint
 	io, _, _, _ := cli.IOTest()
 
 	// webhook created for repo pac/repo

--- a/pkg/cli/webhook/github.go
+++ b/pkg/cli/webhook/github.go
@@ -5,7 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -153,7 +153,7 @@ func (gh *gitHubConfig) create(ctx context.Context) error {
 	}
 
 	if res.Response.StatusCode != http.StatusCreated {
-		payload, err := ioutil.ReadAll(res.Body)
+		payload, err := io.ReadAll(res.Body)
 		if err != nil {
 			return fmt.Errorf("failed to read response body: %w", err)
 		}

--- a/pkg/cli/webhook/github_test.go
+++ b/pkg/cli/webhook/github_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAskGHWebhookConfig(t *testing.T) {
-	// nolint
+	//nolint
 	io, _, _, _ := cli.IOTest()
 	tests := []struct {
 		name          string
@@ -73,7 +73,7 @@ func TestAskGHWebhookConfig(t *testing.T) {
 func TestCreate(t *testing.T) {
 	fakeclient, mux, _, teardown := ghtesthelper.SetupGH()
 	defer teardown()
-	// nolint
+	//nolint
 	io, _, _, _ := cli.IOTest()
 
 	// webhook created for repo pac/valid

--- a/pkg/cli/webhook/gitlab.go
+++ b/pkg/cli/webhook/gitlab.go
@@ -5,7 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -129,7 +129,7 @@ func (gl *gitLabConfig) create() error {
 	}
 
 	if resp.Response.StatusCode != http.StatusCreated {
-		payload, err := ioutil.ReadAll(resp.Body)
+		payload, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return fmt.Errorf("failed to read response body: %w", err)
 		}

--- a/pkg/cli/webhook/gitlab_test.go
+++ b/pkg/cli/webhook/gitlab_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAskGLWebhookConfig(t *testing.T) {
-	// nolint
+	//nolint
 	io, _, _, _ := cli.IOTest()
 	tests := []struct {
 		name          string
@@ -69,7 +69,7 @@ func TestGLCreate(t *testing.T) {
 	ctx, _ := rtesting.SetupFakeContext(t)
 	fakeclient, mux, teardown := thelp.Setup(ctx, t)
 	defer teardown()
-	// nolint
+	//nolint
 	io, _, _, _ := cli.IOTest()
 
 	// webhook created

--- a/pkg/cmd/tknpac/bootstrap/web.go
+++ b/pkg/cmd/tknpac/bootstrap/web.go
@@ -17,7 +17,7 @@ import (
 // startWebServer starts a webserver that will redirect the user to the github app creation page.
 func startWebServer(ctx context.Context, opts *bootstrapOpts, run *params.Run, jeez string) error {
 	m := http.NewServeMux()
-	// nolint: gosec
+	//nolint: gosec
 	s := http.Server{Addr: fmt.Sprintf(":%d", opts.webserverPort), Handler: m}
 	codeCh := make(chan string)
 	m.HandleFunc("/", func(rw http.ResponseWriter, r *http.Request) {
@@ -36,7 +36,7 @@ func startWebServer(ctx context.Context, opts *bootstrapOpts, run *params.Run, j
 	go func() {
 		url := fmt.Sprintf("http://localhost:%d", opts.webserverPort)
 		fmt.Fprintf(opts.ioStreams.Out, "🌍 Starting a web browser on %s, click on the button to create your GitHub APP\n", url)
-		// nolint:errcheck
+		//nolint:errcheck
 		go browser.OpenWebBrowser(url)
 		if err := s.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.Fatal(err)

--- a/pkg/cmd/tknpac/generate/generate.go
+++ b/pkg/cmd/tknpac/generate/generate.go
@@ -3,7 +3,6 @@ package generate
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -234,8 +233,8 @@ func (o *Opts) samplePipeline() error {
 		return err
 	}
 
-	// nolint: gosec
-	err = ioutil.WriteFile(fpath, tmpl.Bytes(), 0o644)
+	//nolint: gosec
+	err = os.WriteFile(fpath, tmpl.Bytes(), 0o644)
 	if err != nil {
 		return fmt.Errorf("cannot write template to %s: %w", fpath, err)
 	}

--- a/pkg/cmd/tknpac/generate/generate_test.go
+++ b/pkg/cmd/tknpac/generate/generate_test.go
@@ -1,7 +1,6 @@
 package generate
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -125,7 +124,7 @@ func TestGenerateTemplate(t *testing.T) {
 				err := os.MkdirAll(filepath.Dir(nd.Join(key)), os.ModePerm)
 				assert.NilError(t, err, "failed to create dir: %s", filepath.Dir(nd.Join(key)))
 
-				err = ioutil.WriteFile(nd.Join(key), []byte(value), 0o600)
+				err = os.WriteFile(nd.Join(key), []byte(value), 0o600)
 				assert.NilError(t, err, "failed to create file", key)
 			}
 
@@ -145,7 +144,7 @@ func TestGenerateTemplate(t *testing.T) {
 			}
 			if tt.checkRegInGeneratedFile != nil {
 				// check if file contains the expected strings
-				b, err := ioutil.ReadFile(nd.Join(tt.checkGeneratedFile))
+				b, err := os.ReadFile(nd.Join(tt.checkGeneratedFile))
 				assert.NilError(t, err)
 				for _, s := range tt.checkRegInGeneratedFile {
 					// check if regexp matches

--- a/pkg/cmd/tknpac/generate/template.go
+++ b/pkg/cmd/tknpac/generate/template.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"embed"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -75,7 +75,7 @@ func (o *Opts) genTmpl() (*bytes.Buffer, error) {
 		log.Fatal(err)
 	}
 	defer embedfile.Close()
-	tmplB, _ := ioutil.ReadAll(embedfile)
+	tmplB, _ := io.ReadAll(embedfile)
 
 	prName := filepath.Base(o.GitInfo.URL)
 

--- a/pkg/cmd/tknpac/list/list_test.go
+++ b/pkg/cmd/tknpac/list/list_test.go
@@ -3,7 +3,7 @@ package list
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -29,7 +29,7 @@ func newIOStream() (*cli.IOStreams, *bytes.Buffer) {
 	out := &bytes.Buffer{}
 	errOut := &bytes.Buffer{}
 	return &cli.IOStreams{
-		In:     ioutil.NopCloser(in),
+		In:     io.NopCloser(in),
 		Out:    out,
 		ErrOut: errOut,
 	}, out

--- a/pkg/cmd/tknpac/logs/logs.go
+++ b/pkg/cmd/tknpac/logs/logs.go
@@ -235,7 +235,7 @@ func showLogsWithWebConsole(lo *logOption, pr string) error {
 }
 
 func showlogswithtkn(tknPath, pr, ns string) error {
-	// nolint: gosec
+	//nolint: gosec
 	if err := syscall.Exec(tknPath, []string{tknPath, "pr", "logs", "-f", "-n", ns, pr}, os.Environ()); err != nil {
 		fmt.Fprintf(os.Stderr, "Command finished with error: %v", err)
 		os.Exit(127)

--- a/pkg/cmd/tknpac/resolve/resolve.go
+++ b/pkg/cmd/tknpac/resolve/resolve.go
@@ -3,7 +3,6 @@ package resolve
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -167,7 +166,7 @@ func resolveFilenames(cs *params.Run, filenames []string, params map[string]stri
 }
 
 func appendYaml(filename string) string {
-	b, err := ioutil.ReadFile(filename)
+	b, err := os.ReadFile(filename)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/cmd/tknpac/resolve/resolve_test.go
+++ b/pkg/cmd/tknpac/resolve/resolve_test.go
@@ -46,7 +46,7 @@ func TestSplitArgsInMap(t *testing.T) {
 func TestCommandFilenameSetProperly(t *testing.T) {
 	tdata := testclient.Data{}
 	ctx, _ := rtesting.SetupFakeContext(t)
-	// nolint
+	//nolint
 	io, _, _, _ := cli.IOTest()
 	stdata, _ := testclient.SeedTestData(t, ctx, tdata)
 	cs := &params.Run{

--- a/pkg/generated/clientset/versioned/fake/register.go
+++ b/pkg/generated/clientset/versioned/fake/register.go
@@ -39,14 +39,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/generated/clientset/versioned/scheme/register.go
+++ b/pkg/generated/clientset/versioned/scheme/register.go
@@ -39,14 +39,14 @@ var (
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -17,7 +17,7 @@ type Info struct {
 func RunGit(dir string, args ...string) (string, error) {
 	gitPath, err := exec.LookPath("git")
 	if err != nil {
-		// nolint: nilerr
+		//nolint: nilerr
 		return "", nil
 	}
 	c := exec.Command(gitPath, args...)

--- a/pkg/kubeinteraction/secrets.go
+++ b/pkg/kubeinteraction/secrets.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	// nolint:gosec
+	//nolint:gosec
 	basicAuthSecretName    = `pac-gitauth-%s`
 	basicAuthGitConfigData = `
 	[credential "%s"]

--- a/pkg/matcher/annotation_tasks_install.go
+++ b/pkg/matcher/annotation_tasks_install.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"regexp"
@@ -54,7 +54,7 @@ func (rt RemoteTasks) getTask(ctx context.Context, logger *zap.SugaredLogger, pr
 		if err != nil {
 			return ret, err
 		}
-		data, _ := ioutil.ReadAll(res.Body)
+		data, _ := io.ReadAll(res.Body)
 		defer res.Body.Close()
 		return rt.convertTotask(string(data))
 	case strings.Contains(task, "/"):
@@ -120,7 +120,7 @@ func getTaskFromLocalFS(taskName string, logger *zap.SugaredLogger) (string, err
 		return "", nil
 	}
 
-	b, err := ioutil.ReadFile(taskName)
+	b, err := os.ReadFile(taskName)
 	data = string(b)
 	if err != nil {
 		return "", err

--- a/pkg/params/clients/clients.go
+++ b/pkg/params/clients/clients.go
@@ -3,7 +3,7 @@ package clients
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/consoleui"
@@ -44,7 +44,7 @@ func (c *Clients) GetURL(ctx context.Context, url string) ([]byte, error) {
 		return nil, fmt.Errorf("Non-OK HTTP status: %d", res.StatusCode)
 	}
 
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 	if err != nil {
 		return []byte{}, err
 	}

--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -214,7 +214,7 @@ func changeSecret(prs []*tektonv1beta1.PipelineRun) error {
 // checks are deprecated/removed to n+1 release of OSP.
 // each check should give a good error message on how to update.
 func (p *PacRun) checkNeedUpdate(tmpl string) (string, bool) {
-	// nolint: gosec
+	//nolint: gosec
 	oldBasicAuthSecretName := `\W*secretName: "pac-git-basic-auth-{{repo_owner}}-{{repo_name}}"`
 	if matched, _ := regexp.MatchString(oldBasicAuthSecretName, tmpl); matched {
 		return `!Update needed! you have a old basic auth secret name, you need to modify your pipelinerun and change the string "secret: pac-git-basic-auth-{{repo_owner}}-{{repo_name}}" to "secret: {{ git_auth_secret }}"`, true

--- a/pkg/pipelineascode/match_test.go
+++ b/pkg/pipelineascode/match_test.go
@@ -19,8 +19,8 @@ func TestPacRun_checkNeedUpdate(t *testing.T) {
 		needupdate           bool
 	}{
 		{
-			name: "old secrets",
-			tmpl: `		  secretName: "pac-git-basic-auth-{{repo_owner}}-{{repo_name}}"`,
+			name:                 "old secrets",
+			tmpl:                 `		  secretName: "pac-git-basic-auth-{{repo_owner}}-{{repo_name}}"`,
 			upgradeMessageSubstr: "old basic auth secret name",
 			needupdate:           true,
 		},

--- a/pkg/pipelineascode/pipelinesascode_github_test.go
+++ b/pkg/pipelineascode/pipelinesascode_github_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -73,7 +73,7 @@ func testSetupCommonGhReplies(t *testing.T, mux *http.ServeMux, runevent info.Ev
 
 	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/check-runs/26", runevent.Organization, runevent.Repository),
 		func(w http.ResponseWriter, r *http.Request) {
-			body, _ := ioutil.ReadAll(r.Body)
+			body, _ := io.ReadAll(r.Body)
 			created := github.CreateCheckRunOptions{}
 			err := json.Unmarshal(body, &created)
 			assert.NilError(t, err)

--- a/pkg/provider/bitbucketcloud/test/bbcloudtest.go
+++ b/pkg/provider/bitbucketcloud/test/bbcloudtest.go
@@ -3,7 +3,7 @@ package test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -142,7 +142,7 @@ func MuxCreateCommitstatus(t *testing.T, mux *http.ServeMux, event *info.Event, 
 	path := fmt.Sprintf("/repositories/%s/%s/commit/%s/statuses/build", event.Organization, event.Repository, event.SHA)
 	mux.HandleFunc(path, func(rw http.ResponseWriter, r *http.Request) {
 		cso := &bitbucket.CommitStatusOptions{}
-		bit, _ := ioutil.ReadAll(r.Body)
+		bit, _ := io.ReadAll(r.Body)
 		err := json.Unmarshal(bit, cso)
 		assert.NilError(t, err)
 
@@ -169,7 +169,7 @@ func MuxCreateComment(t *testing.T, mux *http.ServeMux, event *info.Event, expec
 	path := fmt.Sprintf("/repositories/%s/%s/pullrequests/%s/comments", event.Organization, event.Repository, prID)
 	mux.HandleFunc(path, func(rw http.ResponseWriter, r *http.Request) {
 		cso := &types.Comment{}
-		bit, _ := ioutil.ReadAll(r.Body)
+		bit, _ := io.ReadAll(r.Body)
 		err := json.Unmarshal(bit, cso)
 		assert.NilError(t, err)
 		if expectedCommentSubstr != "" {
@@ -183,7 +183,7 @@ func MuxCreateComment(t *testing.T, mux *http.ServeMux, event *info.Event, expec
 
 func MuxDirContent(t *testing.T, mux *http.ServeMux, event *info.Event, testdir string) {
 	t.Helper()
-	files, err := ioutil.ReadDir(testdir)
+	files, err := os.ReadDir(testdir)
 	assert.NilError(t, err)
 	lastindex := strings.LastIndex(testdir, ".tekton")
 
@@ -208,7 +208,7 @@ func MuxDirContent(t *testing.T, mux *http.ServeMux, event *info.Event, testdir 
 				Path: relativename,
 				Type: btype,
 			})
-			content, err := ioutil.ReadFile(fpath)
+			content, err := os.ReadFile(fpath)
 			assert.NilError(t, err)
 			filecontents[relativename] = string(content)
 		}

--- a/pkg/provider/bitbucketserver/acl_test.go
+++ b/pkg/provider/bitbucketserver/acl_test.go
@@ -1,17 +1,17 @@
 /*
-   Copyright 2021 Red Hat
+Copyright 2021 Red Hat
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 package bitbucketserver
 

--- a/pkg/provider/bitbucketserver/bitbucketserver_test.go
+++ b/pkg/provider/bitbucketserver/bitbucketserver_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto/hmac"
 
-	// nolint
+	//nolint
 	"crypto/sha1"
 	"crypto/sha256"
 	"encoding/hex"

--- a/pkg/provider/bitbucketserver/events_test.go
+++ b/pkg/provider/bitbucketserver/events_test.go
@@ -55,7 +55,7 @@ func TestParsePayload(t *testing.T) {
 					Sender:       "sender",
 					Organization: "PROJ",
 					Repository:   "repo",
-					// nolint: stylecheck
+					//nolint: stylecheck
 					URL: "💢",
 					SHA: "abcd",
 				},

--- a/pkg/provider/bitbucketserver/test/test.go
+++ b/pkg/provider/bitbucketserver/test/test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -58,7 +58,7 @@ func MuxCreateComment(t *testing.T, mux *http.ServeMux, event *info.Event, expec
 	path := fmt.Sprintf("/projects/%s/repos/%s/pull-requests/%d/comments", event.Organization, event.Repository, prID)
 	mux.HandleFunc(path, func(rw http.ResponseWriter, r *http.Request) {
 		cso := &bbv1.Comment{}
-		bit, _ := ioutil.ReadAll(r.Body)
+		bit, _ := io.ReadAll(r.Body)
 		err := json.Unmarshal(bit, cso)
 		assert.NilError(t, err)
 		if expectedCommentSubstr != "" {
@@ -112,7 +112,7 @@ func MakeEvent(event *info.Event) *info.Event {
 }
 
 func MuxDirContent(t *testing.T, mux *http.ServeMux, event *info.Event, testDir string, targetDirName string) {
-	files, err := ioutil.ReadDir(testDir)
+	files, err := os.ReadDir(testDir)
 	if err != nil {
 		// no error just disapointed
 		return
@@ -127,7 +127,7 @@ func MuxDirContent(t *testing.T, mux *http.ServeMux, event *info.Event, testDir 
 		if info, err := os.Stat(fpath); err == nil && info.IsDir() {
 			continue
 		}
-		content, err := ioutil.ReadFile(fpath)
+		content, err := os.ReadFile(fpath)
 		assert.NilError(t, err)
 		filecontents[path] = string(content)
 	}
@@ -205,7 +205,7 @@ func MuxCreateAndTestCommitStatus(t *testing.T, mux *http.ServeMux, event *info.
 	path := fmt.Sprintf("/commits/%s", event.SHA)
 	mux.HandleFunc(path, func(rw http.ResponseWriter, r *http.Request) {
 		cso := &bbv1.BuildStatus{}
-		bit, _ := ioutil.ReadAll(r.Body)
+		bit, _ := io.ReadAll(r.Body)
 		err := json.Unmarshal(bit, cso)
 		assert.NilError(t, err)
 

--- a/pkg/provider/github/github_test.go
+++ b/pkg/provider/github/github_test.go
@@ -5,7 +5,7 @@ import (
 	"crypto/hmac"
 	"strings"
 
-	// nolint: gosec
+	//nolint: gosec
 	"crypto/sha1"
 	"crypto/sha256"
 	"encoding/hex"

--- a/pkg/provider/github/status_test.go
+++ b/pkg/provider/github/status_test.go
@@ -3,7 +3,7 @@ package github
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"path/filepath"
 	"reflect"
@@ -223,7 +223,7 @@ func TestGithubProviderCreateStatus(t *testing.T) {
 			}
 			mux.HandleFunc("/repos/check/run/statuses/sha", func(rw http.ResponseWriter, r *http.Request) {})
 			mux.HandleFunc(fmt.Sprintf("/repos/check/run/check-runs/%d", checkrunid), func(rw http.ResponseWriter, r *http.Request) {
-				bit, _ := ioutil.ReadAll(r.Body)
+				bit, _ := io.ReadAll(r.Body)
 				checkRun := &github.CheckRun{}
 				err := json.Unmarshal(bit, checkRun)
 				assert.NilError(t, err)
@@ -334,13 +334,13 @@ func TestGithubProvidercreateStatusCommit(t *testing.T) {
 			defer teardown()
 			mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/statuses/%s",
 				tt.event.Organization, tt.event.Repository, tt.event.SHA), func(rw http.ResponseWriter, r *http.Request) {
-				body, _ := ioutil.ReadAll(r.Body)
+				body, _ := io.ReadAll(r.Body)
 				assert.Check(t, strings.Contains(string(body), fmt.Sprintf(`"state":"%s"`, tt.expectedConclusion)))
 			})
 			if tt.status.Status == "completed" {
 				mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/issues/%d/comments",
 					tt.event.Organization, tt.event.Repository, issuenumber), func(rw http.ResponseWriter, r *http.Request) {
-					body, _ := ioutil.ReadAll(r.Body)
+					body, _ := io.ReadAll(r.Body)
 					assert.Equal(t, fmt.Sprintf(`{"body":"%s<br>%s"}`, tt.status.Summary, tt.status.Text)+"\n", string(body))
 				})
 			}

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -325,7 +325,7 @@ func (v *Provider) CreateStatus(_ context.Context, _ versioned.Interface, event 
 		TargetURL:   gitlab.String(detailsURL),
 		Description: gitlab.String(statusOpts.Title),
 	}
-	// nolint: dogsled
+	//nolint: dogsled
 	_, _, _ = v.Client.Commits.SetCommitStatus(event.SourceProjectID, event.SHA, opt)
 
 	// only add a note when we are on a MR

--- a/pkg/provider/gitlab/gitlab_test.go
+++ b/pkg/provider/gitlab/gitlab_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 
@@ -346,7 +346,7 @@ func TestSetClient(t *testing.T) {
 }
 
 func TestGetTektonDir(t *testing.T) {
-	samplePR, err := ioutil.ReadFile("../../resolve/testdata/pipeline-finally.yaml")
+	samplePR, err := os.ReadFile("../../resolve/testdata/pipeline-finally.yaml")
 	assert.NilError(t, err)
 	type fields struct {
 		targetProjectID int

--- a/pkg/provider/gitlab/test/test.go
+++ b/pkg/provider/gitlab/test/test.go
@@ -3,7 +3,7 @@ package test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -44,7 +44,7 @@ func Setup(ctx context.Context, t *testing.T) (*gitlab.Client, *http.ServeMux, f
 func MuxNotePost(t *testing.T, mux *http.ServeMux, projectNumber int, mrID int, catchStr string) {
 	path := fmt.Sprintf("/projects/%d/merge_requests/%d/notes", projectNumber, mrID)
 	mux.HandleFunc(path, func(rw http.ResponseWriter, r *http.Request) {
-		bit, _ := ioutil.ReadAll(r.Body)
+		bit, _ := io.ReadAll(r.Body)
 		s := string(bit)
 		if catchStr != "" {
 			assert.Assert(t, strings.Contains(s, catchStr), "%s is not in %s", catchStr, s)
@@ -136,7 +136,7 @@ func (t TEvent) PushEventAsJSON(withcommits bool) string {
 }
 
 func (t TEvent) NoteEventAsJSON(comment string) string {
-	// nolint:misspell
+	//nolint:misspell
 	return fmt.Sprintf(`{
 	"object_kind": "note",
 	"event_type": "note",

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -3,8 +3,9 @@ package reconciler
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -123,7 +124,7 @@ func TestReconciler_ReconcileKind(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, _ := rtesting.SetupFakeContext(t)
-			b, err := ioutil.ReadFile(fmt.Sprintf("testdata/%s.yaml", tt.pipelineRunfile))
+			b, err := os.ReadFile(fmt.Sprintf("testdata/%s.yaml", tt.pipelineRunfile))
 			if err != nil {
 				t.Fatalf("ReadFile() = %v", err)
 			}
@@ -196,7 +197,7 @@ func TestReconciler_ReconcileKind(t *testing.T) {
 func testSetupGHReplies(t *testing.T, mux *http.ServeMux, runevent info.Event, checkrunID, finalStatus, finalStatusText string) {
 	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/check-runs/%s", runevent.Organization, runevent.Repository, checkrunID),
 		func(w http.ResponseWriter, r *http.Request) {
-			body, _ := ioutil.ReadAll(r.Body)
+			body, _ := io.ReadAll(r.Body)
 			created := github.CreateCheckRunOptions{}
 			err := json.Unmarshal(body, &created)
 			assert.NilError(t, err)

--- a/pkg/resolve/resolve.go
+++ b/pkg/resolve/resolve.go
@@ -200,7 +200,7 @@ func Resolve(ctx context.Context, cs *params.Run, logger *zap.SugaredLogger, pro
 	return types.PipelineRuns, nil
 }
 
-// nolint:gochecknoinits
+//nolint:gochecknoinits
 func init() {
 	_ = tektonv1beta1.AddToScheme(k8scheme.Scheme)
 }

--- a/pkg/resolve/resolve_test.go
+++ b/pkg/resolve/resolve_test.go
@@ -1,7 +1,6 @@
 package resolve
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -36,7 +35,7 @@ func setup() {
 func readTDfile(t *testing.T, testname string, generateName bool, remoteTasking bool) (*tektonv1beta1.PipelineRun, *zapobserver.ObservedLogs, error) {
 	t.Helper()
 	ctx, _ := rtesting.SetupFakeContext(t)
-	data, err := ioutil.ReadFile("testdata/" + testname + ".yaml")
+	data, err := os.ReadFile("testdata/" + testname + ".yaml")
 	if err != nil {
 		return &tektonv1beta1.PipelineRun{}, nil, err
 	}

--- a/pkg/test/cli/iostreams.go
+++ b/pkg/test/cli/iostreams.go
@@ -2,7 +2,7 @@ package cli
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
 )
@@ -13,7 +13,7 @@ func NewIOStream() (*cli.IOStreams, *bytes.Buffer) {
 	out := &bytes.Buffer{}
 	errOut := &bytes.Buffer{}
 	return &cli.IOStreams{
-		In:     ioutil.NopCloser(in),
+		In:     io.NopCloser(in),
 		Out:    out,
 		ErrOut: errOut,
 	}, out

--- a/pkg/test/clients/clients.go
+++ b/pkg/test/clients/clients.go
@@ -45,8 +45,7 @@ type Data struct {
 
 // SeedTestData returns Clients and Informers populated with the
 // given Data.
-// nolint: golint, revive
-func SeedTestData(t *testing.T, ctx context.Context, d Data) (Clients, Informers) {
+func SeedTestData(t *testing.T, ctx context.Context, d Data) (Clients, Informers) { //nolint: golint, revive
 	c := Clients{
 		PipelineAsCode: fakepacclient.Get(ctx),
 		Kube:           fakekubeclient.Get(ctx),

--- a/pkg/test/github/github.go
+++ b/pkg/test/github/github.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -76,7 +75,7 @@ func SetupGitTree(t *testing.T, mux *http.ServeMux, dir string, event *info.Even
 		})
 		assert.NilError(t, err)
 	} else {
-		dfiles, err := ioutil.ReadDir(dir)
+		dfiles, err := os.ReadDir(dir)
 		assert.NilError(t, err)
 
 		for _, f := range dfiles {
@@ -113,7 +112,7 @@ func SetupGitTree(t *testing.T, mux *http.ServeMux, dir string, event *info.Even
 					}
 					assert.Assert(t, chosenf.name != "", "sha %s not found", sha)
 
-					s, err := ioutil.ReadFile(chosenf.name)
+					s, err := os.ReadFile(chosenf.name)
 					assert.NilError(t, err)
 					// encode content as base64
 					blob := &github.Blob{

--- a/pkg/test/http/http.go
+++ b/pkg/test/http/http.go
@@ -2,7 +2,7 @@ package http
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"testing"
@@ -26,7 +26,7 @@ func MakeHTTPTestClient(t *testing.T, config map[string]map[string]string) *http
 					Header:     make(http.Header),
 				}
 				if body, ok := v["body"]; ok {
-					resp.Body = ioutil.NopCloser(bytes.NewBufferString(body))
+					resp.Body = io.NopCloser(bytes.NewBufferString(body))
 				}
 			}
 		}

--- a/test/github_pullrequest_remote_annotations_test.go
+++ b/test/github_pullrequest_remote_annotations_test.go
@@ -6,8 +6,8 @@ package test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -28,13 +28,13 @@ func TestGithubPullRequestRemoteAnnotations(t *testing.T) {
 	runcnx, opts, ghcnx, err := tgithub.Setup(ctx, false)
 	assert.NilError(t, err)
 
-	prun, err := ioutil.ReadFile("testdata/pipelinerun_remote_annotations.yaml")
+	prun, err := os.ReadFile("testdata/pipelinerun_remote_annotations.yaml")
 	assert.NilError(t, err)
 
-	pipeline, err := ioutil.ReadFile("testdata/pipeline_remote_annotations.yaml")
+	pipeline, err := os.ReadFile("testdata/pipeline_remote_annotations.yaml")
 	assert.NilError(t, err)
 
-	taskreferencedinternally, err := ioutil.ReadFile("testdata/task_referenced_internally.yaml")
+	taskreferencedinternally, err := os.ReadFile("testdata/task_referenced_internally.yaml")
 	assert.NilError(t, err)
 
 	entries := map[string]string{

--- a/test/pkg/payload/get_entries.go
+++ b/test/pkg/payload/get_entries.go
@@ -2,14 +2,14 @@ package payload
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 )
 
 func GetEntries(yamlfile []string, targetNS, targetBranch, targetEvent string) (map[string]string, error) {
 	entries := map[string]string{}
 	for _, file := range yamlfile {
-		yamlprun, err := ioutil.ReadFile(file)
+		yamlprun, err := os.ReadFile(file)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read yaml file: %w", err)
 		}

--- a/test/pkg/payload/send.go
+++ b/test/pkg/payload/send.go
@@ -4,15 +4,15 @@ import (
 	"bytes"
 	"context"
 	"crypto/hmac"
+	"io"
 	"os"
 
-	// nolint:gosec
+	//nolint:gosec
 	"crypto/sha1"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 
@@ -58,6 +58,6 @@ func Send(ctx context.Context, cs *params.Run, elURL, elWebHookSecret, githubURL
 		return fmt.Errorf("responses Error: %+d", resp.StatusCode)
 	}
 	defer resp.Body.Close()
-	_, err = ioutil.ReadAll(resp.Body)
+	_, err = io.ReadAll(resp.Body)
 	return err
 }


### PR DESCRIPTION
* Remove depreacted linters
* //nolint instead of the // nolint
* migrate from depreacted ioutil to io/os
* use a timeout for http.ListenAndServe Same values on what we have for
  triggers eventlistener.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
