### PR TITLE
remove annotations on e2e pipeliens

### DIFF
--- a/.tekton/e2e-tests.yaml
+++ b/.tekton/e2e-tests.yaml
@@ -4,8 +4,6 @@ kind: PipelineRun
 metadata:
   name: pipelines-as-code-e2e-tests
   annotations:
-    pipelinesascode.tekton.dev/on-event: "[push]"
-    pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/task: "[https://git.io/Jn9Ee]"
     pipelinesascode.tekton.dev/max-keep-runs: "5"
 spec:


### PR DESCRIPTION
Remove annotations on e2e pipelines

It's not supposed to be there since only fired as incoming webhook

and e2e tess are not working atm due of clusters

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
