### PR TITLE
infra: use a config map setting for public route url of uploader

### DIFF
--- a/.tekton/doc.yaml
+++ b/.tekton/doc.yaml
@@ -42,11 +42,17 @@ spec:
             - name: hugo-gen
               image: quay.io/thegeeklab/hugo
               workingDir: $(workspaces.source.path)
+              env:
+                - name: UPLOADER_PUBLIC_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: "uploader-upload-credentials"
+                      key: "public_url"
               script: |
                 git config --global --add safe.directory $(workspaces.source.path)
                 cd docs
                 sed -i '1acanonifyURLs = true' config.toml
-                url="https://preview-pipelines-as-code-ci.apps.psipac.ospqa.com/docs/{{ pull_request_number }}"
+                url="${UPLOADER_PUBLIC_URL}/docs/{{ pull_request_number }}"
                 hugo --gc --minify -d {{ pull_request_number }} -b ${url}
                 echo "Preview URL: ${url}"
             - name: upload-to-static-server
@@ -64,13 +70,19 @@ spec:
                     secretKeyRef:
                       name: "uploader-upload-credentials"
                       key: "credentials"
+                - name: UPLOADER_PUBLIC_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: "uploader-upload-credentials"
+                      key: "public_url"
               script: |
                 cd docs
                 test -d "{{ pull_request_number }}" || exit 0
                 tar czf - "{{ pull_request_number }}" | curl -u ${UPLOADER_UPLOAD_CREDENTIALS} -F path=docs -F targz=true -X POST -F file=@- http://uploader:8080/upload
                 # Post as status
                 set +x
-                curl -H "Authorization: Bearer ${HUB_TOKEN}" -H 'Accept: application/vnd.github.v3+json' -X POST https://api.github.com/repos/{{repo_owner}}/{{repo_name}}/statuses/{{revision}} -d '{"state": "success", "target_url": "https://preview-pipelines-as-code-ci.apps.psipac.ospqa.com/docs/{{ pull_request_number }}", "description": "Generated with brio.", "context": "Pipelines as Code Preview URL"}'
+                curl -H "Authorization: Bearer ${HUB_TOKEN}" -H 'Accept: application/vnd.github.v3+json' -X POST https://api.github.com/repos/{{repo_owner}}/{{repo_name}}/statuses/{{revision}} -d \
+                                                            "{\"state\": \"success\", \"target_url\": \"${UPLOADER_PUBLIC_URL}/docs/{{ pull_request_number }}\", \"description\": \"Generated with brio.\", \"context\": \"Pipelines as Code Preview URL\"}"
 
         workspaces:
           - name: source


### PR DESCRIPTION
just use a configmap and not a static url, since we move the infra often
this make things much easier to setup.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
