### PR TITLE
Add  tkn pac logs --last

### DIFF
--- a/docs/content/docs/guide/running.md
+++ b/docs/content/docs/guide/running.md
@@ -43,7 +43,7 @@ You can follow the execution of your pipeline with the
 [tkn](https://github.com/tektoncd/cli) cli :
 
 ```console
-tkn pr logs -n my-pipeline-ci -Lf
+tkn pac logs -n my-pipeline-ci -L
 ```
 
 Or with the OpenShift console inside your namespace you can follow the

--- a/pkg/cmd/tknpac/deleterepo/delete.go
+++ b/pkg/cmd/tknpac/deleterepo/delete.go
@@ -59,6 +59,11 @@ func repositoryCommand(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command
 
 	cmd.Flags().StringP(
 		namespaceFlag, "n", "", "If present, the namespace scope for this CLI request")
+	_ = cmd.RegisterFlagCompletionFunc(namespaceFlag,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completion.BaseCompletion(namespaceFlag, args)
+		},
+	)
 
 	cmd.Flags().BoolVarP(
 		&cascade, "cascade", "c", false, "Delete the repository and its secrets attached to it")

--- a/pkg/cmd/tknpac/logs/logs.go
+++ b/pkg/cmd/tknpac/logs/logs.go
@@ -125,6 +125,11 @@ func Command(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
 
 	cmd.Flags().StringP(
 		namespaceFlag, "n", "", "If present, the namespace scope for this CLI request")
+	_ = cmd.RegisterFlagCompletionFunc(namespaceFlag,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completion.BaseCompletion(namespaceFlag, args)
+		},
+	)
 
 	cmd.Flags().BoolP(
 		openWebBrowserFlag, "w", false, "Open Web browser to detected console instead of using tkn")

--- a/pkg/cmd/tknpac/logs/logs_test.go
+++ b/pkg/cmd/tknpac/logs/logs_test.go
@@ -35,6 +35,7 @@ func TestLogs(t *testing.T) {
 		currentNamespace string
 		shift            int
 		pruns            []*tektonv1beta1.PipelineRun
+		useLastPR        bool
 	}{
 		{
 			name:             "good/show logs",
@@ -44,6 +45,21 @@ func TestLogs(t *testing.T) {
 			shift:            0,
 			pruns: []*tektonv1beta1.PipelineRun{
 				tektontest.MakePRCompletion(cw, "test-pipeline", ns, completed, map[string]string{
+					keys.Repository: "test",
+				}, 30),
+			},
+		},
+		{
+			name:             "good/show logs",
+			wantErr:          false,
+			repoName:         "test",
+			currentNamespace: ns,
+			useLastPR:        true,
+			pruns: []*tektonv1beta1.PipelineRun{
+				tektontest.MakePRCompletion(cw, "test-pipeline", ns, completed, map[string]string{
+					keys.Repository: "test",
+				}, 30),
+				tektontest.MakePRCompletion(cw, "test-pipeline2", ns, completed, map[string]string{
 					keys.Repository: "test",
 				}, 30),
 			},
@@ -116,6 +132,7 @@ func TestLogs(t *testing.T) {
 				limit:     1,
 				tknPath:   tknPath,
 				ioStreams: io,
+				useLastPR: tt.useLastPR,
 			}
 
 			err = log(ctx, lopts)

--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -26,7 +26,7 @@ const (
 	startingPipelineRunText = `Starting Pipelinerun <b>%s</b> in namespace
   <b>%s</b><br><br>You can follow the execution on the [OpenShift console](%s) pipelinerun viewer or via
   the command line with :
-	<br><code>tkn pr logs -f -n %s %s</code>`
+	<br><code>tkn pac logs -L -n %s %s</code>`
 	queuingPipelineRunText = `PipelineRun <b>%s</b> has been queued Queuing in namespace
   <b>%s</b><br><br>`
 )

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -31,7 +31,7 @@ import (
 const startingPipelineRunText = `Starting Pipelinerun <b>%s</b> in namespace
   <b>%s</b><br><br>You can follow the execution on the [OpenShift console](%s) pipelinerun viewer or via
   the command line with :
-	<br><code>tkn pr logs -f -n %s %s</code>`
+	<br><code>tkn pac logs -L -n %s %s</code>`
 
 type Reconciler struct {
 	run               *params.Run


### PR DESCRIPTION
Add tkn pac logs --last command, which show the last pr log like tkn pr logs does. Make it exposed everywhere on the logs and check run status.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
