### PR TITLE
Use gofumpt extra rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,8 @@ linters-settings:
       - unlambda
   errcheck:
     exclude: .errcheck.txt
+  gofumpt:
+    extra-rules: true
 linters:
   enable:
     - asciicheck

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ fmt:
 
 .PHONY: fumpt ## formats the GO code with gofumpt(excludes vendors dir)
 fumpt:
-	@find test pkg -name '*.go'|xargs -P4 $(GOFUMPT) -w
+	@find test pkg -name '*.go'|xargs -P4 $(GOFUMPT) -w -extra
 
 .PHONY: help
 help: ## print this help

--- a/pkg/acl/acl.go
+++ b/pkg/acl/acl.go
@@ -16,7 +16,7 @@ type ownersConfig struct {
 
 // UserInOwnerFile Parse a Prow type Owner, Approver files and return true if the sender is in
 // there.
-func UserInOwnerFile(ownerContent string, sender string) (bool, error) {
+func UserInOwnerFile(ownerContent, sender string) (bool, error) {
 	oc := ownersConfig{}
 	err := yaml.Unmarshal([]byte(ownerContent), &oc)
 	if err != nil {

--- a/pkg/adapter/incoming.go
+++ b/pkg/adapter/incoming.go
@@ -19,7 +19,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func compareSecret(incomingSecret string, secretValue string) bool {
+func compareSecret(incomingSecret, secretValue string) bool {
 	return subtle.ConstantTimeCompare([]byte(incomingSecret), []byte(secretValue)) != 0
 }
 

--- a/pkg/consoleui/interface.go
+++ b/pkg/consoleui/interface.go
@@ -8,19 +8,19 @@ import (
 )
 
 type Interface interface {
-	DetailURL(ns string, pr string) string
-	TaskLogURL(ns string, pr string, task string) string
+	DetailURL(ns, pr string) string
+	TaskLogURL(ns, pr, task string) string
 	UI(ctx context.Context, kdyn dynamic.Interface) error
 	URL() string
 }
 
 type FallBackConsole struct{}
 
-func (f FallBackConsole) DetailURL(ns string, pr string) string {
+func (f FallBackConsole) DetailURL(ns, pr string) string {
 	return "https://giphy.com/search/random-dogs"
 }
 
-func (f FallBackConsole) TaskLogURL(ns string, pr string, task string) string {
+func (f FallBackConsole) TaskLogURL(ns, pr, task string) string {
 	return "https://giphy.com/search/random-cats"
 }
 

--- a/pkg/consoleui/tektondashboard.go
+++ b/pkg/consoleui/tektondashboard.go
@@ -11,11 +11,11 @@ type TektonDashboard struct {
 	BaseURL string
 }
 
-func (t *TektonDashboard) DetailURL(ns string, pr string) string {
+func (t *TektonDashboard) DetailURL(ns, pr string) string {
 	return fmt.Sprintf("%s/#/namespaces/%s/pipelineruns/%s", t.BaseURL, ns, pr)
 }
 
-func (t *TektonDashboard) TaskLogURL(ns string, pr string, task string) string {
+func (t *TektonDashboard) TaskLogURL(ns, pr, task string) string {
 	return fmt.Sprintf("%s?pipelineTask=%s", t.DetailURL(ns, pr), task)
 }
 

--- a/pkg/kubeinteraction/secrets.go
+++ b/pkg/kubeinteraction/secrets.go
@@ -41,7 +41,7 @@ func (k Interaction) createSecret(ctx context.Context, secretData map[string]str
 
 // CreateBasicAuthSecret Create a secret for git-clone basic-auth workspace
 func (k Interaction) CreateBasicAuthSecret(ctx context.Context, logger *zap.SugaredLogger, runevent *info.Event,
-	targetNamespace string, secretName string,
+	targetNamespace, secretName string,
 ) error {
 	// Bitbucket Server have a different Clone URL than it's Repo URL, so we
 	// have to separate them 👨‍🏭

--- a/pkg/matcher/annotation_matcher.go
+++ b/pkg/matcher/annotation_matcher.go
@@ -195,7 +195,7 @@ func MatchPipelinerunByAnnotation(ctx context.Context, logger *zap.SugaredLogger
 		event.EventType, event.BaseBranch)
 }
 
-func matchOnAnnotation(annotations string, eventType string, branchMatching bool) (bool, error) {
+func matchOnAnnotation(annotations, eventType string, branchMatching bool) (bool, error) {
 	targets, err := getAnnotationValues(annotations)
 	if err != nil {
 		return false, err

--- a/pkg/provider/bitbucketcloud/bitbucket.go
+++ b/pkg/provider/bitbucketcloud/bitbucket.go
@@ -139,7 +139,7 @@ func (v *Provider) getDir(event *info.Event, path string) ([]bitbucket.Repositor
 	return repositoryFiles, nil
 }
 
-func (v *Provider) GetFileInsideRepo(_ context.Context, runevent *info.Event, path string, targetBranch string) (string, error) {
+func (v *Provider) GetFileInsideRepo(_ context.Context, runevent *info.Event, path, targetBranch string) (string, error) {
 	return v.getBlob(runevent, runevent.SHA, path)
 }
 

--- a/pkg/provider/bitbucketcloud/events.go
+++ b/pkg/provider/bitbucketcloud/events.go
@@ -72,7 +72,7 @@ func (v *Provider) checkFromPublicCloudIPS(ctx context.Context, run *params.Run,
 			sourceIP, bitbucketCloudIPrangesList)
 }
 
-func parsePayloadType(event string, rawPayload string) (interface{}, error) {
+func parsePayloadType(event, rawPayload string) (interface{}, error) {
 	var payload interface{}
 
 	var localEvent string

--- a/pkg/provider/bitbucketserver/bitbucketserver.go
+++ b/pkg/provider/bitbucketserver/bitbucketserver.go
@@ -142,7 +142,7 @@ func (v *Provider) concatAllYamlFiles(objects []string, runevent *info.Event) (s
 	return allTemplates, nil
 }
 
-func (v *Provider) getRaw(runevent *info.Event, revision string, path string) (string, error) {
+func (v *Provider) getRaw(runevent *info.Event, revision, path string) (string, error) {
 	localVarOptionals := map[string]interface{}{
 		"at": revision,
 	}
@@ -177,7 +177,7 @@ func (v *Provider) GetTektonDir(ctx context.Context, event *info.Event, path str
 	return v.concatAllYamlFiles(fpathTmpl, event)
 }
 
-func (v *Provider) GetFileInsideRepo(ctx context.Context, event *info.Event, path string, targetBranch string) (string, error) {
+func (v *Provider) GetFileInsideRepo(ctx context.Context, event *info.Event, path, targetBranch string) (string, error) {
 	branch := event.SHA
 	// TODO: this may be buggy? we need to figure out how to get the fromSource ref
 	if targetBranch == event.DefaultBranch {

--- a/pkg/provider/bitbucketserver/test/test.go
+++ b/pkg/provider/bitbucketserver/test/test.go
@@ -111,7 +111,7 @@ func MakeEvent(event *info.Event) *info.Event {
 	return rev
 }
 
-func MuxDirContent(t *testing.T, mux *http.ServeMux, event *info.Event, testDir string, targetDirName string) {
+func MuxDirContent(t *testing.T, mux *http.ServeMux, event *info.Event, testDir, targetDirName string) {
 	files, err := os.ReadDir(testDir)
 	if err != nil {
 		// no error just disapointed
@@ -159,7 +159,7 @@ func MuxDefaultBranch(t *testing.T, mux *http.ServeMux, event *info.Event, defau
 	})
 }
 
-func MuxFiles(t *testing.T, mux *http.ServeMux, event *info.Event, branch string, targetDirName string, filescontents map[string]string) {
+func MuxFiles(t *testing.T, mux *http.ServeMux, event *info.Event, branch, targetDirName string, filescontents map[string]string) {
 	for filename := range filescontents {
 		path := fmt.Sprintf("/projects/%s/repos/%s/raw/%s", event.Organization, event.Repository, filename)
 		mux.HandleFunc(path, func(rw http.ResponseWriter, r *http.Request) {

--- a/pkg/provider/gitlab/test/test.go
+++ b/pkg/provider/gitlab/test/test.go
@@ -41,7 +41,7 @@ func Setup(ctx context.Context, t *testing.T) (*gitlab.Client, *http.ServeMux, f
 	return client, mux, tearDown
 }
 
-func MuxNotePost(t *testing.T, mux *http.ServeMux, projectNumber int, mrID int, catchStr string) {
+func MuxNotePost(t *testing.T, mux *http.ServeMux, projectNumber, mrID int, catchStr string) {
 	path := fmt.Sprintf("/projects/%d/merge_requests/%d/notes", projectNumber, mrID)
 	mux.HandleFunc(path, func(rw http.ResponseWriter, r *http.Request) {
 		bit, _ := io.ReadAll(r.Body)

--- a/pkg/resolve/resolve_test.go
+++ b/pkg/resolve/resolve_test.go
@@ -32,7 +32,7 @@ func setup() {
 }
 
 // Not sure how to get testParams fixtures working
-func readTDfile(t *testing.T, testname string, generateName bool, remoteTasking bool) (*tektonv1beta1.PipelineRun, *zapobserver.ObservedLogs, error) {
+func readTDfile(t *testing.T, testname string, generateName, remoteTasking bool) (*tektonv1beta1.PipelineRun, *zapobserver.ObservedLogs, error) {
 	t.Helper()
 	ctx, _ := rtesting.SetupFakeContext(t)
 	data, err := os.ReadFile("testdata/" + testname + ".yaml")

--- a/pkg/test/kubernetestint/kubernetesint.go
+++ b/pkg/test/kubernetestint/kubernetesint.go
@@ -20,7 +20,7 @@ type KinterfaceTest struct {
 
 var _ kubeinteraction.Interface = (*KinterfaceTest)(nil)
 
-func (k *KinterfaceTest) GetConsoleUI(_ context.Context, _ string, _ string) (string, error) {
+func (k *KinterfaceTest) GetConsoleUI(_ context.Context, _, _ string) (string, error) {
 	if k.ConsoleURLErorring {
 		return "", fmt.Errorf("i want you to errit")
 	}

--- a/pkg/test/provider/testwebvcs.go
+++ b/pkg/test/provider/testwebvcs.go
@@ -72,7 +72,7 @@ func (v *TestProviderImp) GetTektonDir(ctx context.Context, event *info.Event, s
 	return v.TektonDirTemplate, nil
 }
 
-func (v *TestProviderImp) GetFileInsideRepo(ctx context.Context, event *info.Event, file string, targetBranch string) (string, error) {
+func (v *TestProviderImp) GetFileInsideRepo(ctx context.Context, event *info.Event, file, targetBranch string) (string, error) {
 	if val, ok := v.FilesInsideRepo[file]; ok {
 		return val, nil
 	}

--- a/test/pkg/github/setup.go
+++ b/test/pkg/github/setup.go
@@ -66,7 +66,7 @@ func Setup(ctx context.Context, viaDirectWebhook bool) (*params.Run, options.E2E
 	return run, e2eoptions, gprovider, nil
 }
 
-func TearDown(ctx context.Context, t *testing.T, runcnx *params.Run, ghprovider github.Provider, prNumber int, ref string, targetNS string, opts options.E2E) {
+func TearDown(ctx context.Context, t *testing.T, runcnx *params.Run, ghprovider github.Provider, prNumber int, ref, targetNS string, opts options.E2E) {
 	runcnx.Clients.Log.Infof("Closing PR %d", prNumber)
 	if prNumber != -1 {
 		state := "closed"

--- a/test/pkg/gitlab/setup.go
+++ b/test/pkg/gitlab/setup.go
@@ -66,7 +66,7 @@ func Setup(ctx context.Context) (*params.Run, options.E2E, gitlab.Provider, erro
 	return run, e2eoptions, glprovider, nil
 }
 
-func TearDown(ctx context.Context, t *testing.T, runcnx *params.Run, glprovider gitlab.Provider, mrNumber int, ref string, targetNS string, projectid int) {
+func TearDown(ctx context.Context, t *testing.T, runcnx *params.Run, glprovider gitlab.Provider, mrNumber int, ref, targetNS string, projectid int) {
 	runcnx.Clients.Log.Infof("Closing PR %d", mrNumber)
 	if mrNumber != -1 {
 		_, _, err := glprovider.Client.MergeRequests.UpdateMergeRequest(projectid, mrNumber,

--- a/test/pkg/payload/get_entries.go
+++ b/test/pkg/payload/get_entries.go
@@ -9,7 +9,7 @@ import (
 	"text/template"
 )
 
-func vinceMap(a map[string]string, b map[string]string) map[string]string {
+func vinceMap(a, b map[string]string) map[string]string {
 	for k, v := range b {
 		a[k] = v
 	}


### PR DESCRIPTION
make golangci-lint use the extra rules..

more enforced formatting by tools is less worries about formatting 🙃 

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
