### PR TITLE
Fix TestGiteaConfigMaxKeepRun race

### DIFF
--- a/hack/dev/ghapp_token.py
+++ b/hack/dev/ghapp_token.py
@@ -35,7 +35,8 @@ class GitHub:
         self.github_api_url = github_api_url
         self.token = self._get_token(installation_id)
 
-    def _load_private_key(self, pem_key_bytes):
+    @classmethod
+    def _load_private_key(cls, pem_key_bytes):
         return jwk.JWK.from_pem(pem_key_bytes)
 
     def _app_token(self):


### PR DESCRIPTION
We had a race in TestGiteaConfigMaxKeepRun since we were not waiting that the repo status was updated to list the number of prs. It was working sometime on k8 but fails on openshift since it's a slower api server.

Fixed some other linter warning on python script

We wait for the repo status to be updated now before we list the number of pr running..

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
