### PR TITLE
[WIP]Add s390x, ppc64le architecture support

### DIFF
--- a/.github/workflows/build-multiarch-daily.yaml
+++ b/.github/workflows/build-multiarch-daily.yaml
@@ -3,7 +3,7 @@ name: Build and publish Muilti-arch images to ghcr
 on:
   workflow_dispatch:
   schedule:
-    - cron: '10 * * * *'
+    - cron: '*/10 * * * *'
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/build-multiarch-daily.yaml
+++ b/.github/workflows/build-multiarch-daily.yaml
@@ -1,6 +1,9 @@
-name: Create and publish a Docker image to ghcr
+name: Build and publish Muilti-arch images to ghcr
 
-on: ["push"]
+on:
+  schedule:
+    - cron:  '* 15 * * *'
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
@@ -10,7 +13,7 @@ env:
   TKN_PAC_IMAGE_NAME: ${{ github.repository }}-tkn-pac
 
 jobs:
-  build-and-push-image:
+  build-and-push-multiarch-image:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -19,6 +22,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
@@ -39,6 +48,7 @@ jobs:
           context: .
           build-args: |
             BINARY_NAME=pipelines-as-code-controller
+          platforms: linux/amd64,linux/ppc64le,linux/s390x
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -55,6 +65,7 @@ jobs:
           context: .
           build-args: |
             BINARY_NAME=pipelines-as-code-watcher
+          platforms: linux/amd64,linux/ppc64le,linux/s390x
           push: true
           tags: ${{ steps.meta-watcher.outputs.tags }}
           labels: ${{ steps.meta-watcher.outputs.labels }}
@@ -71,6 +82,7 @@ jobs:
           context: .
           build-args: |
             BINARY_NAME=pipelines-as-code-webhook
+          platforms: linux/amd64,linux/ppc64le,linux/s390x
           push: true
           tags: ${{ steps.meta-webhook.outputs.tags }}
           labels: ${{ steps.meta-webhook.outputs.labels }}
@@ -87,6 +99,7 @@ jobs:
           context: .
           build-args: |
             BINARY_NAME=tkn-pac
+          platforms: linux/amd64,linux/ppc64le,linux/s390x
           push: true
           tags: ${{ steps.meta-cli.outputs.tags }}
           labels: ${{ steps.meta-cli.outputs.labels }}

--- a/.github/workflows/build-multiarch-daily.yaml
+++ b/.github/workflows/build-multiarch-daily.yaml
@@ -50,7 +50,7 @@ jobs:
             BINARY_NAME=pipelines-as-code-controller
           platforms: linux/amd64,linux/ppc64le,linux/s390x
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: multi-arch-nightly-image
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Extract metadata (tags, labels) for Docker (Watcher)
@@ -67,7 +67,7 @@ jobs:
             BINARY_NAME=pipelines-as-code-watcher
           platforms: linux/amd64,linux/ppc64le,linux/s390x
           push: true
-          tags: ${{ steps.meta-watcher.outputs.tags }}
+          tags: multi-arch-nightly-image
           labels: ${{ steps.meta-watcher.outputs.labels }}
 
       - name: Extract metadata (tags, labels) for Docker (Webhook)
@@ -84,7 +84,7 @@ jobs:
             BINARY_NAME=pipelines-as-code-webhook
           platforms: linux/amd64,linux/ppc64le,linux/s390x
           push: true
-          tags: ${{ steps.meta-webhook.outputs.tags }}
+          tags: multi-arch-nightly-image
           labels: ${{ steps.meta-webhook.outputs.labels }}
 
       - name: Extract metadata (tags, labels) for tkn-pac
@@ -101,5 +101,5 @@ jobs:
             BINARY_NAME=tkn-pac
           platforms: linux/amd64,linux/ppc64le,linux/s390x
           push: true
-          tags: ${{ steps.meta-cli.outputs.tags }}
+          tags: multi-arch-nightly-image
           labels: ${{ steps.meta-cli.outputs.labels }}

--- a/.github/workflows/build-multiarch-daily.yaml
+++ b/.github/workflows/build-multiarch-daily.yaml
@@ -3,7 +3,7 @@ name: Build and publish Muilti-arch images to ghcr
 on:
   workflow_dispatch:
   schedule:
-    - cron: '*/10 * * * *'
+    - cron: '*/30 * * * *'
 
 env:
   REGISTRY: ghcr.io
@@ -41,6 +41,8 @@ jobs:
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
           images: ${{ env.REGISTRY }}/${{ env.CONTROLLER_IMAGE_NAME }}
+          tags: |
+            type=schedule,pattern={{date 'YYYYMMDD'}}
 
       - name: Build and push controller docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
@@ -50,7 +52,7 @@ jobs:
             BINARY_NAME=pipelines-as-code-controller
           platforms: linux/amd64,linux/ppc64le,linux/s390x
           push: true
-          tags: multi-arch-nightly-image
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Extract metadata (tags, labels) for Docker (Watcher)
@@ -58,7 +60,9 @@ jobs:
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
           images: ${{ env.REGISTRY }}/${{ env.WATCHER_IMAGE_NAME }}
-
+          tags: |
+            type=schedule,pattern={{date 'YYYYMMDD'}}
+            
       - name: Build and push watcher docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
@@ -67,7 +71,7 @@ jobs:
             BINARY_NAME=pipelines-as-code-watcher
           platforms: linux/amd64,linux/ppc64le,linux/s390x
           push: true
-          tags: multi-arch-nightly-image
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta-watcher.outputs.labels }}
 
       - name: Extract metadata (tags, labels) for Docker (Webhook)
@@ -75,7 +79,9 @@ jobs:
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
           images: ${{ env.REGISTRY }}/${{ env.WEBHOOK_IMAGE_NAME }}
-
+          tags: |
+            type=schedule,pattern={{date 'YYYYMMDD'}}
+            
       - name: Build and push webhook docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
@@ -84,7 +90,7 @@ jobs:
             BINARY_NAME=pipelines-as-code-webhook
           platforms: linux/amd64,linux/ppc64le,linux/s390x
           push: true
-          tags: multi-arch-nightly-image
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta-webhook.outputs.labels }}
 
       - name: Extract metadata (tags, labels) for tkn-pac
@@ -92,7 +98,9 @@ jobs:
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
           images: ${{ env.REGISTRY }}/${{ env.TKN_PAC_IMAGE_NAME }}
-
+          tags: |
+            type=schedule,pattern={{date 'YYYYMMDD'}}
+            
       - name: Build and push cli docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
@@ -101,5 +109,5 @@ jobs:
             BINARY_NAME=tkn-pac
           platforms: linux/amd64,linux/ppc64le,linux/s390x
           push: true
-          tags: multi-arch-nightly-image
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta-cli.outputs.labels }}

--- a/.github/workflows/build-multiarch-daily.yaml
+++ b/.github/workflows/build-multiarch-daily.yaml
@@ -60,8 +60,7 @@ jobs:
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
           images: ${{ env.REGISTRY }}/${{ env.WATCHER_IMAGE_NAME }}
-          tags: |
-            type=schedule,pattern={{date 'YYYYMMDD'}}
+          tags: type=schedule,enable=true,priority=1000,prefix=multiarch-image-,suffix=,pattern=nightly
             
       - name: Build and push watcher docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc

--- a/.github/workflows/build-multiarch-daily.yaml
+++ b/.github/workflows/build-multiarch-daily.yaml
@@ -3,7 +3,7 @@ name: Build and publish Muilti-arch images to ghcr
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 10 * * *'
+    - cron: '10 * * * *'
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/build-multiarch-daily.yaml
+++ b/.github/workflows/build-multiarch-daily.yaml
@@ -1,9 +1,9 @@
 name: Build and publish Muilti-arch images to ghcr
 
 on:
-  schedule:
-    - cron:  '* 15 * * *'
   workflow_dispatch:
+  schedule:
+    - cron: '0 10 * * *'
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/ghcr.yaml
+++ b/.github/workflows/ghcr.yaml
@@ -20,6 +20,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
@@ -39,6 +45,7 @@ jobs:
           context: .
           build-args: |
             BINARY_NAME=pipelines-as-code-controller
+          platforms: linux/amd64,linux/ppc64le,linux/s390x
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -55,6 +62,7 @@ jobs:
           context: .
           build-args: |
             BINARY_NAME=pipelines-as-code-watcher
+          platforms: linux/amd64,linux/ppc64le,linux/s390x
           push: true
           tags: ${{ steps.meta-watcher.outputs.tags }}
           labels: ${{ steps.meta-watcher.outputs.labels }}
@@ -71,6 +79,7 @@ jobs:
           context: .
           build-args: |
             BINARY_NAME=pipelines-as-code-webhook
+          platforms: linux/amd64,linux/ppc64le,linux/s390x
           push: true
           tags: ${{ steps.meta-webhook.outputs.tags }}
           labels: ${{ steps.meta-webhook.outputs.labels }}
@@ -87,6 +96,7 @@ jobs:
           context: .
           build-args: |
             BINARY_NAME=tkn-pac
+          platforms: linux/amd64,linux/ppc64le,linux/s390x
           push: true
           tags: ${{ steps.meta-cli.outputs.tags }}
           labels: ${{ steps.meta-cli.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM mirror.gcr.io/library/golang:1.18 AS builder
+FROM --platform=$BUILDPLATFORM mirror.gcr.io/library/golang:1.18 AS builder
 
 ARG BINARY_NAME=pipelines-as-code-controller
+ARG TARGETARCH
 COPY . /src
 WORKDIR /src
 RUN \
-    make /tmp/${BINARY_NAME} LDFLAGS="-s -w" OUTPUT_DIR=/tmp
+    make /tmp/${BINARY_NAME} TARGETARCH=${TARGETARCH} LDFLAGS="-s -w" OUTPUT_DIR=/tmp
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal
 

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ TARGET_NAMESPACE=pipelines-as-code
 GOLANGCI_LINT=golangci-lint
 GOFUMPT=gofumpt
 LDFLAGS=
+TARGETARCH ?= amd64
 OUTPUT_DIR=bin
 GO           = go
 TIMEOUT_UNIT = 5m
@@ -29,7 +30,7 @@ vendor:
 	@go mod tidy -compat=1.17 && go mod vendor
 
 $(OUTPUT_DIR)/%: cmd/% FORCE
-	go build -mod=vendor $(FLAGS)  -v -o $@ ./$<
+	GOARCH=$(TARGETARCH) go build -mod=vendor $(FLAGS)  -v -o $@ ./$<
 
 check: lint test
 


### PR DESCRIPTION
# Changes
As of now pipeline-as-code runs on amd64 platform. This PR will Add support for ppc64le, s390x platform.

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
