### PR TITLE
Validate setting only if defined

### DIFF
--- a/pkg/params/settings/validation.go
+++ b/pkg/params/settings/validation.go
@@ -7,19 +7,19 @@ import (
 )
 
 func Validate(config map[string]string) error {
-	if secretAutoCreation, ok := config[SecretAutoCreateKey]; ok {
+	if secretAutoCreation, ok := config[SecretAutoCreateKey]; ok && secretAutoCreation != "" {
 		if !isValidBool(secretAutoCreation) {
 			return fmt.Errorf("invalid value for key %v, acceptable values: true or false", SecretAutoCreateKey)
 		}
 	}
 
-	if remoteTask, ok := config[RemoteTasksKey]; ok {
+	if remoteTask, ok := config[RemoteTasksKey]; ok && remoteTask != "" {
 		if !isValidBool(remoteTask) {
 			return fmt.Errorf("invalid value for key %v, acceptable values: true or false", RemoteTasksKey)
 		}
 	}
 
-	if check, ok := config[BitbucketCloudCheckSourceIPKey]; ok {
+	if check, ok := config[BitbucketCloudCheckSourceIPKey]; ok && check != "" {
 		if !isValidBool(check) {
 			return fmt.Errorf("invalid value for key %v, acceptable values: true or false", BitbucketCloudCheckSourceIPKey)
 		}
@@ -39,13 +39,13 @@ func Validate(config map[string]string) error {
 		}
 	}
 
-	if check, ok := config[AutoConfigureNewGitHubRepoKey]; ok {
+	if check, ok := config[AutoConfigureNewGitHubRepoKey]; ok && check != "" {
 		if !isValidBool(check) {
 			return fmt.Errorf("invalid value for key %v, acceptable values: true or false", AutoConfigureNewGitHubRepoKey)
 		}
 	}
 
-	if dashboardURL, ok := config[TektonDashboardURLKey]; ok {
+	if dashboardURL, ok := config[TektonDashboardURLKey]; ok && dashboardURL != "" {
 		if _, err := url.ParseRequestURI(dashboardURL); err != nil {
 			return fmt.Errorf("invalid value for key %v, invalid url: %w", TektonDashboardURLKey, err)
 		}

--- a/pkg/params/settings/validation_test.go
+++ b/pkg/params/settings/validation_test.go
@@ -58,6 +58,19 @@ func TestValidate(t *testing.T) {
 			},
 			wantErr: "invalid value for key tekton-dashboard-url, invalid url: parse \"abc.xyz\": invalid URI for request",
 		},
+		{
+			name: "empty values",
+			config: map[string]string{
+				RemoteTasksKey:                 "",
+				SecretAutoCreateKey:            "",
+				BitbucketCloudCheckSourceIPKey: "",
+				TektonDashboardURLKey:          "",
+				MaxKeepRunUpperLimitKey:        "",
+				AutoConfigureNewGitHubRepoKey:  "",
+				DefaultMaxKeepRunsKey:          "",
+			},
+			wantErr: "",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
if settings are not defined and we validate empty string it was failing for tektondashboard url, but anyway we should validate only if value is set.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [x] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [x] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [x] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [x] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
