### PR TITLE
Teardown the created repository on gitea after test

### DIFF
--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -316,7 +316,7 @@ func TestGiteaConfigMaxKeepRun(t *testing.T) {
 	prs, err := topts.Clients.Clients.Tekton.TektonV1beta1().PipelineRuns(topts.TargetNS).List(context.Background(), metav1.ListOptions{})
 	assert.NilError(t, err)
 
-	assert.Equal(t, len(prs.Items), 1, "should have only one pipelinerun, but we have: %d", prs.Items)
+	assert.Equal(t, len(prs.Items), 1, "should have only one pipelinerun, but we have: %d", len(prs.Items))
 }
 
 func TestGiteaPush(t *testing.T) {

--- a/test/pkg/gitea/setup.go
+++ b/test/pkg/gitea/setup.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/gitea"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/repository"
+	"gotest.tools/v3/assert"
 )
 
 func CreateProvider(ctx context.Context, giteaURL, user, password string) (gitea.Provider, error) {
@@ -74,6 +75,8 @@ func Setup(ctx context.Context) (*params.Run, options.E2E, gitea.Provider, error
 	return run, e2eoptions, gprovider, nil
 }
 
-func TearDown(ctx context.Context, t *testing.T, runcnx *params.Run, targetNS string) {
-	repository.NSTearDown(ctx, t, runcnx, targetNS)
+func TearDown(ctx context.Context, t *testing.T, topts *TestOpts) {
+	repository.NSTearDown(ctx, t, topts.Clients, topts.TargetNS)
+	_, err := topts.GiteaCNX.Client.DeleteRepo(topts.Opts.Organization, topts.TargetRefName)
+	assert.NilError(t, err)
 }

--- a/test/pkg/gitea/test.go
+++ b/test/pkg/gitea/test.go
@@ -74,7 +74,7 @@ func TestPR(t *testing.T, topts *TestOpts) func() {
 
 	cleanup := func() {
 		if os.Getenv("TEST_NOCLEANUP") != "true" {
-			defer TearDown(ctx, t, topts.Clients, topts.TargetNS)
+			defer TearDown(ctx, t, topts)
 		}
 	}
 	err = CreateCRD(ctx, topts)


### PR DESCRIPTION
It was designed for temporary clusters, but since we are going to run them on permanent one we may wnat to do some cleanups or we will reach for storage errors after a while.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
