### PR TITLE
let ask the user to install gosmee port forwarder

### DIFF
--- a/docs/content/docs/install/kubernetes.md
+++ b/docs/content/docs/install/kubernetes.md
@@ -8,8 +8,9 @@ Pipelines as Code works on kubernetes/minikube/kind.
 
 ## Prerequisites
 
-You will need to pre-install the [pipeline](https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml) `release.yaml`
-file on your kubernetes cluster.
+You will need to pre-install the
+[pipeline](https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml)
+`release.yaml` file on your kubernetes cluster.
 
 ## Install
 
@@ -41,12 +42,45 @@ All three deployments should have all pods ready before moving on to ingress set
 
 ## Ingress
 
-You will need a `Ingress` to point to the pipelines-as-code controller.
-The ingress configuration depends on your Kubernetes provider.
-Either the ingress hostname or its IP address may be used as the webhook URL.
-You'll provide this configuration when connecting Pipelines as Code to your Git provider.
+You will need a
+[`Ingress`](https://kubernetes.io/docs/concepts/services-networking/ingress/)
+setup to point to make your pipelines-as-code controller available to `Github`,
+`Gitlab` or other `Git` providers.
 
-Here is an example working with the [nginx ingress](https://kubernetes.github.io/ingress-nginx/) controller :
+The ingress configuration depends on your Kubernetes provider. See below for
+some examples.
+
+Either the ingress hostname or its IP address may be used as the webhook URL.
+You'll have to provide this URL when connecting Pipelines as Code to
+your Git provider. You can find the ingress's address via
+`kubectl get ingress pipelines-as-code -n pipelines-as-code`.
+
+If you are quickly trying pipelines-as-code and do not want to setup the Ingress
+access, the `tkn pac bootstrap` [cli](../../guide/cli) command will let you
+set-up a [gosmee](https://github.com/chmouel/gosmee) deployment using the
+webhook URL remote forwarder `https://smee.io`.
+
+### [GKE](https://cloud.google.com/kubernetes-engine)
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  labels:
+    pipelines-as-code/route: controller
+  name: pipelines-as-code
+  namespace: pipelines-as-code
+  annotations:
+    kubernetes.io/ingress.class: gce
+spec:
+  defaultBackend:
+    service:
+      name: pipelines-as-code-controller
+      port:
+        number: 8080
+```
+
+### [Nginx Ingress Controller](https://kubernetes.github.io/ingress-nginx/)
 
 ```yaml
 apiVersion: networking.k8s.io/v1
@@ -71,37 +105,11 @@ spec:
         pathType: Prefix
 ```
 
-In this example `webhook.host.tld` is the hostname that will be used for the Pipelines as Code webhook URL.
-
-Here's an example with GKE:
-
-```yaml
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  labels:
-    pipelines-as-code/route: controller
-  name: pipelines-as-code
-  namespace: pipelines-as-code
-  annotations:
-    kubernetes.io/ingress.class: gce
-spec:
-  defaultBackend:
-    service:
-      name: pipelines-as-code-controller
-      port:
-        number: 8080
-```
-
-In this example, you will use the ingress's IP address rather than a hostname for the webhook URL.
-You can find the ingress's address via `kubectl get ingress pipelines-as-code -n pipelines-as-code`.
-
-If you can't or don't want to set up an ingress on your cluster (for example, you're using a kind cluster,
-or you just want to experiment with Pipelines as Code before setting up an ingress),
-see [Proxy service for PAC controller](./installation.md#proxy-service-for-pac-controller).
+In this example `webhook.host.tld` is the hostname for your pipeline's
+controller to fill as the webhook URL in the Git provider.
 
 ## Tekton Dashboard integration
 
 If you have [Tekton Dashboard](https://github.com/tektoncd/dashboard). You can
-just add the key `tekton-dashboard-url` in the `pipelines-as-code` config map set
-to the full URL of the `Ingress` host to get tekton dashboard logs URL.
+just add the key `tekton-dashboard-url` in the `pipelines-as-code` config map
+set to the full URL of the `Ingress` host to get tekton dashboard logs URL.

--- a/pkg/cmd/tknpac/bootstrap/install.go
+++ b/pkg/cmd/tknpac/bootstrap/install.go
@@ -3,11 +3,19 @@ package bootstrap
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/google/go-github/v48/github"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/random"
+
+	_ "embed"
 )
+
+//go:embed templates/gosmee.yaml
+var gosmeeYaml string
 
 const (
 	pacGHRepoOwner = "openshift-pipelines"
@@ -16,6 +24,11 @@ const (
 
 	openshiftReleaseYaml = "release.yaml"
 	k8ReleaseYaml        = "release.k8s.yaml"
+
+	gosmeeInstallHelpText = `Pipelines as Code does not install a Ingress object to make the controller accessing from the internet
+we can install a webhook forwarder called gosmee (https://github.com/chmouel/gosmee) using a %s URL
+this will let your git platform provider (ie: Github) to reach the controller without having to be having public access`
+	minNumOfCharForRandomForwarderID = 16
 )
 
 func getLatestRelease(ctx context.Context, k8release string) (string, string, error) {
@@ -45,12 +58,39 @@ func kubectlApply(uri string) error {
 	return nil
 }
 
+func installGosmeeForwarder(opts *bootstrapOpts) error {
+	gosmeInstall, err := askYN(true, fmt.Sprintf(gosmeeInstallHelpText, opts.forwarderURL), "Do you want me to install the gosmee forwarder?", opts.ioStreams.Out)
+	if err != nil {
+		return err
+	}
+	if !gosmeInstall {
+		return fmt.Errorf("please install a ingress object pointing to the controller service as documented here: https://is.gd/FzI0eb and pass the full ingress url as argument to the --route-url flag")
+	}
+
+	// maybe we can use https://webhook.chmouel.com too
+	opts.RouteName = fmt.Sprintf("https://smee.io/%s", random.AlphaString(minNumOfCharForRandomForwarderID))
+	tmpl := strings.ReplaceAll(gosmeeYaml, "FORWARD_URL", opts.RouteName)
+	f, err := os.CreateTemp("", "pac-gosmee")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(f.Name())
+	if _, err = f.WriteString(tmpl); err != nil {
+		return err
+	}
+	if err := kubectlApply(f.Name()); err != nil {
+		return err
+	}
+	fmt.Fprintf(opts.ioStreams.Out, "💡 Your gosmee forward URL is %s\n", opts.RouteName)
+	return nil
+}
+
 func installPac(ctx context.Context, run *params.Run, opts *bootstrapOpts) error {
 	var latestVersion, latestReleaseYaml, nightlyReleaseYaml string
 	k8Ext := ""
 
-	routeExist, _ := checkOpenshiftRoute(run)
-	if routeExist {
+	isOpenShift, _ := checkOpenshiftRoute(run)
+	if isOpenShift {
 		nightlyReleaseYaml = openshiftReleaseYaml
 	} else {
 		nightlyReleaseYaml = k8ReleaseYaml
@@ -86,5 +126,9 @@ func installPac(ctx context.Context, run *params.Run, opts *bootstrapOpts) error
 	}
 
 	fmt.Fprintf(opts.ioStreams.Out, "✓ Pipelines-as-Code %s has been installed\n", latestVersion)
+
+	if !isOpenShift && opts.RouteName == "" {
+		return installGosmeeForwarder(opts)
+	}
 	return nil
 }

--- a/pkg/cmd/tknpac/bootstrap/questions.go
+++ b/pkg/cmd/tknpac/bootstrap/questions.go
@@ -60,7 +60,7 @@ func askQuestions(opts *bootstrapOpts) error {
 		opts.GithubAPIURL = "https://" + strings.Trim(opts.GithubAPIURL, "/")
 	}
 
-	if opts.RouteName != "" {
+	if opts.autoDetectedRoute && opts.RouteName != "" {
 		answer, err := askYN(true,
 			fmt.Sprintf("👀 I have detected an OpenShift Route on: %s", opts.RouteName),
 			"Do you want me to use it?", opts.ioStreams.Out)

--- a/pkg/cmd/tknpac/bootstrap/templates/gosmee.yaml
+++ b/pkg/cmd/tknpac/bootstrap/templates/gosmee.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gosmee
+  namespace: pipelines-as-code
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gosmee
+  template:
+    metadata:
+      labels:
+        app: gosmee
+    spec:
+      containers:
+        - image: ghcr.io/chmouel/gosmee:main
+          name: gosmee
+          args:
+            [
+              "client",
+              "--saveDir",
+              "/tmp/save",
+              "FORWARD_URL",
+              "http://pipelines-as-code-controller.pipelines-as-code:8080",
+            ]
+
+# vim: ft=yaml


### PR DESCRIPTION
on bootstrap command when running on kubernetes we didn't have a way to detect the ingress since they are all different by platform provider.

We instead install a gosmee webhook forwarder using https://smee.io by default to let the user uses it so they can quickly use pac if needed.


![image](https://user-images.githubusercontent.com/98980/203104360-7b2059db-6af1-4ac6-98f7-4e189ee7046e.png)

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
