### PR TITLE
Sorts events in describe command with latest displayed first

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/bradleyfalzon/ghinstallation/v2 v2.1.0
 	github.com/cloudevents/sdk-go/v2 v2.11.0
+	github.com/fvbommel/sortorder v1.0.1
 	github.com/gfleury/go-bitbucket-v1 v0.0.0-20220418082332-711d7d5e805f
 	github.com/gobwas/glob v0.2.3
 	github.com/google/cel-go v0.11.3
@@ -38,6 +39,8 @@ require (
 	k8s.io/apimachinery v0.23.9
 	k8s.io/client-go v0.23.9
 	k8s.io/code-generator v0.23.9
+	k8s.io/klog/v2 v2.80.1
+	k8s.io/utils v0.0.0-20220823124924-e9cbc92d1a73
 	knative.dev/eventing v0.34.2
 	knative.dev/pkg v0.0.0-20220818004048-4a03844c0b15
 	sigs.k8s.io/yaml v1.3.0
@@ -129,9 +132,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.23.9 // indirect
 	k8s.io/gengo v0.0.0-20220613173612-397b4ae3bce7 // indirect
-	k8s.io/klog/v2 v2.80.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220124234850-424119656bbf // indirect
-	k8s.io/utils v0.0.0-20220823124924-e9cbc92d1a73 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -215,6 +215,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
+github.com/fvbommel/sortorder v1.0.1 h1:dSnXLt4mJYH25uDDGa3biZNQsozaUWDSWeKJ0qqFfzE=
+github.com/fvbommel/sortorder v1.0.1/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui720w+kxuqRs0=
 github.com/getkin/kin-openapi v0.76.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/gfleury/go-bitbucket-v1 v0.0.0-20220418082332-711d7d5e805f h1:xVRGXRHjGaqT9M+mNNQrsoku+p2z/+Ei/b2gs7ZCbZw=

--- a/pkg/cmd/tknpac/describe/describe.go
+++ b/pkg/cmd/tknpac/describe/describe.go
@@ -20,16 +20,19 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/sort"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 var (
-	namespaceFlag   = "namespace"
-	targetPRFlag    = "target-pipelinerun"
-	useRealTimeFlag = "use-realtime"
-	showEventflag   = "show-events"
+	namespaceFlag     = "namespace"
+	targetPRFlag      = "target-pipelinerun"
+	useRealTimeFlag   = "use-realtime"
+	showEventflag     = "show-events"
+	creationTimestamp = "{.metadata.creationTimestamp}"
 )
 
 //go:embed templates/describe.tmpl
@@ -182,7 +185,12 @@ func describe(ctx context.Context, cs *params.Run, clock clockwork.Clock, opts *
 			return err
 		}
 		events, _ := kinteract.GetEvents(ctx, repository.GetNamespace(), "Repository", repository.GetName())
-		eventList = events.Items
+
+		// events to runtime obj
+		runTimeObj := []runtime.Object{}
+		for i := range events.Items {
+			runTimeObj = append(runTimeObj, &events.Items[i])
+		}
 
 		// we do twice the prun list, but since it's behind a flag and not the default behavior, it's ok (i guess)
 		label := "pipelinesascode.tekton.dev/repository=" + repository.Name
@@ -197,7 +205,16 @@ func describe(ctx context.Context, cs *params.Run, clock clockwork.Clock, opts *
 			if err != nil {
 				continue
 			}
-			eventList = append(eventList, pevents.Items...)
+			for i := range pevents.Items {
+				runTimeObj = append(runTimeObj, &pevents.Items[i])
+			}
+		}
+		sort.ByField(creationTimestamp, runTimeObj)
+
+		// append event in reverse order as they are sorted
+		for i := len(runTimeObj) - 1; i >= 0; i-- {
+			event, _ := runTimeObj[i].(*corev1.Event)
+			eventList = append(eventList, *event)
 		}
 	}
 

--- a/pkg/cmd/tknpac/describe/describe_test.go
+++ b/pkg/cmd/tknpac/describe/describe_test.go
@@ -297,6 +297,81 @@ func TestDescribe(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "repository multiple events",
+			args: args{
+				repoName:         "test-run",
+				currentNamespace: "namespace",
+				opts: &describeOpts{
+					PacCliOpts: cli.PacCliOpts{
+						Namespace: "namespace",
+					},
+					ShowEvents: true,
+				},
+				events: []*corev1.Event{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							CreationTimestamp: metav1.Time{Time: cw.Now().Add(-16 * time.Minute)},
+							Namespace:         "namespace",
+							Name:              "test-run-a",
+						},
+						Message: "Eeny, meeny, miny, moe, Catch a tiger by the toe.",
+						Reason:  "ItchyBack",
+						Type:    corev1.EventTypeNormal,
+						InvolvedObject: corev1.ObjectReference{
+							Name: "test-run", Kind: "Repository", Namespace: "namespace",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							CreationTimestamp: metav1.Time{Time: cw.Now().Add(-10 * time.Minute)},
+							Namespace:         "namespace",
+							Name:              "test-run-b",
+						},
+						Message: "Eeny, meeny, miny, moe, Catch a tiger by the toe.",
+						Reason:  "ItchyBack",
+						Type:    corev1.EventTypeNormal,
+						InvolvedObject: corev1.ObjectReference{
+							Name: "test-run", Kind: "Repository", Namespace: "namespace",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							CreationTimestamp: metav1.Time{Time: cw.Now().Add(-20 * time.Minute)},
+							Namespace:         "namespace",
+							Name:              "test-run-c",
+						},
+						Message: "Eeny, meeny, miny, moe, Catch a tiger by the toe.",
+						Reason:  "ItchyBack",
+						Type:    corev1.EventTypeNormal,
+						InvolvedObject: corev1.ObjectReference{
+							Name: "test-run", Kind: "Repository", Namespace: "namespace",
+						},
+					},
+				},
+				statuses: []v1alpha1.RepositoryRunStatus{
+					{
+						Status: v1beta1.Status{
+							Conditions: []knativeapis.Condition{
+								{
+									Reason: "Success",
+								},
+							},
+						},
+						CollectedTaskInfos: &map[string]v1alpha1.TaskInfos{},
+						PipelineRunName:    "pipelinerun1",
+						LogURL:             github.String("https://everywhere.anwywhere"),
+						StartTime:          &metav1.Time{Time: cw.Now().Add(-16 * time.Minute)},
+						CompletionTime:     &metav1.Time{Time: cw.Now().Add(-15 * time.Minute)},
+						SHA:                github.String("SHA"),
+						SHAURL:             github.String("https://anurl.com/commit/SHA"),
+						Title:              github.String("A title"),
+						TargetBranch:       github.String("TargetBranch"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "multiple repo status",
 			args: args{
 				opts:             &describeOpts{},

--- a/pkg/cmd/tknpac/describe/testdata/TestDescribe-repository_multiple_events.golden
+++ b/pkg/cmd/tknpac/describe/testdata/TestDescribe-repository_multiple_events.golden
@@ -1,0 +1,18 @@
+Name:           test-run
+Namespace:      namespace
+URL:            https://anurl.com
+Status:         Success
+Log:            https://everywhere.anwywhere
+Commit URL:     https://anurl.com/commit/SHA
+PipelineRun:    pipelinerun1
+Event:          <nil>
+Branch:         TargetBranch
+Commit Title:   A title
+StartTime:      16 minutes ago 
+Duration:       1 minute
+
+Events:
+
+• 10 minutes ago - ItchyBack - Eeny, meeny, miny, moe, Catch a tiger by the toe.
+• 16 minutes ago - ItchyBack - Eeny, meeny, miny, moe, Catch a tiger by the toe.
+• 20 minutes ago - ItchyBack - Eeny, meeny, miny, moe, Catch a tiger by the toe.

--- a/pkg/sort/runtime_sort.go
+++ b/pkg/sort/runtime_sort.go
@@ -1,0 +1,234 @@
+package sort
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/jsonpath"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/integer"
+
+	"github.com/fvbommel/sortorder"
+)
+
+// The following code has been take from kubectl get command
+// instead of importing all the dependencies, copying only the required part
+// https://github.com/kubernetes/kubernetes/blob/8e48df135318026d5f8a972a96a2ff665889568a/staging/src/k8s.io/kubectl/pkg/cmd/get/sorter.go#L151
+
+// RuntimeSort is an implementation of the golang sort interface that knows how to sort
+// lists of runtime.Object
+type RuntimeSort struct {
+	field        string
+	objs         []runtime.Object
+	origPosition []int
+}
+
+// NewRuntimeSort creates a new RuntimeSort struct that implements golang sort interface
+func NewRuntimeSort(field string, objs []runtime.Object) *RuntimeSort {
+	sorter := &RuntimeSort{field: field, objs: objs, origPosition: make([]int, len(objs))}
+	for ix := range objs {
+		sorter.origPosition[ix] = ix
+	}
+	return sorter
+}
+
+func (r *RuntimeSort) Len() int {
+	return len(r.objs)
+}
+
+func (r *RuntimeSort) Swap(i, j int) {
+	r.objs[i], r.objs[j] = r.objs[j], r.objs[i]
+	r.origPosition[i], r.origPosition[j] = r.origPosition[j], r.origPosition[i]
+}
+
+func isLess(i, j reflect.Value) (bool, error) {
+	//nolint
+	switch i.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return i.Int() < j.Int(), nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return i.Uint() < j.Uint(), nil
+	case reflect.Float32, reflect.Float64:
+		return i.Float() < j.Float(), nil
+	case reflect.String:
+		return sortorder.NaturalLess(i.String(), j.String()), nil
+	case reflect.Ptr:
+		return isLess(i.Elem(), j.Elem())
+	case reflect.Struct:
+		// sort metav1.Time
+		in := i.Interface()
+		if t, ok := in.(metav1.Time); ok {
+			time := j.Interface().(metav1.Time)
+			return t.Before(&time), nil
+		}
+		// sort resource.Quantity
+		if iQuantity, ok := in.(resource.Quantity); ok {
+			jQuantity := j.Interface().(resource.Quantity)
+			return iQuantity.Cmp(jQuantity) < 0, nil
+		}
+		// fallback to the fields comparison
+		for idx := 0; idx < i.NumField(); idx++ {
+			less, err := isLess(i.Field(idx), j.Field(idx))
+			if err != nil || !less {
+				return less, err
+			}
+		}
+		return true, nil
+	case reflect.Array, reflect.Slice:
+		// note: the length of i and j may be different
+		for idx := 0; idx < integer.IntMin(i.Len(), j.Len()); idx++ {
+			less, err := isLess(i.Index(idx), j.Index(idx))
+			if err != nil || !less {
+				return less, err
+			}
+		}
+		return true, nil
+	case reflect.Interface:
+		//nolint
+		if i.IsNil() && j.IsNil() {
+			return false, nil
+		} else if i.IsNil() {
+			return true, nil
+		} else if j.IsNil() {
+			return false, nil
+		}
+		switch itype := i.Interface().(type) {
+		case uint8:
+			if jtype, ok := j.Interface().(uint8); ok {
+				return itype < jtype, nil
+			}
+		case uint16:
+			if jtype, ok := j.Interface().(uint16); ok {
+				return itype < jtype, nil
+			}
+		case uint32:
+			if jtype, ok := j.Interface().(uint32); ok {
+				return itype < jtype, nil
+			}
+		case uint64:
+			if jtype, ok := j.Interface().(uint64); ok {
+				return itype < jtype, nil
+			}
+		case int8:
+			if jtype, ok := j.Interface().(int8); ok {
+				return itype < jtype, nil
+			}
+		case int16:
+			if jtype, ok := j.Interface().(int16); ok {
+				return itype < jtype, nil
+			}
+		case int32:
+			if jtype, ok := j.Interface().(int32); ok {
+				return itype < jtype, nil
+			}
+		case int64:
+			if jtype, ok := j.Interface().(int64); ok {
+				return itype < jtype, nil
+			}
+		case uint:
+			if jtype, ok := j.Interface().(uint); ok {
+				return itype < jtype, nil
+			}
+		case int:
+			if jtype, ok := j.Interface().(int); ok {
+				return itype < jtype, nil
+			}
+		case float32:
+			if jtype, ok := j.Interface().(float32); ok {
+				return itype < jtype, nil
+			}
+		case float64:
+			if jtype, ok := j.Interface().(float64); ok {
+				return itype < jtype, nil
+			}
+		case string:
+			if jtype, ok := j.Interface().(string); ok {
+				// check if it's a Quantity
+				itypeQuantity, err := resource.ParseQuantity(itype)
+				if err != nil {
+					return sortorder.NaturalLess(itype, jtype), nil
+				}
+				jtypeQuantity, err := resource.ParseQuantity(jtype)
+				if err != nil {
+					return sortorder.NaturalLess(itype, jtype), nil
+				}
+				// Both strings are quantity
+				return itypeQuantity.Cmp(jtypeQuantity) < 0, nil
+			}
+		default:
+			return false, fmt.Errorf("unsortable type: %T", itype)
+		}
+		return false, fmt.Errorf("unsortable interface: %v", i.Kind())
+
+	default:
+		return false, fmt.Errorf("unsortable type: %v", i.Kind())
+	}
+}
+
+func (r *RuntimeSort) Less(i, j int) bool {
+	iObj := r.objs[i]
+	jObj := r.objs[j]
+
+	var iValues [][]reflect.Value
+	var jValues [][]reflect.Value
+	var err error
+
+	parser := jsonpath.New("sorting").AllowMissingKeys(true)
+	err = parser.Parse(r.field)
+	if err != nil {
+		panic(err)
+	}
+
+	iValues, err = findJSONPathResults(parser, iObj)
+	if err != nil {
+		klog.Fatalf("Failed to get i values for %#v using %s (%#v)", iObj, r.field, err)
+	}
+
+	jValues, err = findJSONPathResults(parser, jObj)
+	if err != nil {
+		klog.Fatalf("Failed to get j values for %#v using %s (%v)", jObj, r.field, err)
+	}
+
+	if len(iValues) == 0 || len(iValues[0]) == 0 {
+		return true
+	}
+	if len(jValues) == 0 || len(jValues[0]) == 0 {
+		return false
+	}
+	iField := iValues[0][0]
+	jField := jValues[0][0]
+
+	less, err := isLess(iField, jField)
+	if err != nil {
+		klog.Exitf("Field %s in %T is an unsortable type: %s, err: %v", r.field, iObj, iField.Kind().String(), err)
+	}
+	return less
+}
+
+// OriginalPosition returns the starting (original) position of a particular index.
+// e.g. If OriginalPosition(0) returns 5 than the
+// the item currently at position 0 was at position 5 in the original unsorted array.
+func (r *RuntimeSort) OriginalPosition(ix int) int {
+	if ix < 0 || ix > len(r.origPosition) {
+		return -1
+	}
+	return r.origPosition[ix]
+}
+
+func findJSONPathResults(parser *jsonpath.JSONPath, from runtime.Object) ([][]reflect.Value, error) {
+	if unstructuredObj, ok := from.(*unstructured.Unstructured); ok {
+		return parser.FindResults(unstructuredObj.Object)
+	}
+	return parser.FindResults(reflect.ValueOf(from).Elem().Interface())
+}
+
+// ByField sorts the runtime objects passed by the field
+func ByField(field string, runTimeObj []runtime.Object) {
+	sorter := NewRuntimeSort(field, runTimeObj)
+	sort.Sort(sorter)
+}

--- a/vendor/github.com/fvbommel/sortorder/.gitignore
+++ b/vendor/github.com/fvbommel/sortorder/.gitignore
@@ -1,0 +1,19 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+# Folders
+_obj
+_test
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+_testmain.go
+*.exe
+*.test
+*.prof

--- a/vendor/github.com/fvbommel/sortorder/LICENSE
+++ b/vendor/github.com/fvbommel/sortorder/LICENSE
@@ -1,0 +1,17 @@
+The MIT License (MIT)
+Copyright (c) 2015 Frits van Bommel
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/fvbommel/sortorder/README.md
+++ b/vendor/github.com/fvbommel/sortorder/README.md
@@ -1,0 +1,5 @@
+# sortorder [![PkgGoDev](https://pkg.go.dev/badge/github.com/fvbommel/sortorder)](https://pkg.go.dev/github.com/fvbommel/sortorder)
+
+    import "github.com/fvbommel/sortorder"
+
+Sort orders and comparison functions.

--- a/vendor/github.com/fvbommel/sortorder/doc.go
+++ b/vendor/github.com/fvbommel/sortorder/doc.go
@@ -1,0 +1,5 @@
+// Package sortorder implements sort orders and comparison functions.
+//
+// Currently, it only implements so-called "natural order", where integers
+// embedded in strings are compared by value.
+package sortorder

--- a/vendor/github.com/fvbommel/sortorder/natsort.go
+++ b/vendor/github.com/fvbommel/sortorder/natsort.go
@@ -1,0 +1,76 @@
+package sortorder
+
+// Natural implements sort.Interface to sort strings in natural order. This
+// means that e.g. "abc2" < "abc12".
+//
+// Non-digit sequences and numbers are compared separately. The former are
+// compared bytewise, while the latter are compared numerically (except that
+// the number of leading zeros is used as a tie-breaker, so e.g. "2" < "02")
+//
+// Limitation: only ASCII digits (0-9) are considered.
+type Natural []string
+
+func (n Natural) Len() int           { return len(n) }
+func (n Natural) Swap(i, j int)      { n[i], n[j] = n[j], n[i] }
+func (n Natural) Less(i, j int) bool { return NaturalLess(n[i], n[j]) }
+
+func isdigit(b byte) bool { return '0' <= b && b <= '9' }
+
+// NaturalLess compares two strings using natural ordering. This means that e.g.
+// "abc2" < "abc12".
+//
+// Non-digit sequences and numbers are compared separately. The former are
+// compared bytewise, while the latter are compared numerically (except that
+// the number of leading zeros is used as a tie-breaker, so e.g. "2" < "02")
+//
+// Limitation: only ASCII digits (0-9) are considered.
+func NaturalLess(str1, str2 string) bool {
+	idx1, idx2 := 0, 0
+	for idx1 < len(str1) && idx2 < len(str2) {
+		c1, c2 := str1[idx1], str2[idx2]
+		dig1, dig2 := isdigit(c1), isdigit(c2)
+		switch {
+		case dig1 != dig2: // Digits before other characters.
+			return dig1 // True if LHS is a digit, false if the RHS is one.
+		case !dig1: // && !dig2, because dig1 == dig2
+			// UTF-8 compares bytewise-lexicographically, no need to decode
+			// codepoints.
+			if c1 != c2 {
+				return c1 < c2
+			}
+			idx1++
+			idx2++
+		default: // Digits
+			// Eat zeros.
+			for ; idx1 < len(str1) && str1[idx1] == '0'; idx1++ {
+			}
+			for ; idx2 < len(str2) && str2[idx2] == '0'; idx2++ {
+			}
+			// Eat all digits.
+			nonZero1, nonZero2 := idx1, idx2
+			for ; idx1 < len(str1) && isdigit(str1[idx1]); idx1++ {
+			}
+			for ; idx2 < len(str2) && isdigit(str2[idx2]); idx2++ {
+			}
+			// If lengths of numbers with non-zero prefix differ, the shorter
+			// one is less.
+			if len1, len2 := idx1-nonZero1, idx2-nonZero2; len1 != len2 {
+				return len1 < len2
+			}
+			// If they're equal, string comparison is correct.
+			if nr1, nr2 := str1[nonZero1:idx1], str2[nonZero2:idx2]; nr1 != nr2 {
+				return nr1 < nr2
+			}
+			// Otherwise, the one with less zeros is less.
+			// Because everything up to the number is equal, comparing the index
+			// after the zeros is sufficient.
+			if nonZero1 != nonZero2 {
+				return nonZero1 < nonZero2
+			}
+		}
+		// They're identical so far, so continue comparing.
+	}
+	// So far they are identical. At least one is ended. If the other continues,
+	// it sorts last.
+	return len(str1) < len(str2)
+}

--- a/vendor/k8s.io/client-go/third_party/forked/golang/LICENSE
+++ b/vendor/k8s.io/client-go/third_party/forked/golang/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/k8s.io/client-go/third_party/forked/golang/PATENTS
+++ b/vendor/k8s.io/client-go/third_party/forked/golang/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/k8s.io/client-go/third_party/forked/golang/template/exec.go
+++ b/vendor/k8s.io/client-go/third_party/forked/golang/template/exec.go
@@ -1,0 +1,94 @@
+//This package is copied from Go library text/template.
+//The original private functions indirect and printableValue
+//are exported as public functions.
+package template
+
+import (
+	"fmt"
+	"reflect"
+)
+
+var Indirect = indirect
+var PrintableValue = printableValue
+
+var (
+	errorType       = reflect.TypeOf((*error)(nil)).Elem()
+	fmtStringerType = reflect.TypeOf((*fmt.Stringer)(nil)).Elem()
+)
+
+// indirect returns the item at the end of indirection, and a bool to indicate if it's nil.
+// We indirect through pointers and empty interfaces (only) because
+// non-empty interfaces have methods we might need.
+func indirect(v reflect.Value) (rv reflect.Value, isNil bool) {
+	for ; v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface; v = v.Elem() {
+		if v.IsNil() {
+			return v, true
+		}
+		if v.Kind() == reflect.Interface && v.NumMethod() > 0 {
+			break
+		}
+	}
+	return v, false
+}
+
+// printableValue returns the, possibly indirected, interface value inside v that
+// is best for a call to formatted printer.
+func printableValue(v reflect.Value) (interface{}, bool) {
+	if v.Kind() == reflect.Ptr {
+		v, _ = indirect(v) // fmt.Fprint handles nil.
+	}
+	if !v.IsValid() {
+		return "<no value>", true
+	}
+
+	if !v.Type().Implements(errorType) && !v.Type().Implements(fmtStringerType) {
+		if v.CanAddr() && (reflect.PtrTo(v.Type()).Implements(errorType) || reflect.PtrTo(v.Type()).Implements(fmtStringerType)) {
+			v = v.Addr()
+		} else {
+			switch v.Kind() {
+			case reflect.Chan, reflect.Func:
+				return nil, false
+			}
+		}
+	}
+	return v.Interface(), true
+}
+
+// canBeNil reports whether an untyped nil can be assigned to the type. See reflect.Zero.
+func canBeNil(typ reflect.Type) bool {
+	switch typ.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		return true
+	}
+	return false
+}
+
+// isTrue reports whether the value is 'true', in the sense of not the zero of its type,
+// and whether the value has a meaningful truth value.
+func isTrue(val reflect.Value) (truth, ok bool) {
+	if !val.IsValid() {
+		// Something like var x interface{}, never set. It's a form of nil.
+		return false, true
+	}
+	switch val.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		truth = val.Len() > 0
+	case reflect.Bool:
+		truth = val.Bool()
+	case reflect.Complex64, reflect.Complex128:
+		truth = val.Complex() != 0
+	case reflect.Chan, reflect.Func, reflect.Ptr, reflect.Interface:
+		truth = !val.IsNil()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		truth = val.Int() != 0
+	case reflect.Float32, reflect.Float64:
+		truth = val.Float() != 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		truth = val.Uint() != 0
+	case reflect.Struct:
+		truth = true // Struct values are always true.
+	default:
+		return
+	}
+	return truth, true
+}

--- a/vendor/k8s.io/client-go/third_party/forked/golang/template/funcs.go
+++ b/vendor/k8s.io/client-go/third_party/forked/golang/template/funcs.go
@@ -1,0 +1,599 @@
+//This package is copied from Go library text/template.
+//The original private functions eq, ge, gt, le, lt, and ne
+//are exported as public functions.
+package template
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"reflect"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+var Equal = eq
+var GreaterEqual = ge
+var Greater = gt
+var LessEqual = le
+var Less = lt
+var NotEqual = ne
+
+// FuncMap is the type of the map defining the mapping from names to functions.
+// Each function must have either a single return value, or two return values of
+// which the second has type error. In that case, if the second (error)
+// return value evaluates to non-nil during execution, execution terminates and
+// Execute returns that error.
+type FuncMap map[string]interface{}
+
+var builtins = FuncMap{
+	"and":      and,
+	"call":     call,
+	"html":     HTMLEscaper,
+	"index":    index,
+	"js":       JSEscaper,
+	"len":      length,
+	"not":      not,
+	"or":       or,
+	"print":    fmt.Sprint,
+	"printf":   fmt.Sprintf,
+	"println":  fmt.Sprintln,
+	"urlquery": URLQueryEscaper,
+
+	// Comparisons
+	"eq": eq, // ==
+	"ge": ge, // >=
+	"gt": gt, // >
+	"le": le, // <=
+	"lt": lt, // <
+	"ne": ne, // !=
+}
+
+var builtinFuncs = createValueFuncs(builtins)
+
+// createValueFuncs turns a FuncMap into a map[string]reflect.Value
+func createValueFuncs(funcMap FuncMap) map[string]reflect.Value {
+	m := make(map[string]reflect.Value)
+	addValueFuncs(m, funcMap)
+	return m
+}
+
+// addValueFuncs adds to values the functions in funcs, converting them to reflect.Values.
+func addValueFuncs(out map[string]reflect.Value, in FuncMap) {
+	for name, fn := range in {
+		v := reflect.ValueOf(fn)
+		if v.Kind() != reflect.Func {
+			panic("value for " + name + " not a function")
+		}
+		if !goodFunc(v.Type()) {
+			panic(fmt.Errorf("can't install method/function %q with %d results", name, v.Type().NumOut()))
+		}
+		out[name] = v
+	}
+}
+
+// AddFuncs adds to values the functions in funcs. It does no checking of the input -
+// call addValueFuncs first.
+func addFuncs(out, in FuncMap) {
+	for name, fn := range in {
+		out[name] = fn
+	}
+}
+
+// goodFunc checks that the function or method has the right result signature.
+func goodFunc(typ reflect.Type) bool {
+	// We allow functions with 1 result or 2 results where the second is an error.
+	switch {
+	case typ.NumOut() == 1:
+		return true
+	case typ.NumOut() == 2 && typ.Out(1) == errorType:
+		return true
+	}
+	return false
+}
+
+// findFunction looks for a function in the template, and global map.
+func findFunction(name string) (reflect.Value, bool) {
+	if fn := builtinFuncs[name]; fn.IsValid() {
+		return fn, true
+	}
+	return reflect.Value{}, false
+}
+
+// Indexing.
+
+// index returns the result of indexing its first argument by the following
+// arguments.  Thus "index x 1 2 3" is, in Go syntax, x[1][2][3]. Each
+// indexed item must be a map, slice, or array.
+func index(item interface{}, indices ...interface{}) (interface{}, error) {
+	v := reflect.ValueOf(item)
+	for _, i := range indices {
+		index := reflect.ValueOf(i)
+		var isNil bool
+		if v, isNil = indirect(v); isNil {
+			return nil, fmt.Errorf("index of nil pointer")
+		}
+		switch v.Kind() {
+		case reflect.Array, reflect.Slice, reflect.String:
+			var x int64
+			switch index.Kind() {
+			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+				x = index.Int()
+			case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+				x = int64(index.Uint())
+			default:
+				return nil, fmt.Errorf("cannot index slice/array with type %s", index.Type())
+			}
+			if x < 0 || x >= int64(v.Len()) {
+				return nil, fmt.Errorf("index out of range: %d", x)
+			}
+			v = v.Index(int(x))
+		case reflect.Map:
+			if !index.IsValid() {
+				index = reflect.Zero(v.Type().Key())
+			}
+			if !index.Type().AssignableTo(v.Type().Key()) {
+				return nil, fmt.Errorf("%s is not index type for %s", index.Type(), v.Type())
+			}
+			if x := v.MapIndex(index); x.IsValid() {
+				v = x
+			} else {
+				v = reflect.Zero(v.Type().Elem())
+			}
+		default:
+			return nil, fmt.Errorf("can't index item of type %s", v.Type())
+		}
+	}
+	return v.Interface(), nil
+}
+
+// Length
+
+// length returns the length of the item, with an error if it has no defined length.
+func length(item interface{}) (int, error) {
+	v, isNil := indirect(reflect.ValueOf(item))
+	if isNil {
+		return 0, fmt.Errorf("len of nil pointer")
+	}
+	switch v.Kind() {
+	case reflect.Array, reflect.Chan, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len(), nil
+	}
+	return 0, fmt.Errorf("len of type %s", v.Type())
+}
+
+// Function invocation
+
+// call returns the result of evaluating the first argument as a function.
+// The function must return 1 result, or 2 results, the second of which is an error.
+func call(fn interface{}, args ...interface{}) (interface{}, error) {
+	v := reflect.ValueOf(fn)
+	typ := v.Type()
+	if typ.Kind() != reflect.Func {
+		return nil, fmt.Errorf("non-function of type %s", typ)
+	}
+	if !goodFunc(typ) {
+		return nil, fmt.Errorf("function called with %d args; should be 1 or 2", typ.NumOut())
+	}
+	numIn := typ.NumIn()
+	var dddType reflect.Type
+	if typ.IsVariadic() {
+		if len(args) < numIn-1 {
+			return nil, fmt.Errorf("wrong number of args: got %d want at least %d", len(args), numIn-1)
+		}
+		dddType = typ.In(numIn - 1).Elem()
+	} else {
+		if len(args) != numIn {
+			return nil, fmt.Errorf("wrong number of args: got %d want %d", len(args), numIn)
+		}
+	}
+	argv := make([]reflect.Value, len(args))
+	for i, arg := range args {
+		value := reflect.ValueOf(arg)
+		// Compute the expected type. Clumsy because of variadics.
+		var argType reflect.Type
+		if !typ.IsVariadic() || i < numIn-1 {
+			argType = typ.In(i)
+		} else {
+			argType = dddType
+		}
+		if !value.IsValid() && canBeNil(argType) {
+			value = reflect.Zero(argType)
+		}
+		if !value.Type().AssignableTo(argType) {
+			return nil, fmt.Errorf("arg %d has type %s; should be %s", i, value.Type(), argType)
+		}
+		argv[i] = value
+	}
+	result := v.Call(argv)
+	if len(result) == 2 && !result[1].IsNil() {
+		return result[0].Interface(), result[1].Interface().(error)
+	}
+	return result[0].Interface(), nil
+}
+
+// Boolean logic.
+
+func truth(a interface{}) bool {
+	t, _ := isTrue(reflect.ValueOf(a))
+	return t
+}
+
+// and computes the Boolean AND of its arguments, returning
+// the first false argument it encounters, or the last argument.
+func and(arg0 interface{}, args ...interface{}) interface{} {
+	if !truth(arg0) {
+		return arg0
+	}
+	for i := range args {
+		arg0 = args[i]
+		if !truth(arg0) {
+			break
+		}
+	}
+	return arg0
+}
+
+// or computes the Boolean OR of its arguments, returning
+// the first true argument it encounters, or the last argument.
+func or(arg0 interface{}, args ...interface{}) interface{} {
+	if truth(arg0) {
+		return arg0
+	}
+	for i := range args {
+		arg0 = args[i]
+		if truth(arg0) {
+			break
+		}
+	}
+	return arg0
+}
+
+// not returns the Boolean negation of its argument.
+func not(arg interface{}) (truth bool) {
+	truth, _ = isTrue(reflect.ValueOf(arg))
+	return !truth
+}
+
+// Comparison.
+
+// TODO: Perhaps allow comparison between signed and unsigned integers.
+
+var (
+	errBadComparisonType = errors.New("invalid type for comparison")
+	errBadComparison     = errors.New("incompatible types for comparison")
+	errNoComparison      = errors.New("missing argument for comparison")
+)
+
+type kind int
+
+const (
+	invalidKind kind = iota
+	boolKind
+	complexKind
+	intKind
+	floatKind
+	integerKind
+	stringKind
+	uintKind
+)
+
+func basicKind(v reflect.Value) (kind, error) {
+	switch v.Kind() {
+	case reflect.Bool:
+		return boolKind, nil
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return intKind, nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return uintKind, nil
+	case reflect.Float32, reflect.Float64:
+		return floatKind, nil
+	case reflect.Complex64, reflect.Complex128:
+		return complexKind, nil
+	case reflect.String:
+		return stringKind, nil
+	}
+	return invalidKind, errBadComparisonType
+}
+
+// eq evaluates the comparison a == b || a == c || ...
+func eq(arg1 interface{}, arg2 ...interface{}) (bool, error) {
+	v1 := reflect.ValueOf(arg1)
+	k1, err := basicKind(v1)
+	if err != nil {
+		return false, err
+	}
+	if len(arg2) == 0 {
+		return false, errNoComparison
+	}
+	for _, arg := range arg2 {
+		v2 := reflect.ValueOf(arg)
+		k2, err := basicKind(v2)
+		if err != nil {
+			return false, err
+		}
+		truth := false
+		if k1 != k2 {
+			// Special case: Can compare integer values regardless of type's sign.
+			switch {
+			case k1 == intKind && k2 == uintKind:
+				truth = v1.Int() >= 0 && uint64(v1.Int()) == v2.Uint()
+			case k1 == uintKind && k2 == intKind:
+				truth = v2.Int() >= 0 && v1.Uint() == uint64(v2.Int())
+			default:
+				return false, errBadComparison
+			}
+		} else {
+			switch k1 {
+			case boolKind:
+				truth = v1.Bool() == v2.Bool()
+			case complexKind:
+				truth = v1.Complex() == v2.Complex()
+			case floatKind:
+				truth = v1.Float() == v2.Float()
+			case intKind:
+				truth = v1.Int() == v2.Int()
+			case stringKind:
+				truth = v1.String() == v2.String()
+			case uintKind:
+				truth = v1.Uint() == v2.Uint()
+			default:
+				panic("invalid kind")
+			}
+		}
+		if truth {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// ne evaluates the comparison a != b.
+func ne(arg1, arg2 interface{}) (bool, error) {
+	// != is the inverse of ==.
+	equal, err := eq(arg1, arg2)
+	return !equal, err
+}
+
+// lt evaluates the comparison a < b.
+func lt(arg1, arg2 interface{}) (bool, error) {
+	v1 := reflect.ValueOf(arg1)
+	k1, err := basicKind(v1)
+	if err != nil {
+		return false, err
+	}
+	v2 := reflect.ValueOf(arg2)
+	k2, err := basicKind(v2)
+	if err != nil {
+		return false, err
+	}
+	truth := false
+	if k1 != k2 {
+		// Special case: Can compare integer values regardless of type's sign.
+		switch {
+		case k1 == intKind && k2 == uintKind:
+			truth = v1.Int() < 0 || uint64(v1.Int()) < v2.Uint()
+		case k1 == uintKind && k2 == intKind:
+			truth = v2.Int() >= 0 && v1.Uint() < uint64(v2.Int())
+		default:
+			return false, errBadComparison
+		}
+	} else {
+		switch k1 {
+		case boolKind, complexKind:
+			return false, errBadComparisonType
+		case floatKind:
+			truth = v1.Float() < v2.Float()
+		case intKind:
+			truth = v1.Int() < v2.Int()
+		case stringKind:
+			truth = v1.String() < v2.String()
+		case uintKind:
+			truth = v1.Uint() < v2.Uint()
+		default:
+			panic("invalid kind")
+		}
+	}
+	return truth, nil
+}
+
+// le evaluates the comparison <= b.
+func le(arg1, arg2 interface{}) (bool, error) {
+	// <= is < or ==.
+	lessThan, err := lt(arg1, arg2)
+	if lessThan || err != nil {
+		return lessThan, err
+	}
+	return eq(arg1, arg2)
+}
+
+// gt evaluates the comparison a > b.
+func gt(arg1, arg2 interface{}) (bool, error) {
+	// > is the inverse of <=.
+	lessOrEqual, err := le(arg1, arg2)
+	if err != nil {
+		return false, err
+	}
+	return !lessOrEqual, nil
+}
+
+// ge evaluates the comparison a >= b.
+func ge(arg1, arg2 interface{}) (bool, error) {
+	// >= is the inverse of <.
+	lessThan, err := lt(arg1, arg2)
+	if err != nil {
+		return false, err
+	}
+	return !lessThan, nil
+}
+
+// HTML escaping.
+
+var (
+	htmlQuot = []byte("&#34;") // shorter than "&quot;"
+	htmlApos = []byte("&#39;") // shorter than "&apos;" and apos was not in HTML until HTML5
+	htmlAmp  = []byte("&amp;")
+	htmlLt   = []byte("&lt;")
+	htmlGt   = []byte("&gt;")
+)
+
+// HTMLEscape writes to w the escaped HTML equivalent of the plain text data b.
+func HTMLEscape(w io.Writer, b []byte) {
+	last := 0
+	for i, c := range b {
+		var html []byte
+		switch c {
+		case '"':
+			html = htmlQuot
+		case '\'':
+			html = htmlApos
+		case '&':
+			html = htmlAmp
+		case '<':
+			html = htmlLt
+		case '>':
+			html = htmlGt
+		default:
+			continue
+		}
+		w.Write(b[last:i])
+		w.Write(html)
+		last = i + 1
+	}
+	w.Write(b[last:])
+}
+
+// HTMLEscapeString returns the escaped HTML equivalent of the plain text data s.
+func HTMLEscapeString(s string) string {
+	// Avoid allocation if we can.
+	if strings.IndexAny(s, `'"&<>`) < 0 {
+		return s
+	}
+	var b bytes.Buffer
+	HTMLEscape(&b, []byte(s))
+	return b.String()
+}
+
+// HTMLEscaper returns the escaped HTML equivalent of the textual
+// representation of its arguments.
+func HTMLEscaper(args ...interface{}) string {
+	return HTMLEscapeString(evalArgs(args))
+}
+
+// JavaScript escaping.
+
+var (
+	jsLowUni = []byte(`\u00`)
+	hex      = []byte("0123456789ABCDEF")
+
+	jsBackslash = []byte(`\\`)
+	jsApos      = []byte(`\'`)
+	jsQuot      = []byte(`\"`)
+	jsLt        = []byte(`\x3C`)
+	jsGt        = []byte(`\x3E`)
+)
+
+// JSEscape writes to w the escaped JavaScript equivalent of the plain text data b.
+func JSEscape(w io.Writer, b []byte) {
+	last := 0
+	for i := 0; i < len(b); i++ {
+		c := b[i]
+
+		if !jsIsSpecial(rune(c)) {
+			// fast path: nothing to do
+			continue
+		}
+		w.Write(b[last:i])
+
+		if c < utf8.RuneSelf {
+			// Quotes, slashes and angle brackets get quoted.
+			// Control characters get written as \u00XX.
+			switch c {
+			case '\\':
+				w.Write(jsBackslash)
+			case '\'':
+				w.Write(jsApos)
+			case '"':
+				w.Write(jsQuot)
+			case '<':
+				w.Write(jsLt)
+			case '>':
+				w.Write(jsGt)
+			default:
+				w.Write(jsLowUni)
+				t, b := c>>4, c&0x0f
+				w.Write(hex[t : t+1])
+				w.Write(hex[b : b+1])
+			}
+		} else {
+			// Unicode rune.
+			r, size := utf8.DecodeRune(b[i:])
+			if unicode.IsPrint(r) {
+				w.Write(b[i : i+size])
+			} else {
+				fmt.Fprintf(w, "\\u%04X", r)
+			}
+			i += size - 1
+		}
+		last = i + 1
+	}
+	w.Write(b[last:])
+}
+
+// JSEscapeString returns the escaped JavaScript equivalent of the plain text data s.
+func JSEscapeString(s string) string {
+	// Avoid allocation if we can.
+	if strings.IndexFunc(s, jsIsSpecial) < 0 {
+		return s
+	}
+	var b bytes.Buffer
+	JSEscape(&b, []byte(s))
+	return b.String()
+}
+
+func jsIsSpecial(r rune) bool {
+	switch r {
+	case '\\', '\'', '"', '<', '>':
+		return true
+	}
+	return r < ' ' || utf8.RuneSelf <= r
+}
+
+// JSEscaper returns the escaped JavaScript equivalent of the textual
+// representation of its arguments.
+func JSEscaper(args ...interface{}) string {
+	return JSEscapeString(evalArgs(args))
+}
+
+// URLQueryEscaper returns the escaped value of the textual representation of
+// its arguments in a form suitable for embedding in a URL query.
+func URLQueryEscaper(args ...interface{}) string {
+	return url.QueryEscape(evalArgs(args))
+}
+
+// evalArgs formats the list of arguments into a string. It is therefore equivalent to
+//	fmt.Sprint(args...)
+// except that each argument is indirected (if a pointer), as required,
+// using the same rules as the default string evaluation during template
+// execution.
+func evalArgs(args []interface{}) string {
+	ok := false
+	var s string
+	// Fast path for simple common case.
+	if len(args) == 1 {
+		s, ok = args[0].(string)
+	}
+	if !ok {
+		for i, arg := range args {
+			a, ok := printableValue(reflect.ValueOf(arg))
+			if ok {
+				args[i] = a
+			} // else left fmt do its thing
+		}
+		s = fmt.Sprint(args...)
+	}
+	return s
+}

--- a/vendor/k8s.io/client-go/util/jsonpath/doc.go
+++ b/vendor/k8s.io/client-go/util/jsonpath/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// package jsonpath is a template engine using jsonpath syntax,
+// which can be seen at http://goessner.net/articles/JsonPath/.
+// In addition, it has {range} {end} function to iterate list and slice.
+package jsonpath // import "k8s.io/client-go/util/jsonpath"

--- a/vendor/k8s.io/client-go/util/jsonpath/jsonpath.go
+++ b/vendor/k8s.io/client-go/util/jsonpath/jsonpath.go
@@ -1,0 +1,579 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jsonpath
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+
+	"k8s.io/client-go/third_party/forked/golang/template"
+)
+
+type JSONPath struct {
+	name       string
+	parser     *Parser
+	beginRange int
+	inRange    int
+	endRange   int
+
+	lastEndNode *Node
+
+	allowMissingKeys bool
+	outputJSON       bool
+}
+
+// New creates a new JSONPath with the given name.
+func New(name string) *JSONPath {
+	return &JSONPath{
+		name:       name,
+		beginRange: 0,
+		inRange:    0,
+		endRange:   0,
+	}
+}
+
+// AllowMissingKeys allows a caller to specify whether they want an error if a field or map key
+// cannot be located, or simply an empty result. The receiver is returned for chaining.
+func (j *JSONPath) AllowMissingKeys(allow bool) *JSONPath {
+	j.allowMissingKeys = allow
+	return j
+}
+
+// Parse parses the given template and returns an error.
+func (j *JSONPath) Parse(text string) error {
+	var err error
+	j.parser, err = Parse(j.name, text)
+	return err
+}
+
+// Execute bounds data into template and writes the result.
+func (j *JSONPath) Execute(wr io.Writer, data interface{}) error {
+	fullResults, err := j.FindResults(data)
+	if err != nil {
+		return err
+	}
+	for ix := range fullResults {
+		if err := j.PrintResults(wr, fullResults[ix]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (j *JSONPath) FindResults(data interface{}) ([][]reflect.Value, error) {
+	if j.parser == nil {
+		return nil, fmt.Errorf("%s is an incomplete jsonpath template", j.name)
+	}
+
+	cur := []reflect.Value{reflect.ValueOf(data)}
+	nodes := j.parser.Root.Nodes
+	fullResult := [][]reflect.Value{}
+	for i := 0; i < len(nodes); i++ {
+		node := nodes[i]
+		results, err := j.walk(cur, node)
+		if err != nil {
+			return nil, err
+		}
+
+		// encounter an end node, break the current block
+		if j.endRange > 0 && j.endRange <= j.inRange {
+			j.endRange--
+			j.lastEndNode = &nodes[i]
+			break
+		}
+		// encounter a range node, start a range loop
+		if j.beginRange > 0 {
+			j.beginRange--
+			j.inRange++
+			if len(results) > 0 {
+				for _, value := range results {
+					j.parser.Root.Nodes = nodes[i+1:]
+					nextResults, err := j.FindResults(value.Interface())
+					if err != nil {
+						return nil, err
+					}
+					fullResult = append(fullResult, nextResults...)
+				}
+			} else {
+				// If the range has no results, we still need to process the nodes within the range
+				// so the position will advance to the end node
+				j.parser.Root.Nodes = nodes[i+1:]
+				_, err := j.FindResults(nil)
+				if err != nil {
+					return nil, err
+				}
+			}
+			j.inRange--
+
+			// Fast forward to resume processing after the most recent end node that was encountered
+			for k := i + 1; k < len(nodes); k++ {
+				if &nodes[k] == j.lastEndNode {
+					i = k
+					break
+				}
+			}
+			continue
+		}
+		fullResult = append(fullResult, results)
+	}
+	return fullResult, nil
+}
+
+// EnableJSONOutput changes the PrintResults behavior to return a JSON array of results
+func (j *JSONPath) EnableJSONOutput(v bool) {
+	j.outputJSON = v
+}
+
+// PrintResults writes the results into writer
+func (j *JSONPath) PrintResults(wr io.Writer, results []reflect.Value) error {
+	if j.outputJSON {
+		// convert the []reflect.Value to something that json
+		// will be able to marshal
+		r := make([]interface{}, 0, len(results))
+		for i := range results {
+			r = append(r, results[i].Interface())
+		}
+		results = []reflect.Value{reflect.ValueOf(r)}
+	}
+	for i, r := range results {
+		var text []byte
+		var err error
+		outputJSON := true
+		kind := r.Kind()
+		if kind == reflect.Interface {
+			kind = r.Elem().Kind()
+		}
+		switch kind {
+		case reflect.Map:
+		case reflect.Array:
+		case reflect.Slice:
+		case reflect.Struct:
+		default:
+			outputJSON = false
+		}
+		switch {
+		case outputJSON || j.outputJSON:
+			if j.outputJSON {
+				text, err = json.MarshalIndent(r.Interface(), "", "    ")
+				text = append(text, '\n')
+			} else {
+				text, err = json.Marshal(r.Interface())
+			}
+		default:
+			text, err = j.evalToText(r)
+		}
+		if err != nil {
+			return err
+		}
+		if i != len(results)-1 {
+			text = append(text, ' ')
+		}
+		if _, err = wr.Write(text); err != nil {
+			return err
+		}
+	}
+
+	return nil
+
+}
+
+// walk visits tree rooted at the given node in DFS order
+func (j *JSONPath) walk(value []reflect.Value, node Node) ([]reflect.Value, error) {
+	switch node := node.(type) {
+	case *ListNode:
+		return j.evalList(value, node)
+	case *TextNode:
+		return []reflect.Value{reflect.ValueOf(node.Text)}, nil
+	case *FieldNode:
+		return j.evalField(value, node)
+	case *ArrayNode:
+		return j.evalArray(value, node)
+	case *FilterNode:
+		return j.evalFilter(value, node)
+	case *IntNode:
+		return j.evalInt(value, node)
+	case *BoolNode:
+		return j.evalBool(value, node)
+	case *FloatNode:
+		return j.evalFloat(value, node)
+	case *WildcardNode:
+		return j.evalWildcard(value, node)
+	case *RecursiveNode:
+		return j.evalRecursive(value, node)
+	case *UnionNode:
+		return j.evalUnion(value, node)
+	case *IdentifierNode:
+		return j.evalIdentifier(value, node)
+	default:
+		return value, fmt.Errorf("unexpected Node %v", node)
+	}
+}
+
+// evalInt evaluates IntNode
+func (j *JSONPath) evalInt(input []reflect.Value, node *IntNode) ([]reflect.Value, error) {
+	result := make([]reflect.Value, len(input))
+	for i := range input {
+		result[i] = reflect.ValueOf(node.Value)
+	}
+	return result, nil
+}
+
+// evalFloat evaluates FloatNode
+func (j *JSONPath) evalFloat(input []reflect.Value, node *FloatNode) ([]reflect.Value, error) {
+	result := make([]reflect.Value, len(input))
+	for i := range input {
+		result[i] = reflect.ValueOf(node.Value)
+	}
+	return result, nil
+}
+
+// evalBool evaluates BoolNode
+func (j *JSONPath) evalBool(input []reflect.Value, node *BoolNode) ([]reflect.Value, error) {
+	result := make([]reflect.Value, len(input))
+	for i := range input {
+		result[i] = reflect.ValueOf(node.Value)
+	}
+	return result, nil
+}
+
+// evalList evaluates ListNode
+func (j *JSONPath) evalList(value []reflect.Value, node *ListNode) ([]reflect.Value, error) {
+	var err error
+	curValue := value
+	for _, node := range node.Nodes {
+		curValue, err = j.walk(curValue, node)
+		if err != nil {
+			return curValue, err
+		}
+	}
+	return curValue, nil
+}
+
+// evalIdentifier evaluates IdentifierNode
+func (j *JSONPath) evalIdentifier(input []reflect.Value, node *IdentifierNode) ([]reflect.Value, error) {
+	results := []reflect.Value{}
+	switch node.Name {
+	case "range":
+		j.beginRange++
+		results = input
+	case "end":
+		if j.inRange > 0 {
+			j.endRange++
+		} else {
+			return results, fmt.Errorf("not in range, nothing to end")
+		}
+	default:
+		return input, fmt.Errorf("unrecognized identifier %v", node.Name)
+	}
+	return results, nil
+}
+
+// evalArray evaluates ArrayNode
+func (j *JSONPath) evalArray(input []reflect.Value, node *ArrayNode) ([]reflect.Value, error) {
+	result := []reflect.Value{}
+	for _, value := range input {
+
+		value, isNil := template.Indirect(value)
+		if isNil {
+			continue
+		}
+		if value.Kind() != reflect.Array && value.Kind() != reflect.Slice {
+			return input, fmt.Errorf("%v is not array or slice", value.Type())
+		}
+		params := node.Params
+		if !params[0].Known {
+			params[0].Value = 0
+		}
+		if params[0].Value < 0 {
+			params[0].Value += value.Len()
+		}
+		if !params[1].Known {
+			params[1].Value = value.Len()
+		}
+
+		if params[1].Value < 0 || (params[1].Value == 0 && params[1].Derived) {
+			params[1].Value += value.Len()
+		}
+		sliceLength := value.Len()
+		if params[1].Value != params[0].Value { // if you're requesting zero elements, allow it through.
+			if params[0].Value >= sliceLength || params[0].Value < 0 {
+				return input, fmt.Errorf("array index out of bounds: index %d, length %d", params[0].Value, sliceLength)
+			}
+			if params[1].Value > sliceLength || params[1].Value < 0 {
+				return input, fmt.Errorf("array index out of bounds: index %d, length %d", params[1].Value-1, sliceLength)
+			}
+			if params[0].Value > params[1].Value {
+				return input, fmt.Errorf("starting index %d is greater than ending index %d", params[0].Value, params[1].Value)
+			}
+		} else {
+			return result, nil
+		}
+
+		value = value.Slice(params[0].Value, params[1].Value)
+
+		step := 1
+		if params[2].Known {
+			if params[2].Value <= 0 {
+				return input, fmt.Errorf("step must be > 0")
+			}
+			step = params[2].Value
+		}
+		for i := 0; i < value.Len(); i += step {
+			result = append(result, value.Index(i))
+		}
+	}
+	return result, nil
+}
+
+// evalUnion evaluates UnionNode
+func (j *JSONPath) evalUnion(input []reflect.Value, node *UnionNode) ([]reflect.Value, error) {
+	result := []reflect.Value{}
+	for _, listNode := range node.Nodes {
+		temp, err := j.evalList(input, listNode)
+		if err != nil {
+			return input, err
+		}
+		result = append(result, temp...)
+	}
+	return result, nil
+}
+
+func (j *JSONPath) findFieldInValue(value *reflect.Value, node *FieldNode) (reflect.Value, error) {
+	t := value.Type()
+	var inlineValue *reflect.Value
+	for ix := 0; ix < t.NumField(); ix++ {
+		f := t.Field(ix)
+		jsonTag := f.Tag.Get("json")
+		parts := strings.Split(jsonTag, ",")
+		if len(parts) == 0 {
+			continue
+		}
+		if parts[0] == node.Value {
+			return value.Field(ix), nil
+		}
+		if len(parts[0]) == 0 {
+			val := value.Field(ix)
+			inlineValue = &val
+		}
+	}
+	if inlineValue != nil {
+		if inlineValue.Kind() == reflect.Struct {
+			// handle 'inline'
+			match, err := j.findFieldInValue(inlineValue, node)
+			if err != nil {
+				return reflect.Value{}, err
+			}
+			if match.IsValid() {
+				return match, nil
+			}
+		}
+	}
+	return value.FieldByName(node.Value), nil
+}
+
+// evalField evaluates field of struct or key of map.
+func (j *JSONPath) evalField(input []reflect.Value, node *FieldNode) ([]reflect.Value, error) {
+	results := []reflect.Value{}
+	// If there's no input, there's no output
+	if len(input) == 0 {
+		return results, nil
+	}
+	for _, value := range input {
+		var result reflect.Value
+		value, isNil := template.Indirect(value)
+		if isNil {
+			continue
+		}
+
+		if value.Kind() == reflect.Struct {
+			var err error
+			if result, err = j.findFieldInValue(&value, node); err != nil {
+				return nil, err
+			}
+		} else if value.Kind() == reflect.Map {
+			mapKeyType := value.Type().Key()
+			nodeValue := reflect.ValueOf(node.Value)
+			// node value type must be convertible to map key type
+			if !nodeValue.Type().ConvertibleTo(mapKeyType) {
+				return results, fmt.Errorf("%s is not convertible to %s", nodeValue, mapKeyType)
+			}
+			result = value.MapIndex(nodeValue.Convert(mapKeyType))
+		}
+		if result.IsValid() {
+			results = append(results, result)
+		}
+	}
+	if len(results) == 0 {
+		if j.allowMissingKeys {
+			return results, nil
+		}
+		return results, fmt.Errorf("%s is not found", node.Value)
+	}
+	return results, nil
+}
+
+// evalWildcard extracts all contents of the given value
+func (j *JSONPath) evalWildcard(input []reflect.Value, node *WildcardNode) ([]reflect.Value, error) {
+	results := []reflect.Value{}
+	for _, value := range input {
+		value, isNil := template.Indirect(value)
+		if isNil {
+			continue
+		}
+
+		kind := value.Kind()
+		if kind == reflect.Struct {
+			for i := 0; i < value.NumField(); i++ {
+				results = append(results, value.Field(i))
+			}
+		} else if kind == reflect.Map {
+			for _, key := range value.MapKeys() {
+				results = append(results, value.MapIndex(key))
+			}
+		} else if kind == reflect.Array || kind == reflect.Slice || kind == reflect.String {
+			for i := 0; i < value.Len(); i++ {
+				results = append(results, value.Index(i))
+			}
+		}
+	}
+	return results, nil
+}
+
+// evalRecursive visits the given value recursively and pushes all of them to result
+func (j *JSONPath) evalRecursive(input []reflect.Value, node *RecursiveNode) ([]reflect.Value, error) {
+	result := []reflect.Value{}
+	for _, value := range input {
+		results := []reflect.Value{}
+		value, isNil := template.Indirect(value)
+		if isNil {
+			continue
+		}
+
+		kind := value.Kind()
+		if kind == reflect.Struct {
+			for i := 0; i < value.NumField(); i++ {
+				results = append(results, value.Field(i))
+			}
+		} else if kind == reflect.Map {
+			for _, key := range value.MapKeys() {
+				results = append(results, value.MapIndex(key))
+			}
+		} else if kind == reflect.Array || kind == reflect.Slice || kind == reflect.String {
+			for i := 0; i < value.Len(); i++ {
+				results = append(results, value.Index(i))
+			}
+		}
+		if len(results) != 0 {
+			result = append(result, value)
+			output, err := j.evalRecursive(results, node)
+			if err != nil {
+				return result, err
+			}
+			result = append(result, output...)
+		}
+	}
+	return result, nil
+}
+
+// evalFilter filters array according to FilterNode
+func (j *JSONPath) evalFilter(input []reflect.Value, node *FilterNode) ([]reflect.Value, error) {
+	results := []reflect.Value{}
+	for _, value := range input {
+		value, _ = template.Indirect(value)
+
+		if value.Kind() != reflect.Array && value.Kind() != reflect.Slice {
+			return input, fmt.Errorf("%v is not array or slice and cannot be filtered", value)
+		}
+		for i := 0; i < value.Len(); i++ {
+			temp := []reflect.Value{value.Index(i)}
+			lefts, err := j.evalList(temp, node.Left)
+
+			//case exists
+			if node.Operator == "exists" {
+				if len(lefts) > 0 {
+					results = append(results, value.Index(i))
+				}
+				continue
+			}
+
+			if err != nil {
+				return input, err
+			}
+
+			var left, right interface{}
+			switch {
+			case len(lefts) == 0:
+				continue
+			case len(lefts) > 1:
+				return input, fmt.Errorf("can only compare one element at a time")
+			}
+			left = lefts[0].Interface()
+
+			rights, err := j.evalList(temp, node.Right)
+			if err != nil {
+				return input, err
+			}
+			switch {
+			case len(rights) == 0:
+				continue
+			case len(rights) > 1:
+				return input, fmt.Errorf("can only compare one element at a time")
+			}
+			right = rights[0].Interface()
+
+			pass := false
+			switch node.Operator {
+			case "<":
+				pass, err = template.Less(left, right)
+			case ">":
+				pass, err = template.Greater(left, right)
+			case "==":
+				pass, err = template.Equal(left, right)
+			case "!=":
+				pass, err = template.NotEqual(left, right)
+			case "<=":
+				pass, err = template.LessEqual(left, right)
+			case ">=":
+				pass, err = template.GreaterEqual(left, right)
+			default:
+				return results, fmt.Errorf("unrecognized filter operator %s", node.Operator)
+			}
+			if err != nil {
+				return results, err
+			}
+			if pass {
+				results = append(results, value.Index(i))
+			}
+		}
+	}
+	return results, nil
+}
+
+// evalToText translates reflect value to corresponding text
+func (j *JSONPath) evalToText(v reflect.Value) ([]byte, error) {
+	iface, ok := template.PrintableValue(v)
+	if !ok {
+		return nil, fmt.Errorf("can't print type %s", v.Type())
+	}
+	var buffer bytes.Buffer
+	fmt.Fprint(&buffer, iface)
+	return buffer.Bytes(), nil
+}

--- a/vendor/k8s.io/client-go/util/jsonpath/node.go
+++ b/vendor/k8s.io/client-go/util/jsonpath/node.go
@@ -1,0 +1,256 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jsonpath
+
+import "fmt"
+
+// NodeType identifies the type of a parse tree node.
+type NodeType int
+
+// Type returns itself and provides an easy default implementation
+func (t NodeType) Type() NodeType {
+	return t
+}
+
+func (t NodeType) String() string {
+	return NodeTypeName[t]
+}
+
+const (
+	NodeText NodeType = iota
+	NodeArray
+	NodeList
+	NodeField
+	NodeIdentifier
+	NodeFilter
+	NodeInt
+	NodeFloat
+	NodeWildcard
+	NodeRecursive
+	NodeUnion
+	NodeBool
+)
+
+var NodeTypeName = map[NodeType]string{
+	NodeText:       "NodeText",
+	NodeArray:      "NodeArray",
+	NodeList:       "NodeList",
+	NodeField:      "NodeField",
+	NodeIdentifier: "NodeIdentifier",
+	NodeFilter:     "NodeFilter",
+	NodeInt:        "NodeInt",
+	NodeFloat:      "NodeFloat",
+	NodeWildcard:   "NodeWildcard",
+	NodeRecursive:  "NodeRecursive",
+	NodeUnion:      "NodeUnion",
+	NodeBool:       "NodeBool",
+}
+
+type Node interface {
+	Type() NodeType
+	String() string
+}
+
+// ListNode holds a sequence of nodes.
+type ListNode struct {
+	NodeType
+	Nodes []Node // The element nodes in lexical order.
+}
+
+func newList() *ListNode {
+	return &ListNode{NodeType: NodeList}
+}
+
+func (l *ListNode) append(n Node) {
+	l.Nodes = append(l.Nodes, n)
+}
+
+func (l *ListNode) String() string {
+	return l.Type().String()
+}
+
+// TextNode holds plain text.
+type TextNode struct {
+	NodeType
+	Text string // The text; may span newlines.
+}
+
+func newText(text string) *TextNode {
+	return &TextNode{NodeType: NodeText, Text: text}
+}
+
+func (t *TextNode) String() string {
+	return fmt.Sprintf("%s: %s", t.Type(), t.Text)
+}
+
+// FieldNode holds field of struct
+type FieldNode struct {
+	NodeType
+	Value string
+}
+
+func newField(value string) *FieldNode {
+	return &FieldNode{NodeType: NodeField, Value: value}
+}
+
+func (f *FieldNode) String() string {
+	return fmt.Sprintf("%s: %s", f.Type(), f.Value)
+}
+
+// IdentifierNode holds an identifier
+type IdentifierNode struct {
+	NodeType
+	Name string
+}
+
+func newIdentifier(value string) *IdentifierNode {
+	return &IdentifierNode{
+		NodeType: NodeIdentifier,
+		Name:     value,
+	}
+}
+
+func (f *IdentifierNode) String() string {
+	return fmt.Sprintf("%s: %s", f.Type(), f.Name)
+}
+
+// ParamsEntry holds param information for ArrayNode
+type ParamsEntry struct {
+	Value   int
+	Known   bool // whether the value is known when parse it
+	Derived bool
+}
+
+// ArrayNode holds start, end, step information for array index selection
+type ArrayNode struct {
+	NodeType
+	Params [3]ParamsEntry // start, end, step
+}
+
+func newArray(params [3]ParamsEntry) *ArrayNode {
+	return &ArrayNode{
+		NodeType: NodeArray,
+		Params:   params,
+	}
+}
+
+func (a *ArrayNode) String() string {
+	return fmt.Sprintf("%s: %v", a.Type(), a.Params)
+}
+
+// FilterNode holds operand and operator information for filter
+type FilterNode struct {
+	NodeType
+	Left     *ListNode
+	Right    *ListNode
+	Operator string
+}
+
+func newFilter(left, right *ListNode, operator string) *FilterNode {
+	return &FilterNode{
+		NodeType: NodeFilter,
+		Left:     left,
+		Right:    right,
+		Operator: operator,
+	}
+}
+
+func (f *FilterNode) String() string {
+	return fmt.Sprintf("%s: %s %s %s", f.Type(), f.Left, f.Operator, f.Right)
+}
+
+// IntNode holds integer value
+type IntNode struct {
+	NodeType
+	Value int
+}
+
+func newInt(num int) *IntNode {
+	return &IntNode{NodeType: NodeInt, Value: num}
+}
+
+func (i *IntNode) String() string {
+	return fmt.Sprintf("%s: %d", i.Type(), i.Value)
+}
+
+// FloatNode holds float value
+type FloatNode struct {
+	NodeType
+	Value float64
+}
+
+func newFloat(num float64) *FloatNode {
+	return &FloatNode{NodeType: NodeFloat, Value: num}
+}
+
+func (i *FloatNode) String() string {
+	return fmt.Sprintf("%s: %f", i.Type(), i.Value)
+}
+
+// WildcardNode means a wildcard
+type WildcardNode struct {
+	NodeType
+}
+
+func newWildcard() *WildcardNode {
+	return &WildcardNode{NodeType: NodeWildcard}
+}
+
+func (i *WildcardNode) String() string {
+	return i.Type().String()
+}
+
+// RecursiveNode means a recursive descent operator
+type RecursiveNode struct {
+	NodeType
+}
+
+func newRecursive() *RecursiveNode {
+	return &RecursiveNode{NodeType: NodeRecursive}
+}
+
+func (r *RecursiveNode) String() string {
+	return r.Type().String()
+}
+
+// UnionNode is union of ListNode
+type UnionNode struct {
+	NodeType
+	Nodes []*ListNode
+}
+
+func newUnion(nodes []*ListNode) *UnionNode {
+	return &UnionNode{NodeType: NodeUnion, Nodes: nodes}
+}
+
+func (u *UnionNode) String() string {
+	return u.Type().String()
+}
+
+// BoolNode holds bool value
+type BoolNode struct {
+	NodeType
+	Value bool
+}
+
+func newBool(value bool) *BoolNode {
+	return &BoolNode{NodeType: NodeBool, Value: value}
+}
+
+func (b *BoolNode) String() string {
+	return fmt.Sprintf("%s: %t", b.Type(), b.Value)
+}

--- a/vendor/k8s.io/client-go/util/jsonpath/parser.go
+++ b/vendor/k8s.io/client-go/util/jsonpath/parser.go
@@ -1,0 +1,527 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jsonpath
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+const eof = -1
+
+const (
+	leftDelim  = "{"
+	rightDelim = "}"
+)
+
+type Parser struct {
+	Name  string
+	Root  *ListNode
+	input string
+	pos   int
+	start int
+	width int
+}
+
+var (
+	ErrSyntax        = errors.New("invalid syntax")
+	dictKeyRex       = regexp.MustCompile(`^'([^']*)'$`)
+	sliceOperatorRex = regexp.MustCompile(`^(-?[\d]*)(:-?[\d]*)?(:-?[\d]*)?$`)
+)
+
+// Parse parsed the given text and return a node Parser.
+// If an error is encountered, parsing stops and an empty
+// Parser is returned with the error
+func Parse(name, text string) (*Parser, error) {
+	p := NewParser(name)
+	err := p.Parse(text)
+	if err != nil {
+		p = nil
+	}
+	return p, err
+}
+
+func NewParser(name string) *Parser {
+	return &Parser{
+		Name: name,
+	}
+}
+
+// parseAction parsed the expression inside delimiter
+func parseAction(name, text string) (*Parser, error) {
+	p, err := Parse(name, fmt.Sprintf("%s%s%s", leftDelim, text, rightDelim))
+	// when error happens, p will be nil, so we need to return here
+	if err != nil {
+		return p, err
+	}
+	p.Root = p.Root.Nodes[0].(*ListNode)
+	return p, nil
+}
+
+func (p *Parser) Parse(text string) error {
+	p.input = text
+	p.Root = newList()
+	p.pos = 0
+	return p.parseText(p.Root)
+}
+
+// consumeText return the parsed text since last cosumeText
+func (p *Parser) consumeText() string {
+	value := p.input[p.start:p.pos]
+	p.start = p.pos
+	return value
+}
+
+// next returns the next rune in the input.
+func (p *Parser) next() rune {
+	if p.pos >= len(p.input) {
+		p.width = 0
+		return eof
+	}
+	r, w := utf8.DecodeRuneInString(p.input[p.pos:])
+	p.width = w
+	p.pos += p.width
+	return r
+}
+
+// peek returns but does not consume the next rune in the input.
+func (p *Parser) peek() rune {
+	r := p.next()
+	p.backup()
+	return r
+}
+
+// backup steps back one rune. Can only be called once per call of next.
+func (p *Parser) backup() {
+	p.pos -= p.width
+}
+
+func (p *Parser) parseText(cur *ListNode) error {
+	for {
+		if strings.HasPrefix(p.input[p.pos:], leftDelim) {
+			if p.pos > p.start {
+				cur.append(newText(p.consumeText()))
+			}
+			return p.parseLeftDelim(cur)
+		}
+		if p.next() == eof {
+			break
+		}
+	}
+	// Correctly reached EOF.
+	if p.pos > p.start {
+		cur.append(newText(p.consumeText()))
+	}
+	return nil
+}
+
+// parseLeftDelim scans the left delimiter, which is known to be present.
+func (p *Parser) parseLeftDelim(cur *ListNode) error {
+	p.pos += len(leftDelim)
+	p.consumeText()
+	newNode := newList()
+	cur.append(newNode)
+	cur = newNode
+	return p.parseInsideAction(cur)
+}
+
+func (p *Parser) parseInsideAction(cur *ListNode) error {
+	prefixMap := map[string]func(*ListNode) error{
+		rightDelim: p.parseRightDelim,
+		"[?(":      p.parseFilter,
+		"..":       p.parseRecursive,
+	}
+	for prefix, parseFunc := range prefixMap {
+		if strings.HasPrefix(p.input[p.pos:], prefix) {
+			return parseFunc(cur)
+		}
+	}
+
+	switch r := p.next(); {
+	case r == eof || isEndOfLine(r):
+		return fmt.Errorf("unclosed action")
+	case r == ' ':
+		p.consumeText()
+	case r == '@' || r == '$': //the current object, just pass it
+		p.consumeText()
+	case r == '[':
+		return p.parseArray(cur)
+	case r == '"' || r == '\'':
+		return p.parseQuote(cur, r)
+	case r == '.':
+		return p.parseField(cur)
+	case r == '+' || r == '-' || unicode.IsDigit(r):
+		p.backup()
+		return p.parseNumber(cur)
+	case isAlphaNumeric(r):
+		p.backup()
+		return p.parseIdentifier(cur)
+	default:
+		return fmt.Errorf("unrecognized character in action: %#U", r)
+	}
+	return p.parseInsideAction(cur)
+}
+
+// parseRightDelim scans the right delimiter, which is known to be present.
+func (p *Parser) parseRightDelim(cur *ListNode) error {
+	p.pos += len(rightDelim)
+	p.consumeText()
+	return p.parseText(p.Root)
+}
+
+// parseIdentifier scans build-in keywords, like "range" "end"
+func (p *Parser) parseIdentifier(cur *ListNode) error {
+	var r rune
+	for {
+		r = p.next()
+		if isTerminator(r) {
+			p.backup()
+			break
+		}
+	}
+	value := p.consumeText()
+
+	if isBool(value) {
+		v, err := strconv.ParseBool(value)
+		if err != nil {
+			return fmt.Errorf("can not parse bool '%s': %s", value, err.Error())
+		}
+
+		cur.append(newBool(v))
+	} else {
+		cur.append(newIdentifier(value))
+	}
+
+	return p.parseInsideAction(cur)
+}
+
+// parseRecursive scans the recursive descent operator ..
+func (p *Parser) parseRecursive(cur *ListNode) error {
+	if lastIndex := len(cur.Nodes) - 1; lastIndex >= 0 && cur.Nodes[lastIndex].Type() == NodeRecursive {
+		return fmt.Errorf("invalid multiple recursive descent")
+	}
+	p.pos += len("..")
+	p.consumeText()
+	cur.append(newRecursive())
+	if r := p.peek(); isAlphaNumeric(r) {
+		return p.parseField(cur)
+	}
+	return p.parseInsideAction(cur)
+}
+
+// parseNumber scans number
+func (p *Parser) parseNumber(cur *ListNode) error {
+	r := p.peek()
+	if r == '+' || r == '-' {
+		p.next()
+	}
+	for {
+		r = p.next()
+		if r != '.' && !unicode.IsDigit(r) {
+			p.backup()
+			break
+		}
+	}
+	value := p.consumeText()
+	i, err := strconv.Atoi(value)
+	if err == nil {
+		cur.append(newInt(i))
+		return p.parseInsideAction(cur)
+	}
+	d, err := strconv.ParseFloat(value, 64)
+	if err == nil {
+		cur.append(newFloat(d))
+		return p.parseInsideAction(cur)
+	}
+	return fmt.Errorf("cannot parse number %s", value)
+}
+
+// parseArray scans array index selection
+func (p *Parser) parseArray(cur *ListNode) error {
+Loop:
+	for {
+		switch p.next() {
+		case eof, '\n':
+			return fmt.Errorf("unterminated array")
+		case ']':
+			break Loop
+		}
+	}
+	text := p.consumeText()
+	text = text[1 : len(text)-1]
+	if text == "*" {
+		text = ":"
+	}
+
+	//union operator
+	strs := strings.Split(text, ",")
+	if len(strs) > 1 {
+		union := []*ListNode{}
+		for _, str := range strs {
+			parser, err := parseAction("union", fmt.Sprintf("[%s]", strings.Trim(str, " ")))
+			if err != nil {
+				return err
+			}
+			union = append(union, parser.Root)
+		}
+		cur.append(newUnion(union))
+		return p.parseInsideAction(cur)
+	}
+
+	// dict key
+	value := dictKeyRex.FindStringSubmatch(text)
+	if value != nil {
+		parser, err := parseAction("arraydict", fmt.Sprintf(".%s", value[1]))
+		if err != nil {
+			return err
+		}
+		for _, node := range parser.Root.Nodes {
+			cur.append(node)
+		}
+		return p.parseInsideAction(cur)
+	}
+
+	//slice operator
+	value = sliceOperatorRex.FindStringSubmatch(text)
+	if value == nil {
+		return fmt.Errorf("invalid array index %s", text)
+	}
+	value = value[1:]
+	params := [3]ParamsEntry{}
+	for i := 0; i < 3; i++ {
+		if value[i] != "" {
+			if i > 0 {
+				value[i] = value[i][1:]
+			}
+			if i > 0 && value[i] == "" {
+				params[i].Known = false
+			} else {
+				var err error
+				params[i].Known = true
+				params[i].Value, err = strconv.Atoi(value[i])
+				if err != nil {
+					return fmt.Errorf("array index %s is not a number", value[i])
+				}
+			}
+		} else {
+			if i == 1 {
+				params[i].Known = true
+				params[i].Value = params[0].Value + 1
+				params[i].Derived = true
+			} else {
+				params[i].Known = false
+				params[i].Value = 0
+			}
+		}
+	}
+	cur.append(newArray(params))
+	return p.parseInsideAction(cur)
+}
+
+// parseFilter scans filter inside array selection
+func (p *Parser) parseFilter(cur *ListNode) error {
+	p.pos += len("[?(")
+	p.consumeText()
+	begin := false
+	end := false
+	var pair rune
+
+Loop:
+	for {
+		r := p.next()
+		switch r {
+		case eof, '\n':
+			return fmt.Errorf("unterminated filter")
+		case '"', '\'':
+			if begin == false {
+				//save the paired rune
+				begin = true
+				pair = r
+				continue
+			}
+			//only add when met paired rune
+			if p.input[p.pos-2] != '\\' && r == pair {
+				end = true
+			}
+		case ')':
+			//in rightParser below quotes only appear zero or once
+			//and must be paired at the beginning and end
+			if begin == end {
+				break Loop
+			}
+		}
+	}
+	if p.next() != ']' {
+		return fmt.Errorf("unclosed array expect ]")
+	}
+	reg := regexp.MustCompile(`^([^!<>=]+)([!<>=]+)(.+?)$`)
+	text := p.consumeText()
+	text = text[:len(text)-2]
+	value := reg.FindStringSubmatch(text)
+	if value == nil {
+		parser, err := parseAction("text", text)
+		if err != nil {
+			return err
+		}
+		cur.append(newFilter(parser.Root, newList(), "exists"))
+	} else {
+		leftParser, err := parseAction("left", value[1])
+		if err != nil {
+			return err
+		}
+		rightParser, err := parseAction("right", value[3])
+		if err != nil {
+			return err
+		}
+		cur.append(newFilter(leftParser.Root, rightParser.Root, value[2]))
+	}
+	return p.parseInsideAction(cur)
+}
+
+// parseQuote unquotes string inside double or single quote
+func (p *Parser) parseQuote(cur *ListNode, end rune) error {
+Loop:
+	for {
+		switch p.next() {
+		case eof, '\n':
+			return fmt.Errorf("unterminated quoted string")
+		case end:
+			//if it's not escape break the Loop
+			if p.input[p.pos-2] != '\\' {
+				break Loop
+			}
+		}
+	}
+	value := p.consumeText()
+	s, err := UnquoteExtend(value)
+	if err != nil {
+		return fmt.Errorf("unquote string %s error %v", value, err)
+	}
+	cur.append(newText(s))
+	return p.parseInsideAction(cur)
+}
+
+// parseField scans a field until a terminator
+func (p *Parser) parseField(cur *ListNode) error {
+	p.consumeText()
+	for p.advance() {
+	}
+	value := p.consumeText()
+	if value == "*" {
+		cur.append(newWildcard())
+	} else {
+		cur.append(newField(strings.Replace(value, "\\", "", -1)))
+	}
+	return p.parseInsideAction(cur)
+}
+
+// advance scans until next non-escaped terminator
+func (p *Parser) advance() bool {
+	r := p.next()
+	if r == '\\' {
+		p.next()
+	} else if isTerminator(r) {
+		p.backup()
+		return false
+	}
+	return true
+}
+
+// isTerminator reports whether the input is at valid termination character to appear after an identifier.
+func isTerminator(r rune) bool {
+	if isSpace(r) || isEndOfLine(r) {
+		return true
+	}
+	switch r {
+	case eof, '.', ',', '[', ']', '$', '@', '{', '}':
+		return true
+	}
+	return false
+}
+
+// isSpace reports whether r is a space character.
+func isSpace(r rune) bool {
+	return r == ' ' || r == '\t'
+}
+
+// isEndOfLine reports whether r is an end-of-line character.
+func isEndOfLine(r rune) bool {
+	return r == '\r' || r == '\n'
+}
+
+// isAlphaNumeric reports whether r is an alphabetic, digit, or underscore.
+func isAlphaNumeric(r rune) bool {
+	return r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r)
+}
+
+// isBool reports whether s is a boolean value.
+func isBool(s string) bool {
+	return s == "true" || s == "false"
+}
+
+//UnquoteExtend is almost same as strconv.Unquote(), but it support parse single quotes as a string
+func UnquoteExtend(s string) (string, error) {
+	n := len(s)
+	if n < 2 {
+		return "", ErrSyntax
+	}
+	quote := s[0]
+	if quote != s[n-1] {
+		return "", ErrSyntax
+	}
+	s = s[1 : n-1]
+
+	if quote != '"' && quote != '\'' {
+		return "", ErrSyntax
+	}
+
+	// Is it trivial?  Avoid allocation.
+	if !contains(s, '\\') && !contains(s, quote) {
+		return s, nil
+	}
+
+	var runeTmp [utf8.UTFMax]byte
+	buf := make([]byte, 0, 3*len(s)/2) // Try to avoid more allocations.
+	for len(s) > 0 {
+		c, multibyte, ss, err := strconv.UnquoteChar(s, quote)
+		if err != nil {
+			return "", err
+		}
+		s = ss
+		if c < utf8.RuneSelf || !multibyte {
+			buf = append(buf, byte(c))
+		} else {
+			n := utf8.EncodeRune(runeTmp[:], c)
+			buf = append(buf, runeTmp[:n]...)
+		}
+	}
+	return string(buf), nil
+}
+
+func contains(s string, c byte) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] == c {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -91,6 +91,9 @@ github.com/evanphx/json-patch/v5
 ## explicit; go 1.13
 # github.com/fsnotify/fsnotify v1.5.1
 ## explicit; go 1.13
+# github.com/fvbommel/sortorder v1.0.1
+## explicit; go 1.13
+github.com/fvbommel/sortorder
 # github.com/gfleury/go-bitbucket-v1 v0.0.0-20220418082332-711d7d5e805f
 ## explicit; go 1.14
 github.com/gfleury/go-bitbucket-v1
@@ -1002,6 +1005,7 @@ k8s.io/client-go/rest
 k8s.io/client-go/rest/fake
 k8s.io/client-go/rest/watch
 k8s.io/client-go/testing
+k8s.io/client-go/third_party/forked/golang/template
 k8s.io/client-go/tools/auth
 k8s.io/client-go/tools/cache
 k8s.io/client-go/tools/clientcmd
@@ -1020,6 +1024,7 @@ k8s.io/client-go/util/cert
 k8s.io/client-go/util/connrotation
 k8s.io/client-go/util/flowcontrol
 k8s.io/client-go/util/homedir
+k8s.io/client-go/util/jsonpath
 k8s.io/client-go/util/keyutil
 k8s.io/client-go/util/retry
 k8s.io/client-go/util/workqueue


### PR DESCRIPTION
this sorts the events for the repository and displays them with the latest one first and is the default behaviour.
```
// The following code has been take from kubectl get command
// instead of importing all the dependencies, copying only the required part
// https://github.com/kubernetes/kubernetes/blob/8e48df135318026d5f8a972a96a2ff665889568a/staging/src/k8s.io/kubectl/pkg/cmd/get/sorter.go#L151
```


Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
