### PR TITLE
Fetch github url with token

### DIFF
--- a/.github/workflows/kind-e2e-tests.yaml
+++ b/.github/workflows/kind-e2e-tests.yaml
@@ -10,7 +10,7 @@ on:
       - "go.sum"
       - "!docs/**"
     tags-ignore:
-      - '*.*'
+      - "*.*"
     branches:
       - main
   pull_request_target:
@@ -98,6 +98,9 @@ jobs:
 
       - name: Run E2E Tests
         run: |
+          export TEST_GITHUB_PRIVATE_TASK_URL="https://github.com/openshift-pipelines/pipelines-as-code-e2e-tests-webhook/blob/main/testdatas/remote_task.yaml"
+          export TEST_GITHUB_PRIVATE_TASK_NAME="task-remote""
+
           export GO_TEST_FLAGS="-v -race -failfast"
 
           export TEST_BITBUCKET_CLOUD_API_URL=https://api.bitbucket.org/2.0

--- a/docs/content/docs/guide/resolver.md
+++ b/docs/content/docs/guide/resolver.md
@@ -56,6 +56,8 @@ or multiple tasks with an array :
 pipelinesascode.tekton.dev/task: "[git-clone, pylint]"
 ```
 
+### [Tekton Hub](https://hub.tekton.dev)
+
 The syntax above installs the
 [git-clone](https://github.com/tektoncd/catalog/tree/main/task/git-clone) task
 from the [tekton hub](https://hub.tekton.dev) repository querying for the latest
@@ -89,14 +91,41 @@ this example :
 pipelinesascode.tekton.dev/task: "[git-clone:0.1]" # this will install git-clone 0.1 from tekton.hub
 ```
 
+### Remote HTTP URL
+
 If you have a string starting with http:// or https://, `Pipelines as Code`
 will fetch the task directly from that remote URL :
 
 ```yaml
-  pipelinesascode.tekton.dev/task: "[https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.3/git-clone.yaml]"
+  pipelinesascode.tekton.dev/task: "[https://remote.url/task.yaml]"
 ```
 
-Additionally, you can as well have a reference to a task from a YAML file inside your repo if you specify the relative path to it, for example :
+With the Github Provider; If the remote task URL uses the same host as where the repo
+CRD is, PAC will use the  Github token and fetch the URL using the Github API.
+
+For example if my repo URL is :
+
+<https://github.com/organization/repository>
+
+The recognized URLs are:
+
+<https://github.com/organization/repository/blob/mainbranch/path/file>
+
+or Github rawURL (only the public instance of Github at the moment):
+
+<https://raw.githubusercontent.com/organization/repository/mainbranch/path/file>
+
+With the Github app, if you have a private repository in the same
+organization as where the repo matches from, it will be able to fetch the files
+from that private repository with the github app token.
+
+If you are using the Github webhook method you are able to fetch any  private or
+public repositories on any organization where the personal token is allowed.
+
+### Same repository
+
+Additionally, you can as well have a reference to a task from a YAML file inside
+your repo if you specify the relative path to it, for example :
 
 ```yaml
 pipelinesascode.tekton.dev/task: "[share/tasks/git-clone.yaml]"

--- a/hack/dev/kind/install.sh
+++ b/hack/dev/kind/install.sh
@@ -139,8 +139,6 @@ function install_pac() {
         cd ${oldPwd}
     fi
     configure_pac
-    [[ -n ${INSTALL_GITEA} ]] && install_gitea
-    echo "And we are done :) URLS: "
     echo "controller: http://controller.${DOMAIN_NAME}"
     echo "dashboard: http://dashboard.${DOMAIN_NAME}"
 }
@@ -198,6 +196,8 @@ main() {
 	install_nginx
 	install_tekton
 	install_pac
+    install_gitea
+    echo "And we are done :): "
 }
 
 while getopts "Gpcrb" o; do

--- a/pkg/matcher/annotation_tasks_install.go
+++ b/pkg/matcher/annotation_tasks_install.go
@@ -138,10 +138,10 @@ func (rt RemoteTasks) GetTaskFromAnnotations(ctx context.Context, annotations ma
 	for _, v := range tasks {
 		data, err := rt.getRemote(ctx, v, true)
 		if err != nil {
-			return nil, fmt.Errorf("error getting remote task %s: %w", v, err)
+			return nil, fmt.Errorf("error getting remote task \"%s\": %w", v, err)
 		}
 		if data == "" {
-			return nil, fmt.Errorf("could not get task \"%s\": returning empty", v)
+			return nil, fmt.Errorf("error getting remote task \"%s\": returning empty", v)
 		}
 
 		task, err := rt.convertTotask(data)

--- a/pkg/matcher/annotation_tasks_install.go
+++ b/pkg/matcher/annotation_tasks_install.go
@@ -71,7 +71,7 @@ func (rt RemoteTasks) getRemote(ctx context.Context, uri string, fromHub bool) (
 			return "", err
 		}
 		if res.StatusCode != http.StatusOK {
-			return "", fmt.Errorf("could not get remote resource \"%s\": %s", uri, res.Status)
+			return "", fmt.Errorf("cannot get remote resource: \"%s\": %s", uri, res.Status)
 		}
 		data, _ := io.ReadAll(res.Body)
 		defer res.Body.Close()

--- a/pkg/matcher/annotation_tasks_install.go
+++ b/pkg/matcher/annotation_tasks_install.go
@@ -63,6 +63,10 @@ func (rt RemoteTasks) convertTotask(data string) (*tektonv1beta1.Task, error) {
 }
 
 func (rt RemoteTasks) getRemote(ctx context.Context, uri string, fromHub bool) (string, error) {
+	if fetchedFromURIFromProvider, task, err := rt.ProviderInterface.GetTaskURI(ctx, rt.Run, rt.Event, uri); fetchedFromURIFromProvider {
+		return task, err
+	}
+
 	switch {
 	case strings.HasPrefix(uri, "https://"), strings.HasPrefix(uri, "http://"):
 		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil)

--- a/pkg/matcher/annotation_tasks_install_test.go
+++ b/pkg/matcher/annotation_tasks_install_test.go
@@ -61,14 +61,15 @@ func TestMain(m *testing.M) {
 
 func TestRemoteTasksGetTaskFromAnnotations(t *testing.T) {
 	tests := []struct {
-		annotations     map[string]string
-		filesInsideRepo map[string]string
-		gotTaskName     string
-		name            string
-		remoteURLS      map[string]map[string]string
-		runevent        info.Event
-		wantErr         string
-		wantLog         string
+		annotations            map[string]string
+		filesInsideRepo        map[string]string
+		gotTaskName            string
+		name                   string
+		remoteURLS             map[string]map[string]string
+		runevent               info.Event
+		wantErr                string
+		wantLog                string
+		wantProviderRemoteTask bool
 	}{
 		{
 			name: "test-annotations-error-remote-http-not-k8",
@@ -82,6 +83,22 @@ func TestRemoteTasksGetTaskFromAnnotations(t *testing.T) {
 				},
 			},
 			wantErr: "returning empty",
+		},
+		{
+			name: "test-good-coming-from-provider",
+			annotations: map[string]string{
+				pipelinesascode.GroupName + "/task": "http://provider/remote.task",
+			},
+			wantProviderRemoteTask: true,
+			wantErr:                "returning empty",
+		},
+		{
+			name: "test-bad-coming-from-provider",
+			annotations: map[string]string{
+				pipelinesascode.GroupName + "/task": "http://provider/remote.task",
+			},
+			wantProviderRemoteTask: false,
+			wantErr:                "error getting remote task",
 		},
 		{
 			name: "test-annotations-remote-http",
@@ -218,7 +235,8 @@ func TestRemoteTasksGetTaskFromAnnotations(t *testing.T) {
 				Run:    cs,
 				Logger: logger,
 				ProviderInterface: &provider.TestProviderImp{
-					FilesInsideRepo: tt.filesInsideRepo,
+					FilesInsideRepo:        tt.filesInsideRepo,
+					WantProviderRemoteTask: tt.wantProviderRemoteTask,
 				},
 				Event: &tt.runevent,
 			}

--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -151,9 +151,6 @@ is that what you want? make sure you use -n when generating the secret, eg: echo
 	}
 	if pipelineRuns == nil {
 		msg := fmt.Sprintf("cannot locate templates in %s/ directory for this repository in %s", tektonDir, p.event.HeadBranch)
-		if err != nil {
-			msg += fmt.Sprintf(" err: %s", err.Error())
-		}
 		p.eventEmitter.EmitMessage(nil, zap.InfoLevel, msg)
 		return nil, nil, nil
 	}

--- a/pkg/provider/bitbucketcloud/bitbucket.go
+++ b/pkg/provider/bitbucketcloud/bitbucket.go
@@ -23,6 +23,11 @@ type Provider struct {
 	Username      *string
 }
 
+// GetTaskURI TODO: Implement ME
+func (v *Provider) GetTaskURI(ctx context.Context, params *params.Run, event *info.Event, uri string) (bool, string, error) {
+	return false, "", nil
+}
+
 const taskStatusTemplate = `| **Status** | **Duration** | **Name** |
 | --- | --- | --- |
 {{range $taskrun := .TaskRunList }}|{{ formatCondition $taskrun.Status.Conditions }}|{{ formatDuration $taskrun.Status.StartTime $taskrun.Status.CompletionTime }}|{{ $taskrun.ConsoleLogURL }}|

--- a/pkg/provider/bitbucketserver/bitbucketserver.go
+++ b/pkg/provider/bitbucketserver/bitbucketserver.go
@@ -30,6 +30,11 @@ type Provider struct {
 	projectKey                string
 }
 
+// GetTaskURI TODO: Implement ME
+func (v *Provider) GetTaskURI(ctx context.Context, params *params.Run, event *info.Event, uri string) (bool, string, error) {
+	return false, "", nil
+}
+
 func (v *Provider) SetLogger(logger *zap.SugaredLogger) {
 	v.Logger = logger
 }

--- a/pkg/provider/gitea/gitea.go
+++ b/pkg/provider/gitea/gitea.go
@@ -46,6 +46,11 @@ type Provider struct {
 	Password string
 }
 
+// GetTaskURI TODO: Implement ME
+func (v *Provider) GetTaskURI(ctx context.Context, params *params.Run, event *info.Event, uri string) (bool, string, error) {
+	return false, "", nil
+}
+
 func (v *Provider) SetLogger(logger *zap.SugaredLogger) {
 	v.Logger = logger
 }

--- a/pkg/provider/github/github_test.go
+++ b/pkg/provider/github/github_test.go
@@ -33,6 +33,66 @@ func getLogger() *zap.SugaredLogger {
 	return logger
 }
 
+func TestGithubSplitURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		wantOrg  string
+		wantRepo string
+		wantRef  string
+		wantPath string
+		wantErr  bool
+	}{
+		{
+			name:     "Split URL",
+			url:      "https://github.com/openshift-pipelines/pipelines-as-code/blob/main/testdatas/remote_task.yaml",
+			wantOrg:  "openshift-pipelines",
+			wantRepo: "pipelines-as-code",
+			wantRef:  "main",
+			wantPath: "testdatas/remote_task.yaml",
+		},
+		{
+			name:     "Split raw URL",
+			url:      "https://raw.githubusercontent.com/openshift-pipelines/pipelines-as-code/main/testdatas/remote_task.yaml",
+			wantOrg:  "openshift-pipelines",
+			wantRepo: "pipelines-as-code",
+			wantRef:  "main",
+			wantPath: "testdatas/remote_task.yaml",
+		},
+		{
+			name:     "Split raw URL2",
+			url:      "https://raw.githubusercontent.com/openshift-pipelines/pipelines-as-code/main/remote_task.yaml",
+			wantOrg:  "openshift-pipelines",
+			wantRepo: "pipelines-as-code",
+			wantRef:  "main",
+			wantPath: "remote_task.yaml",
+		},
+		{
+			name:    "Too small URL",
+			url:     "https://raw.githubusercontent.com/openshift-pipelines/pipelines-as-code",
+			wantErr: true,
+		},
+		{
+			name:    "Invalid no path URL",
+			url:     "https://raw.githubusercontent.com/openshift-pipelines/pipelines-as-code/main",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			org, repo, path, ref, err := splitGithubURL(tt.url)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SplitURL() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			assert.Equal(t, tt.wantOrg, org)
+			assert.Equal(t, tt.wantRepo, repo)
+			assert.Equal(t, tt.wantRef, ref)
+			assert.Equal(t, tt.wantPath, path)
+		})
+	}
+}
+
 func TestGetTektonDir(t *testing.T) {
 	testGetTektonDir := []struct {
 		treepath       string

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -46,6 +46,11 @@ type Provider struct {
 	repoURL           string
 }
 
+// GetTaskURI TODO: Implement me
+func (v *Provider) GetTaskURI(ctx context.Context, params *params.Run, event *info.Event, uri string) (bool, string, error) {
+	return false, "", nil
+}
+
 func (v *Provider) SetLogger(logger *zap.SugaredLogger) {
 	v.Logger = logger
 }

--- a/pkg/provider/interface.go
+++ b/pkg/provider/interface.go
@@ -36,6 +36,7 @@ type Interface interface {
 	GetCommitInfo(context.Context, *info.Event) error
 	GetConfig() *info.ProviderConfig
 	GetFiles(context.Context, *info.Event) ([]string, error)
+	GetTaskURI(ctx context.Context, params *params.Run, event *info.Event, uri string) (bool, string, error)
 }
 
 const DefaultProviderAPIUser = "git"

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"net/url"
 	"regexp"
 	"strings"
 )
@@ -45,4 +46,18 @@ func GetPipelineRunFromComment(comment string) string {
 	getFirstLine := strings.Split(splitTest[1], "\n")
 	// trim spaces
 	return strings.TrimSpace(getFirstLine[0])
+}
+
+// CompareHostOfURLS compares the host of two parsed URLs and returns true if
+// they are
+func CompareHostOfURLS(uri1, uri2 string) bool {
+	u1, err := url.Parse(uri1)
+	if err != nil || u1.Host == "" {
+		return false
+	}
+	u2, err := url.Parse(uri2)
+	if err != nil || u2.Host == "" {
+		return false
+	}
+	return u1.Host == u2.Host
 }

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -188,3 +188,41 @@ func TestGetPipelineRunFromComment(t *testing.T) {
 		})
 	}
 }
+
+func TestCompareHostOfURLS(t *testing.T) {
+	tests := []struct {
+		name string
+		url1 string
+		url2 string
+		want bool
+	}{
+		{
+			name: "same same",
+			url1: "https://shivam.com/foo/bar",
+			url2: "https://shivam.com/hello/moto",
+			want: true,
+		},
+		{
+			name: "same same but different",
+			url1: "https://shivam.com/foo/bar",
+			url2: "https://vincent.com/foo/bar",
+			want: false,
+		},
+		{
+			name: "bad url1",
+			url1: "i am such a bad url",
+			want: false,
+		},
+		{
+			name: "bad url2",
+			url2: "i am the baddest, choose me!",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CompareHostOfURLS(tt.url1, tt.url2)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/test/provider/testwebvcs.go
+++ b/pkg/test/provider/testwebvcs.go
@@ -12,12 +12,15 @@ import (
 	"go.uber.org/zap"
 )
 
+var _ provider.Interface = (*TestProviderImp)(nil)
+
 type TestProviderImp struct {
-	AllowIT              bool
-	Event                *info.Event
-	TektonDirTemplate    string
-	CreateStatusErorring bool
-	FilesInsideRepo      map[string]string
+	AllowIT                bool
+	Event                  *info.Event
+	TektonDirTemplate      string
+	CreateStatusErorring   bool
+	FilesInsideRepo        map[string]string
+	WantProviderRemoteTask bool
 }
 
 func (v *TestProviderImp) SetLogger(logger *zap.SugaredLogger) {
@@ -52,6 +55,10 @@ func (v *TestProviderImp) IsAllowed(ctx context.Context, event *info.Event) (boo
 		return true, nil
 	}
 	return false, nil
+}
+
+func (v *TestProviderImp) GetTaskURI(ctx context.Context, params *params.Run, event *info.Event, task string) (bool, string, error) {
+	return v.WantProviderRemoteTask, "", nil
 }
 
 func (v *TestProviderImp) CreateStatus(ctx context.Context, _ versioned.Interface, event *info.Event, opts *info.PacOpts, statusOpts provider.StatusOpts) error {

--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -430,16 +430,16 @@ func TestGiteaWithCLI(t *testing.T) {
 	defer tgitea.TestPR(t, topts)()
 	output, err := tknpactest.ExecCommand(topts.Clients, tknpaclist.Root, "pipelinerun", "list", "-n", topts.TargetNS)
 	assert.NilError(t, err)
-	assert.Assert(t, strings.Contains(output, "Succeeded   pac-e2e-test-"), "should have a successful pipelinerun in CLI listing")
+	assert.Assert(t, strings.Contains(output, "Succeeded   pac-e2e-test-"), "should have a successful pipelinerun in CLI listing: %s", output)
 
 	output, err = tknpactest.ExecCommand(topts.Clients, tknpacdesc.Root, "-n", topts.TargetNS)
 	assert.NilError(t, err)
-	assert.Assert(t, strings.Contains(output, "Succeeded"), "should have a successful pipelinerun in CLI describe and auto select the first one")
+	assert.Assert(t, strings.Contains(output, "Succeeded"), "should have a Succeeded pipelinerun in CLI describe and auto select the first one: %s", output)
 
 	output, err = tknpactest.ExecCommand(topts.Clients, tknpacdelete.Root, "-n", topts.TargetNS, "repository", topts.TargetNS, "--cascade")
 	assert.NilError(t, err)
 	expectedOutput := fmt.Sprintf("secret gitea-secret has been deleted\nrepository %s has been deleted\n", topts.TargetNS)
-	assert.Assert(t, output == expectedOutput, topts.TargetRefName, "delete command should have output ", expectedOutput)
+	assert.Assert(t, output == expectedOutput, topts.TargetRefName, "delete command should have this output: %s received: %s", expectedOutput, output)
 }
 
 func TestGiteaWithCLIGeneratePipeline(t *testing.T) {

--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -45,6 +45,11 @@ func TestGiteaPullRequestTaskAnnotations(t *testing.T) {
 			".other-tasks/task-referenced-internally.yaml": "testdata/task_referenced_internally.yaml",
 			".tekton/pr.yaml":                              "testdata/pipelinerun_remote_task_annotations.yaml",
 		},
+		CheckForStatus: "success",
+		ExtraArgs: map[string]string{
+			"RemoteTaskURL":  options.RemoteTaskURL,
+			"RemoteTaskName": options.RemoteTaskName,
+		},
 	}
 	defer tgitea.TestPR(t, topts)()
 }
@@ -56,7 +61,12 @@ func TestGiteaPullRequestPipelineAnnotations(t *testing.T) {
 		YAMLFiles: map[string]string{
 			".tekton/pr.yaml": "testdata/pipelinerun_remote_pipeline_annotations.yaml",
 		},
-		ExpectEvents: false,
+		ExpectEvents:   false,
+		CheckForStatus: "success",
+		ExtraArgs: map[string]string{
+			"RemoteTaskURL":  options.RemoteTaskURL,
+			"RemoteTaskName": options.RemoteTaskName,
+		},
 	}
 	defer tgitea.TestPR(t, topts)()
 }
@@ -68,7 +78,8 @@ func TestGiteaPullRequestPrivateRepository(t *testing.T) {
 		YAMLFiles: map[string]string{
 			".tekton/pipeline.yaml": "testdata/pipelinerun_git_clone_private-gitea.yaml",
 		},
-		ExpectEvents: false,
+		ExpectEvents:   false,
+		CheckForStatus: "success",
 	}
 	defer tgitea.TestPR(t, topts)()
 }
@@ -201,7 +212,7 @@ func TestGiteaRetestAfterPush(t *testing.T) {
 	defer tgitea.TestPR(t, topts)()
 
 	newyamlFiles := map[string]string{".tekton/pr.yaml": "testdata/pipelinerun.yaml"}
-	entries, err := payload.GetEntries(newyamlFiles, topts.TargetNS, topts.DefaultBranch, topts.TargetEvent)
+	entries, err := payload.GetEntries(newyamlFiles, topts.TargetNS, topts.DefaultBranch, topts.TargetEvent, map[string]string{})
 	assert.NilError(t, err)
 	tgitea.PushFilesToRefGit(t, topts, entries, topts.TargetRefName)
 	topts.CheckForStatus = "success"
@@ -368,7 +379,7 @@ func TestGiteaClusterTasks(t *testing.T) {
 	// create first the cluster tasks
 	ctname := fmt.Sprintf(".tekton/%s.yaml", topts.TargetNS)
 	newyamlFiles := map[string]string{ctname: "testdata/clustertask.yaml"}
-	entries, err := payload.GetEntries(newyamlFiles, topts.TargetNS, "main", "pull_request")
+	entries, err := payload.GetEntries(newyamlFiles, topts.TargetNS, "main", "pull_request", map[string]string{})
 	assert.NilError(t, err)
 	ct := v1beta1.ClusterTask{}
 	assert.NilError(t, yaml.Unmarshal([]byte(entries[ctname]), &ct))

--- a/test/github_pullrequest_concurrency_test.go
+++ b/test/github_pullrequest_concurrency_test.go
@@ -58,7 +58,7 @@ func TestGithubPullRequestConcurrency(t *testing.T) {
 		yamlFiles[fmt.Sprintf(".tekton/prlongrunnning-%d.yaml", i)] = "testdata/pipelinerun_long_running.yaml"
 	}
 
-	entries, err := payload.GetEntries(yamlFiles, targetNS, options.MainBranch, options.PullRequestEvent)
+	entries, err := payload.GetEntries(yamlFiles, targetNS, options.MainBranch, options.PullRequestEvent, map[string]string{})
 	assert.NilError(t, err)
 
 	targetRefName := fmt.Sprintf("refs/heads/%s",

--- a/test/github_pullrequest_remote_task_annotations_test.go
+++ b/test/github_pullrequest_remote_task_annotations_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -28,11 +29,23 @@ func TestGithubPullRequestRemoteTaskAnnotations(t *testing.T) {
 	runcnx, opts, ghcnx, err := tgithub.Setup(ctx, false)
 	assert.NilError(t, err)
 
+	remoteTaskURL := options.RemoteTaskURL
+	if os.Getenv("TEST_GITHUB_PRIVATE_TASK_URL") != "" {
+		remoteTaskURL = os.Getenv("TEST_GITHUB_PRIVATE_TASK_URL")
+	}
+	remoteTaskName := options.RemoteTaskName
+	if os.Getenv("TEST_GITHUB_PRIVATE_TASK_NAME") != "" {
+		remoteTaskName = os.Getenv("TEST_GITHUB_PRIVATE_TASK_NAME")
+	}
+
 	entries, err := payload.GetEntries(map[string]string{
 		".tekton/pr.yaml":                              "testdata/pipelinerun_remote_task_annotations.yaml",
 		".tekton/pipeline.yaml":                        "testdata/pipeline_in_tektondir.yaml",
 		".other-tasks/task-referenced-internally.yaml": "testdata/task_referenced_internally.yaml",
-	}, targetNS, options.MainBranch, options.PullRequestEvent)
+	}, targetNS, options.MainBranch, options.PullRequestEvent, map[string]string{
+		"RemoteTaskURL":  remoteTaskURL,
+		"RemoteTaskName": remoteTaskName,
+	})
 	assert.NilError(t, err)
 
 	repoinfo, resp, err := ghcnx.Client.Repositories.Get(ctx, opts.Organization, opts.Repo)

--- a/test/github_push_test.go
+++ b/test/github_push_test.go
@@ -48,7 +48,7 @@ func TestGithubPush(t *testing.T) {
 
 		entries, err := payload.GetEntries(
 			map[string]string{".tekton/pipelinerun-on-push.yaml": "testdata/pipelinerun-on-push.yaml"},
-			targetNS, targetBranch, targetEvent)
+			targetNS, targetBranch, targetEvent, map[string]string{})
 		assert.NilError(t, err)
 
 		title := "TestPush "

--- a/test/gitlab_incoming_webhook_test.go
+++ b/test/gitlab_incoming_webhook_test.go
@@ -55,7 +55,7 @@ func TestGitlabIncomingWebhook(t *testing.T) {
 
 	entries, err := payload.GetEntries(map[string]string{
 		".tekton/pr.yaml": "testdata/pipelinerun.yaml", ".tekton/pr-clone.yaml": "testdata/pipelinerun-clone.yaml",
-	}, randomedString, randomedString, options.PushEvent)
+	}, randomedString, randomedString, options.PushEvent, map[string]string{})
 	assert.NilError(t, err)
 
 	title := "TestIncomingWebhook - " + randomedString

--- a/test/gitlab_merge_request_test.go
+++ b/test/gitlab_merge_request_test.go
@@ -36,7 +36,7 @@ func TestGitlabMergeRequest(t *testing.T) {
 		".tekton/pipelinerun.yaml":       "testdata/pipelinerun.yaml",
 		".tekton/pipelinerun-clone.yaml": "testdata/pipelinerun-clone.yaml",
 	}, targetNS, projectinfo.DefaultBranch,
-		options.PullRequestEvent)
+		options.PullRequestEvent, map[string]string{})
 	assert.NilError(t, err)
 
 	targetRefName := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test")

--- a/test/pkg/bitbucketcloud/pr.go
+++ b/test/pkg/bitbucketcloud/pr.go
@@ -21,7 +21,7 @@ func MakePR(t *testing.T, bprovider bitbucketcloud.Provider, runcnx *params.Run,
 
 	entries, err := payload.GetEntries(
 		map[string]string{".tekton/pipelinerun.yaml": "testdata/pipelinerun.yaml"},
-		targetNS, options.MainBranch, options.PullRequestEvent)
+		targetNS, options.MainBranch, options.PullRequestEvent, map[string]string{})
 	assert.NilError(t, err)
 	tmpfile := fs.NewFile(t, "pipelinerun", fs.WithContent(entries[".tekton/pipelinerun.yaml"]))
 	defer tmpfile.Remove()

--- a/test/pkg/gitea/test.go
+++ b/test/pkg/gitea/test.go
@@ -26,6 +26,7 @@ type TestOpts struct {
 	TargetEvent          string
 	Regexp               *regexp.Regexp
 	YAMLFiles            map[string]string
+	ExtraArgs            map[string]string
 	CheckForStatus       string
 	TargetRefName        string
 	CheckForNumberStatus int
@@ -59,7 +60,9 @@ func TestPR(t *testing.T, topts *TestOpts) func() {
 	topts.Opts = opts
 	assert.NilError(t, err, fmt.Errorf("cannot do gitea setup: %w", err))
 	hookURL := os.Getenv("TEST_GITEA_SMEEURL")
-
+	if topts.ExtraArgs == nil {
+		topts.ExtraArgs = map[string]string{}
+	}
 	if topts.TargetRefName == "" {
 		topts.TargetRefName = names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test")
 	}
@@ -81,7 +84,7 @@ func TestPR(t *testing.T, topts *TestOpts) func() {
 	err = CreateCRD(ctx, topts)
 	assert.NilError(t, err)
 
-	entries, err := payload.GetEntries(topts.YAMLFiles, topts.TargetNS, repoInfo.DefaultBranch, topts.TargetEvent)
+	entries, err := payload.GetEntries(topts.YAMLFiles, topts.TargetNS, repoInfo.DefaultBranch, topts.TargetEvent, topts.ExtraArgs)
 	assert.NilError(t, err)
 
 	url, err := MakeGitCloneURL(repoInfo.CloneURL, os.Getenv("TEST_GITEA_USERNAME"), os.Getenv("TEST_GITEA_PASSWORD"))

--- a/test/pkg/github/pr.go
+++ b/test/pkg/github/pr.go
@@ -121,7 +121,7 @@ func RunPullRequest(ctx context.Context, t *testing.T, label string, yamlFiles [
 		yamlEntries[filepath.Join(".tekton", filepath.Base(v))] = v
 	}
 
-	entries, err := payload.GetEntries(yamlEntries, targetNS, options.MainBranch, options.PullRequestEvent)
+	entries, err := payload.GetEntries(yamlEntries, targetNS, options.MainBranch, options.PullRequestEvent, map[string]string{})
 	assert.NilError(t, err)
 
 	targetRefName := fmt.Sprintf("refs/heads/%s",

--- a/test/pkg/options/options.go
+++ b/test/pkg/options/options.go
@@ -12,4 +12,6 @@ var (
 	MainBranch       = "main"
 	PullRequestEvent = "pull_request"
 	PushEvent        = "push"
+	RemoteTaskURL    = "https://raw.githubusercontent.com/openshift-pipelines/pipelines-as-code/main/pkg/pipelineascode/testdata/pull_request/.tekton/task.yaml"
+	RemoteTaskName   = "task-from-tektondir"
 )

--- a/test/pkg/payload/get_entries.go
+++ b/test/pkg/payload/get_entries.go
@@ -9,7 +9,14 @@ import (
 	"text/template"
 )
 
-func GetEntries(yamlfile map[string]string, targetNS, targetBranch, targetEvent string) (map[string]string, error) {
+func vinceMap(a map[string]string, b map[string]string) map[string]string {
+	for k, v := range b {
+		a[k] = v
+	}
+	return a
+}
+
+func GetEntries(yamlfile map[string]string, targetNS, targetBranch, targetEvent string, extraParams map[string]string) (map[string]string, error) {
 	params := map[string]string{
 		"TargetNamespace": targetNS,
 		"TargetBranch":    targetBranch,
@@ -18,8 +25,11 @@ func GetEntries(yamlfile map[string]string, targetNS, targetBranch, targetEvent 
 	entries := map[string]string{}
 	for target, file := range yamlfile {
 		name := strings.TrimSuffix(filepath.Base(target), filepath.Ext(target))
-		params["PipelineName"] = name
-		output, err := ApplyTemplate(file, params)
+		extraParams["PipelineName"] = name
+		// PipelineName can be overridden by extraParams
+		newParams := vinceMap(params, extraParams)
+
+		output, err := ApplyTemplate(file, newParams)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read yaml file: %w", err)
 		}

--- a/test/testdata/pipeline_in_tektondir.yaml
+++ b/test/testdata/pipeline_in_tektondir.yaml
@@ -14,9 +14,9 @@ spec:
               echo "Hello from taskSpec"
               exit 0
 
-    - name: task-from-remote
+    - name: \\ .RemoteTaskName //
       taskRef:
-        name: task-remote
+        name: \\ .RemoteTaskName //
 
     - name: task-referenced-internally
       taskRef:

--- a/test/testdata/pipelinerun_remote_task_annotations.yaml
+++ b/test/testdata/pipelinerun_remote_task_annotations.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
     pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
     pipelinesascode.tekton.dev/task: "[.other-tasks/task-referenced-internally.yaml]"
-    pipelinesascode.tekton.dev/task-1: "[https://raw.githubusercontent.com/chmouel/scratchmyback/10c5ea559615c6783aa1a1aa9d93ea988b68dad7/.other-tasks/task-remote.yaml]"
+    pipelinesascode.tekton.dev/task-1: "[\\ .RemoteTaskURL //]"
     pipelinesascode.tekton.dev/task-2: "pylint"
 spec:
   pipelineRef:


### PR DESCRIPTION
If the user has a remote task coming from the same github host as the
repo url host. (i.e: https://github.com/foo/bar from a repo crd coming
from https://github.com/hello/moto) then try to use the token to query
the Github api  and resolve it.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com><!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
