### PR TITLE
DNM: Fetch tasks/pipeline from other repos where github app is installed

### DIFF
--- a/.tekton/doc.yaml
+++ b/.tekton/doc.yaml
@@ -50,7 +50,7 @@ spec:
                 echo "Preview URL: https://preview-pipelines-as-code-ci.apps.paac.devcluster.openshift.com/docs/{{ pull_request_number }}"
             - name: upload-to-static-server
               # it has curl and we already pulled it
-              image: mirror.gcr.io/library/golang:1.18
+              image: mirror.gcr.io/curlimages/curl:7.85.0
               workingDir: $(workspaces.source.path)
               env:
                 - name: HUB_TOKEN
@@ -65,8 +65,8 @@ spec:
                       key: "credentials"
               script: |
                 cd docs
-                [[ -d {{ pull_request_number }} ]]  || exit 0
-                tar czf - {{ pull_request_number }} | curl -u ${UPLOADER_UPLOAD_CREDENTIALS} -F path=docs -F targz=true -X POST -F file=@- http://uploader:8080/upload
+                test -d "{{ pull_request_number }}" || exit 0
+                tar czf - "{{ pull_request_number }}" | curl -u ${UPLOADER_UPLOAD_CREDENTIALS} -F path=docs -F targz=true -X POST -F file=@- http://uploader:8080/upload
                 # Post as status
                 set +x
                 curl -H "Authorization: Bearer ${HUB_TOKEN}" -H 'Accept: application/vnd.github.v3+json' -X POST https://api.github.com/repos/{{repo_owner}}/{{repo_name}}/statuses/{{revision}} -d '{"state": "success", "target_url": "https://preview-pipelines-as-code-ci.apps.paac.devcluster.openshift.com/docs/{{ pull_request_number }}", "description": "Generated with brio.", "context": "Pipelines as Code Preview URL"}'

--- a/docs/content/docs/guide/resolver.md
+++ b/docs/content/docs/guide/resolver.md
@@ -5,47 +5,45 @@ weight: 2
 # Pipelines as Code resolver
 
 If `Pipelines as Code` sees a PipelineRun with a reference to a `Task` or a
-`Pipeline`, `Pipelines as Code` will try to *resolves* it (see below) as a
-single PipelineRun with an embedded `PipelineSpec` to a `PipelineRun`.
+`Pipeline` in any YAML file located in the `.tekton/` directory, `Pipelines as
+Code` will automatically try to *resolves* it (see below) as a single
+PipelineRun with an embedded `PipelineSpec` to a `PipelineRun`.
 
-It will transform the Pipeline `Name` field to a `generateName` based on the
-Pipeline name as well.
-
-This allows you to have multiple runs in the same namespace from the same
+The resolver will transform the Pipeline `Name` field to a `generateName` based on the
+Pipeline name as well. This allows you to have multiple runs in the same namespace from the same
 PipelineRun with no risk of conflicts.
 
-Everything that runs your pipelinerun and its references need to be inside the
-`.tekton/` directory and subdirectories as referenced with a remote task (see
+Every task or pipeline your PipelineRun references will need to be inside the
+`.tekton/` directory or subdirectories or referenced with a remote task (see
 below on how the remote tasks are referenced).
 
-If you have a taskRef to a task located in any directory or subdirectories of the
-`.tekton/` directory it will be automatically embedded even if it's not in the
-annotations.
-
-The resolver will skip resolving if he sees these type of tasks:
+The resolver will skip resolving if it sees these type of tasks:
 
 * a reference to a [`ClusterTask`](https://github.com/tektoncd/pipeline/blob/main/docs/tasks.md#task-vs-clustertask)
 * a `Task` or `Pipeline` [`Bundle`](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#tekton-bundles)
-* or a [Custom Task](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#using-custom-tasks) with an apiVersion that doesn't have a `tekton.dev/` prefix.
+* a [Custom Task](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#using-custom-tasks) with an apiVersion that doesn't have a `tekton.dev/` prefix.
 
-It just use them "as is" and will not try to do anything with it.
+It just uses them "as is" and will not try to do anything with it.
 
-If pipelines as code cannot resolve the referenced tasks in the `Pipeline` or
+If Pipelines as Code cannot resolve the referenced tasks in the `Pipeline` or
 `PipelineSpec`, the run will fail before applying the pipelinerun onto the
-cluster. You should be able to the issue on your Git provider platform or
+cluster.
+
+You should be able to see the issue on your Git provider platform or
 through the log of the controller.
 
 If you need to test your `PipelineRun` locally before sending it in a PR, you
 can use the `resolve` command from the `tkn-pac` CLI See the `--help` of the
 command to learn about how to use it.
 
-## Remote Task support
+## Remote Task annotations
 
-`Pipelines as Code` support fetching remote tasks from remote location through
+`Pipelines as Code` support fetching remote tasks or pipeline from remote location through
 annotations on PipelineRun.
 
-If the resolver sees a PipelineRun referencing a remote task through its name in
-a Pipeline or a PipelineSpec it will automatically inlines it.
+If the resolver sees a PipelineRun referencing a remote task or a pipeline in
+the reference name of a Pipeline or a PipelineSpec it will automatically inlines
+it.
 
 An annotation to a remote task looks like this :
 
@@ -113,3 +111,21 @@ If there is any error fetching those resources, `Pipelines as Code` will error
 out and not process the pipeline.
 
 If the object fetched cannot be parsed as a Tekton `Task` it will error out.
+
+## Remote Pipeline annotations
+
+Remote Pipeline can be referenced by annotation, this allows you to share your Pipeline definition across.
+
+Only one Pipeline is allowed in annotation.
+
+An annotation to a remote pipeline looks like this :
+
+```yaml
+pipelinesascode.tekton.dev/task: "https://git.provider/raw/pipeline.yaml
+```
+
+It supports remote URL and files inside the same Git repository.
+
+{{< hint info >}}
+[Tekton Hub](https://hub.tekton.dev) doesn't currently have support for `Pipeline`.
+{{< /hint >}}

--- a/hack/dev/kind/install.sh
+++ b/hack/dev/kind/install.sh
@@ -139,8 +139,6 @@ function install_pac() {
         cd ${oldPwd}
     fi
     configure_pac
-    [[ -n ${INSTALL_GITEA} ]] && install_gitea
-    echo "And we are done :) URLS: "
     echo "controller: http://controller.${DOMAIN_NAME}"
     echo "dashboard: http://dashboard.${DOMAIN_NAME}"
 }
@@ -198,6 +196,8 @@ main() {
 	install_nginx
 	install_tekton
 	install_pac
+    install_gitea
+    echo "And we are done :): "
 }
 
 while getopts "Gpcrb" o; do

--- a/pkg/matcher/annotation_matcher.go
+++ b/pkg/matcher/annotation_matcher.go
@@ -155,7 +155,7 @@ func MatchPipelinerunByAnnotation(ctx context.Context, logger *zap.SugaredLogger
 		if celExpr, ok := prun.GetObjectMeta().GetAnnotations()[filepath.Join(pipelinesascode.GroupName, onCelExpression)]; ok {
 			out, err := celEvaluate(ctx, celExpr, event, vcx)
 			if err != nil {
-				logger.Error(fmt.Errorf("there was an error evaluating CEL expression, skipping: %w", err))
+				logger.Errorf("there was an error evaluating CEL expression, skipping: %w", err)
 				continue
 			}
 			if out != types.True {

--- a/pkg/matcher/annotation_matcher.go
+++ b/pkg/matcher/annotation_matcher.go
@@ -2,7 +2,6 @@ package matcher
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"path/filepath"
 	"regexp"
@@ -49,7 +48,7 @@ func getAnnotationValues(annotation string) ([]string, error) {
 	annotation = strings.TrimSpace(annotation)
 	match := re.Match([]byte(annotation))
 	if !match {
-		return nil, errors.New("annotations in pipeline are in wrong format")
+		return nil, fmt.Errorf("annotations in pipeline are in wrong format: %s", annotation)
 	}
 
 	// if it's not an array then it would be a single string
@@ -64,7 +63,7 @@ func getAnnotationValues(annotation string) ([]string, error) {
 	}
 
 	if splitted[0] == "" {
-		return nil, errors.New("annotations in pipeline are empty")
+		return nil, fmt.Errorf("annotation \"%s\" has empty values", annotation)
 	}
 
 	return splitted, nil

--- a/pkg/matcher/annotation_tasks_install.go
+++ b/pkg/matcher/annotation_tasks_install.go
@@ -63,7 +63,10 @@ func (rt RemoteTasks) convertTotask(data string) (*tektonv1beta1.Task, error) {
 }
 
 func (rt RemoteTasks) getRemote(ctx context.Context, uri string, fromHub bool) (string, error) {
+	fetchedFromTaskURI, task, err := rt.ProviderInterface.GetTaskURI(ctx, rt.Run, rt.Event, uri)
 	switch {
+	case fetchedFromTaskURI:
+		return task, err
 	case strings.HasPrefix(uri, "https://"), strings.HasPrefix(uri, "http://"):
 		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil)
 		res, err := rt.Run.Clients.HTTP.Do(req)

--- a/pkg/matcher/annotation_tasks_install.go
+++ b/pkg/matcher/annotation_tasks_install.go
@@ -21,11 +21,30 @@ import (
 )
 
 const (
-	taskAnnotationsRegexp = `task(-[0-9]+)?$`
+	taskAnnotationsRegexp     = `task(-[0-9]+)?$`
+	pipelineAnnotationsRegexp = `pipeline(-[0-9]+)?$`
 )
 
 type RemoteTasks struct {
-	Run *params.Run
+	Run               *params.Run
+	ProviderInterface provider.Interface
+	Event             *info.Event
+	Logger            *zap.SugaredLogger
+}
+
+func (rt RemoteTasks) convertToPipeline(data string) (*tektonv1beta1.Pipeline, error) {
+	decoder := k8scheme.Codecs.UniversalDeserializer()
+	obj, _, err := decoder.Decode([]byte(data), nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("we have a pipeline that is not looking like a kubernetes resource: pipeline: %s resource: %w", data, err)
+	}
+
+	pipeline, ok := obj.(*tektonv1beta1.Pipeline)
+	if !ok {
+		return nil, fmt.Errorf("this doesn't seem to be a proper pipeline")
+	}
+
+	return pipeline, nil
 }
 
 func (rt RemoteTasks) convertTotask(data string) (*tektonv1beta1.Task, error) {
@@ -43,67 +62,117 @@ func (rt RemoteTasks) convertTotask(data string) (*tektonv1beta1.Task, error) {
 	return task, nil
 }
 
-func (rt RemoteTasks) getTask(ctx context.Context, logger *zap.SugaredLogger, providerintf provider.Interface, event *info.Event, task string) (*tektonv1beta1.Task, error) {
-	var ret *tektonv1beta1.Task
-
-	// TODO: print a log info when getting the task from which location
+func (rt RemoteTasks) getRemote(ctx context.Context, uri string, fromHub bool) (string, error) {
 	switch {
-	case strings.HasPrefix(task, "https://"), strings.HasPrefix(task, "http://"):
-		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, task, nil)
+	case strings.HasPrefix(uri, "https://"), strings.HasPrefix(uri, "http://"):
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil)
 		res, err := rt.Run.Clients.HTTP.Do(req)
 		if err != nil {
-			return ret, err
+			return "", err
+		}
+		if res.StatusCode != http.StatusOK {
+			return "", fmt.Errorf("could not get remote resource %s: %s", uri, res.Status)
 		}
 		data, _ := io.ReadAll(res.Body)
 		defer res.Body.Close()
-		return rt.convertTotask(string(data))
-	case strings.Contains(task, "/"):
+		rt.Logger.Info("successfully fetched %s from remote https url", uri)
+		return string(data), nil
+	case strings.Contains(uri, "/"):
 		var data string
 		var err error
-		if event.SHA != "" {
-			data, err = providerintf.GetFileInsideRepo(ctx, event, task, "")
+		if rt.Event.SHA != "" {
+			data, err = rt.ProviderInterface.GetFileInsideRepo(ctx, rt.Event, uri, "")
 			if err != nil {
-				return ret, err
+				return "", err
 			}
 		} else {
-			data, err = getTaskFromLocalFS(task, logger)
+			data, err = getTaskFromLocalFS(uri, rt.Logger)
 			if err != nil {
-				return nil, err
+				return "", err
 			}
 			if data == "" {
-				return nil, nil
+				return "", nil
 			}
 		}
 
-		return rt.convertTotask(data)
-	default:
-		data, err := hub.GetTask(ctx, rt.Run, task)
+		rt.Logger.Info("successfully fetched %s inside repository", uri)
+		return data, nil
+	case fromHub:
+		data, err := hub.GetTask(ctx, rt.Run, uri)
 		if err != nil {
-			return nil, err
+			return "", err
 		}
-		return rt.convertTotask(data)
+		rt.Logger.Info("successfully fetched %s from hub on %s", uri, rt.Run.Info.Pac.HubURL)
+		return data, nil
 	}
+	return "", fmt.Errorf(`cannot find "%s" anywhere`, uri)
 }
 
-// GetTaskFromAnnotations Get task remotely if they are on Annotations
-func (rt RemoteTasks) GetTaskFromAnnotations(ctx context.Context, logger *zap.SugaredLogger, providerintf provider.Interface, event *info.Event, annotations map[string]string) ([]*tektonv1beta1.Task, error) {
-	var ret []*tektonv1beta1.Task
-	rtareg := regexp.MustCompile(fmt.Sprintf("%s/%s", pipelinesascode.GroupName, taskAnnotationsRegexp))
+func grabValuesFromAnnotations(annotations map[string]string, annotationReg string) ([]string, error) {
+	rtareg := regexp.MustCompile(fmt.Sprintf("%s/%s", pipelinesascode.GroupName, annotationReg))
+	var ret []string
 	for annotationK, annotationV := range annotations {
 		if !rtareg.Match([]byte(annotationK)) {
 			continue
 		}
-		tasks, err := getAnnotationValues(annotationV)
+		items, err := getAnnotationValues(annotationV)
 		if err != nil {
 			return ret, err
 		}
-		for _, v := range tasks {
-			task, err := rt.getTask(ctx, logger, providerintf, event, v)
-			if err != nil {
-				return ret, fmt.Errorf("error getting remote task %s: %w", v, err)
-			}
-			ret = append(ret, task)
+		ret = append(items, ret...)
+	}
+	return ret, nil
+}
+
+// GetTaskFromAnnotations Get task remotely if they are on Annotations
+func (rt RemoteTasks) GetTaskFromAnnotations(ctx context.Context, annotations map[string]string) ([]*tektonv1beta1.Task, error) {
+	ret := []*tektonv1beta1.Task{}
+	tasks, err := grabValuesFromAnnotations(annotations, taskAnnotationsRegexp)
+	if err != nil {
+		return nil, err
+	}
+	for _, v := range tasks {
+		data, err := rt.getRemote(ctx, v, true)
+		if err != nil {
+			return nil, fmt.Errorf("error getting remote task %s: %w", v, err)
 		}
+		if data == "" {
+			return nil, fmt.Errorf("could not get task \"%s\": returning empty", v)
+		}
+
+		task, err := rt.convertTotask(data)
+		if err != nil {
+			return nil, err
+		}
+		ret = append(ret, task)
+	}
+	return ret, nil
+}
+
+// GetPipelineFromAnnotations Get pipeline remotely if they are on Annotations
+// TODO: merge in a generic between the two
+func (rt RemoteTasks) GetPipelineFromAnnotations(ctx context.Context, annotations map[string]string) ([]*tektonv1beta1.Pipeline, error) {
+	ret := []*tektonv1beta1.Pipeline{}
+	pipelinesAnnotation, err := grabValuesFromAnnotations(annotations, pipelineAnnotationsRegexp)
+	if err != nil {
+		return nil, err
+	}
+	if len(pipelinesAnnotation) > 1 {
+		return nil, fmt.Errorf("only one pipeline is allowed on remote resolution, we have received multiple of them: %+v", pipelinesAnnotation)
+	}
+	for _, v := range pipelinesAnnotation {
+		data, err := rt.getRemote(ctx, v, false)
+		if err != nil {
+			return nil, fmt.Errorf("error getting remote pipeline %s: %w", v, err)
+		}
+		if data == "" {
+			return nil, fmt.Errorf("could not get pipeline \"%s\": returning empty", v)
+		}
+		pipeline, err := rt.convertToPipeline(data)
+		if err != nil {
+			return nil, err
+		}
+		ret = append(ret, pipeline)
 	}
 	return ret, nil
 }

--- a/pkg/matcher/annotation_tasks_install.go
+++ b/pkg/matcher/annotation_tasks_install.go
@@ -71,11 +71,11 @@ func (rt RemoteTasks) getRemote(ctx context.Context, uri string, fromHub bool) (
 			return "", err
 		}
 		if res.StatusCode != http.StatusOK {
-			return "", fmt.Errorf("could not get remote resource %s: %s", uri, res.Status)
+			return "", fmt.Errorf("could not get remote resource \"%s\": %s", uri, res.Status)
 		}
 		data, _ := io.ReadAll(res.Body)
 		defer res.Body.Close()
-		rt.Logger.Info("successfully fetched %s from remote https url", uri)
+		rt.Logger.Infof("successfully fetched \"%s\" from remote https url", uri)
 		return string(data), nil
 	case strings.Contains(uri, "/"):
 		var data string
@@ -95,14 +95,14 @@ func (rt RemoteTasks) getRemote(ctx context.Context, uri string, fromHub bool) (
 			}
 		}
 
-		rt.Logger.Info("successfully fetched %s inside repository", uri)
+		rt.Logger.Infof("successfully fetched \"%s\" inside repository", uri)
 		return data, nil
 	case fromHub:
 		data, err := hub.GetTask(ctx, rt.Run, uri)
 		if err != nil {
 			return "", err
 		}
-		rt.Logger.Info("successfully fetched %s from hub on %s", uri, rt.Run.Info.Pac.HubURL)
+		rt.Logger.Infof("successfully fetched \"%s\" from hub URL: %s", uri, rt.Run.Info.Pac.HubURL)
 		return data, nil
 	}
 	return "", fmt.Errorf(`cannot find "%s" anywhere`, uri)

--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -120,7 +120,7 @@ is that what you want? make sure you use -n when generating the secret, eg: echo
 
 	rawTemplates, err := p.vcx.GetTektonDir(ctx, p.event, tektonDir)
 	if err != nil {
-		p.logger.Info("I could not get the tekton directory: %s", err.Error())
+		p.logger.Infof("could not get the tekton directory: %s", err.Error())
 		return nil, nil, nil
 	}
 
@@ -149,7 +149,7 @@ is that what you want? make sure you use -n when generating the secret, eg: echo
 	// if /test command is used then filter out the pipelinerun
 	pipelineRuns = filterRunningPipelineRunOnTargetTest(p.event.TargetTestPipelineRun, pipelineRuns)
 	if pipelineRuns == nil {
-		p.logger.Info(fmt.Sprintf("cannot find pipelinerun %s in this repository", p.event.TargetTestPipelineRun))
+		p.logger.Infof("cannot find pipelinerun %s in this repository", p.event.TargetTestPipelineRun)
 		return nil, nil, nil
 	}
 

--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -49,7 +49,9 @@ func (p *PacRun) Run(ctx context.Context) error {
 			DetailsURL: p.run.Clients.ConsoleUI.URL(),
 		})
 		if createStatusErr != nil {
-			p.logger.Errorf("Cannot create status: %s: %s", err, createStatusErr)
+			p.logger.Errorf("cannot create status: %s: %s", err.Error(), createStatusErr.Error())
+		} else {
+			p.logger.Infof("reported error on provider status: %s", err.Error())
 		}
 	}
 

--- a/pkg/provider/bitbucketcloud/bitbucket.go
+++ b/pkg/provider/bitbucketcloud/bitbucket.go
@@ -23,6 +23,11 @@ type Provider struct {
 	Username      *string
 }
 
+func (v *Provider) GetTaskURI(ctx context.Context, params *params.Run, event *info.Event, uri string) (bool, string, error) {
+	// TODO implement me
+	panic("implement me")
+}
+
 const taskStatusTemplate = `| **Status** | **Duration** | **Name** |
 | --- | --- | --- |
 {{range $taskrun := .TaskRunList }}|{{ formatCondition $taskrun.Status.Conditions }}|{{ formatDuration $taskrun.Status.StartTime $taskrun.Status.CompletionTime }}|{{ $taskrun.ConsoleLogURL }}|

--- a/pkg/provider/bitbucketserver/bitbucketserver.go
+++ b/pkg/provider/bitbucketserver/bitbucketserver.go
@@ -30,6 +30,11 @@ type Provider struct {
 	projectKey                string
 }
 
+func (v *Provider) GetTaskURI(ctx context.Context, params *params.Run, event *info.Event, uri string) (bool, string, error) {
+	// TODO implement me
+	panic("implement me")
+}
+
 func (v *Provider) SetLogger(logger *zap.SugaredLogger) {
 	v.Logger = logger
 }

--- a/pkg/provider/gitea/gitea.go
+++ b/pkg/provider/gitea/gitea.go
@@ -46,6 +46,11 @@ type Provider struct {
 	Password string
 }
 
+func (v *Provider) GetTaskURI(ctx context.Context, params *params.Run, event *info.Event, uri string) (bool, string, error) {
+	// TODO implement me
+	panic("implement me")
+}
+
 func (v *Provider) SetLogger(logger *zap.SugaredLogger) {
 	v.Logger = logger
 }

--- a/pkg/provider/github/events.go
+++ b/pkg/provider/github/events.go
@@ -42,7 +42,6 @@ func (v *Provider) getAppToken(ctx context.Context, kube kubernetes.Interface, g
 	privateKey := secret.Data["github-private-key"]
 
 	tr := http.DefaultTransport
-
 	itr, err := ghinstallation.New(tr, applicationID, installationID, privateKey)
 	if err != nil {
 		return "", err
@@ -57,6 +56,9 @@ func (v *Provider) getAppToken(ctx context.Context, kube kubernetes.Interface, g
 	} else {
 		v.Client = github.NewClient(&http.Client{Transport: itr})
 	}
+
+	v.GithubAppAppID = applicationID
+	v.GithubAppPrivateKey = privateKey
 
 	// This is a hack when we have auth and api disassociated
 	reqTokenURL := os.Getenv("PAC_GIT_PROVIDER_TOKEN_APIURL")

--- a/pkg/provider/github/github_app.go
+++ b/pkg/provider/github/github_app.go
@@ -1,0 +1,178 @@
+package github
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	jwt "github.com/golang-jwt/jwt/v4"
+	"github.com/google/go-github/v47/github"
+)
+
+const acceptHeader = "application/vnd.github.v3+json"
+
+type InstallationRepositories struct {
+	Repositories []*github.Repository
+}
+
+// can't use ghinstallation because
+// https://github.com/bradleyfalzon/ghinstallation/issues/39 and seems simpler
+// than redoing our client again
+func makeHTTPRequestWithBearerToken(ctx context.Context, url, method, bearerToken string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, method, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+bearerToken)
+	req.Header.Set("Accept", acceptHeader)
+	return http.DefaultClient.Do(req)
+}
+
+func (v *Provider) getFileContentViaAPI(ctx context.Context, url, token string) (*github.RepositoryContent, error) {
+	resp, err := makeHTTPRequestWithBearerToken(ctx, url, "GET", token)
+	if err != nil {
+		return nil, err
+	}
+	ret, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("error getting content from github: %d: %s", resp.StatusCode, ret)
+	}
+	repoContent := &github.RepositoryContent{}
+	if err := json.Unmarshal(ret, repoContent); err != nil {
+		return nil, err
+	}
+	return repoContent, nil
+}
+
+func (v *Provider) matchTaskRepoInstallURL(ctx context.Context, installationID int64, uri string) (bool, string, error) {
+	jwToken, err := v.generateJWTToken()
+	if err != nil {
+		return false, "", err
+	}
+	token, err := v.getAccessTokenForInstallation(ctx, &installationID, jwToken)
+	if err != nil {
+		return false, "", err
+	}
+	spOrg, spRepo, spPath, spRef, err := v.splitGithubURL(uri)
+	if err != nil {
+		return false, "", err
+	}
+	url := fmt.Sprintf("%srepos/%s/%s/contents/%s?ref=%s", *v.APIURL, spOrg, spRepo, spPath, spRef)
+	content, err := v.getFileContentViaAPI(ctx, url, *token.Token)
+	if err != nil {
+		return false, "", err
+	}
+	if content.GetType() != "file" {
+		return false, "", fmt.Errorf("URL %s does not seem to be a proper proper file", uri)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(*content.Content)
+	if err != nil {
+		return false, "", err
+	}
+	return true, string(decoded), nil
+}
+
+func (v *Provider) generateJWTToken() (string, error) {
+	key, err := jwt.ParseRSAPrivateKeyFromPEM(v.GithubAppPrivateKey)
+	if err != nil {
+		return "", fmt.Errorf("could not parse private key: %w", err)
+	}
+	iss := &jwt.NumericDate{Time: time.Now().Add(-30 * time.Second).Truncate(time.Second)}
+	exp := &jwt.NumericDate{Time: iss.Add(2 * time.Minute)}
+	claims := &jwt.RegisteredClaims{
+		IssuedAt:  iss,
+		ExpiresAt: exp,
+		Issuer:    strconv.FormatInt(v.GithubAppAppID, 10),
+	}
+	bearer := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	return bearer.SignedString(key)
+}
+
+func (v *Provider) getAllInstallationOfApp(ctx context.Context) error {
+	jwtToken, err := v.generateJWTToken()
+	if err != nil {
+		return err
+	}
+	resp, err := makeHTTPRequestWithBearerToken(ctx, fmt.Sprintf("%sapp/installations", *v.APIURL), "GET", jwtToken)
+	if err != nil {
+		return err
+	}
+	ret, err := io.ReadAll(resp.Body)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("error getting installation token for the github app: %d, %s", resp.StatusCode, ret)
+	}
+
+	var installations []*github.Installation
+	if err := json.Unmarshal(ret, &installations); err != nil {
+		return err
+	}
+	v.GithubAppInstallations = map[int64][]*github.Repository{}
+	for _, installation := range installations {
+		repos, err := v.getReposOfAnInstallation(ctx, installation.ID)
+		if err != nil {
+			return err
+		}
+		v.GithubAppInstallations[*installation.ID] = repos.Repositories
+	}
+	return err
+}
+
+func (v *Provider) getAccessTokenForInstallation(ctx context.Context, installationID *int64, jwtToken string) (*github.InstallationToken, error) {
+	resp, err := makeHTTPRequestWithBearerToken(ctx,
+		fmt.Sprintf("%sapp/installations/%d/access_tokens",
+			*v.APIURL, *installationID), "POST", jwtToken)
+	if err != nil {
+		return nil, err
+	}
+	ret, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("error getting installation token for the github app %d: %d, %s", *installationID, resp.StatusCode, ret)
+	}
+	var installToken *github.InstallationToken
+	if err := json.Unmarshal(ret, &installToken); err != nil {
+		return nil, err
+	}
+	return installToken, nil
+}
+
+func (v *Provider) getReposOfAnInstallation(ctx context.Context, installationID *int64) (*InstallationRepositories, error) {
+	jwtToken, err := v.generateJWTToken()
+	if err != nil {
+		return nil, err
+	}
+	token, err := v.getAccessTokenForInstallation(ctx, installationID, jwtToken)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := makeHTTPRequestWithBearerToken(ctx,
+		fmt.Sprintf("%sinstallation/repositories", *v.APIURL), "GET", *token.Token)
+	if err != nil {
+		return nil, err
+	}
+
+	ret, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var installationRepositories *InstallationRepositories
+	if err := json.Unmarshal(ret, &installationRepositories); err != nil {
+		return nil, err
+	}
+	return installationRepositories, nil
+}

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -46,6 +46,11 @@ type Provider struct {
 	repoURL           string
 }
 
+func (v *Provider) GetTaskURI(ctx context.Context, params *params.Run, event *info.Event, uri string) (bool, string, error) {
+	// TODO implement me
+	panic("implement me")
+}
+
 func (v *Provider) SetLogger(logger *zap.SugaredLogger) {
 	v.Logger = logger
 }

--- a/pkg/provider/interface.go
+++ b/pkg/provider/interface.go
@@ -36,6 +36,7 @@ type Interface interface {
 	GetCommitInfo(context.Context, *info.Event) error
 	GetConfig() *info.ProviderConfig
 	GetFiles(context.Context, *info.Event) ([]string, error)
+	GetTaskURI(ctx context.Context, params *params.Run, event *info.Event, uri string) (bool, string, error)
 }
 
 const DefaultProviderAPIUser = "git"

--- a/pkg/test/provider/testwebvcs.go
+++ b/pkg/test/provider/testwebvcs.go
@@ -54,6 +54,10 @@ func (v *TestProviderImp) IsAllowed(ctx context.Context, event *info.Event) (boo
 	return false, nil
 }
 
+func (v *TestProviderImp) GetTaskURI(ctx context.Context, params *params.Run, event *info.Event, task string) (bool, string, error) {
+	return false, "", nil
+}
+
 func (v *TestProviderImp) CreateStatus(ctx context.Context, _ versioned.Interface, event *info.Event, opts *info.PacOpts, statusOpts provider.StatusOpts) error {
 	if v.CreateStatusErorring {
 		return fmt.Errorf("you want me to error I error for you")

--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -37,14 +37,25 @@ var (
 	failureRegexp = regexp.MustCompile(`There was an issue validating the commit: "cannot find task task-non-existing in input"`)
 )
 
-func TestGiteaPullRequestAnnotations(t *testing.T) {
+func TestGiteaPullRequestTaskAnnotations(t *testing.T) {
 	topts := &tgitea.TestOpts{
 		Regexp:      successRegexp,
 		TargetEvent: options.PullRequestEvent,
 		YAMLFiles: map[string]string{
-			".tekton/pipeline.yaml":                        "testdata/pipeline_remote_annotations.yaml",
+			".tekton/pipeline.yaml":                        "testdata/pipeline_in_tektondir.yaml",
 			".other-tasks/task-referenced-internally.yaml": "testdata/task_referenced_internally.yaml",
-			".tekton/pr.yaml":                              "testdata/pipelinerun_remote_annotations.yaml",
+			".tekton/pr.yaml":                              "testdata/pipelinerun_remote_task_annotations.yaml",
+		},
+	}
+	defer tgitea.TestPR(t, topts)()
+}
+
+func TestGiteaPullRequestPipelineAnnotations(t *testing.T) {
+	topts := &tgitea.TestOpts{
+		Regexp:      successRegexp,
+		TargetEvent: options.PullRequestEvent,
+		YAMLFiles: map[string]string{
+			".tekton/pr.yaml": "testdata/pipelinerun_remote_pipeline_annotations.yaml",
 		},
 	}
 	defer tgitea.TestPR(t, topts)()

--- a/test/github_pullrequest_remote_task_annotations_test.go
+++ b/test/github_pullrequest_remote_task_annotations_test.go
@@ -22,15 +22,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestGithubPullRequestRemoteAnnotations(t *testing.T) {
+func TestGithubPullRequestRemoteTaskAnnotations(t *testing.T) {
 	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
 	ctx := context.Background()
 	runcnx, opts, ghcnx, err := tgithub.Setup(ctx, false)
 	assert.NilError(t, err)
 
 	entries, err := payload.GetEntries(map[string]string{
-		".tekton/pr.yaml":                              "testdata/pipelinerun_remote_annotations.yaml",
-		".tekton/pipeline.yaml":                        "testdata/pipeline_remote_annotations.yaml",
+		".tekton/pr.yaml":                              "testdata/pipelinerun_remote_task_annotations.yaml",
+		".tekton/pipeline.yaml":                        "testdata/pipeline_in_tektondir.yaml",
 		".other-tasks/task-referenced-internally.yaml": "testdata/task_referenced_internally.yaml",
 	}, targetNS, options.MainBranch, options.PullRequestEvent)
 	assert.NilError(t, err)

--- a/test/testdata/pipeline_in_tektondir.yaml
+++ b/test/testdata/pipeline_in_tektondir.yaml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
-  name: pipeline-remote-annotations
+  name: pipeline-in-tekton-dir
 spec:
   tasks:
     - name: task-spec

--- a/test/testdata/pipeline_in_tektondir.yaml
+++ b/test/testdata/pipeline_in_tektondir.yaml
@@ -14,9 +14,9 @@ spec:
               echo "Hello from taskSpec"
               exit 0
 
-    - name: task-from-remote
+    - name: task-from-remote-in-private
       taskRef:
-        name: task-remote
+        name: task-from-remote-in-private
 
     - name: task-referenced-internally
       taskRef:

--- a/test/testdata/pipelinerun_remote_pipeline_annotations.yaml
+++ b/test/testdata/pipelinerun_remote_pipeline_annotations.yaml
@@ -7,9 +7,7 @@ metadata:
     pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
     pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
     pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
-    pipelinesascode.tekton.dev/task: "[.other-tasks/task-referenced-internally.yaml]"
-    pipelinesascode.tekton.dev/task-1: "[https://raw.githubusercontent.com/chmouel/scratchmyback/10c5ea559615c6783aa1a1aa9d93ea988b68dad7/.other-tasks/task-remote.yaml]"
-    pipelinesascode.tekton.dev/task-2: "pylint"
+    pipelinesascode.tekton.dev/pipeline: "[https://raw.githubusercontent.com/chmouel/scratchmyback/main/pipelinerun-http.yaml]"
 spec:
   pipelineRef:
-    name: pipeline-remote-annotations
+    name: pipeline-from-remote

--- a/test/testdata/pipelinerun_remote_task_annotations.yaml
+++ b/test/testdata/pipelinerun_remote_task_annotations.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
     pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
     pipelinesascode.tekton.dev/task: "[.other-tasks/task-referenced-internally.yaml]"
-    pipelinesascode.tekton.dev/task-1: "[https://raw.githubusercontent.com/chmouel/scratchmyback/10c5ea559615c6783aa1a1aa9d93ea988b68dad7/.other-tasks/task-remote.yaml]"
+    pipelinesascode.tekton.dev/task-1: "https://github.com/openshift-pipelines/pipelines-as-code-e2e-tests/blob/main/pipeline/task_from_remote.yaml"
     pipelinesascode.tekton.dev/task-2: "pylint"
 spec:
   pipelineRef:

--- a/test/testdata/pipelinerun_remote_task_annotations.yaml
+++ b/test/testdata/pipelinerun_remote_task_annotations.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: "piplinerun-remote-annotations"
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
+    pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
+    pipelinesascode.tekton.dev/task: "[.other-tasks/task-referenced-internally.yaml]"
+    pipelinesascode.tekton.dev/task-1: "[https://raw.githubusercontent.com/chmouel/scratchmyback/10c5ea559615c6783aa1a1aa9d93ea988b68dad7/.other-tasks/task-remote.yaml]"
+    pipelinesascode.tekton.dev/task-2: "pylint"
+spec:
+  pipelineRef:
+    name: pipeline-in-tekton-dir


### PR DESCRIPTION
Add interface for fetching task from provider

Let tere be a way for provider to intercept the task uri and sees what
to do with it.

Implemention for github see bullet 3 from
https://github.com/openshift-pipelines/pipelines-as-code/issues/872 for details


(needs some repo setup on e2e tests to make it work so expect it to fail)

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
