### PR TITLE
Let find kubeconfig path on Windows

### DIFF
--- a/.vale/styles/RedHat/ConfigMap.yml
+++ b/.vale/styles/RedHat/ConfigMap.yml
@@ -1,8 +1,0 @@
----
-extends: existence
-ignorecase: true
-level: error
-link: https://redhat-documentation.github.io/vale-at-red-hat/docs/reference-guide/configmap/
-message: "Do not use 'config', unless it is followed by 'map'."
-raw:
-    - 'config([[:punct:]]|$|\s(?!maps?\b))'

--- a/docs/content/docs/guide/cli.md
+++ b/docs/content/docs/guide/cli.md
@@ -31,6 +31,10 @@ Available operating systems are :
 * Linux - ARM 64bits - RPM, Debian packages and tarballs.
 * Windows - Arm 64 Bits and x86 architecture.
 
+{{< hint info >}}
+On windows tkn-pac will look for the kubernetes config in `%USERPROFILE%\.kube\config` on Linux and MacOS it will use the standard $HOME/.kube/config.
+{{< /hint >}}
+
 {{< /tab >}}
 
 {{< tab "Homebrew" >}}

--- a/docs/content/docs/guide/repositorycrd.md
+++ b/docs/content/docs/guide/repositorycrd.md
@@ -63,7 +63,7 @@ Namespace rather than trying to match it from all available repository on cluste
 
 ```yaml
 spec:
-  concurrency_limit: <number> 
+  concurrency_limit: <number>
 ```
 
 Example:

--- a/pkg/params/info/kube.go
+++ b/pkg/params/info/kube.go
@@ -3,6 +3,7 @@ package info
 import (
 	"fmt"
 	"os"
+	"runtime"
 
 	"github.com/spf13/cobra"
 )
@@ -13,10 +14,21 @@ type KubeOpts struct {
 	Namespace  string
 }
 
+func userHomeDir() string {
+	if runtime.GOOS == "windows" {
+		home := os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
+		if home == "" {
+			home = os.Getenv("USERPROFILE")
+		}
+		return home
+	}
+	return os.Getenv("HOME")
+}
+
 func (k *KubeOpts) AddFlags(cmd *cobra.Command) {
 	envkconfig := os.Getenv("KUBECONFIG")
 	if envkconfig == "" {
-		envkconfig = "$HOME/.kube/config"
+		envkconfig = fmt.Sprintf("%s/.kube/config", userHomeDir())
 	}
 	cmd.PersistentFlags().StringVarP(
 		&k.ConfigPath,


### PR DESCRIPTION
We were  looking in HOME but windows has other ideas of what home should be.
(ie: like in the song you know)

Seems to work as long you have your files in %USERPROFILE%/.kube/config

![image](https://user-images.githubusercontent.com/98980/197552083-bfd58357-a71d-4b3f-ab0c-3b27612f41b4.png)


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
