### PR TITLE
Enable TestGiteaBadYaml

### DIFF
--- a/test/pkg/logs/pod.go
+++ b/test/pkg/logs/pod.go
@@ -1,0 +1,41 @@
+package log
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/google/go-github/v45/github"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1i "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+func GetPodLog(ctx context.Context, kclient corev1i.CoreV1Interface, labelselector, containerName string) (string, error) {
+	ns, err := kclient.Namespaces().Get(ctx, "pipelines-as-code", metav1.GetOptions{})
+	if err != nil {
+		ns, err = kclient.Namespaces().Get(ctx, "openshift-pipelines", metav1.GetOptions{})
+		if err != nil {
+			return "", err
+		}
+	}
+	items, err := kclient.Pods(ns.GetName()).List(ctx, metav1.ListOptions{
+		LabelSelector: labelselector,
+	})
+	if err != nil {
+		return "", err
+	}
+	if len(items.Items) == 0 {
+		return "", fmt.Errorf("could not match any pod to label selector: %s", labelselector)
+	}
+	// maybe one day there is going to be multiple controller containers and then we would need to handle it here
+	ios, err := kclient.Pods(ns.GetName()).GetLogs(items.Items[0].GetName(), &v1.PodLogOptions{
+		Container: containerName,
+		TailLines: github.Int64(10),
+	}).Stream(ctx)
+	if err != nil {
+		return "", err
+	}
+	log, err := io.ReadAll(ios)
+	return string(log), err
+}

--- a/test/pkg/wait/logs.go
+++ b/test/pkg/wait/logs.go
@@ -1,0 +1,27 @@
+package wait
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	tlogs "github.com/openshift-pipelines/pipelines-as-code/test/pkg/logs"
+)
+
+func RegexpMatchingInPodLog(ctx context.Context, clients *params.Run, labelselector, containerName string, reg regexp.Regexp, maxNumberOfLoop int) error {
+	for i := 0; i <= maxNumberOfLoop; i++ {
+		output, err := tlogs.GetPodLog(ctx, clients.Clients.Kube.CoreV1(), labelselector, containerName)
+		if err != nil {
+			return err
+		}
+
+		if reg.MatchString(output) {
+			clients.Clients.Log.Infof("matched regexp %s in %s:%s labelSelector/pod for regexp: %s", reg.String(), labelselector, containerName)
+			return nil
+		}
+		time.Sleep(5 * time.Second)
+	}
+	return fmt.Errorf("could not find a match in %s:%s labelSelector/pod for regexp: %s", labelselector, containerName, reg.String())
+}

--- a/test/testdata/failures/pipeline_bad_format.yaml
+++ b/test/testdata/failures/pipeline_bad_format.yaml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: "\\ .PipelineName //"
+  name: "\\ .PipelineName //-\\ .TargetNamespace //"
   annotations:
     pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
     pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"


### PR DESCRIPTION
This test goes deep, it would use a bad yaml that has bad format and check inside the controller logs (it has a random unique id as the pipeline name) to make sure we errored out properly on it.

More stuff to come with regard to dig into controller logs (or events log namespace when this will be imp) tests.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
