### PR TITLE
Use named regexp for annotations failure matching

### DIFF
--- a/config/302-pac-configmap.yaml
+++ b/config/302-pac-configmap.yaml
@@ -44,18 +44,9 @@ data:
   # Use -1 for unlimited lines.
   error-detection-max-number-of-lines: "50"
 
-  # The label or annotations of the tasks to detect simple errors
-  # simple errors are of the makefile/grep format for example :
-  #
-  # filename:line:column: error message
-  #
-  # most linter with the "Code Quality" label in the tekton hub will output
-  # in that simple format.
-  error-detection-simple-filter-to-task-labels: "Code Quality"
-
   # The default regexp used when we use the simple error detection
   error-detection-simple-regexp: |
-    ^([^:]*):(\d+):(\d+):\s*(.*)
+    ^(?P<filename>[^:]*):(?P<line>[0-9]+):(?P<column>[0-9]+):[ ]*(?P<error>.*)
 
   # Since public bitbucket doesn't have the concept of Secret, we need to be
   # able to secure the request by querying https://ip-ranges.atlassian.com/,

--- a/docs/content/docs/guide/statuses.md
+++ b/docs/content/docs/guide/statuses.md
@@ -25,7 +25,11 @@ filename:line:column: error message
 
 tools like `golangci-lint`, `pylint`, `yamllint` and many others are able to output errors in this format.
 
-You can customize the regexp used to detect the errors with the `error-detection-simple-regexp` setting.
+You can customize the regexp used to detect the errors with the
+`error-detection-simple-regexp` setting. The regexp used [named
+groups](https://www.regular-expressions.info/named.html) to give flexibility on
+how to specify the matching. The groups needed to match is `filename`, `line` and `error`
+(`column` is not used) see the default regexp in the configmap.
 
 By default pipelines as code will look for the last 50 lines of the container
 logs. You can increase this value in the `error-detection-max-number-of-lines`

--- a/pkg/params/settings/config.go
+++ b/pkg/params/settings/config.go
@@ -35,7 +35,7 @@ const (
 	ErrorDetectionSimpleRegexpKey     = "error-detection-simple-regexp"
 	errorDetectionValue               = "false"
 	errorDetectionNumberOfLinesValue  = 50
-	errorDetectionSimpleRegexpValue   = `^([^:]*):(\d+):(\d+):\s*(.*)`
+	errorDetectionSimpleRegexpValue   = `^(?P<filename>[^:]*):(?P<line>[0-9]+):(?P<column>[0-9]+):[ ]*(?P<error>.*)`
 )
 
 type Settings struct {
@@ -128,16 +128,15 @@ func ConfigToSettings(logger *zap.SugaredLogger, setting *Settings, config map[s
 	}
 
 	errorDetectNumberOfLines, _ := strconv.Atoi(config[ErrorDetectionNumberOfLinesKey])
-	if setting.ErrorDetectionNumberOfLines != errorDetectNumberOfLines {
+	if setting.ErrorDetection && setting.ErrorDetectionNumberOfLines != errorDetectNumberOfLines {
 		logger.Infof("CONFIG: setting error detection limit of container log to %v", errorDetectNumberOfLines)
 		setting.ErrorDetectionNumberOfLines = errorDetectNumberOfLines
 	}
 
-	if setting.ErrorDetectionSimpleRegexp != config[ErrorDetectionSimpleRegexpKey] {
+	if setting.ErrorDetection && setting.ErrorDetectionSimpleRegexp != config[ErrorDetectionSimpleRegexpKey] {
 		// replace double backslash with single backslash because kube configmap is giving us things double backslashes
-		fixedRegexpBackslash := strings.ReplaceAll(config[ErrorDetectionSimpleRegexpKey], `\\`, `\`)
 		logger.Infof("CONFIG: setting error detection regexp to %v", config[ErrorDetectionSimpleRegexpKey])
-		setting.ErrorDetectionSimpleRegexp = fixedRegexpBackslash
+		setting.ErrorDetectionSimpleRegexp = strings.TrimSpace(config[ErrorDetectionSimpleRegexpKey])
 	}
 
 	return nil


### PR DESCRIPTION
Use named regexp to give flexibility on how to specify the regexp matches.

Since yaml is ***censored**, we don't use backslash and shenaningans anymore just used [ ]* for matching space or [0-9]* for numbers etc..

Since yaml is ****censored *2***, we strip the \n at the end

Tested directly on cluster in https://github.com/openshift-pipelines/pipelines-as-code/pull/977/checks?check_run_id=9496773214

Remove ./ in file name prefix to make it matched in github annotations

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
