### PR TITLE
Update gitea python script to run smee for both Kubernetes and Openshift

### DIFF
--- a/hack/dev/kind/gitea/deploy.py
+++ b/hack/dev/kind/gitea/deploy.py
@@ -20,6 +20,7 @@ GITEA_NS = os.environ.get("GITEA_NS", "gitea")
 GITEA_REPO_NAME_E2E = os.environ.get("GITEA_REPO_NAME", "pac-e2e")
 GITEA_REPO_NAME_PERSO = os.environ.get("GITEA_REPO_NAME_PERSO", "pac")
 OPENSHIFT_ROUTE_FORCE_HTTP = os.environ.get("OPENSHIFT_ROUTE_FORCE_HTTP", False)
+PAC_CONTROLLER_NAMESPACE = os.environ.get("PAC_CONTROLLER_NAMESPACE", "pipelines-as-code")
 
 GITEA_SMEE_HOOK_URL = os.environ.get("TEST_GITEA_SMEEURL", "")  # will fail if not set
 if GITEA_SMEE_HOOK_URL == "":
@@ -38,6 +39,7 @@ GITEA_REPOS = {
 class ProvisionGitea:
     gitea_host = GITEA_HOST
     gitea_url = GITEA_URL
+    namespace = PAC_CONTROLLER_NAMESPACE
     headers = {"Content-Type": "application/json"}
     token_name = "token"
 
@@ -50,6 +52,7 @@ class ProvisionGitea:
                 .replace("VAR_GITEA_HOST", self.gitea_host)
                 .replace("VAR_GITEA_URL", self.gitea_url)
                 .replace("VAR_GITEA_SMEE_HOOK_URL", GITEA_SMEE_HOOK_URL)
+                .replace("VAR_URL", f"http://pipelines-as-code-controller.{self.namespace}:8080")
             )
             self.apply_kubectl(replaced)
 

--- a/hack/dev/kind/gitea/gitea-deployment.yaml
+++ b/hack/dev/kind/gitea/gitea-deployment.yaml
@@ -115,7 +115,7 @@ spec:
               "--saveDir",
               "/tmp/save",
               "VAR_GITEA_SMEE_HOOK_URL",
-              "http://pipelines-as-code-controller.pipelines-as-code:8080",
+              "VAR_URL",
             ]
 
 ---


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Added changes to python script In order to run GITEA tests on both Kind and Openshift

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
