### PR TITLE
Fixes target branch match, if annotation has refs/head

### DIFF
--- a/pkg/matcher/annotation_matcher.go
+++ b/pkg/matcher/annotation_matcher.go
@@ -37,6 +37,15 @@ func branchMatch(prunBranch, baseBranch string) bool {
 		return true
 	}
 
+	// if target is refs/heads/.. and base is without ref (for pullRequest)
+	if strings.HasPrefix(prunBranch, "refs/heads") && !strings.Contains(baseBranch, "/") {
+		ref := "refs/heads/" + baseBranch
+		g := glob.MustCompile(prunBranch)
+		if g.Match(ref) {
+			return true
+		}
+	}
+
 	// match globs like refs/tags/0.*
 	g := glob.MustCompile(prunBranch)
 	return g.Match(baseBranch)


### PR DESCRIPTION
in case of pullreq, base branch is just a name without refs/heads but if user in annotation has provided values in regex form eg. refs/head/rel-* then it use to fail as we didn't have refs/heads in base branch prefix, for those cases we add prefix and check if they match.

Fixes #944 

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
