### PR TITLE
Fix validation when dashboard URL is empty

### DIFF
--- a/pkg/params/settings/validation.go
+++ b/pkg/params/settings/validation.go
@@ -45,7 +45,7 @@ func Validate(config map[string]string) error {
 		}
 	}
 
-	if dashboardURL, ok := config[TektonDashboardURLKey]; ok {
+	if dashboardURL, ok := config[TektonDashboardURLKey]; ok && dashboardURL != "" {
 		if _, err := url.ParseRequestURI(dashboardURL); err != nil {
 			return fmt.Errorf("invalid value for key %v, invalid url: %w", TektonDashboardURLKey, err)
 		}

--- a/pkg/params/settings/validation_test.go
+++ b/pkg/params/settings/validation_test.go
@@ -58,6 +58,13 @@ func TestValidate(t *testing.T) {
 			},
 			wantErr: "invalid value for key tekton-dashboard-url, invalid url: parse \"abc.xyz\": invalid URI for request",
 		},
+		{
+			name: "empty value for TektonDashboardURLKey",
+			config: map[string]string{
+				TektonDashboardURLKey: "",
+			},
+			wantErr: "",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fixes validation when dashboard URL is empty
Issue:
```
$ kubectl logs -f pipelines-as-code-controller-995fd4b84-bqt2d -n pipelines-as-code 

{"severity":"INFO","timestamp":"2022-11-09T14:42:50.691406814Z","logger":"pipelinesascode","caller":"adapter/adapter.go:68","message":"Starting Pipelines as Code version: nightly","commit":"94d1024"}
2022/11/09 14:42:50 failed to get defaults : config validation failed: invalid value for key tekton-dashboard-url, invalid url: parse "": empty url
```

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
