### PR TITLE
Fix linter error wrapping key should be %w not %v

### DIFF
--- a/pkg/params/settings/validation.go
+++ b/pkg/params/settings/validation.go
@@ -48,7 +48,7 @@ func Validate(config map[string]string) error {
 	if dashboardURL, ok := config[TektonDashboardURLKey]; ok {
 		_, err := url.ParseRequestURI(dashboardURL)
 		if err != nil {
-			return fmt.Errorf("invalid value for key %v, invalid url: %v", TektonDashboardURLKey, err)
+			return fmt.Errorf("invalid value for key %v, invalid url: %w", TektonDashboardURLKey, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
I have no idea how come this went into origin/main passing the CI green.....

<img width="1387" alt="image" src="https://user-images.githubusercontent.com/98980/200515404-d4cc51cc-2c30-4a05-8f88-81225bc4ad69.png">

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
