### PR TITLE
fixes pod breaking due to nil client & removes duplication

### DIFF
--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -231,7 +231,7 @@ func (r *Reconciler) updatePipelineRunToInProgress(ctx context.Context, logger *
 		event.Provider.WebhookSecret, _ = pipelineascode.GetCurrentNSWebhookSecret(ctx, r.kinteract)
 	}
 
-	err = p.SetClient(ctx, nil, event)
+	err = p.SetClient(ctx, r.run, event)
 	if err != nil {
 		return fmt.Errorf("cannot set client: %w", err)
 	}


### PR DESCRIPTION
watcher was breaking due to `v.Run.Info.Pac.ErrorDetection` v.Run was nil as we were not setting it. this fixes that also removes using logger from v.Run in status as the logger coming from reconciler has labels for debugging.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
