### PR TITLE
Fix  E2E  tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,7 +45,7 @@ linters:
       # - goconst
       # - gocyclo
     # - goerr113
-    - gofmt
+    # - gofmt
     - goheader
     - gomodguard
     - goprintffuncname

--- a/pkg/matcher/annotation_matcher.go
+++ b/pkg/matcher/annotation_matcher.go
@@ -148,7 +148,7 @@ func MatchPipelinerunByAnnotation(ctx context.Context, logger *zap.SugaredLogger
 			prMatch.Config["target-namespace"] = targetNS
 			prMatch.Repo, _ = MatchEventURLRepo(ctx, cs, event, targetNS)
 			if prMatch.Repo == nil {
-				logger.Warnf("could not find Repository CRD in branch %s, the pipelineRun %s has a label that explictely targets it", targetNS, prun.GetGenerateName())
+				logger.Warnf("could not find Repository CRD in branch %s, the pipelineRun %s has a label that explicitly targets it", targetNS, prun.GetGenerateName())
 				continue
 			}
 		}

--- a/pkg/matcher/annotation_matcher.go
+++ b/pkg/matcher/annotation_matcher.go
@@ -148,7 +148,7 @@ func MatchPipelinerunByAnnotation(ctx context.Context, logger *zap.SugaredLogger
 			prMatch.Config["target-namespace"] = targetNS
 			prMatch.Repo, _ = MatchEventURLRepo(ctx, cs, event, targetNS)
 			if prMatch.Repo == nil {
-				logger.Warnf("could not find Repository CRD in %s while pipelineRun %s targets it", targetNS, prun.GetGenerateName())
+				logger.Warnf("could not find Repository CRD in branch %s, the pipelineRun %s has a label that explictely targets it", targetNS, prun.GetGenerateName())
 				continue
 			}
 		}

--- a/pkg/pipelineascode/match_test.go
+++ b/pkg/pipelineascode/match_test.go
@@ -20,7 +20,7 @@ func TestPacRun_checkNeedUpdate(t *testing.T) {
 	}{
 		{
 			name:                 "old secrets",
-			tmpl:                 `		  secretName: "pac-git-basic-auth-{{repo_owner}}-{{repo_name}}"`,
+			tmpl:                 `secretName: "pac-git-basic-auth-{{repo_owner}}-{{repo_name}}"`,
 			upgradeMessageSubstr: "old basic auth secret name",
 			needupdate:           true,
 		},

--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -52,7 +52,7 @@ func TestGiteaPullRequestPrivateRepository(t *testing.T) {
 		Regexp:      successRegexp,
 		TargetEvent: options.PullRequestEvent,
 		YAMLFiles: map[string]string{
-			".tekton/pipeline.yaml": "testdata/pipelinerun_git_clone_private.yaml.specific.to.gitea",
+			".tekton/pipeline.yaml": "testdata/pipelinerun_git_clone_private-gitea.yaml",
 		},
 	}
 	tgitea.TestPR(t, topts)()

--- a/test/github_pullrequest_concurrency_test.go
+++ b/test/github_pullrequest_concurrency_test.go
@@ -42,7 +42,10 @@ func TestGithubPullRequestConcurrency(t *testing.T) {
 	err = tgithub.CreateCRD(ctx, t, repoinfo, runcnx, opts, targetNS)
 	assert.NilError(t, err)
 
-	yamlFiles := map[string]string{".tekton/pr_longrunning.yaml": "testdata/pipelinerun_long_running.yaml", ".tekton/pr_longrunninganother": "testdata/pipelinerun_long_running_another.yaml"}
+	yamlFiles := map[string]string{
+		".tekton/prlongrunning.yaml":  "testdata/pipelinerun_long_running.yaml",
+		".tekton/prlongrunning2.yaml": "testdata/pipelinerun_long_running_another.yaml",
+	}
 	entries, err := payload.GetEntries(yamlFiles, targetNS, options.MainBranch, options.PullRequestEvent)
 	assert.NilError(t, err)
 

--- a/test/pkg/gitea/setup.go
+++ b/test/pkg/gitea/setup.go
@@ -64,6 +64,7 @@ func Setup(ctx context.Context) (*params.Run, options.E2E, gitea.Provider, error
 	if err := run.Clients.NewClients(ctx, &run.Info); err != nil {
 		return nil, options.E2E{}, gitea.Provider{}, fmt.Errorf("cannot create new client: %w", err)
 	}
+	// Repo is actually not used
 	e2eoptions := options.E2E{Organization: splitted[0], Repo: splitted[1]}
 	gprovider, err := CreateProvider(ctx, giteaURL, splitted[0], giteaPassword)
 	if err != nil {

--- a/test/pkg/payload/get_entries.go
+++ b/test/pkg/payload/get_entries.go
@@ -3,6 +3,7 @@ package payload
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"text/template"
@@ -30,7 +31,15 @@ func GetEntries(yamlfile map[string]string, targetNS, targetBranch, targetEvent 
 func ApplyTemplate(templateFile string, params map[string]string) (string, error) {
 	// read templates from file and  apply variables
 	var buf bytes.Buffer
-	tmpl := template.Must(template.ParseFiles(templateFile))
+	templateContent, err := os.ReadFile(templateFile)
+	if err != nil {
+		return "", err
+	}
+	// need to use \\ // as delimiters or we would confilict with pac delimiters
+	tmpl, err := template.New("yamltemplates").Delims("\\\\", "//").Parse(string(templateContent))
+	if err != nil {
+		return "", err
+	}
 	if err := tmpl.Execute(&buf, params); err != nil {
 		return "", fmt.Errorf("failed to apply template: %w", err)
 	}

--- a/test/testdata/failures/pipeline_bad_format.yaml
+++ b/test/testdata/failures/pipeline_bad_format.yaml
@@ -2,10 +2,10 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: {{.PipelineName}}
+  name: "\\ .PipelineName //"
   annotations:
-    pipelinesascode.tekton.dev/target-namespace: "{{.TargetNamespace}}"
-    pipelinesascode.tekton.dev/on-target-branch: "[{{.TargetBranch}}]"
-    pipelinesascode.tekton.dev/on-event: "[{{.TargetEvent}}]"
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
+    pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
 spec:
   pipelineRef:

--- a/test/testdata/failures/pipeline_remote_annotations_nonexisting_taskref.yaml
+++ b/test/testdata/failures/pipeline_remote_annotations_nonexisting_taskref.yaml
@@ -2,11 +2,11 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: {{.PipelineName}}
+  name: "\\ .PipelineName //"
   annotations:
-    pipelinesascode.tekton.dev/target-namespace: "{{.TargetNamespace}}"
-    pipelinesascode.tekton.dev/on-target-branch: "[{{.TargetBranch}}]"
-    pipelinesascode.tekton.dev/on-event: "[{{.TargetEvent}}]"
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
+    pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
 spec:
   pipelineRef:
     name: pipeline-non-exiting-annotation

--- a/test/testdata/failures/pipelinerun-exit-1.yaml
+++ b/test/testdata/failures/pipelinerun-exit-1.yaml
@@ -2,11 +2,11 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: pr
+  name: "\\.PipelineName//"
   annotations:
-    pipelinesascode.tekton.dev/target-namespace: "{{.TargetNamespace}}"
-    pipelinesascode.tekton.dev/on-target-branch: "[{{.TargetBranch}}]"
-    pipelinesascode.tekton.dev/on-event: "[{{.TargetEvent}}]"
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
+    pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
 spec:
   pipelineSpec:
     tasks:

--- a/test/testdata/pipelinerun-alt.yaml
+++ b/test/testdata/pipelinerun-alt.yaml
@@ -2,11 +2,11 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: "{{ .PipelineName }}"
+  name: "\\ .PipelineName //"
   annotations:
-    pipelinesascode.tekton.dev/target-namespace: "{{.TargetNamespace}}"
-    pipelinesascode.tekton.dev/on-target-branch: "[{{.TargetBranch}}]"
-    pipelinesascode.tekton.dev/on-event: "[{{.TargetEvent}}]"
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
+    pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
 spec:
   pipelineSpec:
     tasks:
@@ -15,4 +15,4 @@ spec:
           steps:
             - name: task
               image: registry.access.redhat.com/ubi9/ubi-micro
-              command: ["/bin/bash", "-c", "{{.Command}}"]
+              command: ["/bin/bash", "-c", "\\ .Command //"]

--- a/test/testdata/pipelinerun-cel-annotation.yaml
+++ b/test/testdata/pipelinerun-cel-annotation.yaml
@@ -2,11 +2,11 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: {{.PipelineName}}
+  name: "\\ .PipelineName //"
   annotations:
-    pipelinesascode.tekton.dev/target-namespace: "{{.TargetNamespace}}"
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
     pipelinesascode.tekton.dev/on-cel-expression: |
-      target_branch == "{{.TargetBranch}}" && event == "{{.TargetEvent}}"
+      target_branch == "\\ .TargetBranch //" && event == "\\ .TargetEvent //"
 spec:
   pipelineSpec:
     tasks:

--- a/test/testdata/pipelinerun-clone.yaml
+++ b/test/testdata/pipelinerun-clone.yaml
@@ -2,11 +2,11 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: {{.PipelineName}}
+  name: "\\ .PipelineName //"
   annotations:
-    pipelinesascode.tekton.dev/target-namespace: "{{.TargetNamespace}}"
-    pipelinesascode.tekton.dev/on-target-branch: "[{{.TargetBranch}}]"
-    pipelinesascode.tekton.dev/on-event: "[{{.TargetEvent}}]"
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
+    pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
 spec:
   pipelineSpec:
     tasks:

--- a/test/testdata/pipelinerun-max-keep-run-1.yaml
+++ b/test/testdata/pipelinerun-max-keep-run-1.yaml
@@ -2,11 +2,11 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: {{.PipelineName}}
+  name: "\\ .PipelineName //"
   annotations:
-    pipelinesascode.tekton.dev/target-namespace: "{{.TargetNamespace}}"
-    pipelinesascode.tekton.dev/on-target-branch: "[{{.TargetBranch}}]"
-    pipelinesascode.tekton.dev/on-event: "[{{.TargetEvent}}]"
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
+    pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
     pipelinesascode.tekton.dev/max-keep-runs: "1"
 spec:
   pipelineSpec:

--- a/test/testdata/pipelinerun-on-push.yaml
+++ b/test/testdata/pipelinerun-on-push.yaml
@@ -2,10 +2,10 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: "{{ .PipelineName }}"
+  name: "\\ .PipelineName //"
   annotations:
-    pipelinesascode.tekton.dev/target-namespace: "{{.TargetNamespace}}"
-    pipelinesascode.tekton.dev/on-target-branch: "[{{.TargetBranch}}]"
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
     pipelinesascode.tekton.dev/on-event: "[push]"
 spec:
   pipelineSpec:

--- a/test/testdata/pipelinerun.yaml
+++ b/test/testdata/pipelinerun.yaml
@@ -2,11 +2,11 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: {{.PipelineName}}
+  name: "\\ .PipelineName //"
   annotations:
-    pipelinesascode.tekton.dev/target-namespace: "{{.TargetNamespace}}"
-    pipelinesascode.tekton.dev/on-target-branch: "[{{.TargetBranch}}]"
-    pipelinesascode.tekton.dev/on-event: "[{{.TargetEvent}}]"
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
+    pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
 spec:
   pipelineSpec:
     tasks:

--- a/test/testdata/pipelinerun_git_clone_private-gitea.yaml
+++ b/test/testdata/pipelinerun_git_clone_private-gitea.yaml
@@ -2,11 +2,11 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: "{{ .PipelineName }}"
+  name: "\\ .PipelineName //"
   annotations:
-    pipelinesascode.tekton.dev/target-namespace: "{{.TargetNamespace}}"
-    pipelinesascode.tekton.dev/on-target-branch: "[{{.TargetBranch}}]"
-    pipelinesascode.tekton.dev/on-event: "[{{.TargetEvent}}]"
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
+    pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
     pipelinesascode.tekton.dev/task: "[git-clone]"
 spec:
   workspaces:
@@ -20,15 +20,15 @@ spec:
               storage: 1Gi
     - name: basic-auth
       secret:
-        secretName: "{{"{{"}} git_auth_secret {{"}}"}}"
+        secretName: "{{ git_auth_secret }}"
   params:
     - name: repo_url
       # not great but can't do otherwise due of networking and how we run self contained tests
       # under gitea. Since we are working on convention here this will break
       # easily on refactoring so something to watch out.
-      value: "http://gitea.gitea:3000/pac/{{.TargetNamespace}}"
+      value: "http://gitea.gitea:3000/pac/\\ .TargetNamespace //"
     - name: revision
-      value: "{{"{{"}} revision {{"}}"}}"
+      value: "{{ revision }}"
     - name: sslVerify
       value: "false"
   pipelineSpec:

--- a/test/testdata/pipelinerun_git_clone_private.yaml
+++ b/test/testdata/pipelinerun_git_clone_private.yaml
@@ -2,11 +2,11 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: {{.PipelineName}}
+  name: git-clone-private
   annotations:
-    pipelinesascode.tekton.dev/target-namespace: "{{.TargetNamespace}}"
-    pipelinesascode.tekton.dev/on-target-branch: "[{{.TargetBranch}}]"
-    pipelinesascode.tekton.dev/on-event: "[{{.TargetEvent}}]"
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
+    pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
     pipelinesascode.tekton.dev/task: "[git-clone]"
 spec:
   workspaces:

--- a/test/testdata/pipelinerun_long_running.yaml
+++ b/test/testdata/pipelinerun_long_running.yaml
@@ -2,11 +2,11 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: {{.PipelineName}}
+  name: "\\ .PipelineName //"
   annotations:
-    pipelinesascode.tekton.dev/target-namespace: "{{.TargetNamespace}}"
-    pipelinesascode.tekton.dev/on-target-branch: "[{{.TargetBranch}}]"
-    pipelinesascode.tekton.dev/on-event: "[{{.TargetEvent}}]"
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
+    pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
 spec:
   pipelineSpec:
     tasks:

--- a/test/testdata/pipelinerun_long_running_another.yaml
+++ b/test/testdata/pipelinerun_long_running_another.yaml
@@ -2,11 +2,11 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: {{.PipelineName}}
+  name: "\\ .PipelineName //"
   annotations:
-    pipelinesascode.tekton.dev/target-namespace: "{{.TargetNamespace}}"
-    pipelinesascode.tekton.dev/on-target-branch: "[{{.TargetBranch}}]"
-    pipelinesascode.tekton.dev/on-event: "[{{.TargetEvent}}]"
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
+    pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
 spec:
   pipelineSpec:
     tasks:

--- a/test/testdata/pipelinerun_remote_annotations.yaml
+++ b/test/testdata/pipelinerun_remote_annotations.yaml
@@ -2,11 +2,11 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: {{.PipelineName}}
+  name: "piplinerun-remote-annotations"
   annotations:
-    pipelinesascode.tekton.dev/target-namespace: "{{.TargetNamespace}}"
-    pipelinesascode.tekton.dev/on-target-branch: "[{{.TargetBranch}}]"
-    pipelinesascode.tekton.dev/on-event: "[{{.TargetEvent}}]"
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
+    pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
     pipelinesascode.tekton.dev/task: "[.other-tasks/task-referenced-internally.yaml]"
     pipelinesascode.tekton.dev/task-1: "[https://raw.githubusercontent.com/chmouel/scratchmyback/10c5ea559615c6783aa1a1aa9d93ea988b68dad7/.other-tasks/task-remote.yaml]"
     pipelinesascode.tekton.dev/task-2: "pylint"


### PR DESCRIPTION
we are using templates in the yamls of the e2e tests but `{{ }}` template holders (or whatever it's called) is already taken by pipelines as code, so the two would be confused (and it's actually the reason i did fmt.Sprintf simple replace at first).... 

let use something else, we can't do `[[ ]]` because that break array (it shows as [[[ ]]] and go text/template just barf on it), so we use instead `\\ //`, what a beauty isnt it ? 🙃