### PR TITLE
Escape square brackets in k8s label values

### DIFF
--- a/pkg/formatting/k8labels.go
+++ b/pkg/formatting/k8labels.go
@@ -6,6 +6,6 @@ import "strings"
 // full ref, we replace the "/" by "-". The tools probably need to be aware of
 // it when querying.
 func K8LabelsCleanup(s string) string {
-	replasoeur := strings.NewReplacer("/", "-", " ", "_")
+	replasoeur := strings.NewReplacer("/", "-", " ", "_", "[", "__", "]", "__")
 	return replasoeur.Replace(s)
 }

--- a/pkg/formatting/k8labels_test.go
+++ b/pkg/formatting/k8labels_test.go
@@ -18,6 +18,11 @@ func TestK8LabelsCleanup(t *testing.T) {
 			str:  "foo-bar_hello",
 			want: "foo-bar_hello",
 		},
+		{
+			name: "github bot name",
+			str:  "github-actions[bot]",
+			want: "github-actions__bot__",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This problem arises whenever the `pipelinesascode.tekton.dev/sender` label is set for a pipelinerun trigger by a commit pushed by a GitHub bot. The bot's name `github-actions[bot]` is not a valid label value, which causes the PipelineRun to fail admission.

Related https://issues.redhat.com/browse/SRVKP-2461

# Changes

This adds additional characters to the existing escape list, handling the case of github bot names.

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [x] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [x] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [x] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [x] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
