### PR TITLE
Adds dashboard url validaton and updates default auto repo configure value

### DIFF
--- a/pkg/params/run.go
+++ b/pkg/params/run.go
@@ -89,7 +89,7 @@ func (r *Run) UpdatePACInfo(ctx context.Context) error {
 		return err
 	}
 
-	if r.Info.Pac.Settings.TektonDashboardURL != r.Clients.ConsoleUI.URL() {
+	if r.Info.Pac.Settings.TektonDashboardURL != "" && r.Info.Pac.Settings.TektonDashboardURL != r.Clients.ConsoleUI.URL() {
 		r.Clients.Log.Infof("updating console url to: %s", r.Info.Pac.Settings.TektonDashboardURL)
 		r.Clients.ConsoleUI = &consoleui.TektonDashboard{BaseURL: r.Info.Pac.Settings.TektonDashboardURL}
 	}

--- a/pkg/params/settings/config.go
+++ b/pkg/params/settings/config.go
@@ -28,7 +28,7 @@ const (
 	PACApplicationNameDefaultValue          = "Pipelines as Code CI"
 	HubURLDefaultValue                      = "https://api.hub.tekton.dev/v1"
 	hubCatalogNameDefaultValue              = "tekton"
-	AutoConfigureNewGitHubRepoDefaultValue  = "true"
+	AutoConfigureNewGitHubRepoDefaultValue  = "false"
 )
 
 type Settings struct {

--- a/pkg/params/settings/validation.go
+++ b/pkg/params/settings/validation.go
@@ -2,6 +2,7 @@ package settings
 
 import (
 	"fmt"
+	"net/url"
 	"strconv"
 )
 
@@ -41,6 +42,13 @@ func Validate(config map[string]string) error {
 	if check, ok := config[AutoConfigureNewGitHubRepoKey]; ok {
 		if !isValidBool(check) {
 			return fmt.Errorf("invalid value for key %v, acceptable values: true or false", AutoConfigureNewGitHubRepoKey)
+		}
+	}
+
+	if dashboardURL, ok := config[TektonDashboardURLKey]; ok {
+		_, err := url.ParseRequestURI(dashboardURL)
+		if err != nil {
+			return fmt.Errorf("invalid value for key %v, invalid url: %v", TektonDashboardURLKey, err)
 		}
 	}
 	return nil

--- a/pkg/params/settings/validation_test.go
+++ b/pkg/params/settings/validation_test.go
@@ -51,6 +51,13 @@ func TestValidate(t *testing.T) {
 			},
 			wantErr: "invalid value for key bitbucket-cloud-check-source-ip, acceptable values: true or false",
 		},
+		{
+			name: "invalid url value",
+			config: map[string]string{
+				TektonDashboardURLKey: "abc.xyz",
+			},
+			wantErr: "invalid value for key tekton-dashboard-url, invalid url: parse \"abc.xyz\": invalid URI for request",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
Previously, ConsoleUI was getting set to 
`&consoleui.TektonDashboard{BaseURL: r.Info.Pac.Settings.TektonDashboardURL}`
but in the configmap the  default value for `TektonDashboardURL` is `""` and we didn't had `!= ""` check.
due to which an empty string was getting used to generate the logURL which is used in checkrun and
as the logURL was not a valid URL, checkrun was failing to create. 

also adds validation check for valid URL in settings.



Fixes #954 

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
