### PR TITLE
Reuses skipped checkrun, as we can't remove it

### DIFF
--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -212,7 +212,7 @@ func (l listener) detectProvider(req *http.Request, reqBody string) (provider.In
 		return nil, &log, fmt.Errorf("invalid event body format: %w", err)
 	}
 
-	gitHub := &github.Provider{}
+	gitHub := github.New()
 	isGH, processReq, logger, reason, err := gitHub.Detect(req, reqBody, &log)
 	if isGH {
 		return l.processRes(processReq, gitHub, logger, reason, err)

--- a/pkg/adapter/incoming.go
+++ b/pkg/adapter/incoming.go
@@ -98,7 +98,7 @@ func (l *listener) processIncoming(targetRepo *v1alpha1.Repository) (provider.In
 	var provider provider.Interface
 	switch targetRepo.Spec.GitProvider.Type {
 	case "github":
-		provider = &github.Provider{}
+		provider = github.New()
 	case "gitlab":
 		provider = &gitlab.Provider{}
 	case "gitea":

--- a/pkg/adapter/incoming_test.go
+++ b/pkg/adapter/incoming_test.go
@@ -429,7 +429,7 @@ func Test_listener_processIncoming(t *testing.T) {
 	}{
 		{
 			name:     "process/github",
-			want:     &github.Provider{},
+			want:     github.New(),
 			wantOrg:  "owner",
 			wantRepo: "repo",
 			targetRepo: &v1alpha1.Repository{

--- a/pkg/cmd/tknpac/resolve/resolve.go
+++ b/pkg/cmd/tknpac/resolve/resolve.go
@@ -148,7 +148,7 @@ func resolveFilenames(cs *params.Run, filenames []string, params map[string]stri
 		SkipInlining: skipInlining,
 	}
 	// We use github here but since we don't do remotetask we would not care
-	providerintf := &github.Provider{}
+	providerintf := github.New()
 	event := info.NewEvent()
 	prun, err := resolve.Resolve(ctx, cs, cs.Clients.Log, providerintf, event, allTemplates, ropt)
 	if err != nil {

--- a/pkg/params/settings/validation.go
+++ b/pkg/params/settings/validation.go
@@ -7,19 +7,19 @@ import (
 )
 
 func Validate(config map[string]string) error {
-	if secretAutoCreation, ok := config[SecretAutoCreateKey]; ok {
+	if secretAutoCreation, ok := config[SecretAutoCreateKey]; ok && secretAutoCreation != "" {
 		if !isValidBool(secretAutoCreation) {
 			return fmt.Errorf("invalid value for key %v, acceptable values: true or false", SecretAutoCreateKey)
 		}
 	}
 
-	if remoteTask, ok := config[RemoteTasksKey]; ok {
+	if remoteTask, ok := config[RemoteTasksKey]; ok && remoteTask != "" {
 		if !isValidBool(remoteTask) {
 			return fmt.Errorf("invalid value for key %v, acceptable values: true or false", RemoteTasksKey)
 		}
 	}
 
-	if check, ok := config[BitbucketCloudCheckSourceIPKey]; ok {
+	if check, ok := config[BitbucketCloudCheckSourceIPKey]; ok && check != "" {
 		if !isValidBool(check) {
 			return fmt.Errorf("invalid value for key %v, acceptable values: true or false", BitbucketCloudCheckSourceIPKey)
 		}
@@ -39,13 +39,13 @@ func Validate(config map[string]string) error {
 		}
 	}
 
-	if check, ok := config[AutoConfigureNewGitHubRepoKey]; ok {
+	if check, ok := config[AutoConfigureNewGitHubRepoKey]; ok && check != "" {
 		if !isValidBool(check) {
 			return fmt.Errorf("invalid value for key %v, acceptable values: true or false", AutoConfigureNewGitHubRepoKey)
 		}
 	}
 
-	if dashboardURL, ok := config[TektonDashboardURLKey]; ok {
+	if dashboardURL, ok := config[TektonDashboardURLKey]; ok && dashboardURL != "" {
 		if _, err := url.ParseRequestURI(dashboardURL); err != nil {
 			return fmt.Errorf("invalid value for key %v, invalid url: %w", TektonDashboardURLKey, err)
 		}

--- a/pkg/params/settings/validation_test.go
+++ b/pkg/params/settings/validation_test.go
@@ -58,6 +58,19 @@ func TestValidate(t *testing.T) {
 			},
 			wantErr: "invalid value for key tekton-dashboard-url, invalid url: parse \"abc.xyz\": invalid URI for request",
 		},
+		{
+			name: "empty values",
+			config: map[string]string{
+				RemoteTasksKey:                 "",
+				SecretAutoCreateKey:            "",
+				BitbucketCloudCheckSourceIPKey: "",
+				TektonDashboardURLKey:          "",
+				MaxKeepRunUpperLimitKey:        "",
+				AutoConfigureNewGitHubRepoKey:  "",
+				DefaultMaxKeepRunsKey:          "",
+			},
+			wantErr: "",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/reconciler/event.go
+++ b/pkg/reconciler/event.go
@@ -30,7 +30,7 @@ func (r *Reconciler) detectProvider(ctx context.Context, logger *zap.SugaredLogg
 	var provider provider.Interface
 	switch gitProvider {
 	case "github", "github-enterprise":
-		gh := &github.Provider{}
+		gh := github.New()
 		if event.InstallationID != 0 {
 			if err := gh.InitAppClient(ctx, r.run.Clients.Kube, event); err != nil {
 				return nil, nil, err

--- a/test/pkg/github/pr.go
+++ b/test/pkg/github/pr.go
@@ -85,7 +85,7 @@ func PushFilesToRef(ctx context.Context, client *github.Client, commitMessage, b
 	return commit.GetSHA(), nil
 }
 
-func PRCreate(ctx context.Context, cs *params.Run, ghcnx ghprovider.Provider, owner, repo, targetRef, defaultBranch, title string) (int, error) {
+func PRCreate(ctx context.Context, cs *params.Run, ghcnx *ghprovider.Provider, owner, repo, targetRef, defaultBranch, title string) (int, error) {
 	pr, _, err := ghcnx.Client.PullRequests.Create(ctx, owner, repo, &github.NewPullRequest{
 		Title: &title,
 		Head:  &targetRef,
@@ -99,7 +99,7 @@ func PRCreate(ctx context.Context, cs *params.Run, ghcnx ghprovider.Provider, ow
 	return pr.GetNumber(), nil
 }
 
-func RunPullRequest(ctx context.Context, t *testing.T, label string, yamlFiles []string, webhook bool) (*params.Run, ghprovider.Provider, options.E2E, string, string, int, string) {
+func RunPullRequest(ctx context.Context, t *testing.T, label string, yamlFiles []string, webhook bool) (*params.Run, *ghprovider.Provider, options.E2E, string, string, int, string) {
 	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
 	runcnx, opts, ghcnx, err := Setup(ctx, webhook)
 	assert.NilError(t, err)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

 Reuses skipped checkrun, as we can't remove it

skipped runs were not getting removed a authorised user adds /ok-to-test
on a pull req from a new user, this is to fix that case.

we cannot delete a checkrun so we reuse it for the pipelinerun, when the
CI is triggered later.
as we execute pipelineruns parallely, to make sure only one pipelinerun uses that
checkrunid we use mutex to store that checkrunid.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [x] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [x] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [x] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [x] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
