### PR TITLE
Remove the fake secret from the testdata fixtures on gitea

### DIFF
--- a/.github/workflows/kind-e2e-tests.yaml
+++ b/.github/workflows/kind-e2e-tests.yaml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"os/exec"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -8,6 +9,12 @@ import (
 )
 
 func TestGetGitInfo(t *testing.T) {
+	gitPath, _ := exec.LookPath("git")
+	if gitPath == "" {
+		t.Skip("could not find the git binary in path, skipping test")
+		return
+	}
+
 	tests := []struct {
 		name         string
 		want         Info

--- a/pkg/provider/gitea/testdata/push.json
+++ b/pkg/provider/gitea/testdata/push.json
@@ -1,5 +1,4 @@
 {
-    "secret": "3gEsCfjlV2ugRwgpU#w1*WaW*wa4NXgGmpCfkbG3",
     "ref": "refs/heads/develop",
     "before": "28e1879d029cb852e4844d9c718537df08844e03",
     "after": "bffeb74224043ba2feb48d137756c8a9331c449a",


### PR DESCRIPTION
It's coming from the official documentation
https://docs.gitea.io/en-us/webhooks/ but our internal splunk security system thinks it's a leak....

(but before anyone freak out, it isn't :p)

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
