### PR TITLE
Fix deployment with ko

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,1 +1,1 @@
-defaultBaseImage: registry.access.redhat.com/ubi9/ubi-minimal
+defaultBaseImage: gcr.io/distroless/base-debian11:nonroot


### PR DESCRIPTION
Use a non root image with ko
needs an image that has "USER $nonroot" for ko, or otherwise we would see this error : 

```
22m         Warning   Failed              pod/pipelines-as-code-webhook-5ff9dbd5d7-vtjb8       Error: container has runAsNonRoot and image will run as root (pod: "pipelines-as-code-webhook-5ff9dbd5d7-vtjb8_pipelines-as-code(39216b45-8ea7-4a2f-acff-99b2644808ce)", container: pac-webhook)
```
openshift by default random the users so we wont have that issue

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
