### PR TITLE
[Revert & Revert] Replaces update by patch 🙃 

### DIFF
--- a/config/201-controller-role.yaml
+++ b/config/201-controller-role.yaml
@@ -73,7 +73,7 @@ rules:
     verbs: ["create", "get", "list", "update"]
   - apiGroups: ["tekton.dev"]
     resources: ["pipelineruns"]
-    verbs: ["get", "delete", "list", "create", "watch", "update"]
+    verbs: ["get", "delete", "list", "create", "watch", "update", "patch"]
   - apiGroups: ["route.openshift.io"]
     resources: ["routes"]
     verbs: ["get"]

--- a/pkg/provider/github/status.go
+++ b/pkg/provider/github/status.go
@@ -109,6 +109,9 @@ func (v *Provider) getOrUpdateCheckRunStatus(ctx context.Context, tekton version
 				return err
 			}
 		}
+		if err := v.updatePipelineRunWithCheckRunID(ctx, tekton, status.PipelineRun, checkRunID); err != nil {
+			return err
+		}
 	}
 
 	checkRunOutput := &github.CheckRunOutput{
@@ -134,15 +137,6 @@ func (v *Provider) getOrUpdateCheckRunStatus(ctx context.Context, tekton version
 	}
 
 	_, _, err = v.Client.Checks.UpdateCheckRun(ctx, runevent.Organization, runevent.Repository, *checkRunID, opts)
-	if err != nil {
-		return err
-	}
-
-	if !found {
-		if err := v.updatePipelineRunWithCheckRunID(ctx, tekton, status.PipelineRun, checkRunID); err != nil {
-			return err
-		}
-	}
 	return err
 }
 
@@ -155,13 +149,6 @@ func (v *Provider) updatePipelineRunWithCheckRunID(ctx context.Context, tekton v
 		pr, err := tekton.TektonV1beta1().PipelineRuns(pr.GetNamespace()).Get(ctx, pr.GetName(), v1.GetOptions{})
 		if err != nil {
 			return err
-		}
-		// temp fix: wait for tekton.dev/pipeline label to avoid race condition
-		// https://github.com/openshift-pipelines/pipelines-as-code/issues/786
-		if _, ok := pr.Labels["tekton.dev/pipeline"]; !ok {
-			v.Logger.Infof("PipelineRun %v/%v don't have tekton label yet, waiting for it", pr.GetNamespace(), pr.GetName())
-			time.Sleep(2 * time.Second)
-			continue
 		}
 		pr = pr.DeepCopy()
 		pr.GetLabels()[filepath.Join(apipac.GroupName, checkRunIDKey)] = strconv.FormatInt(*checkRunID, 10)

--- a/test/github_pullrequest_concurrency_test.go
+++ b/test/github_pullrequest_concurrency_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
 	"github.com/tektoncd/pipeline/pkg/names"
 	"gotest.tools/v3/assert"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestGithubPullRequestConcurrency(t *testing.T) {
@@ -77,27 +76,6 @@ func TestGithubPullRequestConcurrency(t *testing.T) {
 		TargetSHA:       sha,
 	}
 	assert.NilError(t, wait.UntilMinPRAppeared(ctx, runcnx.Clients, waitOpts, numberOfPipelineRuns))
-
-	allPR, err := runcnx.Clients.Tekton.TektonV1beta1().PipelineRuns(targetNS).List(ctx, metav1.ListOptions{})
-	assert.NilError(t, err)
-
-	var pending, running bool
-	for _, pr := range allPR.Items {
-		if pr.Spec.Status == "" {
-			running = true
-		} else {
-			pending = true
-		}
-	}
-	if !(pending && running) {
-		runcnx.Clients.Log.Fatal("one pipelineRun must be in running state and one in pending")
-	}
-
-	wait.Succeeded(ctx, t, runcnx, opts, options.PullRequestEvent, targetNS, len(yamlFiles), sha, logmsg)
-
-	runcnx.Clients.Log.Infof("Waiting for Repository to be updated for second pipelineRun")
-	err = wait.UntilRepositoryUpdated(ctx, runcnx.Clients, waitOpts)
-	assert.NilError(t, err)
 
 	finished := 1
 	runningChecks := 0


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

as https://github.com/openshift-pipelines/pipelines-as-code/issues/786 is hopefully fixed with the fix in tektoncd/pipeline
this patch revert couple of commits to do one api call instead of two
 

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
