### PR TITLE
 E2E Test ClusterTask references

### DIFF
--- a/test/testdata/clustertask.yaml
+++ b/test/testdata/clustertask.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: ClusterTask
+metadata:
+  name: "clustertask-\\ .PipelineName //"
+spec:
+  steps:
+    - name: echo
+      image: registry.access.redhat.com/ubi9/ubi-micro
+      script: |
+        echo "hello from clustertask"

--- a/test/testdata/pipelinerunclustertasks.yaml
+++ b/test/testdata/pipelinerunclustertasks.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: "\\ .PipelineName //"
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
+    pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: task
+        taskRef:
+          kind: ClusterTask
+          name: "clustertask-\\ .TargetNamespace //"


### PR DESCRIPTION
We were not testing properly ClusterTasks in our E2E. Let's add one in
Gitea so we won't have issues with rate limitation.

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
Use a non root image.
needs an image that has "USER $nonroot" for ko openshift by default
random the users so we wont have that issue