### PR TITLE
Moves all keys at single place for labels and annotations

### DIFF
--- a/pkg/apis/pipelinesascode/keys/keys.go
+++ b/pkg/apis/pipelinesascode/keys/keys.go
@@ -1,0 +1,49 @@
+/*
+CoCopyright 2022 Red Hat
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keys
+
+import "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
+
+const (
+	Task            = pipelinesascode.GroupName + "/task"
+	Pipeline        = pipelinesascode.GroupName + "/pipeline"
+	URLOrg          = pipelinesascode.GroupName + "/url-org"
+	URLRepository   = pipelinesascode.GroupName + "/url-repository"
+	SHA             = pipelinesascode.GroupName + "/sha"
+	Sender          = pipelinesascode.GroupName + "/sender"
+	EventType       = pipelinesascode.GroupName + "/event-type"
+	Branch          = pipelinesascode.GroupName + "/branch"
+	Repository      = pipelinesascode.GroupName + "/repository"
+	GitProvider     = pipelinesascode.GroupName + "/git-provider"
+	State           = pipelinesascode.GroupName + "/state"
+	ShaTitle        = pipelinesascode.GroupName + "/sha-title"
+	ShaURL          = pipelinesascode.GroupName + "/sha-url"
+	RepoURL         = pipelinesascode.GroupName + "/repo-url"
+	PullRequest     = pipelinesascode.GroupName + "/pull-request"
+	InstallationID  = pipelinesascode.GroupName + "/installation-id"
+	GHEURL          = pipelinesascode.GroupName + "/ghe-url"
+	SourceProjectID = pipelinesascode.GroupName + "/source-project-id"
+	TargetProjectID = pipelinesascode.GroupName + "/target-project-id"
+	OriginalPRName  = pipelinesascode.GroupName + "/original-prname"
+	GitAuthSecret   = pipelinesascode.GroupName + "/git-auth-secret"
+	CheckRunID      = pipelinesascode.GroupName + "/check-run-id"
+	OnEvent         = pipelinesascode.GroupName + "/on-event"
+	OnTargetBranch  = pipelinesascode.GroupName + "/on-target-branch"
+	OnCelExpression = pipelinesascode.GroupName + "/on-cel-expression"
+	TargetNamespace = pipelinesascode.GroupName + "/target-namespace"
+	MaxKeepRuns     = pipelinesascode.GroupName + "/max-keep-runs"
+)

--- a/pkg/cmd/tknpac/logs/logs.go
+++ b/pkg/cmd/tknpac/logs/logs.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/jonboulle/clockwork"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli/browser"
@@ -147,8 +147,8 @@ func getTknPath() (string, error) {
 // getPipelineRunsToRepo returns all pipelinesruns running in a namespace
 func getPipelineRunsToRepo(ctx context.Context, lopt *logOption, repoName string) ([]string, error) {
 	opts := metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("%s/repository=%s",
-			pipelinesascode.GroupName, repoName),
+		LabelSelector: fmt.Sprintf("%s=%s",
+			keys.Repository, repoName),
 	}
 	runs, err := lopt.cs.Clients.Tekton.TektonV1beta1().PipelineRuns(lopt.opts.Namespace).List(ctx, opts)
 	if err != nil {

--- a/pkg/cmd/tknpac/logs/logs_test.go
+++ b/pkg/cmd/tknpac/logs/logs_test.go
@@ -1,12 +1,11 @@
 package logs
 
 import (
-	"fmt"
 	"os/exec"
 	"testing"
 
 	"github.com/jonboulle/clockwork"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/consoleui"
@@ -45,7 +44,7 @@ func TestLogs(t *testing.T) {
 			shift:            0,
 			pruns: []*tektonv1beta1.PipelineRun{
 				tektontest.MakePRCompletion(cw, "test-pipeline", ns, completed, map[string]string{
-					fmt.Sprintf("%s/repository", pipelinesascode.GroupName): "test",
+					keys.Repository: "test",
 				}, 30),
 			},
 		},
@@ -57,7 +56,7 @@ func TestLogs(t *testing.T) {
 			shift:            2,
 			pruns: []*tektonv1beta1.PipelineRun{
 				tektontest.MakePRCompletion(cw, "test-pipeline", ns, completed, map[string]string{
-					fmt.Sprintf("%s/repository", pipelinesascode.GroupName): "test",
+					keys.Repository: "test",
 				}, 30),
 			},
 		},

--- a/pkg/events/emit.go
+++ b/pkg/events/emit.go
@@ -2,9 +2,9 @@ package events
 
 import (
 	"context"
-	"path/filepath"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -56,7 +56,7 @@ func makeEvent(repo *v1alpha1.Repository, loggerLevel zapcore.Level, reason, mes
 			GenerateName: repo.Name + "-",
 			Namespace:    repo.Namespace,
 			Labels: map[string]string{
-				filepath.Join(pipelinesascode.GroupName, "repository"): repo.Name,
+				keys.Repository: repo.Name,
 			},
 		},
 		Message: message,

--- a/pkg/kubeinteraction/cleanups.go
+++ b/pkg/kubeinteraction/cleanups.go
@@ -3,9 +3,8 @@ package kubeinteraction
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	psort "github.com/openshift-pipelines/pipelines-as-code/pkg/sort"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -15,17 +14,15 @@ import (
 )
 
 func (k Interaction) CleanupPipelines(ctx context.Context, logger *zap.SugaredLogger, repo *v1alpha1.Repository, pr *v1beta1.PipelineRun, maxKeep int) error {
-	repoLabel := filepath.Join(pipelinesascode.GroupName, "repository")
-	originalPRLabel := filepath.Join(pipelinesascode.GroupName, "original-prname")
-	if _, ok := pr.GetLabels()[originalPRLabel]; !ok {
+	if _, ok := pr.GetLabels()[keys.OriginalPRName]; !ok {
 		return fmt.Errorf("generate pipelienrun should have had the %s label for selection set but we could not find"+
 			" it",
-			originalPRLabel)
+			keys.OriginalPRName)
 	}
 
 	// Select PR by repository and by its true pipelineRun name (not auto generated one)
 	labelSelector := fmt.Sprintf("%s=%s,%s=%s",
-		repoLabel, repo.GetName(), originalPRLabel, pr.GetLabels()[originalPRLabel])
+		keys.Repository, repo.GetName(), keys.OriginalPRName, pr.GetLabels()[keys.OriginalPRName])
 	logger.Infof("selecting pipelineruns by labels \"%s\" for deletion", labelSelector)
 
 	pruns, err := k.Run.Clients.Tekton.TektonV1beta1().PipelineRuns(repo.GetNamespace()).List(ctx,

--- a/pkg/kubeinteraction/labels.go
+++ b/pkg/kubeinteraction/labels.go
@@ -1,10 +1,10 @@
 package kubeinteraction
 
 import (
-	"path/filepath"
 	"strconv"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	apipac "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
@@ -22,45 +22,45 @@ func AddLabelsAndAnnotations(event *info.Event, pipelineRun *tektonv1beta1.Pipel
 	// Add labels on the soon to be created pipelinerun so UI/CLI can easily
 	// query them.
 	labels := map[string]string{
-		"app.kubernetes.io/managed-by":                             pipelinesascode.GroupName,
-		"app.kubernetes.io/version":                                version.Version,
-		filepath.Join(pipelinesascode.GroupName, "url-org"):        formatting.K8LabelsCleanup(event.Organization),
-		filepath.Join(pipelinesascode.GroupName, "url-repository"): formatting.K8LabelsCleanup(event.Repository),
-		filepath.Join(pipelinesascode.GroupName, "sha"):            formatting.K8LabelsCleanup(event.SHA),
-		filepath.Join(pipelinesascode.GroupName, "sender"):         formatting.K8LabelsCleanup(event.Sender),
-		filepath.Join(pipelinesascode.GroupName, "event-type"):     formatting.K8LabelsCleanup(event.EventType),
-		filepath.Join(pipelinesascode.GroupName, "branch"):         formatting.K8LabelsCleanup(event.BaseBranch),
-		filepath.Join(pipelinesascode.GroupName, "repository"):     formatting.K8LabelsCleanup(repo.GetName()),
-		filepath.Join(pipelinesascode.GroupName, "git-provider"):   providerinfo.Name,
-		filepath.Join(pipelinesascode.GroupName, "state"):          StateStarted,
+		"app.kubernetes.io/managed-by": pipelinesascode.GroupName,
+		"app.kubernetes.io/version":    version.Version,
+		keys.URLOrg:                    formatting.K8LabelsCleanup(event.Organization),
+		keys.URLRepository:             formatting.K8LabelsCleanup(event.Repository),
+		keys.SHA:                       formatting.K8LabelsCleanup(event.SHA),
+		keys.Sender:                    formatting.K8LabelsCleanup(event.Sender),
+		keys.EventType:                 formatting.K8LabelsCleanup(event.EventType),
+		keys.Branch:                    formatting.K8LabelsCleanup(event.BaseBranch),
+		keys.Repository:                formatting.K8LabelsCleanup(repo.GetName()),
+		keys.GitProvider:               providerinfo.Name,
+		keys.State:                     StateStarted,
 	}
 
 	annotations := map[string]string{
-		filepath.Join(pipelinesascode.GroupName, "sha-title"): event.SHATitle,
-		filepath.Join(pipelinesascode.GroupName, "sha-url"):   event.SHAURL,
-		filepath.Join(pipelinesascode.GroupName, "repo-url"):  event.URL,
+		keys.ShaTitle: event.SHATitle,
+		keys.ShaURL:   event.SHAURL,
+		keys.RepoURL:  event.URL,
 	}
 
 	if event.PullRequestNumber != 0 {
-		annotations[filepath.Join(pipelinesascode.GroupName, "pull-request")] = strconv.Itoa(event.PullRequestNumber)
+		annotations[keys.PullRequest] = strconv.Itoa(event.PullRequestNumber)
 	}
 
 	// TODO: move to provider specific function
 	if providerinfo.Name == "github" || providerinfo.Name == "github-enterprise" {
 		if event.InstallationID != -1 {
-			annotations[filepath.Join(pipelinesascode.GroupName, "installation-id")] = strconv.FormatInt(event.InstallationID, 10)
+			annotations[keys.InstallationID] = strconv.FormatInt(event.InstallationID, 10)
 		}
 		if event.GHEURL != "" {
-			annotations[filepath.Join(pipelinesascode.GroupName, "ghe-url")] = event.GHEURL
+			annotations[keys.GHEURL] = event.GHEURL
 		}
 	}
 
 	// GitLab
 	if event.SourceProjectID != 0 {
-		annotations[filepath.Join(pipelinesascode.GroupName, "source-project-id")] = strconv.Itoa(event.SourceProjectID)
+		annotations[keys.SourceProjectID] = strconv.Itoa(event.SourceProjectID)
 	}
 	if event.TargetProjectID != 0 {
-		annotations[filepath.Join(pipelinesascode.GroupName, "target-project-id")] = strconv.Itoa(event.TargetProjectID)
+		annotations[keys.TargetProjectID] = strconv.Itoa(event.TargetProjectID)
 	}
 
 	for k, v := range labels {

--- a/pkg/kubeinteraction/labels_test.go
+++ b/pkg/kubeinteraction/labels_test.go
@@ -1,10 +1,9 @@
 package kubeinteraction
 
 import (
-	"path/filepath"
 	"testing"
 
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	apipac "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -52,10 +51,9 @@ func TestAddLabelsAndAnnotations(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			AddLabelsAndAnnotations(tt.args.event, tt.args.pipelineRun, tt.args.repo, &info.ProviderConfig{})
-			assert.Assert(t, tt.args.pipelineRun.Labels[filepath.Join(pipelinesascode.GroupName, "url-org")] == tt.args.event.Organization, "'%s' != %s",
-				tt.args.pipelineRun.Labels[filepath.Join(pipelinesascode.GroupName, "url-org")], tt.args.event.Organization)
-			assert.Assert(t, tt.args.pipelineRun.Annotations[filepath.Join(pipelinesascode.GroupName,
-				"sha-url")] == tt.args.event.SHAURL)
+			assert.Assert(t, tt.args.pipelineRun.Labels[keys.URLOrg] == tt.args.event.Organization, "'%s' != %s",
+				tt.args.pipelineRun.Labels[keys.URLOrg], tt.args.event.Organization)
+			assert.Assert(t, tt.args.pipelineRun.Annotations[keys.ShaURL] == tt.args.event.SHAURL)
 		})
 	}
 }

--- a/pkg/matcher/annotation_tasks_install_test.go
+++ b/pkg/matcher/annotation_tasks_install_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
@@ -75,7 +76,7 @@ func TestRemoteTasksGetTaskFromAnnotations(t *testing.T) {
 		{
 			name: "test-annotations-error-remote-http-not-k8",
 			annotations: map[string]string{
-				pipelinesascode.GroupName + "/task": "[http://remote.task]",
+				keys.Task: "[http://remote.task]",
 			},
 			remoteURLS: map[string]map[string]string{
 				"http://remote.task": {
@@ -88,7 +89,7 @@ func TestRemoteTasksGetTaskFromAnnotations(t *testing.T) {
 		{
 			name: "test-good-coming-from-provider",
 			annotations: map[string]string{
-				pipelinesascode.GroupName + "/task": "http://provider/remote.task",
+				keys.Task: "http://provider/remote.task",
 			},
 			wantProviderRemoteTask: true,
 			wantErr:                "returning empty",
@@ -96,7 +97,7 @@ func TestRemoteTasksGetTaskFromAnnotations(t *testing.T) {
 		{
 			name: "test-bad-coming-from-provider",
 			annotations: map[string]string{
-				pipelinesascode.GroupName + "/task": "http://provider/remote.task",
+				keys.Task: "http://provider/remote.task",
 			},
 			wantProviderRemoteTask: false,
 			wantErr:                "error getting remote task",
@@ -104,7 +105,7 @@ func TestRemoteTasksGetTaskFromAnnotations(t *testing.T) {
 		{
 			name: "test-annotations-remote-http",
 			annotations: map[string]string{
-				pipelinesascode.GroupName + "/task": "[http://remote.task]",
+				keys.Task: "[http://remote.task]",
 			},
 			gotTaskName: "task",
 			remoteURLS: map[string]map[string]string{
@@ -117,7 +118,7 @@ func TestRemoteTasksGetTaskFromAnnotations(t *testing.T) {
 		{
 			name: "test-annotations-remote-https",
 			annotations: map[string]string{
-				pipelinesascode.GroupName + "/task": "[https://remote.task]",
+				keys.Task: "[https://remote.task]",
 			},
 			gotTaskName: "task",
 			remoteURLS: map[string]map[string]string{
@@ -130,7 +131,7 @@ func TestRemoteTasksGetTaskFromAnnotations(t *testing.T) {
 		{
 			name: "test-annotations-inside-repo",
 			annotations: map[string]string{
-				pipelinesascode.GroupName + "/task": "[be/healthy]",
+				keys.Task: "[be/healthy]",
 			},
 			gotTaskName: "task",
 			filesInsideRepo: map[string]string{
@@ -143,7 +144,7 @@ func TestRemoteTasksGetTaskFromAnnotations(t *testing.T) {
 		{
 			name: "test-annotations-remote-http-skipping-notmatching",
 			annotations: map[string]string{
-				pipelinesascode.GroupName + "/task":  "[http://remote.task]",
+				keys.Task:                            "[http://remote.task]",
 				pipelinesascode.GroupName + "/taskA": "[http://other.task]", // That's wrong this would be skipped
 			},
 			gotTaskName: "task",
@@ -157,14 +158,14 @@ func TestRemoteTasksGetTaskFromAnnotations(t *testing.T) {
 		{
 			name: "test-annotations-remote-http-bad-annotation",
 			annotations: map[string]string{
-				pipelinesascode.GroupName + "/task": "[http://remote.task",
+				keys.Task: "[http://remote.task",
 			},
 			wantErr: "annotations in pipeline are in wrong format",
 		},
 		{
 			name: "test-annotations-remote-inside-file-not-found",
 			annotations: map[string]string{
-				pipelinesascode.GroupName + "/task": "[pas/la]",
+				keys.Task: "[pas/la]",
 			},
 			wantErr: "could not find",
 			runevent: info.Event{
@@ -174,7 +175,7 @@ func TestRemoteTasksGetTaskFromAnnotations(t *testing.T) {
 		{
 			name: "test-annotations-remote-no-event-not-found-no-error",
 			annotations: map[string]string{
-				pipelinesascode.GroupName + "/task": "[not/here]",
+				keys.Task: "[not/here]",
 			},
 			wantLog: "could not find remote task not/here",
 			wantErr: "returning empty",
@@ -183,7 +184,7 @@ func TestRemoteTasksGetTaskFromAnnotations(t *testing.T) {
 			name:        "test-get-from-hub-latest",
 			gotTaskName: "task",
 			annotations: map[string]string{
-				pipelinesascode.GroupName + "/task": "[chmouzie]",
+				keys.Task: "[chmouzie]",
 			},
 			remoteURLS: map[string]map[string]string{
 				testHubURL + "/resource/" + testCatalogHubName + "/task/chmouzie": {
@@ -200,7 +201,7 @@ func TestRemoteTasksGetTaskFromAnnotations(t *testing.T) {
 			name:        "test-get-from-hub-specific-version",
 			gotTaskName: "task",
 			annotations: map[string]string{
-				pipelinesascode.GroupName + "/task": "[chmouzie:0.2]",
+				keys.Task: "[chmouzie:0.2]",
 			},
 			remoteURLS: map[string]map[string]string{
 				testHubURL + "/resource/" + testCatalogHubName + "/task/chmouzie/0.2": {
@@ -277,7 +278,7 @@ func TestGetPipelineFromAnnotations(t *testing.T) {
 			name:            "good/fetching from remote http",
 			gotPipelineName: "pipeline",
 			annotations: map[string]string{
-				pipelinesascode.GroupName + "/pipeline": "[http://remote.pipeline]",
+				keys.Pipeline: "[http://remote.pipeline]",
 			},
 			remoteURLS: map[string]map[string]string{
 				"http://remote.pipeline": {
@@ -289,7 +290,7 @@ func TestGetPipelineFromAnnotations(t *testing.T) {
 		{
 			name: "bad/error getting pipeline",
 			annotations: map[string]string{
-				pipelinesascode.GroupName + "/pipeline": "[http://remote.pipeline]",
+				keys.Pipeline: "[http://remote.pipeline]",
 			},
 			remoteURLS: map[string]map[string]string{
 				"http://remote.pipeline": {
@@ -301,7 +302,7 @@ func TestGetPipelineFromAnnotations(t *testing.T) {
 		{
 			name: "bad/not a pipeline",
 			annotations: map[string]string{
-				pipelinesascode.GroupName + "/pipeline": "[http://remote.pipeline]",
+				keys.Pipeline: "[http://remote.pipeline]",
 			},
 			remoteURLS: map[string]map[string]string{
 				"http://remote.pipeline": {
@@ -314,14 +315,14 @@ func TestGetPipelineFromAnnotations(t *testing.T) {
 		{
 			name: "bad/could not get remote",
 			annotations: map[string]string{
-				pipelinesascode.GroupName + "/pipeline": "[http://nowhere.pipeline]",
+				keys.Pipeline: "[http://nowhere.pipeline]",
 			},
 			wantErr: "error getting remote pipeline",
 		},
 		{
 			name: "bad/returning empty",
 			annotations: map[string]string{
-				pipelinesascode.GroupName + "/pipeline": "[http://remote.pipeline]",
+				keys.Pipeline: "[http://remote.pipeline]",
 			},
 			remoteURLS: map[string]map[string]string{
 				"http://remote.pipeline": {
@@ -334,7 +335,7 @@ func TestGetPipelineFromAnnotations(t *testing.T) {
 		{
 			name: "bad/more than one pipeline",
 			annotations: map[string]string{
-				pipelinesascode.GroupName + "/pipeline": "[http://foo.bar, http://remote.pipeline]",
+				keys.Pipeline: "[http://foo.bar, http://remote.pipeline]",
 			},
 			wantErr: "only one pipeline is allowed on remote",
 		},

--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"path/filepath"
 	"regexp"
 	"strings"
 
-	apipac "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
+	apipac "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/matcher"
@@ -18,8 +17,6 @@ import (
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"go.uber.org/zap"
 )
-
-var gitAuthSecretAnnotation = filepath.Join(apipac.GroupName, "git-auth-secret")
 
 // matchRepoPR matches the repo and the PRs from the event
 func (p *PacRun) matchRepoPR(ctx context.Context) ([]matcher.Match, *v1alpha1.Repository, error) {
@@ -184,7 +181,7 @@ func filterRunningPipelineRunOnTargetTest(testPipeline string, prs []*tektonv1be
 		return prs
 	}
 	for _, pr := range prs {
-		if prName, ok := pr.GetLabels()[filepath.Join(apipac.GroupName, "original-prname")]; ok {
+		if prName, ok := pr.GetLabels()[apipac.OriginalPRName]; ok {
 			if prName == testPipeline {
 				return []*tektonv1beta1.PipelineRun{pr}
 			}
@@ -217,7 +214,7 @@ func changeSecret(prs []*tektonv1beta1.PipelineRun) error {
 		if np.Annotations == nil {
 			np.Annotations = map[string]string{}
 		}
-		np.Annotations[gitAuthSecretAnnotation] = name
+		np.Annotations[apipac.GitAuthSecret] = name
 		prs[k] = np
 	}
 	return nil

--- a/pkg/pipelineascode/match_test.go
+++ b/pkg/pipelineascode/match_test.go
@@ -1,11 +1,10 @@
 package pipelineascode
 
 import (
-	"path/filepath"
 	"strings"
 	"testing"
 
-	apipac "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
+	apipac "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -55,7 +54,7 @@ func TestChangeSecret(t *testing.T) {
 	err := changeSecret(prs)
 	assert.NilError(t, err)
 	assert.Assert(t, strings.HasPrefix(prs[0].GetName(), "pac-gitauth"), prs[0].GetName(), "has no pac-gitauth prefix")
-	assert.Assert(t, prs[0].GetAnnotations()[gitAuthSecretAnnotation] != "")
+	assert.Assert(t, prs[0].GetAnnotations()[apipac.GitAuthSecret] != "")
 }
 
 func TestFilterRunningPipelineRunOnTargetTest(t *testing.T) {
@@ -65,7 +64,7 @@ func TestFilterRunningPipelineRunOnTargetTest(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "pipelinerun-" + testPipeline,
 				Labels: map[string]string{
-					filepath.Join(apipac.GroupName, "original-prname"): testPipeline,
+					apipac.OriginalPRName: testPipeline,
 				},
 			},
 		},

--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -3,10 +3,9 @@ package pipelineascode
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"sync"
 
-	apipac "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
+	apipac "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/events"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/matcher"
@@ -83,10 +82,10 @@ func (p *PacRun) startPR(ctx context.Context, match matcher.Match) error {
 
 	// Automatically create a secret with the token to be reused by git-clone task
 	if p.run.Info.Pac.SecretAutoCreation {
-		if annotation, ok := match.PipelineRun.GetAnnotations()[gitAuthSecretAnnotation]; ok {
+		if annotation, ok := match.PipelineRun.GetAnnotations()[apipac.GitAuthSecret]; ok {
 			gitAuthSecretName = annotation
 		} else {
-			return fmt.Errorf("cannot get annotation %s as set on PR", gitAuthSecretAnnotation)
+			return fmt.Errorf("cannot get annotation %s as set on PR", apipac.GitAuthSecret)
 		}
 
 		var err error
@@ -104,7 +103,7 @@ func (p *PacRun) startPR(ctx context.Context, match matcher.Match) error {
 		// pending status
 		match.PipelineRun.Spec.Status = v1beta1.PipelineRunSpecStatusPending
 		// pac state as queued
-		match.PipelineRun.Labels[filepath.Join(apipac.GroupName, "state")] = kubeinteraction.StateQueued
+		match.PipelineRun.Labels[apipac.State] = kubeinteraction.StateQueued
 	}
 
 	// Create the actual pipeline
@@ -129,7 +128,7 @@ func (p *PacRun) startPR(ctx context.Context, match matcher.Match) error {
 		DetailsURL:              consoleURL,
 		PipelineRunName:         pr.GetName(),
 		PipelineRun:             pr,
-		OriginalPipelineRunName: pr.GetLabels()[filepath.Join(apipac.GroupName, "original-prname")],
+		OriginalPipelineRunName: pr.GetLabels()[apipac.OriginalPRName],
 	}
 
 	// if pipelineRun is in pending state then report status as queued

--- a/pkg/provider/github/status.go
+++ b/pkg/provider/github/status.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/google/go-github/v47/github"
-	apipac "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli/status"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
@@ -35,8 +34,6 @@ const taskStatusTemplate = `
 </td></tr>
 {{- end }}
 </table>`
-
-const checkRunIDKey = "check-run-id"
 
 func getCheckName(status provider.StatusOpts, pacopts *info.PacOpts) string {
 	if pacopts.ApplicationName != "" {
@@ -186,7 +183,7 @@ func (v *Provider) getOrUpdateCheckRunStatus(ctx context.Context, tekton version
 	// check if pipelineRun has the label with checkRun-id
 	if statusOpts.PipelineRun != nil {
 		var id string
-		id, found = statusOpts.PipelineRun.GetLabels()[filepath.Join(apipac.GroupName, checkRunIDKey)]
+		id, found = statusOpts.PipelineRun.GetLabels()[keys.CheckRunID]
 		if found {
 			checkID, err := strconv.Atoi(id)
 			if err != nil {
@@ -252,7 +249,7 @@ func (v *Provider) updatePipelineRunWithCheckRunID(ctx context.Context, tekton v
 		mergePatch := map[string]interface{}{
 			"metadata": map[string]interface{}{
 				"labels": map[string]string{
-					filepath.Join(apipac.GroupName, checkRunIDKey): strconv.FormatInt(*checkRunID, 10),
+					keys.CheckRunID: strconv.FormatInt(*checkRunID, 10),
 				},
 			},
 		}
@@ -267,7 +264,7 @@ func (v *Provider) updatePipelineRunWithCheckRunID(ctx context.Context, tekton v
 			continue
 		}
 
-		v.Logger.Infof("PipelineRun %v/%v patched with checkRunID : %v", pr.GetNamespace(), pr.GetName(), updatedPR.Labels[filepath.Join(apipac.GroupName, checkRunIDKey)])
+		v.Logger.Infof("PipelineRun %v/%v patched with checkRunID : %v", pr.GetNamespace(), pr.GetName(), updatedPR.Labels[keys.CheckRunID])
 		return nil
 	}
 	return fmt.Errorf("cannot patch pipelineRun %v/%v with checkRunID", pr.GetNamespace(), pr.GetName())

--- a/pkg/provider/github/status_test.go
+++ b/pkg/provider/github/status_test.go
@@ -5,14 +5,13 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/google/go-github/v47/github"
-	apipac "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
@@ -140,7 +139,7 @@ func TestGithubProviderCreateStatus(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: prname,
 			Labels: map[string]string{
-				filepath.Join(apipac.GroupName, checkRunIDKey): strconv.Itoa(int(checkrunid)),
+				keys.CheckRunID: strconv.Itoa(int(checkrunid)),
 			},
 		},
 	}

--- a/pkg/reconciler/cleanup.go
+++ b/pkg/reconciler/cleanup.go
@@ -3,23 +3,20 @@ package reconciler
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"strconv"
 
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"go.uber.org/zap"
 )
 
-var gitAuthSecretAnnotation = filepath.Join(pipelinesascode.GroupName, "git-auth-secret")
-
 func (r *Reconciler) cleanupSecrets(ctx context.Context, logger *zap.SugaredLogger, repo *v1alpha1.Repository, pr *v1beta1.PipelineRun) error {
 	var gitAuthSecretName string
-	if annotation, ok := pr.Annotations[gitAuthSecretAnnotation]; ok {
+	if annotation, ok := pr.Annotations[keys.GitAuthSecret]; ok {
 		gitAuthSecretName = annotation
 	} else {
-		return fmt.Errorf("cannot get annotation %s as set on PR", gitAuthSecretAnnotation)
+		return fmt.Errorf("cannot get annotation %s as set on PR", keys.GitAuthSecret)
 	}
 
 	err := r.kinteract.DeleteBasicAuthSecret(ctx, logger, repo.GetNamespace(), gitAuthSecretName)
@@ -30,7 +27,7 @@ func (r *Reconciler) cleanupSecrets(ctx context.Context, logger *zap.SugaredLogg
 }
 
 func (r *Reconciler) cleanupPipelineRuns(ctx context.Context, logger *zap.SugaredLogger, repo *v1alpha1.Repository, pr *v1beta1.PipelineRun) error {
-	keepMaxPipeline, ok := pr.Annotations[filepath.Join(pipelinesascode.GroupName, "max-keep-runs")]
+	keepMaxPipeline, ok := pr.Annotations[keys.MaxKeepRuns]
 	if ok {
 		max, err := strconv.Atoi(keepMaxPipeline)
 		if err != nil {

--- a/pkg/reconciler/controller.go
+++ b/pkg/reconciler/controller.go
@@ -3,9 +3,9 @@ package reconciler
 import (
 	"context"
 	"log"
-	"path/filepath"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/events"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/metrics"
@@ -74,7 +74,7 @@ func checkStateAndEnqueue(impl *controller.Impl) func(obj interface{}) {
 	return func(obj interface{}) {
 		object, err := kmeta.DeletionHandlingAccessor(obj)
 		if err == nil {
-			_, exist := object.GetLabels()[filepath.Join(pipelinesascode.GroupName, "state")]
+			_, exist := object.GetLabels()[keys.State]
 			if exist {
 				impl.EnqueueKey(types.NamespacedName{Namespace: object.GetNamespace(), Name: object.GetName()})
 			}
@@ -87,7 +87,7 @@ func ctrlOpts() func(impl *controller.Impl) controller.Options {
 		return controller.Options{
 			FinalizerName: pipelinesascode.GroupName,
 			PromoteFilterFunc: func(obj interface{}) bool {
-				_, exist := obj.(*v1beta1.PipelineRun).GetLabels()[filepath.Join(pipelinesascode.GroupName, "state")]
+				_, exist := obj.(*v1beta1.PipelineRun).GetLabels()[keys.State]
 				return exist
 			},
 		}

--- a/pkg/reconciler/event.go
+++ b/pkg/reconciler/event.go
@@ -3,10 +3,9 @@ package reconciler
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"strconv"
 
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
@@ -20,7 +19,7 @@ import (
 )
 
 func (r *Reconciler) detectProvider(ctx context.Context, logger *zap.SugaredLogger, pr *v1beta1.PipelineRun) (provider.Interface, *info.Event, error) {
-	gitProvider, ok := pr.GetLabels()[filepath.Join(pipelinesascode.GroupName, "git-provider")]
+	gitProvider, ok := pr.GetLabels()[keys.GitProvider]
 	if !ok {
 		return nil, nil, fmt.Errorf("failed to detect git provider for pipleinerun %s : git-provider label not found", pr.GetName())
 	}
@@ -58,38 +57,38 @@ func buildEventFromPipelineRun(pr *v1beta1.PipelineRun) *info.Event {
 	prLabels := pr.GetLabels()
 	prAnno := pr.GetAnnotations()
 
-	event.URL = prAnno[filepath.Join(pipelinesascode.GroupName, "repo-url")]
+	event.URL = prAnno[keys.RepoURL]
 	// it's safer to get repo, org from repo.url since we have to remove the / and other chars in labels which drops
 	// the SubPath that gitlab is using.
 	repo, org, _ := formatting.GetRepoOwnerSplitted(event.URL)
 	event.Organization = repo
 	event.Repository = org
-	event.EventType = prLabels[filepath.Join(pipelinesascode.GroupName, "event-type")]
-	event.BaseBranch = prLabels[filepath.Join(pipelinesascode.GroupName, "branch")]
-	event.SHA = prLabels[filepath.Join(pipelinesascode.GroupName, "sha")]
+	event.EventType = prLabels[keys.EventType]
+	event.BaseBranch = prLabels[keys.Branch]
+	event.SHA = prLabels[keys.SHA]
 
-	event.SHATitle = prAnno[filepath.Join(pipelinesascode.GroupName, "sha-title")]
-	event.SHAURL = prAnno[filepath.Join(pipelinesascode.GroupName, "sha-url")]
+	event.SHATitle = prAnno[keys.ShaTitle]
+	event.SHAURL = prAnno[keys.ShaURL]
 
-	prNumber := prAnno[filepath.Join(pipelinesascode.GroupName, "pull-request")]
+	prNumber := prAnno[keys.PullRequest]
 	if prNumber != "" {
 		event.PullRequestNumber, _ = strconv.Atoi(prNumber)
 	}
 
 	// GitHub
-	if installationID, ok := prAnno[filepath.Join(pipelinesascode.GroupName, "installation-id")]; ok {
+	if installationID, ok := prAnno[keys.InstallationID]; ok {
 		id, _ := strconv.Atoi(installationID)
 		event.InstallationID = int64(id)
 	}
-	if gheURL, ok := prAnno[filepath.Join(pipelinesascode.GroupName, "ghe-url")]; ok {
+	if gheURL, ok := prAnno[keys.GHEURL]; ok {
 		event.GHEURL = gheURL
 	}
 
 	// Gitlab
-	if projectID, ok := prAnno[filepath.Join(pipelinesascode.GroupName, "source-project-id")]; ok {
+	if projectID, ok := prAnno[keys.SourceProjectID]; ok {
 		event.SourceProjectID, _ = strconv.Atoi(projectID)
 	}
-	if projectID, ok := prAnno[filepath.Join(pipelinesascode.GroupName, "target-project-id")]; ok {
+	if projectID, ok := prAnno[keys.TargetProjectID]; ok {
 		event.TargetProjectID, _ = strconv.Atoi(projectID)
 	}
 	return event

--- a/pkg/reconciler/event_test.go
+++ b/pkg/reconciler/event_test.go
@@ -2,10 +2,9 @@ package reconciler
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -41,25 +40,25 @@ func TestBuildEventFromPipelineRun(t *testing.T) {
 			pipelineRun: &tektonv1beta1.PipelineRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						filepath.Join(pipelinesascode.GroupName, "url-org"):        "url-org",
-						filepath.Join(pipelinesascode.GroupName, "url-repository"): "repo",
-						filepath.Join(pipelinesascode.GroupName, "sha"):            "sha",
-						filepath.Join(pipelinesascode.GroupName, "event-type"):     "push",
-						filepath.Join(pipelinesascode.GroupName, "branch"):         "branch",
-						filepath.Join(pipelinesascode.GroupName, "state"):          kubeinteraction.StateStarted,
+						keys.URLOrg:        "url-org",
+						keys.URLRepository: "repo",
+						keys.SHA:           "sha",
+						keys.EventType:     "push",
+						keys.Branch:        "branch",
+						keys.State:         kubeinteraction.StateStarted,
 					},
 					Annotations: map[string]string{
-						filepath.Join(pipelinesascode.GroupName, "sha-title"):    "sha-title",
-						filepath.Join(pipelinesascode.GroupName, "sha-url"):      "sha-url",
-						filepath.Join(pipelinesascode.GroupName, "pull-request"): "1234",
+						keys.ShaTitle:    "sha-title",
+						keys.ShaURL:      "sha-url",
+						keys.PullRequest: "1234",
 
 						// github
-						filepath.Join(pipelinesascode.GroupName, "installation-id"): "12345678",
-						filepath.Join(pipelinesascode.GroupName, "ghe-url"):         "http://ghe",
+						keys.InstallationID: "12345678",
+						keys.GHEURL:         "http://ghe",
 
 						// gitlab
-						filepath.Join(pipelinesascode.GroupName, "source-project-id"): "1234",
-						filepath.Join(pipelinesascode.GroupName, "target-project-id"): "2345",
+						keys.SourceProjectID: "1234",
+						keys.TargetProjectID: "2345",
 					},
 				},
 			},
@@ -115,7 +114,7 @@ func TestDetectProvider(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "test",
 						Labels: map[string]string{
-							filepath.Join(pipelinesascode.GroupName, "git-provider"): tt.label,
+							keys.GitProvider: tt.label,
 						},
 					},
 				}

--- a/pkg/reconciler/finalizer.go
+++ b/pkg/reconciler/finalizer.go
@@ -2,10 +2,9 @@ package reconciler
 
 import (
 	"context"
-	"path/filepath"
 	"strings"
 
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -17,13 +16,13 @@ import (
 
 func (r *Reconciler) FinalizeKind(ctx context.Context, pr *v1beta1.PipelineRun) pkgreconciler.Event {
 	logger := logging.FromContext(ctx)
-	state, exist := pr.GetLabels()[filepath.Join(pipelinesascode.GroupName, "state")]
+	state, exist := pr.GetLabels()[keys.State]
 	if !exist || state == kubeinteraction.StateCompleted {
 		return nil
 	}
 
 	if state == kubeinteraction.StateQueued || state == kubeinteraction.StateStarted {
-		repoName, ok := pr.GetLabels()[filepath.Join(pipelinesascode.GroupName, "repository")]
+		repoName, ok := pr.GetLabels()[keys.Repository]
 		if !ok {
 			return nil
 		}

--- a/pkg/reconciler/finalizer_test.go
+++ b/pkg/reconciler/finalizer_test.go
@@ -1,10 +1,9 @@
 package reconciler
 
 import (
-	"path/filepath"
 	"testing"
 
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
@@ -43,8 +42,8 @@ func getTestPR(name, state string) *v1beta1.PipelineRun {
 			Name:      name,
 			Namespace: finalizeTestRepo.Namespace,
 			Labels: map[string]string{
-				filepath.Join(pipelinesascode.GroupName, "state"):      state,
-				filepath.Join(pipelinesascode.GroupName, "repository"): finalizeTestRepo.Name,
+				keys.State:      state,
+				keys.Repository: finalizeTestRepo.Name,
 			},
 		},
 		Spec: v1beta1.PipelineRunSpec{
@@ -68,7 +67,7 @@ func TestReconciler_FinalizeKind(t *testing.T) {
 			pipelinerun: &v1beta1.PipelineRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						filepath.Join(pipelinesascode.GroupName, "state"): kubeinteraction.StateCompleted,
+						keys.State: kubeinteraction.StateCompleted,
 					},
 				},
 			},

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -6,12 +6,11 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/google/go-github/v47/github"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/consoleui"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
@@ -135,7 +134,7 @@ func TestReconciler_ReconcileKind(t *testing.T) {
 				t.Fatalf("yaml.Unmarshal() = %v", err)
 			}
 
-			secretName := pr.Annotations[filepath.Join(pipelinesascode.GroupName, "git-auth-secret")]
+			secretName := pr.Annotations[keys.GitAuthSecret]
 
 			testData := testclient.Data{
 				Repositories: []*v1alpha1.Repository{testRepo},
@@ -197,7 +196,7 @@ func TestReconciler_ReconcileKind(t *testing.T) {
 			assert.Error(t, err, fmt.Sprintf("secrets \"%s\" not found", secretName))
 
 			// state must be updated to completed
-			assert.Equal(t, got.Labels[filepath.Join(pipelinesascode.GroupName, "state")], kubeinteraction.StateCompleted)
+			assert.Equal(t, got.Labels[keys.State], kubeinteraction.StateCompleted)
 		})
 	}
 }
@@ -233,7 +232,7 @@ func TestUpdatePipelineRunState(t *testing.T) {
 					Namespace: "test",
 					Name:      "test",
 					Labels: map[string]string{
-						filepath.Join(pipelinesascode.GroupName, "state"): kubeinteraction.StateQueued,
+						keys.State: kubeinteraction.StateQueued,
 					},
 				},
 				Spec: v1beta1.PipelineRunSpec{
@@ -250,7 +249,7 @@ func TestUpdatePipelineRunState(t *testing.T) {
 					Namespace: "test",
 					Name:      "test",
 					Labels: map[string]string{
-						filepath.Join(pipelinesascode.GroupName, "state"): kubeinteraction.StateStarted,
+						keys.State: kubeinteraction.StateStarted,
 					},
 				},
 				Spec:   v1beta1.PipelineRunSpec{},
@@ -277,7 +276,7 @@ func TestUpdatePipelineRunState(t *testing.T) {
 			updatedPR, err := r.updatePipelineRunState(ctx, fakelogger, tt.pipelineRun, tt.state)
 			assert.NilError(t, err)
 
-			assert.Equal(t, updatedPR.Labels[filepath.Join(pipelinesascode.GroupName, "state")], tt.state)
+			assert.Equal(t, updatedPR.Labels[keys.State], tt.state)
 			assert.Equal(t, updatedPR.Spec.Status, v1beta1.PipelineRunSpecStatus(""))
 		})
 	}

--- a/pkg/reconciler/status.go
+++ b/pkg/reconciler/status.go
@@ -3,10 +3,9 @@ package reconciler
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 
 	"github.com/google/go-github/v47/github"
-	apipac "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
+	apipac "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	pacv1a1 "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
@@ -87,7 +86,7 @@ func (r *Reconciler) postFinalStatus(ctx context.Context, logger *zap.SugaredLog
 		Text:                    taskStatus,
 		PipelineRunName:         pr.Name,
 		DetailsURL:              r.run.Clients.ConsoleUI.DetailURL(pr.GetNamespace(), pr.GetName()),
-		OriginalPipelineRunName: pr.GetLabels()[filepath.Join(apipac.GroupName, "original-prname")],
+		OriginalPipelineRunName: pr.GetLabels()[apipac.OriginalPRName],
 	}
 
 	err = vcx.CreateStatus(ctx, r.run.Clients.Tekton, event, r.run.Info.Pac, status)

--- a/pkg/resolve/resolve.go
+++ b/pkg/resolve/resolve.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"path/filepath"
 	"regexp"
 	"strings"
 
-	apipac "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
+	apipac "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/matcher"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
@@ -207,7 +206,7 @@ func Resolve(ctx context.Context, cs *params.Run, logger *zap.SugaredLogger, pro
 		if pipelinerun.ObjectMeta.Labels == nil {
 			pipelinerun.ObjectMeta.Labels = map[string]string{}
 		}
-		pipelinerun.ObjectMeta.Labels[filepath.Join(apipac.GroupName, "original-prname")] = originPipelinerunName
+		pipelinerun.ObjectMeta.Labels[apipac.OriginalPRName] = originPipelinerunName
 	}
 	return types.PipelineRuns, nil
 }

--- a/pkg/sync/queue_manager.go
+++ b/pkg/sync/queue_manager.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/generated/clientset/versioned"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
@@ -137,7 +137,7 @@ func (qm *QueueManager) InitQueues(ctx context.Context, tekton versioned2.Interf
 		// add all pipelineRuns in queued state to pending queue
 		prs, err := tekton.TektonV1beta1().PipelineRuns(repo.Namespace).
 			List(ctx, v1.ListOptions{
-				LabelSelector: fmt.Sprintf("%s/%s=%s", pipelinesascode.GroupName, "state", kubeinteraction.StateQueued),
+				LabelSelector: fmt.Sprintf("%s=%s", keys.State, kubeinteraction.StateQueued),
 			})
 		if err != nil {
 			return err
@@ -157,7 +157,7 @@ func (qm *QueueManager) InitQueues(ctx context.Context, tekton versioned2.Interf
 		// now fetch all started pipelineRun and update the running queue
 		prs, err = tekton.TektonV1beta1().PipelineRuns(repo.Namespace).
 			List(ctx, v1.ListOptions{
-				LabelSelector: fmt.Sprintf("%s/%s=%s", pipelinesascode.GroupName, "state", kubeinteraction.StateStarted),
+				LabelSelector: fmt.Sprintf("%s=%s", keys.State, kubeinteraction.StateStarted),
 			})
 		if err != nil {
 			return err

--- a/pkg/sync/queue_manager_test.go
+++ b/pkg/sync/queue_manager_test.go
@@ -1,12 +1,11 @@
 package sync
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
 	"github.com/jonboulle/clockwork"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
 	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
@@ -112,10 +111,10 @@ func TestQueueManager_InitQueues(t *testing.T) {
 	cw := clockwork.NewFakeClock()
 
 	startedLabel := map[string]string{
-		fmt.Sprintf("%s/%s", pipelinesascode.GroupName, "state"): kubeinteraction.StateStarted,
+		keys.State: kubeinteraction.StateStarted,
 	}
 	queuedLabel := map[string]string{
-		fmt.Sprintf("%s/%s", pipelinesascode.GroupName, "state"): kubeinteraction.StateQueued,
+		keys.State: kubeinteraction.StateQueued,
 	}
 
 	repo := newTestRepo("test", 1)

--- a/pkg/webhook/reconciler.go
+++ b/pkg/webhook/reconciler.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
+	pipelinesascode "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
 	pac "github.com/openshift-pipelines/pipelines-as-code/pkg/generated/listers/pipelinesascode/v1alpha1"
 	"go.uber.org/zap"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"

--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -14,7 +14,7 @@ import (
 
 	"code.gitea.io/sdk/gitea"
 	"github.com/google/go-github/v47/github"
-	pacapi "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
+	pacapi "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	tknpacdelete "github.com/openshift-pipelines/pipelines-as-code/pkg/cmd/tknpac/deleterepo"
 	tknpacdesc "github.com/openshift-pipelines/pipelines-as-code/pkg/cmd/tknpac/describe"
 	tknpacgenerate "github.com/openshift-pipelines/pipelines-as-code/pkg/cmd/tknpac/generate"
@@ -356,7 +356,7 @@ func TestGiteaPush(t *testing.T) {
 	tgitea.WaitForStatus(t, topts, topts.PullRequest.Head.Sha)
 	time.Sleep(5 * time.Second)
 	prs, err := topts.Clients.Clients.Tekton.TektonV1beta1().PipelineRuns(topts.TargetNS).List(context.Background(), metav1.ListOptions{
-		LabelSelector: filepath.Join(pacapi.GroupName, "event-type") + "=push",
+		LabelSelector: pacapi.EventType + "=push",
 	})
 	assert.NilError(t, err)
 	assert.Equal(t, len(prs.Items), 1, "should have only one push pipelinerun")
@@ -551,7 +551,7 @@ func TestGiteaWithCLIGeneratePipeline(t *testing.T) {
 			tgitea.WaitForStatus(t, topts, topts.TargetRefName)
 
 			prs, err := topts.Clients.Clients.Tekton.TektonV1beta1().PipelineRuns(topts.TargetNS).List(context.Background(), metav1.ListOptions{
-				LabelSelector: filepath.Join(pacapi.GroupName, "event-type") + "=pull_request",
+				LabelSelector: pacapi.EventType + "=pull_request",
 			})
 			assert.NilError(t, err)
 			assert.Assert(t, len(prs.Items) >= 2, "should have at least 2 pipelineruns")

--- a/test/pkg/gitea/test.go
+++ b/test/pkg/gitea/test.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"regexp"
 	"testing"
 	"time"
 
 	"code.gitea.io/sdk/gitea"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	pgitea "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/gitea"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
@@ -113,7 +112,7 @@ func TestPR(t *testing.T, topts *TestOpts) func() {
 	}
 
 	events, err := topts.Clients.Clients.Kube.CoreV1().Events(topts.TargetNS).List(ctx, metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("%s=%s", filepath.Join(pipelinesascode.GroupName, "repository"), topts.TargetNS),
+		LabelSelector: fmt.Sprintf("%s=%s", keys.Repository, topts.TargetNS),
 	})
 	assert.NilError(t, err)
 	if topts.ExpectEvents {
@@ -123,7 +122,7 @@ func TestPR(t *testing.T, topts *TestOpts) func() {
 		if len(events.Items) == 0 {
 			time.Sleep(time.Second * 5)
 			events, err = topts.Clients.Clients.Kube.CoreV1().Events(topts.TargetNS).List(ctx, metav1.ListOptions{
-				LabelSelector: fmt.Sprintf("%s=%s", filepath.Join(pipelinesascode.GroupName, "repository"), topts.TargetNS),
+				LabelSelector: fmt.Sprintf("%s=%s", keys.Repository, topts.TargetNS),
 			})
 			assert.NilError(t, err)
 		}


### PR DESCRIPTION
we were using filepath to create keys everywhere, this moves all keys at single place so that easy to reference across files and pkgs.

Closes #946 

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
