### PR TITLE
Improve TestGithubPullRequestConcurrency test

### DIFF
--- a/hack/dev/kind/gitea/deploy.py
+++ b/hack/dev/kind/gitea/deploy.py
@@ -35,6 +35,7 @@ class ProvisionGitea:
     gitea_host = GITEA_HOST
     gitea_url = GITEA_URL
     headers = {"Content-Type": "application/json"}
+    token_name = "token"
 
     def apply_deployment_template(self):
         tmpl = os.path.join(os.path.dirname(__file__), "gitea-deployment.yaml")
@@ -107,11 +108,15 @@ class ProvisionGitea:
         resp.raise_for_status()
 
     def create_token_for_user(self) -> str:
-        jeez = """{"name": "token"}"""
-        headers = {"Content-Type": "application/json"}
+        requests.delete(
+            url=f"{self.gitea_url}/api/v1/users/{GITEA_USER}/tokens/{self.token_name}",
+            headers=self.headers,
+            auth=(GITEA_USER, GITEA_PASSWORD),
+        )
+        jeez = """{"name": "%s"}""" % (self.token_name)
         resp = requests.post(
             url=f"{self.gitea_url}/api/v1/users/{GITEA_USER}/tokens",
-            headers=headers,
+            headers=self.headers,
             auth=(GITEA_USER, GITEA_PASSWORD),
             data=jeez,
         )
@@ -236,9 +241,7 @@ def main():
             m.create_repo_crd(config["name"], token)
     print(
         f"SUCCESS: gitea is available on {m.gitea_url}\n"
-        f"User: {GITEA_USER} Password: {GITEA_PASSWORD} Token: {token}\n"
-        f"E2E Repository: {m.gitea_url}/{GITEA_USER}/{GITEA_REPO_NAME_E2E}\n"
-        f"Play Repository: {m.gitea_url}/{GITEA_USER}/{GITEA_REPO_NAME_PERSO}"
+        f"User: {GITEA_USER} Password: {GITEA_PASSWORD} Token: {token}"
     )
 
 

--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -106,7 +106,7 @@ func TestGiteaMultiplesParallelPipelines(t *testing.T) {
 
 // multiple pipelineruns in the same .tekton directory and a concurrency of 1
 func TestGiteaConcurrencyExclusivenessMultiplePipelines(t *testing.T) {
-	numPipelines := 2
+	numPipelines := 10
 	yamlFiles := map[string]string{}
 	for i := 0; i < numPipelines; i++ {
 		yamlFiles[fmt.Sprintf(".tekton/pr%d.yaml", i)] = "testdata/pipelinerun.yaml"

--- a/test/pkg/github/pr.go
+++ b/test/pkg/github/pr.go
@@ -21,7 +21,7 @@ import (
 func PushFilesToRef(ctx context.Context, client *github.Client, commitMessage, baseBranch, targetRef, owner, repo string, files map[string]string) (string, error) {
 	maintree, _, err := client.Git.GetTree(ctx, owner, repo, baseBranch, false)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("error getting tree: %w", err)
 	}
 	mainSha := maintree.GetSHA()
 	entries := []*github.TreeEntry{}
@@ -34,7 +34,7 @@ func PushFilesToRef(ctx context.Context, client *github.Client, commitMessage, b
 			Encoding: &encoding,
 		})
 		if err != nil {
-			return "", err
+			return "", fmt.Errorf("error creating blobs: %w", err)
 		}
 		sha := blob.GetSHA()
 


### PR DESCRIPTION
 Improve TestGithubPullRequestConcurrency
 Use the api to check if the checks was updated properly. Use GH api to check if we are not running more pr than concurrency dictate. default to a run concurrency of 10 with concurrency of 3 🙃 timeout is high for ratelimitation

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
When it wasn't it's own driver

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>