### PR TITLE
Add condition to check existence of GithubApp only for github repo and not for Gitlab or Bitbucket

### DIFF
--- a/pkg/cmd/tknpac/create/repository.go
+++ b/pkg/cmd/tknpac/create/repository.go
@@ -87,17 +87,19 @@ func repositoryCommand(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command
 			}
 
 			if pacCMInfo.Provider == provider.ProviderGitHubApp {
-				msg := "👌 A GitHub App is configured for your cluster, Would you like to setup webhook for your repository?"
-				var setupWebhook bool
-				if err := prompt.SurveyAskOne(&survey.Confirm{Message: msg, Default: false}, &setupWebhook); err != nil {
-					return err
-				}
-				if !setupWebhook {
-					fmt.Fprintln(ioStreams.Out, "✓ Skipped webhook setup")
-					if err := createOpts.generateTemplate(nil); err != nil {
+				if strings.Contains(createOpts.Event.URL, "github") {
+					msg := "👌 A GitHub App is configured for your cluster, Would you like to setup webhook for your repository?"
+					var setupWebhook bool
+					if err := prompt.SurveyAskOne(&survey.Confirm{Message: msg, Default: false}, &setupWebhook); err != nil {
 						return err
 					}
-					return nil
+					if !setupWebhook {
+						fmt.Fprintln(ioStreams.Out, "✓ Skipped webhook setup")
+						if err := createOpts.generateTemplate(nil); err != nil {
+							return err
+						}
+						return nil
+					}
 				}
 			}
 


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR fixes small UX of tkn-pac cli command of `tkn pac create repo`

**Issue:**
When a GithubApp is configured and when user execute `tkn pac create repo` for Gitlab or Bitbucket it use to show
```
👌 A GitHub App is configured for your cluster, Would you like to setup webhook for your repository?
```
Which should not be the case for other than Github Provider

**Result:**

**_GithubApp is configured_**

1. **Should ask for configuring webhook only for Github Repo**

![Screenshot from 2022-11-25 14-03-05](https://user-images.githubusercontent.com/9441662/203936474-8147b3f2-cd21-4dd6-9ed1-9db20341c770.png)


![Screenshot from 2022-11-25 14-01-18](https://user-images.githubusercontent.com/9441662/203936138-72ade197-3eb6-433b-a890-840775d37a02.png)


2. **Should not ask for configuring webhook for Gitlab and Bitbucket Cloud**

![Screenshot from 2022-11-25 13-38-12](https://user-images.githubusercontent.com/9441662/203934951-c05cba50-4d8f-4214-b34d-6be5c89c41d5.png)



<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
