### PR TITLE
Pins down k8s version to avoid failure due to deprecated res in pipelines

### DIFF
--- a/hack/dev/kind/install.sh
+++ b/hack/dev/kind/install.sh
@@ -71,7 +71,7 @@ containerdConfigPatches:
     endpoint = ["http://${REG_NAME}:5000"]
 EOF
 
-	${SUDO} ${kind} create cluster --name ${KIND_CLUSTER_NAME} --config  ${TMPD}/kconfig.yaml
+	${SUDO} ${kind} create cluster --image kindest/node:v1.24.0 --name ${KIND_CLUSTER_NAME} --config  ${TMPD}/kconfig.yaml
 	mkdir -p $(dirname ${KUBECONFIG})
 	${SUDO} ${kind} --name ${KIND_CLUSTER_NAME} get kubeconfig > ${KUBECONFIG}
 


### PR DESCRIPTION
…ines

k8s 1.25:
 no matches for kind "HorizontalPodAutoscaler" in version "autoscaling/v2beta1"
 no matches for kind "PodSecurityPolicy" in version "policy/v1beta1"
and pipelines latest release still have HPA and PSP,

so till pipelines updates those resources we pin down k8s.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
