### PR TITLE
Limits number of events in describe command

### DIFF
--- a/pkg/cmd/tknpac/describe/describe.go
+++ b/pkg/cmd/tknpac/describe/describe.go
@@ -33,6 +33,7 @@ var (
 	useRealTimeFlag   = "use-realtime"
 	showEventflag     = "show-events"
 	creationTimestamp = "{.metadata.creationTimestamp}"
+	maxEventLimit     = 50
 )
 
 //go:embed templates/describe.tmpl
@@ -215,6 +216,11 @@ func describe(ctx context.Context, cs *params.Run, clock clockwork.Clock, opts *
 		for i := len(runTimeObj) - 1; i >= 0; i-- {
 			event, _ := runTimeObj[i].(*corev1.Event)
 			eventList = append(eventList, *event)
+		}
+		// if there are more events than the max limit, take only the latest
+		// equal to max limit
+		if len(eventList) > maxEventLimit {
+			eventList = eventList[:maxEventLimit-1]
 		}
 	}
 


### PR DESCRIPTION
if there are lot of events for a repository now
repository show only the latest 50.
https://issues.redhat.com/browse/SRVKP-2601

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
