### PR TITLE
failfast on e2e tests

### DIFF
--- a/.github/workflows/kind-e2e-tests.yaml
+++ b/.github/workflows/kind-e2e-tests.yaml
@@ -98,28 +98,32 @@ jobs:
 
       - name: Run E2E Tests
         run: |
+          export GO_TEST_FLAGS="-v -race -failfast"
+
+          export TEST_BITBUCKET_CLOUD_API_URL=https://api.bitbucket.org/2.0
+          export TEST_BITBUCKET_CLOUD_E2E_REPOSITORY=chmouelb/pac-e2e-test
+          export TEST_BITBUCKET_CLOUD_TOKEN=${{ secrets.BITBUCKET_CLOUD_TOKEN }}
+          export TEST_BITBUCKET_CLOUD_USER=chmouelb
+
+          export TEST_EL_URL="http://${CONTROLLER_DOMAIN_URL}"
+          export TEST_EL_WEBHOOK_SECRET="${{ secrets.WEBHOOK_SECRET }}"
+
+          export TEST_GITEA_API_URL="http://localhost:3000"
+          export TEST_GITEA_PASSWORD=pac
+          export TEST_GITEA_REPO_OWNER=pac/pac
+          export TEST_GITEA_SMEEURL="${{ secrets.TEST_GITEA_SMEEURL }}"
+          export TEST_GITEA_USERNAME=pac
+
           export TEST_GITHUB_API_URL=api.github.com
+          export TEST_GITHUB_REPO_INSTALLATION_ID="${{ secrets.INSTALLATION_ID }}"
           export TEST_GITHUB_REPO_OWNER_GITHUBAPP=openshift-pipelines/pipelines-as-code-e2e-tests
           export TEST_GITHUB_REPO_OWNER_WEBHOOK=openshift-pipelines/pipelines-as-code-e2e-tests-webhook
           export TEST_GITHUB_TOKEN="${{ secrets.GH_APPS_TOKEN }}"
-          export TEST_EL_WEBHOOK_SECRET="${{ secrets.WEBHOOK_SECRET }}"
-          export TEST_GITEA_SMEEURL="${{ secrets.TEST_GITEA_SMEEURL }}"
-          export TEST_GITHUB_REPO_INSTALLATION_ID="${{ secrets.INSTALLATION_ID }}"
-          export TEST_EL_URL="http://${CONTROLLER_DOMAIN_URL}"
-          export TEST_BITBUCKET_CLOUD_API_URL=https://api.bitbucket.org/2.0
-          export TEST_BITBUCKET_CLOUD_USER=chmouelb
-          export TEST_BITBUCKET_CLOUD_E2E_REPOSITORY=chmouelb/pac-e2e-test
-          export TEST_BITBUCKET_CLOUD_TOKEN=${{ secrets.BITBUCKET_CLOUD_TOKEN }}
-          # https://gitlab.com/gitlab-com/alliances/ibm-red-hat/sandbox/openshift-pipelines/pac-e2e-tests
+
           export TEST_GITLAB_API_URL="https://gitlab.com"
           export TEST_GITLAB_PROJECT_ID="34405323"
           export TEST_GITLAB_TOKEN=${{ secrets.GITLAB_TOKEN }}
-          export TEST_GITEA_API_URL="http://localhost:3000"
-          export TEST_GITEA_SMEEURL="${{ secrets.TEST_GITEA_SMEEURL }}"
-          export TEST_GITEA_PASSWORD=pac
-          export TEST_GITEA_USERNAME=pac
-          export TEST_GITEA_REPO_OWNER=pac/pac
-          export GO_TEST_FLAGS="-v -race"
+          # https://gitlab.com/gitlab-com/alliances/ibm-red-hat/sandbox/openshift-pipelines/pac-e2e-tests
           make test-e2e
       # - name: Setup tmate session
       #   uses: mxschmitt/action-tmate@v3

--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -315,6 +315,8 @@ func TestGiteaConfigMaxKeepRun(t *testing.T) {
 	err := twait.UntilRepositoryUpdated(context.Background(), topts.Clients.Clients, waitOpts)
 	assert.NilError(t, err)
 
+	time.Sleep(15 * time.Second) // “Evil does not sleep. It waits.” - Galadriel
+
 	prs, err := topts.Clients.Clients.Tekton.TektonV1beta1().PipelineRuns(topts.TargetNS).List(context.Background(), metav1.ListOptions{})
 	assert.NilError(t, err)
 

--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -21,12 +21,14 @@ import (
 	tknpacgenerate "github.com/openshift-pipelines/pipelines-as-code/pkg/cmd/tknpac/generate"
 	tknpaclist "github.com/openshift-pipelines/pipelines-as-code/pkg/cmd/tknpac/list"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/git"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	tknpactest "github.com/openshift-pipelines/pipelines-as-code/test/pkg/cli"
 	tgitea "github.com/openshift-pipelines/pipelines-as-code/test/pkg/gitea"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
 	twait "github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/names"
 	"gopkg.in/yaml.v2"
 	"gotest.tools/v3/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -306,7 +308,7 @@ func TestGiteaConfigMaxKeepRun(t *testing.T) {
 	waitOpts := twait.Opts{
 		RepoName:        topts.TargetNS,
 		Namespace:       topts.TargetNS,
-		MinNumberStatus: 1,
+		MinNumberStatus: 1, // 1 means 2 🙃
 		PollTimeout:     twait.DefaultTimeout,
 		TargetSHA:       topts.PullRequest.Head.Sha,
 	}
@@ -349,29 +351,54 @@ func TestGiteaPush(t *testing.T) {
 }
 
 func TestGiteaClusterTasks(t *testing.T) {
+	// we need to make sure to create clustertask before pushing the files
+	// so we have to create a new client and do a lot of manual things we get for free in TestPR
 	topts := &tgitea.TestOpts{
 		TargetEvent: "pull_request, push",
 		YAMLFiles: map[string]string{
 			".tekton/prcluster.yaml": "testdata/pipelinerunclustertasks.yaml",
 		},
-		ExpectEvents:            false,
-		WaitForResourceCreation: true,
+		ExpectEvents: false,
 	}
-	defer tgitea.TestPR(t, topts)()
-	prname := fmt.Sprintf(".tekton/%s.yaml", topts.TargetNS)
-	newyamlFiles := map[string]string{prname: "testdata/clustertask.yaml"}
-	entries, err := payload.GetEntries(newyamlFiles, topts.TargetNS, topts.DefaultBranch, topts.TargetEvent)
-	assert.NilError(t, err)
+	topts.TargetRefName = names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test")
+	topts.TargetNS = topts.TargetRefName
 
+	// create first the cluster tasks
+	ctname := fmt.Sprintf(".tekton/%s.yaml", topts.TargetNS)
+	newyamlFiles := map[string]string{ctname: "testdata/clustertask.yaml"}
+	entries, err := payload.GetEntries(newyamlFiles, topts.TargetNS, "main", "pull_request")
+	assert.NilError(t, err)
 	ct := v1beta1.ClusterTask{}
-	assert.NilError(t, yaml.Unmarshal([]byte(entries[prname]), &ct))
+	assert.NilError(t, yaml.Unmarshal([]byte(entries[ctname]), &ct))
 	ct.ObjectMeta.Name = "clustertask-" + topts.TargetNS
-	_, err = topts.Clients.Clients.Tekton.TektonV1beta1().ClusterTasks().Create(context.TODO(), &ct, metav1.CreateOptions{})
-	topts.Clients.Clients.Log.Infof("%s has been created", ct.GetName())
+
+	run := &params.Run{}
+	assert.NilError(t, run.Clients.NewClients(context.Background(), &run.Info))
+	_, err = run.Clients.Tekton.TektonV1beta1().ClusterTasks().Create(context.TODO(), &ct, metav1.CreateOptions{})
+	assert.NilError(t, err)
+	run.Clients.Log.Infof("%s has been created", ct.GetName())
 	defer (func() {
 		assert.NilError(t, topts.Clients.Clients.Tekton.TektonV1beta1().ClusterTasks().Delete(context.TODO(), ct.ObjectMeta.Name, metav1.DeleteOptions{}))
+		run.Clients.Log.Infof("%s is deleted", ct.GetName())
 	})()
+
+	// start PR
+	defer tgitea.TestPR(t, topts)()
+
+	// wait for it
+	waitOpts := twait.Opts{
+		RepoName:  topts.TargetNS,
+		Namespace: topts.TargetNS,
+		// 0 means 1 🙃 (we test for >, while we actually should do >=, but i
+		// need to go all over the code to make sure it's not going to break
+		// anything else)
+		MinNumberStatus: 0,
+		PollTimeout:     twait.DefaultTimeout,
+		TargetSHA:       topts.PullRequest.Head.Sha,
+	}
+	err = twait.UntilRepositoryUpdated(context.Background(), topts.Clients.Clients, waitOpts)
 	assert.NilError(t, err)
+
 	topts.CheckForStatus = "success"
 	tgitea.WaitForStatus(t, topts, topts.TargetRefName)
 }

--- a/test/pkg/gitea/test.go
+++ b/test/pkg/gitea/test.go
@@ -21,26 +21,25 @@ import (
 )
 
 type TestOpts struct {
-	NoCleanup               bool
-	TargetNS                string
-	TargetEvent             string
-	Regexp                  *regexp.Regexp
-	YAMLFiles               map[string]string
-	CheckForStatus          string
-	TargetRefName           string
-	CheckForNumberStatus    int
-	ConcurrencyLimit        *int
-	Clients                 *params.Run
-	GiteaCNX                pgitea.Provider
-	Opts                    options.E2E
-	PullRequest             *gitea.PullRequest
-	DefaultBranch           string
-	GitCloneURL             string
-	GitHTMLURL              string
-	GiteaAPIURL             string
-	GiteaPassword           string
-	ExpectEvents            bool
-	WaitForResourceCreation bool
+	NoCleanup            bool
+	TargetNS             string
+	TargetEvent          string
+	Regexp               *regexp.Regexp
+	YAMLFiles            map[string]string
+	CheckForStatus       string
+	TargetRefName        string
+	CheckForNumberStatus int
+	ConcurrencyLimit     *int
+	Clients              *params.Run
+	GiteaCNX             pgitea.Provider
+	Opts                 options.E2E
+	PullRequest          *gitea.PullRequest
+	DefaultBranch        string
+	GitCloneURL          string
+	GitHTMLURL           string
+	GiteaAPIURL          string
+	GiteaPassword        string
+	ExpectEvents         bool
 }
 
 func PostCommentOnPullRequest(t *testing.T, topt *TestOpts, body string) {
@@ -61,7 +60,9 @@ func TestPR(t *testing.T, topts *TestOpts) func() {
 	assert.NilError(t, err, fmt.Errorf("cannot do gitea setup: %w", err))
 	hookURL := os.Getenv("TEST_GITEA_SMEEURL")
 
-	topts.TargetRefName = names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test")
+	if topts.TargetRefName == "" {
+		topts.TargetRefName = names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test")
+	}
 	if topts.TargetNS == "" {
 		topts.TargetNS = topts.TargetRefName
 	}
@@ -87,12 +88,6 @@ func TestPR(t *testing.T, topts *TestOpts) func() {
 	assert.NilError(t, err)
 	topts.GitCloneURL = url
 	PushFilesToRefGit(t, topts, entries, topts.DefaultBranch)
-	// in case of some test we create resources before creating pull req
-	// for eg. ClusterTask test, pipeline is getting executed before ClusterTask
-	// is getting created, this is to add some delay in case of that test
-	if topts.WaitForResourceCreation {
-		time.Sleep(time.Second * 5)
-	}
 	pr, _, err := giteacnx.Client.CreatePullRequest(opts.Organization, repoInfo.Name, gitea.CreatePullRequestOption{
 		Title: "Test Pull Request - " + topts.TargetRefName,
 		Head:  topts.TargetRefName,


### PR DESCRIPTION
- Fix TestGiteaClusterTasks race.
- TestGiteaMaxKeeprun: add a sleep 😴
- fail as soon as possible on e2e tests
