### PR TITLE
Defines global max and default value for max-runs

### DIFF
--- a/config/302-pac-configmap.yaml
+++ b/config/302-pac-configmap.yaml
@@ -42,6 +42,14 @@ data:
   # Add extra IPS (ie: 127.0.0.1) or networks (127.0.0.0/16) separated by commas.
   bitbucket-cloud-additional-source-ip: ""
 
+  # max-keep-run-upper-limit defines the upper limit for max-keep-run annotation value which a user can set on
+  # pipelineRun. the value set on annotation should be less than or equal to the upper limit otherwise
+  # the upper limit will be used while cleaning up
+  max-keep-run-upper-limit: ""
+
+  # if defined then applies to all pipelineRun who doesn't have max-keep-runs annotation
+  default-max-keep-runs: ""
+
 kind: ConfigMap
 metadata:
   name: pipelines-as-code

--- a/docs/content/docs/install/settings.md
+++ b/docs/content/docs/install/settings.md
@@ -50,3 +50,13 @@ There is a few things you can configure through the configmap
 
   This will provide us to give extra IPS (ie: 127.0.0.1) or networks (127.0.0.0/16)
   separated by commas.
+
+* `max-keep-run-upper-limit`
+
+  This let the user define a max limit for the max-keep-run value. When the user has defined a max-keep-run annotation
+  on a pipelineRun then its value should be less than or equal to the upper limit, otherwise upper limit will be used for cleanup.
+
+* `default-max-keep-runs`
+
+  This allows user to define a default limit for max-keep-run value. If defined then it's applied to all the pipelineRun
+  which do not have `max-keep-runs` annotation.

--- a/pkg/params/info/pac.go
+++ b/pkg/params/info/pac.go
@@ -8,15 +8,17 @@ import (
 )
 
 type PacOpts struct {
-	LogURL             string
-	ApplicationName    string // the Application Name for example "Pipelines as Code"
-	SecretAutoCreation bool   // secret auto creation in target namespace
-	WebhookType        string
-	PayloadFile        string
-	TektonDashboardURL string
-	HubURL             string
-	HubCatalogName     string
-	RemoteTasks        bool
+	LogURL                string
+	ApplicationName       string // the Application Name for example "Pipelines as Code"
+	SecretAutoCreation    bool   // secret auto creation in target namespace
+	WebhookType           string
+	PayloadFile           string
+	TektonDashboardURL    string
+	HubURL                string
+	HubCatalogName        string
+	RemoteTasks           bool
+	MaxKeepRunsUpperLimit int
+	DefaultMaxKeepRuns    int
 
 	// bitbucket cloud specific fields
 	BitbucketCloudCheckSourceIP      bool

--- a/pkg/params/run.go
+++ b/pkg/params/run.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/consoleui"
@@ -123,6 +124,20 @@ func (r *Run) UpdatePACInfo(ctx context.Context) error {
 
 	if sourceIP, ok := cfg.Data["bitbucket-cloud-additional-source-ip"]; ok {
 		r.Info.Pac.BitbucketCloudAdditionalSourceIP = sourceIP
+	}
+
+	if runs, ok := cfg.Data["max-keep-run-upper-limit"]; ok && runs != "" {
+		r.Info.Pac.MaxKeepRunsUpperLimit, err = strconv.Atoi(runs)
+		if err != nil {
+			return fmt.Errorf("failed to convert max-keep-run-upper-limit value to int: %w", err)
+		}
+	}
+
+	if runs, ok := cfg.Data["default-max-keep-runs"]; ok && runs != "" {
+		r.Info.Pac.DefaultMaxKeepRuns, err = strconv.Atoi(runs)
+		if err != nil {
+			return fmt.Errorf("failed to convert default-max-keep-run value to int: %w", err)
+		}
 	}
 
 	return nil

--- a/pkg/reconciler/cleanup.go
+++ b/pkg/reconciler/cleanup.go
@@ -36,8 +36,23 @@ func (r *Reconciler) cleanupPipelineRuns(ctx context.Context, logger *zap.Sugare
 		if err != nil {
 			return err
 		}
-
+		// if annotation value is more than max limit defined in config then use from config
+		if r.run.Info.Pac.MaxKeepRunsUpperLimit > 0 && max > r.run.Info.Pac.MaxKeepRunsUpperLimit {
+			logger.Infof("max-keep-run value in annotation (%v) is more than max-keep-run-upper-limit (%v), so using upper-limit", max, r.run.Info.Pac.MaxKeepRunsUpperLimit)
+			max = r.run.Info.Pac.MaxKeepRunsUpperLimit
+		}
 		err = r.kinteract.CleanupPipelines(ctx, logger, repo, pr, max)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	// if annotation is not defined but default max-keep-run value is defined then use that
+	if r.run.Info.Pac.DefaultMaxKeepRuns > 0 {
+		max := r.run.Info.Pac.DefaultMaxKeepRuns
+
+		err := r.kinteract.CleanupPipelines(ctx, logger, repo, pr, max)
 		if err != nil {
 			return err
 		}

--- a/pkg/reconciler/cleanup_test.go
+++ b/pkg/reconciler/cleanup_test.go
@@ -1,0 +1,168 @@
+package reconciler
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
+	tektontest "github.com/openshift-pipelines/pipelines-as-code/pkg/test/tekton"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"go.uber.org/zap"
+	zapobserver "go.uber.org/zap/zaptest/observer"
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	rtesting "knative.dev/pkg/reconciler/testing"
+)
+
+func TestCleanupPipelineRuns(t *testing.T) {
+	ns := "namespace"
+	cleanupRepoName := "clean-me-up-before-you-go-go-go-go"
+	cleanupPRName := "clean-me-pleaze"
+	cleanupLabels := map[string]string{
+		"pipelinesascode.tekton.dev/original-prname": cleanupPRName,
+		"pipelinesascode.tekton.dev/repository":      cleanupRepoName,
+	}
+
+	maxRunsAnno := func(run int) map[string]string {
+		return map[string]string{
+			"pipelinesascode.tekton.dev/max-keep-runs": strconv.Itoa(run),
+		}
+	}
+
+	clock := clockwork.NewFakeClock()
+	tests := []struct {
+		name               string
+		pruns              []*v1beta1.PipelineRun
+		currentpr          *v1beta1.PipelineRun
+		maxkeepruns        int
+		defaultmaxkeepruns int
+		repoNs             string
+		repoName           string
+		afterCleanup       int
+	}{
+		{
+			name: "using from annotation",
+			pruns: []*v1beta1.PipelineRun{
+				tektontest.MakePRCompletion(clock, "pipeline-newest", ns,
+					v1beta1.PipelineRunReasonSuccessful.String(), cleanupLabels, 10),
+				tektontest.MakePRCompletion(clock, "pipeline-middest", ns,
+					v1beta1.PipelineRunReasonSuccessful.String(), cleanupLabels, 20),
+				tektontest.MakePRCompletion(clock, "pipeline-oldest", ns,
+					v1beta1.PipelineRunReasonSuccessful.String(), cleanupLabels, 30),
+			},
+			repoNs:       ns,
+			repoName:     cleanupRepoName,
+			currentpr:    &v1beta1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Labels: cleanupLabels, Annotations: maxRunsAnno(2)}},
+			afterCleanup: 2,
+		},
+		{
+			name: "using from config, as annotation value is more than config",
+			pruns: []*v1beta1.PipelineRun{
+				tektontest.MakePRCompletion(clock, "pipeline-newest", ns,
+					v1beta1.PipelineRunReasonSuccessful.String(), cleanupLabels, 10),
+				tektontest.MakePRCompletion(clock, "pipeline-middest", ns,
+					v1beta1.PipelineRunReasonSuccessful.String(), cleanupLabels, 20),
+				tektontest.MakePRCompletion(clock, "pipeline-oldest", ns,
+					v1beta1.PipelineRunReasonSuccessful.String(), cleanupLabels, 30),
+			},
+			repoNs:       ns,
+			repoName:     cleanupRepoName,
+			currentpr:    &v1beta1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Labels: cleanupLabels, Annotations: maxRunsAnno(2)}},
+			afterCleanup: 1,
+			maxkeepruns:  1,
+		},
+		{
+			name: "using from annotation, as annotation value is less than config",
+			pruns: []*v1beta1.PipelineRun{
+				tektontest.MakePRCompletion(clock, "pipeline-newest", ns,
+					v1beta1.PipelineRunReasonSuccessful.String(), cleanupLabels, 10),
+				tektontest.MakePRCompletion(clock, "pipeline-middest", ns,
+					v1beta1.PipelineRunReasonSuccessful.String(), cleanupLabels, 20),
+				tektontest.MakePRCompletion(clock, "pipeline-oldest", ns,
+					v1beta1.PipelineRunReasonSuccessful.String(), cleanupLabels, 30),
+			},
+			repoNs:       ns,
+			repoName:     cleanupRepoName,
+			currentpr:    &v1beta1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Labels: cleanupLabels, Annotations: maxRunsAnno(2)}},
+			afterCleanup: 2,
+			maxkeepruns:  3,
+		},
+		{
+			name: "no annotation, using default from config",
+			pruns: []*v1beta1.PipelineRun{
+				tektontest.MakePRCompletion(clock, "pipeline-newest", ns,
+					v1beta1.PipelineRunReasonSuccessful.String(), cleanupLabels, 10),
+				tektontest.MakePRCompletion(clock, "pipeline-middest", ns,
+					v1beta1.PipelineRunReasonSuccessful.String(), cleanupLabels, 20),
+				tektontest.MakePRCompletion(clock, "pipeline-oldest", ns,
+					v1beta1.PipelineRunReasonSuccessful.String(), cleanupLabels, 30),
+			},
+			repoNs:             ns,
+			repoName:           cleanupRepoName,
+			currentpr:          &v1beta1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Labels: cleanupLabels}},
+			afterCleanup:       2,
+			defaultmaxkeepruns: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			repo := &v1alpha1.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tt.repoName,
+					Namespace: tt.repoNs,
+				},
+			}
+
+			tdata := testclient.Data{
+				PipelineRuns: tt.pruns,
+				Namespaces: []*corev1.Namespace{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: ns,
+						},
+					},
+				},
+			}
+			stdata, _ := testclient.SeedTestData(t, ctx, tdata)
+			observer, _ := zapobserver.New(zap.InfoLevel)
+			fakelogger := zap.New(observer).Sugar()
+			kint := kubeinteraction.Interaction{
+				Run: &params.Run{
+					Clients: clients.Clients{
+						Kube:   stdata.Kube,
+						Tekton: stdata.Pipeline,
+					},
+				},
+			}
+
+			r := &Reconciler{
+				run: &params.Run{
+					Info: info.Info{
+						Pac: &info.PacOpts{
+							MaxKeepRunsUpperLimit: tt.maxkeepruns,
+							DefaultMaxKeepRuns:    tt.defaultmaxkeepruns,
+						},
+					},
+				},
+				kinteract: kint,
+			}
+
+			err := r.cleanupPipelineRuns(ctx, fakelogger, repo, tt.currentpr)
+			assert.NilError(t, err)
+
+			plist, err := kint.Run.Clients.Tekton.TektonV1beta1().PipelineRuns(tt.repoNs).List(
+				ctx, metav1.ListOptions{})
+			assert.NilError(t, err)
+			assert.Equal(t, tt.afterCleanup, len(plist.Items))
+		})
+	}
+}


### PR DESCRIPTION
Part of https://issues.redhat.com/browse/SRVKP-2416

- Admin can set global max value for max-keep-runs
- Admin can set default max-keep-runs to apply to pipelineruns that don't have any value set

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [x] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [x] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [x] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [x] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
