### PR TITLE
Revert "Added ppc64le support" until we figure out an optimise way

### DIFF
--- a/.github/workflows/ghcr.yaml
+++ b/.github/workflows/ghcr.yaml
@@ -20,12 +20,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
@@ -45,7 +39,6 @@ jobs:
           context: .
           build-args: |
             BINARY_NAME=pipelines-as-code-controller
-          platforms: linux/amd64,linux/ppc64le
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -62,7 +55,6 @@ jobs:
           context: .
           build-args: |
             BINARY_NAME=pipelines-as-code-watcher
-          platforms: linux/amd64,linux/ppc64le
           push: true
           tags: ${{ steps.meta-watcher.outputs.tags }}
           labels: ${{ steps.meta-watcher.outputs.labels }}
@@ -79,7 +71,6 @@ jobs:
           context: .
           build-args: |
             BINARY_NAME=pipelines-as-code-webhook
-          platforms: linux/amd64,linux/ppc64le
           push: true
           tags: ${{ steps.meta-webhook.outputs.tags }}
           labels: ${{ steps.meta-webhook.outputs.labels }}
@@ -96,7 +87,6 @@ jobs:
           context: .
           build-args: |
             BINARY_NAME=tkn-pac
-          platforms: linux/amd64,linux/ppc64le
           push: true
           tags: ${{ steps.meta-cli.outputs.tags }}
           labels: ${{ steps.meta-cli.outputs.labels }}


### PR DESCRIPTION
This reverts commit d2b396a508054775dd2b680a65a1674fc073e6fe as building multi arch images taking a lot of time.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
