### PR TITLE
Fixes condition to use secret referred in Repository CR

### DIFF
--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -59,13 +59,13 @@ func (p *PacRun) matchRepoPR(ctx context.Context) ([]matcher.Match, *v1alpha1.Re
 	// allow webhook providers users to have a global webhook secret to be used,
 	// so instead of having to specify their in Repo each time, they use a
 	// shared one from pac.
-	if repo.Spec.GitProvider != nil && p.event.InstallationID <= 0 {
+	if p.event.InstallationID > 0 {
+		p.event.Provider.WebhookSecret, _ = GetCurrentNSWebhookSecret(ctx, p.k8int)
+	} else {
 		err := SecretFromRepository(ctx, p.run, p.k8int, p.vcx.GetConfig(), p.event, repo, p.logger)
 		if err != nil {
 			return nil, nil, err
 		}
-	} else {
-		p.event.Provider.WebhookSecret, _ = GetCurrentNSWebhookSecret(ctx, p.k8int)
 	}
 
 	// validate payload  for webhook secret

--- a/pkg/pipelineascode/secret.go
+++ b/pkg/pipelineascode/secret.go
@@ -23,12 +23,18 @@ const (
 // SecretFromRepository grab the secret from the repository CRD
 func SecretFromRepository(ctx context.Context, cs *params.Run, k8int kubeinteraction.Interface, config *info.ProviderConfig, event *info.Event, repo *apipac.Repository, logger *zap.SugaredLogger) error {
 	var err error
+	if repo.Spec.GitProvider == nil {
+		return fmt.Errorf("failed to find git_provider details in repository spec: %v/%v", repo.Namespace, repo.Name)
+	}
 	if repo.Spec.GitProvider.URL == "" {
 		repo.Spec.GitProvider.URL = config.APIURL
 	} else {
 		event.Provider.URL = repo.Spec.GitProvider.URL
 	}
 
+	if repo.Spec.GitProvider.Secret == nil {
+		return fmt.Errorf("failed to find secret in git_provider section in repository spec: %v/%v", repo.Namespace, repo.Name)
+	}
 	gitProviderSecretKey := repo.Spec.GitProvider.Secret.Key
 	if gitProviderSecretKey == "" {
 		gitProviderSecretKey = defaultGitProviderSecretKey


### PR DESCRIPTION
Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

   this fixes cases when we try to look for secret but it is not set
    so pac was breaking due to accessing nil so we handle that.


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [x] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [x] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [x] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [x] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
