### PR TITLE
Fixes involved object in Event emitted

### DIFF
--- a/pkg/apis/pipelinesascode/register.go
+++ b/pkg/apis/pipelinesascode/register.go
@@ -18,5 +18,7 @@ package pipelinesascode
 
 // GroupName is the group name used in this package
 const (
-	GroupName = "pipelinesascode.tekton.dev"
+	GroupName       = "pipelinesascode.tekton.dev"
+	RepositoryKind  = "Repository"
+	V1alpha1Version = "v1alpha1"
 )

--- a/pkg/events/emit.go
+++ b/pkg/events/emit.go
@@ -63,9 +63,15 @@ func makeEvent(repo *v1alpha1.Repository, loggerLevel zapcore.Level, reason, mes
 		Reason:  reason,
 		Type:    v1.EventTypeWarning,
 		InvolvedObject: v1.ObjectReference{
-			Kind:      "Repository",
-			Name:      repo.Name,
-			Namespace: repo.Namespace,
+			APIVersion:      pipelinesascode.V1alpha1Version,
+			Kind:            pipelinesascode.RepositoryKind,
+			Namespace:       repo.Namespace,
+			Name:            repo.Name,
+			UID:             repo.UID,
+			ResourceVersion: repo.ResourceVersion,
+		},
+		Source: v1.EventSource{
+			Component: "Pipelines As Code",
 		},
 	}
 	if loggerLevel == zap.InfoLevel {

--- a/pkg/events/emit_test.go
+++ b/pkg/events/emit_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
 	"go.uber.org/zap"
@@ -45,6 +46,7 @@ func TestEventEmitter_EmitMessage(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-repo",
 					Namespace: "test-ns",
+					UID:       "uid",
 				},
 				Spec: v1alpha1.RepositorySpec{},
 			},
@@ -76,6 +78,12 @@ func TestEventEmitter_EmitMessage(t *testing.T) {
 				assert.Equal(t, events.Items[0].Message, tt.message)
 				assert.Equal(t, events.Items[0].Type, v1.EventTypeNormal)
 				assert.Equal(t, events.Items[0].Reason, tt.reason)
+				assert.Equal(t, events.Items[0].InvolvedObject.Name, tt.repo.Name)
+				assert.Equal(t, events.Items[0].InvolvedObject.Namespace, tt.repo.Namespace)
+				assert.Equal(t, events.Items[0].InvolvedObject.UID, tt.repo.UID)
+				assert.Equal(t, events.Items[0].InvolvedObject.Kind, pipelinesascode.RepositoryKind)
+				assert.Equal(t, events.Items[0].InvolvedObject.APIVersion, pipelinesascode.V1alpha1Version)
+				assert.Assert(t, events.Items[0].Source.Component != "")
 			}
 		})
 	}


### PR DESCRIPTION
when we emit event, we add repository as involved object but were adding only name and namespace, which was causing failure in filtering out events so we add rest of the metadata now.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [x] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [x] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [x] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [x] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
