### PR TITLE
Hide secrets from log snippets

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -23,6 +23,8 @@ SkippedScopes = script, style, pre, figure, code, tt, blockquote, listingblock, 
 
 RedHat.ConfigMap = NO
 RedHat.CaseSensitiveTerms = NO
+Vale.Spelling = NO
+
 # Match Markdown files. See: https://docs.errata.ai/vale/scoping
 # Match also `*.properties` files (see the `format` section).
 [*.md]

--- a/docs/content/docs/guide/statuses.md
+++ b/docs/content/docs/guide/statuses.md
@@ -15,7 +15,18 @@ with a short recap of how long each task of your pipeline took and the output of
 When we detect an error  in one of the task of the Pipeline we will show a small
 snippet of the last 3 lines in the task breakdown.
 
-This will only show the output of the first task that failed (due of the limitation of the API not allowing to have many characters).
+This will only show the output of the first failed task (due of the
+limitation of the API not allowing to have many characters).
+
+Pipelines as Code try to avoid leaking secrets by looking into the PipelineRun
+and replace the secrets values by hidden characters.
+We fetch every secrets on environment variable attached to any tasks and steps,
+check if there is any match of those values in the snippet and *blindly* replace them
+with a `*****` placeholder.
+
+This doesn't support hiding secrets coming from workspaces and
+[envFrom](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#envfromsource-v1-core)
+source.
 
 ![log snippet](/images/snippet-failure-message.png)
 
@@ -24,7 +35,7 @@ This will only show the output of the first task that failed (due of the limitat
 If you set `error-detection-from-container-logs` to `true` in the
 `pipeline-as-code` [config map](/docs/install/settings.md), pipelines-as-code
 will try to detect the errors from the container logs and add them as
-annotations on the Pull Request where the error occured.
+annotations on the Pull Request where the error occurred.
 
 We currently support only the simple case  where the error looks like `makefile` or `grep` output of this format:
 

--- a/docs/content/docs/install/settings.md
+++ b/docs/content/docs/install/settings.md
@@ -96,7 +96,7 @@ There is a few things you can configure through the config map
   It will show the last 3 lines of the first container of the first task
   that has error in the pipeline.
 
-  ***NOTE***: You may want to disable this if you think your pipeline may leak some value
+  If it find any strings matching the values of secrets attached to the PipelineRun it will replace it with the placeholder `******`
 
 ## Pipelines-As-Code Info
 

--- a/pkg/adapter/incoming.go
+++ b/pkg/adapter/incoming.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/matcher"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketcloud"
@@ -16,6 +15,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/gitea"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/github"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/gitlab"
+	ktypes "github.com/openshift-pipelines/pipelines-as-code/pkg/secrets/types"
 	"go.uber.org/zap"
 )
 
@@ -53,7 +53,7 @@ func (l *listener) detectIncoming(ctx context.Context, req *http.Request, payloa
 		return false, nil, fmt.Errorf("branch '%s' has not matched any rules in repo incoming webhooks spec: %+v", branch, *repo.Spec.Incomings)
 	}
 
-	secretOpts := kubeinteraction.GetSecretOpt{
+	secretOpts := ktypes.GetSecretOpt{
 		Namespace: repo.Namespace,
 		Name:      hook.Secret.Name,
 		Key:       hook.Secret.Key,

--- a/pkg/kubeinteraction/kubeinteraction.go
+++ b/pkg/kubeinteraction/kubeinteraction.go
@@ -8,19 +8,15 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"go.uber.org/zap"
-)
 
-type GetSecretOpt struct {
-	Namespace string
-	Name      string
-	Key       string
-}
+	ktypes "github.com/openshift-pipelines/pipelines-as-code/pkg/secrets/types"
+)
 
 type Interface interface {
 	CleanupPipelines(context.Context, *zap.SugaredLogger, *v1alpha1.Repository, *v1beta1.PipelineRun, int) error
 	CreateBasicAuthSecret(context.Context, *zap.SugaredLogger, *info.Event, string, string) error
 	DeleteBasicAuthSecret(context.Context, *zap.SugaredLogger, string, string) error
-	GetSecret(context.Context, GetSecretOpt) (string, error)
+	GetSecret(context.Context, ktypes.GetSecretOpt) (string, error)
 	GetPodLogs(context.Context, string, string, string, int64) (string, error)
 }
 

--- a/pkg/kubeinteraction/secrets.go
+++ b/pkg/kubeinteraction/secrets.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/random"
+	ktypes "github.com/openshift-pipelines/pipelines-as-code/pkg/secrets/types"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -43,7 +44,7 @@ func (k Interaction) createSecret(ctx context.Context, secretData map[string]str
 func (k Interaction) CreateBasicAuthSecret(ctx context.Context, logger *zap.SugaredLogger, runevent *info.Event,
 	targetNamespace, secretName string,
 ) error {
-	// Bitbucket Server have a different Clone URL than it's Repo URL, so we
+	// Bitbucket Server have a different Clone URL than it's Repository URL, so we
 	// have to separate them 👨‍🏭
 	cloneURL := runevent.URL
 	if runevent.CloneURL != "" {
@@ -60,11 +61,11 @@ func (k Interaction) CreateBasicAuthSecret(ctx context.Context, logger *zap.Suga
 		gitUser = runevent.Provider.User
 	}
 
-	// Bitbucket server token have / into it, so unless we do urlquote them it's
+	// Bitbucket server token have / into it, so unless we quote the URL them it's
 	// impossible to use it🤡
 	//
-	// It supposed not working on github according to
-	// https://stackoverflow.com/a/24719496 but arguably github have a better
+	// It supposed not working on GitHub according to
+	// https://stackoverflow.com/a/24719496 but arguably GitHub have a better
 	// product and would not do such things.
 	//
 	// maybe we could patch the git-clone task too but that probably be a pain
@@ -91,7 +92,7 @@ func (k Interaction) CreateBasicAuthSecret(ctx context.Context, logger *zap.Suga
 	return nil
 }
 
-func (k Interaction) GetSecret(ctx context.Context, secretopt GetSecretOpt) (string, error) {
+func (k Interaction) GetSecret(ctx context.Context, secretopt ktypes.GetSecretOpt) (string, error) {
 	secret, err := k.Run.Clients.Kube.CoreV1().Secrets(secretopt.Namespace).Get(
 		ctx, secretopt.Name, metav1.GetOptions{})
 	if err != nil {
@@ -115,3 +116,5 @@ func (k Interaction) DeleteBasicAuthSecret(ctx context.Context, logger *zap.Suga
 	logger.Infof("Secret %s has been deleted in namespace %s", secretName, targetNamespace)
 	return nil
 }
+
+// TODO: support envSource

--- a/pkg/pipelineascode/secret.go
+++ b/pkg/pipelineascode/secret.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	ktypes "github.com/openshift-pipelines/pipelines-as-code/pkg/secrets/types"
 	"go.uber.org/zap"
 )
 
@@ -40,7 +41,7 @@ func SecretFromRepository(ctx context.Context, cs *params.Run, k8int kubeinterac
 		gitProviderSecretKey = DefaultGitProviderSecretKey
 	}
 
-	if event.Provider.Token, err = k8int.GetSecret(ctx, kubeinteraction.GetSecretOpt{
+	if event.Provider.Token, err = k8int.GetSecret(ctx, ktypes.GetSecretOpt{
 		Namespace: repo.GetNamespace(),
 		Name:      repo.Spec.GitProvider.Secret.Name,
 		Key:       gitProviderSecretKey,
@@ -71,7 +72,7 @@ func SecretFromRepository(ctx context.Context, cs *params.Run, k8int kubeinterac
 		repo.Spec.GitProvider.User,
 		repo.Spec.GitProvider.Secret.Name,
 		gitProviderSecretKey)
-	if event.Provider.WebhookSecret, err = k8int.GetSecret(ctx, kubeinteraction.GetSecretOpt{
+	if event.Provider.WebhookSecret, err = k8int.GetSecret(ctx, ktypes.GetSecretOpt{
 		Namespace: repo.GetNamespace(),
 		Name:      repo.Spec.GitProvider.WebhookSecret.Name,
 		Key:       gitProviderWebhookSecretKey,
@@ -92,7 +93,7 @@ func SecretFromRepository(ctx context.Context, cs *params.Run, k8int kubeinterac
 
 // GetCurrentNSWebhookSecret get secret from current namespace if it exists
 func GetCurrentNSWebhookSecret(ctx context.Context, k8int kubeinteraction.Interface) (string, error) {
-	s, err := k8int.GetSecret(ctx, kubeinteraction.GetSecretOpt{
+	s, err := k8int.GetSecret(ctx, ktypes.GetSecretOpt{
 		Namespace: os.Getenv("SYSTEM_NAMESPACE"),
 		Name:      defaultPipelinesAscodeSecretName,
 		Key:       defaultPipelinesAscodeSecretWebhookSecretKey,

--- a/pkg/provider/gitea/gitea.go
+++ b/pkg/provider/gitea/gitea.go
@@ -150,9 +150,12 @@ func (v *Provider) createStatusCommit(event *info.Event, pacopts *info.PacOpts, 
 	}
 
 	if status.Text != "" && event.EventType == "pull_request" {
+		// insane? yes, but gitea has some issues and need some random number
+		// to update the comment or we get a 422, may need to be removed
+		status.Text = fmt.Sprintf(status.Text, "\n", " \n ")
 		_, _, err := v.Client.CreateIssueComment(event.Organization, event.Repository,
 			int64(event.PullRequestNumber), gitea.CreateIssueCommentOption{
-				Body: fmt.Sprintf("%s<br>%s", status.Summary, status.Text),
+				Body: fmt.Sprintf("%s\n%s", status.Summary, status.Text),
 			},
 		)
 		if err != nil {

--- a/pkg/reconciler/status.go
+++ b/pkg/reconciler/status.go
@@ -13,6 +13,7 @@ import (
 	kstatus "github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction/status"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/secrets"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/sort"
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"go.uber.org/zap"
@@ -104,6 +105,8 @@ func (r *Reconciler) postFinalStatus(ctx context.Context, logger *zap.SugaredLog
 	if r.run.Info.Pac.ErrorLogSnippet {
 		failures := r.getFailureSnippet(ctx, pr)
 		if failures != "" {
+			secretValues := secrets.GetSecretsAttachedToPipelineRun(ctx, r.kinteract, pr)
+			failures = secrets.ReplaceSecretsInText(failures, secretValues)
 			taskStatusText = fmt.Sprintf(failureReasonText, taskStatusText, failures)
 		}
 	}

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -1,0 +1,67 @@
+package secrets
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
+	ktypes "github.com/openshift-pipelines/pipelines-as-code/pkg/secrets/types"
+	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+)
+
+const leakedReplacement = "*****"
+
+// GetSecretsAttachedToPipelineRun get all secrets attached to a PipelineRun and grab their values
+func GetSecretsAttachedToPipelineRun(ctx context.Context, k kubeinteraction.Interface, pr *tektonv1beta1.PipelineRun) []ktypes.SecretValue {
+	ret := []ktypes.SecretValue{}
+	// check if pipelineRef is defined or exist
+	if pr.Spec.PipelineSpec == nil {
+		return ret
+	}
+
+	for _, pt := range append(pr.Spec.PipelineSpec.Finally, pr.Spec.PipelineSpec.Tasks...) {
+		for _, step := range pt.TaskSpec.Steps {
+			for _, ev := range step.Env {
+				if ev.ValueFrom == nil {
+					continue
+				}
+				if ev.ValueFrom.SecretKeyRef == nil {
+					continue
+				}
+				secretValue, err := k.GetSecret(ctx, ktypes.GetSecretOpt{
+					Name:      ev.ValueFrom.SecretKeyRef.Name,
+					Key:       ev.ValueFrom.SecretKeyRef.Key,
+					Namespace: pr.GetNamespace(),
+				})
+				// that really should not happen but let's go on and continue if that's the case
+				if err != nil {
+					continue
+				}
+				keyv := fmt.Sprintf("%s-%s", ev.ValueFrom.SecretKeyRef.Name, ev.ValueFrom.SecretKeyRef.Key)
+				there := false
+				for _, value := range ret {
+					if value.Name == keyv {
+						there = true
+					}
+				}
+				if !there {
+					ret = append(ret, ktypes.SecretValue{
+						Name:  keyv,
+						Value: secretValue,
+					})
+				}
+			}
+		}
+	}
+
+	return ret
+}
+
+// ReplaceSecretsInText this will take a text snippet and hide the leaked secret
+func ReplaceSecretsInText(text string, values []ktypes.SecretValue) string {
+	for _, sv := range values {
+		text = strings.ReplaceAll(text, sv.Value, leakedReplacement)
+	}
+	return text
+}

--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -1,0 +1,206 @@
+package secrets
+
+import (
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/secrets/types"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/test/kubernetestint"
+	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	rtesting "knative.dev/pkg/reconciler/testing"
+)
+
+func TestGetSecretsAttachedToPipelineRun(t *testing.T) {
+	samplePr := tektonv1beta1.PipelineRun{
+		Spec: tektonv1beta1.PipelineRunSpec{
+			PipelineSpec: &tektonv1beta1.PipelineSpec{
+				Tasks: []tektonv1beta1.PipelineTask{
+					{
+						TaskSpec: &tektonv1beta1.EmbeddedTask{
+							TaskSpec: tektonv1beta1.TaskSpec{
+								Steps: []tektonv1beta1.Step{
+									{
+										Env: []corev1.EnvVar{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	tests := []struct {
+		name           string
+		pr             tektonv1beta1.PipelineRun
+		envs           []corev1.EnvVar
+		secretsFake    map[string]string
+		results        []types.SecretValue
+		nosecretKeyRef bool
+	}{
+		{
+			name: "get secrets",
+			pr:   samplePr,
+			secretsFake: map[string]string{
+				"secret1": "uno",
+				"secret2": "segundo",
+			},
+			envs: []corev1.EnvVar{
+				{
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							Key: "key1",
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "secret1",
+							},
+						},
+					},
+				},
+				{
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							Key: "key2",
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "secret2",
+							},
+						},
+					},
+				},
+			},
+			results: []types.SecretValue{
+				{
+					Name:  "secret1-key1",
+					Value: "uno",
+				},
+				{
+					Name:  "secret2-key2",
+					Value: "segundo",
+				},
+			},
+		},
+		{
+			name: "remove doublons",
+			pr:   samplePr,
+			secretsFake: map[string]string{
+				"secret1": "uno",
+			},
+			envs: []corev1.EnvVar{
+				{
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							Key: "key1",
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "secret1",
+							},
+						},
+					},
+				},
+				{
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							Key: "key1",
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "secret1",
+							},
+						},
+					},
+				},
+			},
+			results: []types.SecretValue{
+				{
+					Name:  "secret1-key1",
+					Value: "uno",
+				},
+			},
+		},
+		{
+			name: "no secrets skip",
+			secretsFake: map[string]string{
+				"secret1": "uno",
+			},
+			pr: samplePr,
+			envs: []corev1.EnvVar{
+				{
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							Key: "key1",
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "secret1",
+							},
+						},
+					},
+				},
+				{
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							Key: "key2",
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "secret2",
+							},
+						},
+					},
+				},
+			},
+			results: []types.SecretValue{
+				{
+					Name:  "secret1-key1",
+					Value: "uno",
+				},
+			},
+		},
+		{
+			name:           "no secret key ref skip",
+			pr:             samplePr,
+			nosecretKeyRef: true,
+			results:        []types.SecretValue{},
+			envs: []corev1.EnvVar{
+				{
+					ValueFrom: &corev1.EnvVarSource{
+						ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "config",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.pr.Spec.PipelineSpec.Tasks[0].TaskSpec.TaskSpec.Steps[0].Env = tt.envs
+			k := &kubernetestint.KinterfaceTest{
+				GetSecretResult: tt.secretsFake,
+			}
+			ctx, _ := rtesting.SetupFakeContext(t)
+			ret := GetSecretsAttachedToPipelineRun(ctx, k, &tt.pr)
+			assert.DeepEqual(t, tt.results, ret)
+		})
+	}
+}
+
+func TestReplaceSecretsInText(t *testing.T) {
+	tests := []struct {
+		name, text, result string
+		values             []types.SecretValue
+	}{
+		{
+			name:   "replace secrets in text",
+			text:   "I am beautiful",
+			result: "I am *****",
+			values: []types.SecretValue{
+				{
+					Name:  "beautiful-secret",
+					Value: "beautiful",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ret := ReplaceSecretsInText(tt.text, tt.values)
+			assert.Equal(t, ret, tt.result)
+		})
+	}
+}

--- a/pkg/secrets/types/types.go
+++ b/pkg/secrets/types/types.go
@@ -1,0 +1,12 @@
+package types
+
+type SecretValue struct {
+	Name  string
+	Value string
+}
+
+type GetSecretOpt struct {
+	Namespace string
+	Name      string
+	Key       string
+}

--- a/pkg/test/kubernetestint/kubernetesint.go
+++ b/pkg/test/kubernetestint/kubernetesint.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	ktypes "github.com/openshift-pipelines/pipelines-as-code/pkg/secrets/types"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"go.uber.org/zap"
 )
@@ -18,8 +18,6 @@ type KinterfaceTest struct {
 	GetSecretResult          map[string]string
 	GetPodLogsOutput         map[string]string
 }
-
-var _ kubeinteraction.Interface = (*KinterfaceTest)(nil)
 
 func (k *KinterfaceTest) GetConsoleUI(_ context.Context, _, _ string) (string, error) {
 	if k.ConsoleURLErorring {
@@ -43,12 +41,12 @@ func (k *KinterfaceTest) DeleteBasicAuthSecret(_ context.Context, _ *zap.Sugared
 	return nil
 }
 
-func (k *KinterfaceTest) GetSecret(_ context.Context, secretopt kubeinteraction.GetSecretOpt) (string, error) {
+func (k *KinterfaceTest) GetSecret(ctx context.Context, secret ktypes.GetSecretOpt) (string, error) {
 	// check if secret exist in k.GetSecretResult
-	if k.GetSecretResult[secretopt.Name] == "" {
-		return "", fmt.Errorf("secret %s does not exist", secretopt.Name)
+	if k.GetSecretResult[secret.Name] == "" {
+		return "", fmt.Errorf("secret %s does not exist", secret.Name)
 	}
-	return k.GetSecretResult[secretopt.Name], nil
+	return k.GetSecretResult[secret.Name], nil
 }
 
 func (k *KinterfaceTest) CleanupPipelines(_ context.Context, _ *zap.SugaredLogger, _ *v1alpha1.Repository,

--- a/test/pkg/gitea/crd.go
+++ b/test/pkg/gitea/crd.go
@@ -2,7 +2,6 @@ package gitea
 
 import (
 	"context"
-	"os"
 
 	"code.gitea.io/sdk/gitea"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
@@ -20,10 +19,6 @@ func createToken(topts *TestOpts) (string, error) {
 }
 
 func CreateCRD(ctx context.Context, topts *TestOpts) error {
-	internalGitea, _ := os.LookupEnv("TEST_GITEA_INTERNAL_URL")
-	if internalGitea == "" {
-		internalGitea = "http://gitea.gitea:3000"
-	}
 	if err := pacrepo.CreateNS(ctx, topts.TargetNS, topts.Clients); err != nil {
 		return err
 	}
@@ -45,7 +40,7 @@ func CreateCRD(ctx context.Context, topts *TestOpts) error {
 				Type: "gitea",
 				// caveat this assume gitea running on the same cluster, which
 				// we do and need for e2e tests but that may be changed somehow
-				URL:    internalGitea,
+				URL:    topts.InternalGiteaURL,
 				Secret: &v1alpha1.Secret{Name: "gitea-secret", Key: "token"},
 			},
 			ConcurrencyLimit: topts.ConcurrencyLimit,

--- a/test/testdata/pipelinerun_git_clone_private-gitea.yaml
+++ b/test/testdata/pipelinerun_git_clone_private-gitea.yaml
@@ -26,7 +26,7 @@ spec:
       # not great but can't do otherwise due of networking and how we run self contained tests
       # under gitea. Since we are working on convention here this will break
       # easily on refactoring so something to watch out.
-      value: "http://gitea.gitea:3000/pac/\\ .TargetNamespace //"
+      value: "\\ .ProviderURL ///pac/\\ .TargetNamespace //"
     - name: revision
       value: "{{ revision }}"
     - name: sslVerify


### PR DESCRIPTION
Try to avoid leaking secrets by looking into the PipelineRun. We grab the environment variable on every tasks and steps attached to the PipelineRun, fetch the values of the secrets and if there is any match of those values in the snippet it will replace them with `*****`

* Fix a gitea regression, new gitea version is not accepting `<br>` anymore



Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
