### PR TITLE
Provides ability to cancel  pipelineruns through comments

### DIFF
--- a/config/201-controller-role.yaml
+++ b/config/201-controller-role.yaml
@@ -73,7 +73,7 @@ rules:
     verbs: ["create", "list"]
   - apiGroups: ["tekton.dev"]
     resources: ["pipelineruns"]
-    verbs: ["get", "create", "patch"]
+    verbs: ["get", "list", "create", "patch"]
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create"]

--- a/docs/content/docs/guide/running.md
+++ b/docs/content/docs/guide/running.md
@@ -96,3 +96,29 @@ roses are red, violets are blue. pipeline are bound to flake by design.
 
 /test <pipelinerun-name>
 ```
+
+## Cancelling the PipelineRun
+
+You can cancel a running PipelineRun by commenting on the PullRequest.
+
+For example. you want to cancel all your pipeline you can add a comment starting
+with `/cancel` and all PipelineRun attached to that pull or merge request will be cancelled.
+
+Example :
+
+```text
+It seems the infra is down, so cancelling the pipelineruns.
+
+/cancel
+```
+
+If you have multiple `PipelineRun` and you want to target a specific
+`PipelineRun` you can use the `/cancel` comment with the PipelineRun name
+
+Example:
+
+```text
+roses are red, violets are blue. why to run the pipeline when the infra is down.
+
+/cancel <pipelinerun-name>
+```

--- a/pkg/action/patch.go
+++ b/pkg/action/patch.go
@@ -1,0 +1,37 @@
+package action
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+)
+
+func PatchPipelineRun(ctx context.Context, logger *zap.SugaredLogger, tekton versioned.Interface, pr *v1beta1.PipelineRun, mergePatch map[string]interface{}) error {
+	if pr == nil {
+		return nil
+	}
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		patch, err := json.Marshal(mergePatch)
+		if err != nil {
+			return err
+		}
+		patchedPR, err := tekton.TektonV1beta1().PipelineRuns(pr.GetNamespace()).Patch(ctx, pr.GetName(), types.MergePatchType, patch, metav1.PatchOptions{})
+		if err != nil {
+			logger.Infof("could not patch Pipelinerun, retrying %v/%v: %v", pr.GetNamespace(), pr.GetName(), err)
+			return err
+		}
+		logger.Infof("patched pipelinerun: %v/%v", patchedPR.Namespace, patchedPR.Name)
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to patch pipelinerun %v/%v: %w", pr.Namespace, pr.Name, err)
+	}
+	return nil
+}

--- a/pkg/action/patch_test.go
+++ b/pkg/action/patch_test.go
@@ -1,0 +1,58 @@
+package action
+
+import (
+	"path/filepath"
+	"testing"
+
+	apipac "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/consoleui"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
+	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
+	tektontest "github.com/openshift-pipelines/pipelines-as-code/pkg/test/tekton"
+	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"go.uber.org/zap"
+	zapobserver "go.uber.org/zap/zaptest/observer"
+	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	rtesting "knative.dev/pkg/reconciler/testing"
+)
+
+func TestPatchPipelineRun(t *testing.T) {
+	ctx, _ := rtesting.SetupFakeContext(t)
+	observer, _ := zapobserver.New(zap.InfoLevel)
+	logger := zap.New(observer).Sugar()
+
+	testPR := tektontest.MakePR("namespace", "force-me", map[string]*pipelinev1beta1.PipelineRunTaskRunStatus{
+		"first":  tektontest.MakePrTrStatus("first", 5),
+		"last":   tektontest.MakePrTrStatus("last", 15),
+		"middle": tektontest.MakePrTrStatus("middle", 10),
+	}, nil)
+
+	tdata := testclient.Data{
+		PipelineRuns: []*pipelinev1beta1.PipelineRun{testPR},
+	}
+
+	stdata, _ := testclient.SeedTestData(t, ctx, tdata)
+	fakeClients := clients.Clients{
+		Tekton:    stdata.Pipeline,
+		ConsoleUI: &consoleui.TektonDashboard{BaseURL: "https://localhost.console"},
+	}
+
+	err := PatchPipelineRun(ctx, logger, fakeClients.Tekton, testPR, getLogURLMergePatch(fakeClients, testPR))
+	assert.NilError(t, err)
+
+	pr, err := fakeClients.Tekton.TektonV1beta1().PipelineRuns("namespace").Get(ctx, "force-me", metav1.GetOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, pr.Annotations[filepath.Join(apipac.GroupName, "log-url")], "https://localhost.console/#/namespaces/namespace/pipelineruns/force-me")
+}
+
+func getLogURLMergePatch(clients clients.Clients, pr *pipelinev1beta1.PipelineRun) map[string]interface{} {
+	return map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": map[string]string{
+				keys.LogURL: clients.ConsoleUI.DetailURL(pr.GetNamespace(), pr.GetName()),
+			},
+		},
+	}
+}

--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -119,6 +119,7 @@ func (l listener) handleEvent() http.HandlerFunc {
 			if err := json.Unmarshal(payload, &event); err != nil {
 				l.logger.Errorf("Invalid event body format format: %s", err)
 				response.WriteHeader(http.StatusBadRequest)
+				return
 			}
 		}
 

--- a/pkg/cli/webhook/gitlab.go
+++ b/pkg/cli/webhook/gitlab.go
@@ -9,7 +9,6 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli/prompt"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/random"
 	"github.com/xanzy/go-gitlab"
 )
@@ -22,10 +21,6 @@ type gitLabConfig struct {
 	webhookSecret       string
 	personalAccessToken string
 	APIURL              string
-}
-
-func (gl *gitLabConfig) GetName() string {
-	return provider.ProviderGitLabWebhook
 }
 
 func (gl *gitLabConfig) Run(_ context.Context, opts *Options) (*response, error) {

--- a/pkg/kubeinteraction/labels.go
+++ b/pkg/kubeinteraction/labels.go
@@ -42,7 +42,7 @@ func AddLabelsAndAnnotations(event *info.Event, pipelineRun *tektonv1beta1.Pipel
 	}
 
 	if event.PullRequestNumber != 0 {
-		annotations[keys.PullRequest] = strconv.Itoa(event.PullRequestNumber)
+		labels[keys.PullRequest] = strconv.Itoa(event.PullRequestNumber)
 	}
 
 	// TODO: move to provider specific function

--- a/pkg/params/info/events.go
+++ b/pkg/params/info/events.go
@@ -57,7 +57,8 @@ type Event struct {
 }
 
 type State struct {
-	TargetTestPipelineRun string // PipelineRun name to run
+	TargetTestPipelineRun string
+	CancelPipelineRuns    bool
 }
 
 type Provider struct {

--- a/pkg/params/info/events.go
+++ b/pkg/params/info/events.go
@@ -57,8 +57,9 @@ type Event struct {
 }
 
 type State struct {
-	TargetTestPipelineRun string
-	CancelPipelineRuns    bool
+	TargetTestPipelineRun   string
+	CancelPipelineRuns      bool
+	TargetCancelPipelineRun string
 }
 
 type Provider struct {

--- a/pkg/pipelineascode/cancel_pipelinerun_test.go
+++ b/pkg/pipelineascode/cancel_pipelinerun_test.go
@@ -1,0 +1,226 @@
+package pipelineascode
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
+	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"go.uber.org/zap"
+	zapobserver "go.uber.org/zap/zaptest/observer"
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	rtesting "knative.dev/pkg/reconciler/testing"
+)
+
+var (
+	fooRepo = &v1alpha1.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "foo",
+			Name:      "foo",
+		},
+		Spec: v1alpha1.RepositorySpec{
+			URL: "https://github.com/fooorg/foo",
+		},
+	}
+	fooRepoLabels = map[string]string{
+		keys.URLRepository: formatting.K8LabelsCleanup("foo"),
+		keys.SHA:           formatting.K8LabelsCleanup("foosha"),
+		keys.PullRequest:   strconv.Itoa(11),
+	}
+	fooRepoLabelsPrFooAbc = map[string]string{
+		keys.URLRepository:  formatting.K8LabelsCleanup("foo"),
+		keys.SHA:            formatting.K8LabelsCleanup("foosha"),
+		keys.PullRequest:    strconv.Itoa(11),
+		keys.OriginalPRName: "pr-foo-abc",
+	}
+)
+
+func TestCancelPipelinerun(t *testing.T) {
+	observer, _ := zapobserver.New(zap.InfoLevel)
+	logger := zap.New(observer).Sugar()
+	tests := []struct {
+		name                  string
+		event                 *info.Event
+		repo                  *v1alpha1.Repository
+		pipelineRuns          []*pipelinev1beta1.PipelineRun
+		cancelledPipelineRuns map[string]bool
+	}{
+		{
+			name: "not a pull request event",
+			event: &info.Event{
+				TriggerTarget: "push",
+			},
+		},
+		{
+			name: "cancel running",
+			event: &info.Event{
+				Repository:        "foo",
+				SHA:               "foosha",
+				TriggerTarget:     "pull_request",
+				PullRequestNumber: 11,
+				State: info.State{
+					CancelPipelineRuns: true,
+				},
+			},
+			pipelineRuns: []*pipelinev1beta1.PipelineRun{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pr-foo",
+						Namespace: "foo",
+						Labels:    fooRepoLabels,
+					},
+					Spec: pipelinev1beta1.PipelineRunSpec{},
+				},
+			},
+			repo: fooRepo,
+			cancelledPipelineRuns: map[string]bool{
+				"pr-foo": true,
+			},
+		},
+		{
+			name: "no pipelineruns found",
+			event: &info.Event{
+				Repository:        "foo",
+				SHA:               "foosha",
+				TriggerTarget:     "pull_request",
+				PullRequestNumber: 11,
+				State: info.State{
+					CancelPipelineRuns: true,
+				},
+			},
+			pipelineRuns:          []*pipelinev1beta1.PipelineRun{},
+			repo:                  fooRepo,
+			cancelledPipelineRuns: map[string]bool{},
+		},
+		{
+			name: "cancel a specific run",
+			event: &info.Event{
+				Repository:        "foo",
+				SHA:               "foosha",
+				TriggerTarget:     "pull_request",
+				PullRequestNumber: 11,
+				State: info.State{
+					CancelPipelineRuns:      true,
+					TargetCancelPipelineRun: "pr-foo-abc",
+				},
+			},
+			pipelineRuns: []*pipelinev1beta1.PipelineRun{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pr-foo",
+						Namespace: "foo",
+						Labels:    fooRepoLabels,
+					},
+					Spec: pipelinev1beta1.PipelineRunSpec{},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pr-foo-abc-123",
+						Namespace: "foo",
+						Labels:    fooRepoLabelsPrFooAbc,
+					},
+					Spec: pipelinev1beta1.PipelineRunSpec{},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pr-foo-pqr",
+						Namespace: "foo",
+						Labels:    fooRepoLabels,
+					},
+					Spec: pipelinev1beta1.PipelineRunSpec{},
+				},
+			},
+			repo: fooRepo,
+			cancelledPipelineRuns: map[string]bool{
+				"pr-foo-abc-123": true,
+			},
+		},
+		{
+			name: "cancelling a done pipelinerun or already cancelled pipelinerun",
+			event: &info.Event{
+				Repository:        "foo",
+				SHA:               "foosha",
+				TriggerTarget:     "pull_request",
+				PullRequestNumber: 11,
+				State: info.State{
+					CancelPipelineRuns: true,
+				},
+			},
+			pipelineRuns: []*pipelinev1beta1.PipelineRun{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pr-foo",
+						Namespace: "foo",
+						Labels:    fooRepoLabels,
+					},
+					Spec: pipelinev1beta1.PipelineRunSpec{},
+					Status: pipelinev1beta1.PipelineRunStatus{
+						Status: duckv1beta1.Status{
+							Conditions: duckv1beta1.Conditions{
+								apis.Condition{
+									Type:   apis.ConditionSucceeded,
+									Status: corev1.ConditionTrue,
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pr-foo-1",
+						Namespace: "foo",
+						Labels:    fooRepoLabels,
+					},
+					Spec: pipelinev1beta1.PipelineRunSpec{
+						Status: pipelinev1beta1.PipelineRunSpecStatusStoppedRunFinally,
+					},
+				},
+			},
+			repo:                  fooRepo,
+			cancelledPipelineRuns: map[string]bool{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+
+			tdata := testclient.Data{
+				PipelineRuns: tt.pipelineRuns,
+			}
+			stdata, _ := testclient.SeedTestData(t, ctx, tdata)
+			cs := &params.Run{
+				Clients: clients.Clients{
+					Log:    logger,
+					Tekton: stdata.Pipeline,
+					Kube:   stdata.Kube,
+				},
+			}
+			pac := NewPacs(tt.event, nil, cs, nil, logger)
+			err := pac.cancelPipelineRuns(ctx, tt.repo)
+			assert.NilError(t, err)
+
+			got, err := cs.Clients.Tekton.TektonV1beta1().PipelineRuns("foo").List(ctx, metav1.ListOptions{})
+			assert.NilError(t, err)
+
+			for _, pr := range got.Items {
+				// from the list only the ones which are in cancelled map should have cancel status
+				if _, ok := tt.cancelledPipelineRuns[pr.Name]; ok {
+					assert.Equal(t, string(pr.Spec.Status), pipelinev1beta1.PipelineRunSpecStatusCancelledRunFinally)
+					continue
+				}
+				assert.Assert(t, string(pr.Spec.Status) != pipelinev1beta1.PipelineRunSpecStatusCancelledRunFinally)
+			}
+		})
+	}
+}

--- a/pkg/pipelineascode/cancel_pipelineruns.go
+++ b/pkg/pipelineascode/cancel_pipelineruns.go
@@ -1,0 +1,91 @@
+package pipelineascode
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"sync"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/action"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"go.uber.org/zap"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+)
+
+var cancelMergePatch = map[string]interface{}{
+	"spec": map[string]interface{}{
+		"status": v1beta1.PipelineRunSpecStatusCancelledRunFinally,
+	},
+}
+
+func (p *PacRun) cancelPipelineRuns(ctx context.Context, repo *v1alpha1.Repository) error {
+	if p.event.TriggerTarget != "pull_request" {
+		msg := fmt.Sprintf("not a pullRequest event, event: %v", p.event.TriggerTarget)
+		p.eventEmitter.EmitMessage(repo, zap.WarnLevel, "RepositoryEvent", msg)
+		return nil
+	}
+
+	prs, err := p.run.Clients.Tekton.TektonV1beta1().PipelineRuns(repo.Namespace).List(ctx, v1.ListOptions{
+		LabelSelector: getLabelSelector(map[string]string{
+			keys.URLRepository: formatting.K8LabelsCleanup(p.event.Repository),
+			keys.SHA:           formatting.K8LabelsCleanup(p.event.SHA),
+			keys.PullRequest:   strconv.Itoa(p.event.PullRequestNumber),
+		}),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list pipelineRuns : %w", err)
+	}
+
+	if len(prs.Items) == 0 {
+		msg := fmt.Sprintf("no pipelinerun found for repository: %v , sha: %v and pulRequest %v",
+			p.event.Repository, p.event.SHA, p.event.PullRequestNumber)
+		p.eventEmitter.EmitMessage(repo, zap.InfoLevel, "RepositoryPipelineRun", msg)
+		return nil
+	}
+
+	var wg sync.WaitGroup
+	for _, pr := range prs.Items {
+		if p.event.TargetCancelPipelineRun != "" {
+			if prName, ok := pr.GetLabels()[keys.OriginalPRName]; !ok || prName != p.event.TargetCancelPipelineRun {
+				continue
+			}
+		}
+		if pr.IsDone() {
+			p.logger.Infof("pipelinerun %v/%v is done, skipping cancellation", pr.GetNamespace(), pr.GetName())
+			continue
+		}
+		if pr.IsCancelled() || pr.IsGracefullyCancelled() || pr.IsGracefullyStopped() {
+			p.logger.Infof("pipelinerun %v/%v is already in %v state", pr.GetNamespace(), pr.GetName(), pr.Spec.Status)
+			continue
+		}
+
+		wg.Add(1)
+		go func(ctx context.Context, pr v1beta1.PipelineRun) {
+			defer wg.Done()
+			p.logger.Infof("patching pipelinerun %v/%v with cancel patch", pr.Namespace, pr.Name)
+			if err := action.PatchPipelineRun(ctx, p.logger, p.run.Clients.Tekton, &pr, cancelMergePatch); err != nil {
+				errMsg := fmt.Sprintf("failed to cancel pipelineRun %s/%s: %s", pr.GetNamespace(), pr.GetName(), err.Error())
+				p.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "RepositoryPipelineRun", errMsg)
+			}
+		}(ctx, pr)
+	}
+	wg.Wait()
+
+	return nil
+}
+
+func getLabelSelector(labelsMap map[string]string) string {
+	labelSelector := labels.NewSelector()
+	for k, v := range labelsMap {
+		req, _ := labels.NewRequirement(k, selection.Equals, []string{v})
+		if req != nil {
+			labelSelector = labelSelector.Add(*req)
+		}
+	}
+	return labelSelector.String()
+}

--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -27,6 +27,10 @@ func (p *PacRun) matchRepoPR(ctx context.Context) ([]matcher.Match, *v1alpha1.Re
 		return nil, nil, nil
 	}
 
+	if p.event.CancelPipelineRuns {
+		return nil, repo, p.cancelPipelineRuns(ctx, repo)
+	}
+
 	matchedPRs, err := p.getPipelineRunsFromRepo(ctx, repo)
 	if err != nil {
 		return nil, repo, err

--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -18,19 +18,36 @@ import (
 	"go.uber.org/zap"
 )
 
-// matchRepoPR matches the repo and the PRs from the event
 func (p *PacRun) matchRepoPR(ctx context.Context) ([]matcher.Match, *v1alpha1.Repository, error) {
+	repo, err := p.verifyRepoAndUser(ctx)
+	if err != nil {
+		return nil, repo, err
+	}
+	if repo == nil {
+		return nil, nil, nil
+	}
+
+	matchedPRs, err := p.getPipelineRunsFromRepo(ctx, repo)
+	if err != nil {
+		return nil, repo, err
+	}
+	return matchedPRs, repo, nil
+}
+
+// verifyRepoAndUser verifies if the Repo CR exists for the Git Repository,
+// if the user has permission to run CI  and also initialise provider client
+func (p *PacRun) verifyRepoAndUser(ctx context.Context) (*v1alpha1.Repository, error) {
 	// Match the Event URL to a Repository URL,
 	repo, err := matcher.MatchEventURLRepo(ctx, p.run, p.event, "")
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	if repo == nil {
 		if p.event.Provider.Token == "" {
 			msg := fmt.Sprintf("cannot set status since no repository has been matched on %s", p.event.URL)
 			p.eventEmitter.EmitMessage(nil, zap.WarnLevel, "RepositorySetStatus", msg)
-			return nil, nil, nil
+			return nil, nil
 		}
 		msg := fmt.Sprintf("cannot find a namespace match for %s", p.event.URL)
 		p.eventEmitter.EmitMessage(nil, zap.WarnLevel, "RepositoryNamespaceMatch", msg)
@@ -42,9 +59,9 @@ func (p *PacRun) matchRepoPR(ctx context.Context) ([]matcher.Match, *v1alpha1.Re
 			DetailsURL: "https://tenor.com/search/sad-cat-gifs",
 		}
 		if err := p.vcx.CreateStatus(ctx, p.run.Clients.Tekton, p.event, p.run.Info.Pac, status); err != nil {
-			return nil, nil, fmt.Errorf("failed to run create status on repo not found: %w", err)
+			return nil, fmt.Errorf("failed to run create status on repo not found: %w", err)
 		}
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	// If we have a git_provider field in repository spec, then get all the
@@ -61,7 +78,7 @@ func (p *PacRun) matchRepoPR(ctx context.Context) ([]matcher.Match, *v1alpha1.Re
 	} else {
 		err := SecretFromRepository(ctx, p.run, p.k8int, p.vcx.GetConfig(), p.event, repo, p.logger)
 		if err != nil {
-			return nil, repo, err
+			return repo, err
 		}
 	}
 
@@ -76,7 +93,7 @@ it seems that we have detected a \n or a space at the end of your webhook secret
 is that what you want? make sure you use -n when generating the secret, eg: echo -n secret|base64`
 				p.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "RepositorySecretValidation", msg)
 			}
-			return nil, repo, fmt.Errorf("could not validate payload, check your webhook secret?: %w", err)
+			return repo, fmt.Errorf("could not validate payload, check your webhook secret?: %w", err)
 		}
 	}
 
@@ -84,20 +101,20 @@ is that what you want? make sure you use -n when generating the secret, eg: echo
 	// token or secret or we won't be able to do much.
 	err = p.vcx.SetClient(ctx, p.run, p.event)
 	if err != nil {
-		return nil, repo, err
+		return repo, err
 	}
 
 	// Get the SHA commit info, we want to get the URL and commit title
 	err = p.vcx.GetCommitInfo(ctx, p.event)
 	if err != nil {
-		return nil, repo, err
+		return repo, err
 	}
 
 	// Check if the submitter is allowed to run this.
 	if p.event.TriggerTarget != "push" {
 		allowed, err := p.vcx.IsAllowed(ctx, p.event)
 		if err != nil {
-			return nil, repo, err
+			return repo, err
 		}
 		if !allowed {
 			msg := fmt.Sprintf("User %s is not allowed to run CI on this repo.", p.event.Sender)
@@ -113,12 +130,16 @@ is that what you want? make sure you use -n when generating the secret, eg: echo
 				DetailsURL: "https://tenor.com/search/police-cat-gifs",
 			}
 			if err := p.vcx.CreateStatus(ctx, p.run.Clients.Tekton, p.event, p.run.Info.Pac, status); err != nil {
-				return nil, repo, fmt.Errorf("failed to run create status, user is not allowed to run: %w", err)
+				return repo, fmt.Errorf("failed to run create status, user is not allowed to run: %w", err)
 			}
-			return nil, repo, nil
+			return repo, nil
 		}
 	}
+	return repo, nil
+}
 
+// getPipelineRunsFromRepo fetches pipelineruns from git repository and prepare them for creation
+func (p *PacRun) getPipelineRunsFromRepo(ctx context.Context, repo *v1alpha1.Repository) ([]matcher.Match, error) {
 	rawTemplates, err := p.vcx.GetTektonDir(ctx, p.event, tektonDir)
 	if err != nil || rawTemplates == "" {
 		msg := fmt.Sprintf("cannot locate templates in %s/ directory for this repository in %s", tektonDir, p.event.HeadBranch)
@@ -126,14 +147,14 @@ is that what you want? make sure you use -n when generating the secret, eg: echo
 			msg += fmt.Sprintf(" err: %s", err.Error())
 		}
 		p.eventEmitter.EmitMessage(nil, zap.InfoLevel, "RepositoryPipelineRunNotFound", msg)
-		return nil, repo, nil
+		return nil, nil
 	}
 
 	// check for condition if need update the pipelinerun with regexp from the
 	// "raw" pipelinerun string
 	if msg, needUpdate := p.checkNeedUpdate(rawTemplates); needUpdate {
 		p.eventEmitter.EmitMessage(repo, zap.InfoLevel, "RepositoryNeedUpdate", msg)
-		return nil, repo, fmt.Errorf(msg)
+		return nil, fmt.Errorf(msg)
 	}
 
 	// Replace those {{var}} placeholders user has in her template to the run.Info variable
@@ -144,12 +165,12 @@ is that what you want? make sure you use -n when generating the secret, eg: echo
 	})
 	if err != nil {
 		p.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "RepositoryFailedToMatch", fmt.Sprintf("failed to match pipelineRuns: %s", err.Error()))
-		return nil, repo, err
+		return nil, err
 	}
 	if pipelineRuns == nil {
 		msg := fmt.Sprintf("cannot locate templates in %s/ directory for this repository in %s", tektonDir, p.event.HeadBranch)
 		p.eventEmitter.EmitMessage(nil, zap.InfoLevel, "RepositoryCannotLocatePipelineRun", msg)
-		return nil, repo, nil
+		return nil, nil
 	}
 
 	// if /test command is used then filter out the pipelinerun
@@ -157,12 +178,12 @@ is that what you want? make sure you use -n when generating the secret, eg: echo
 	if pipelineRuns == nil {
 		msg := fmt.Sprintf("cannot find pipelinerun %s in this repository", p.event.TargetTestPipelineRun)
 		p.eventEmitter.EmitMessage(repo, zap.InfoLevel, "RepositoryCannotLocatePipelineRun", msg)
-		return nil, repo, nil
+		return nil, nil
 	}
 
 	err = changeSecret(pipelineRuns)
 	if err != nil {
-		return nil, repo, err
+		return nil, err
 	}
 
 	// Match the PipelineRun with annotation
@@ -170,10 +191,10 @@ is that what you want? make sure you use -n when generating the secret, eg: echo
 	if err != nil {
 		// Don't fail when you don't have a match between pipeline and annotations
 		p.eventEmitter.EmitMessage(nil, zap.WarnLevel, "RepositoryNoMatch", err.Error())
-		return nil, repo, nil
+		return nil, nil
 	}
 
-	return matchedPRs, repo, nil
+	return matchedPRs, nil
 }
 
 func filterRunningPipelineRunOnTargetTest(testPipeline string, prs []*tektonv1beta1.PipelineRun) []*tektonv1beta1.PipelineRun {

--- a/pkg/provider/bitbucketcloud/detect.go
+++ b/pkg/provider/bitbucketcloud/detect.go
@@ -47,6 +47,9 @@ func (v *Provider) Detect(req *http.Request, payload string, logger *zap.Sugared
 			if provider.IsOkToTestComment(e.Comment.Content.Raw) {
 				return setLoggerAndProceed(true, "", nil)
 			}
+			if provider.IsCancelComment(e.Comment.Content.Raw) {
+				return setLoggerAndProceed(true, "", nil)
+			}
 		}
 		return setLoggerAndProceed(false, fmt.Sprintf("not a valid gitops comment: \"%s\"", event), nil)
 

--- a/pkg/provider/bitbucketcloud/detect_test.go
+++ b/pkg/provider/bitbucketcloud/detect_test.go
@@ -101,6 +101,32 @@ func TestProvider_Detect(t *testing.T) {
 			isBC:       true,
 			processReq: true,
 		},
+		{
+			name: "cancel comment",
+			event: types.PullRequestEvent{
+				Comment: types.Comment{
+					Content: types.Content{
+						Raw: "/cancel",
+					},
+				},
+			},
+			eventType:  "pullrequest:comment_created",
+			isBC:       true,
+			processReq: true,
+		},
+		{
+			name: "cancel a pr",
+			event: types.PullRequestEvent{
+				Comment: types.Comment{
+					Content: types.Content{
+						Raw: "/cancel dummy",
+					},
+				},
+			},
+			eventType:  "pullrequest:comment_created",
+			isBC:       true,
+			processReq: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/provider/bitbucketcloud/parse_payload.go
+++ b/pkg/provider/bitbucketcloud/parse_payload.go
@@ -138,7 +138,7 @@ func (v *Provider) ParsePayload(ctx context.Context, run *params.Run, request *h
 				} else {
 					processedEvent.EventType = "retest-comment"
 				}
-				processedEvent.TargetTestPipelineRun = provider.GetPipelineRunFromComment(e.Comment.Content.Raw)
+				processedEvent.TargetTestPipelineRun = provider.GetPipelineRunFromTestComment(e.Comment.Content.Raw)
 			case provider.IsOkToTestComment(e.Comment.Content.Raw):
 				processedEvent.TriggerTarget = "pull_request"
 				processedEvent.EventType = "ok-to-test-comment"

--- a/pkg/provider/bitbucketcloud/parse_payload.go
+++ b/pkg/provider/bitbucketcloud/parse_payload.go
@@ -142,6 +142,11 @@ func (v *Provider) ParsePayload(ctx context.Context, run *params.Run, request *h
 			case provider.IsOkToTestComment(e.Comment.Content.Raw):
 				processedEvent.TriggerTarget = "pull_request"
 				processedEvent.EventType = "ok-to-test-comment"
+			case provider.IsCancelComment(e.Comment.Content.Raw):
+				processedEvent.TriggerTarget = "pull_request"
+				processedEvent.EventType = "cancel-comment"
+				processedEvent.CancelPipelineRuns = true
+				processedEvent.TargetTestPipelineRun = provider.GetPipelineRunFromCancelComment(e.Comment.Content.Raw)
 			}
 		}
 		processedEvent.Organization = e.Repository.Workspace.Slug

--- a/pkg/provider/bitbucketcloud/parse_payload.go
+++ b/pkg/provider/bitbucketcloud/parse_payload.go
@@ -146,7 +146,7 @@ func (v *Provider) ParsePayload(ctx context.Context, run *params.Run, request *h
 				processedEvent.TriggerTarget = "pull_request"
 				processedEvent.EventType = "cancel-comment"
 				processedEvent.CancelPipelineRuns = true
-				processedEvent.TargetTestPipelineRun = provider.GetPipelineRunFromCancelComment(e.Comment.Content.Raw)
+				processedEvent.TargetCancelPipelineRun = provider.GetPipelineRunFromCancelComment(e.Comment.Content.Raw)
 			}
 		}
 		processedEvent.Organization = e.Repository.Workspace.Slug

--- a/pkg/provider/bitbucketcloud/parse_payload_test.go
+++ b/pkg/provider/bitbucketcloud/parse_payload_test.go
@@ -174,6 +174,23 @@ func TestParsePayload(t *testing.T) {
 			expectedSender:    "sender",
 			expectedSHA:       "sha",
 		},
+		{
+			name:              "cancel comment with a pipelinerun",
+			payloadEvent:      bbcloudtest.MakePREvent("account", "sender", "sha", "/cancel dummy"),
+			eventType:         "pullrequest:comment_created",
+			expectedAccountID: "account",
+			expectedSender:    "sender",
+			expectedSHA:       "sha",
+			targetPipelinerun: "dummy",
+		},
+		{
+			name:              "cancel all comment",
+			payloadEvent:      bbcloudtest.MakePREvent("account", "sender", "sha", "/cancel"),
+			eventType:         "pullrequest:comment_created",
+			expectedAccountID: "account",
+			expectedSender:    "sender",
+			expectedSHA:       "sha",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/provider/bitbucketcloud/parse_payload_test.go
+++ b/pkg/provider/bitbucketcloud/parse_payload_test.go
@@ -27,6 +27,7 @@ func TestParsePayload(t *testing.T) {
 		allowedConfig             map[string]map[string]string
 		additionalAllowedsourceIP string
 		targetPipelinerun         string
+		cancelPipelinerun         string
 	}{
 		{
 			name:              "parse push request",
@@ -181,7 +182,7 @@ func TestParsePayload(t *testing.T) {
 			expectedAccountID: "account",
 			expectedSender:    "sender",
 			expectedSHA:       "sha",
-			targetPipelinerun: "dummy",
+			cancelPipelinerun: "dummy",
 		},
 		{
 			name:              "cancel all comment",
@@ -234,6 +235,9 @@ func TestParsePayload(t *testing.T) {
 			assert.Equal(t, tt.expectedSHA, got.SHA, "%s != %s", tt.expectedSHA, got.SHA)
 			if tt.targetPipelinerun != "" {
 				assert.Equal(t, tt.targetPipelinerun, got.TargetTestPipelineRun, tt.targetPipelinerun, got.TargetTestPipelineRun)
+			}
+			if tt.cancelPipelinerun != "" {
+				assert.Equal(t, tt.cancelPipelinerun, got.TargetCancelPipelineRun, tt.cancelPipelinerun, got.TargetCancelPipelineRun)
 			}
 		})
 	}

--- a/pkg/provider/bitbucketserver/detect.go
+++ b/pkg/provider/bitbucketserver/detect.go
@@ -48,6 +48,9 @@ func (v *Provider) Detect(req *http.Request, payload string, logger *zap.Sugared
 			if provider.IsOkToTestComment(e.Comment.Text) {
 				return setLoggerAndProceed(true, "", nil)
 			}
+			if provider.IsCancelComment(e.Comment.Text) {
+				return setLoggerAndProceed(true, "", nil)
+			}
 		}
 		return setLoggerAndProceed(false, fmt.Sprintf("not a recognized bitbucket event: \"%s\"", event), nil)
 

--- a/pkg/provider/bitbucketserver/detect_test.go
+++ b/pkg/provider/bitbucketserver/detect_test.go
@@ -92,6 +92,24 @@ func TestProvider_Detect(t *testing.T) {
 			isBS:       true,
 			processReq: true,
 		},
+		{
+			name: "cancel comment",
+			event: types.PullRequestEvent{
+				Comment: bbv1.Comment{Text: "/cancel"},
+			},
+			eventType:  "pr:comment:added",
+			isBS:       true,
+			processReq: true,
+		},
+		{
+			name: "cancel a pipelinerun comment",
+			event: types.PullRequestEvent{
+				Comment: bbv1.Comment{Text: "/cancel dummy"},
+			},
+			eventType:  "pr:comment:added",
+			isBS:       true,
+			processReq: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/provider/bitbucketserver/parse_payload.go
+++ b/pkg/provider/bitbucketserver/parse_payload.go
@@ -67,7 +67,7 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 				processedEvent.TriggerTarget = "pull_request"
 				processedEvent.EventType = "cancel-comment"
 				processedEvent.CancelPipelineRuns = true
-				processedEvent.TargetTestPipelineRun = provider.GetPipelineRunFromCancelComment(e.Comment.Text)
+				processedEvent.TargetCancelPipelineRun = provider.GetPipelineRunFromCancelComment(e.Comment.Text)
 			}
 		}
 		// TODO: It's Really not an OWNER but a PROJECT

--- a/pkg/provider/bitbucketserver/parse_payload.go
+++ b/pkg/provider/bitbucketserver/parse_payload.go
@@ -59,7 +59,7 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 				} else {
 					processedEvent.EventType = "retest-comment"
 				}
-				processedEvent.TargetTestPipelineRun = provider.GetPipelineRunFromComment(e.Comment.Text)
+				processedEvent.TargetTestPipelineRun = provider.GetPipelineRunFromTestComment(e.Comment.Text)
 			case provider.IsOkToTestComment(e.Comment.Text):
 				processedEvent.TriggerTarget = "pull_request"
 				processedEvent.EventType = "ok-to-test-comment"

--- a/pkg/provider/bitbucketserver/parse_payload.go
+++ b/pkg/provider/bitbucketserver/parse_payload.go
@@ -63,6 +63,11 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 			case provider.IsOkToTestComment(e.Comment.Text):
 				processedEvent.TriggerTarget = "pull_request"
 				processedEvent.EventType = "ok-to-test-comment"
+			case provider.IsCancelComment(e.Comment.Text):
+				processedEvent.TriggerTarget = "pull_request"
+				processedEvent.EventType = "cancel-comment"
+				processedEvent.CancelPipelineRuns = true
+				processedEvent.TargetTestPipelineRun = provider.GetPipelineRunFromCancelComment(e.Comment.Text)
 			}
 		}
 		// TODO: It's Really not an OWNER but a PROJECT

--- a/pkg/provider/bitbucketserver/parse_payload_test.go
+++ b/pkg/provider/bitbucketserver/parse_payload_test.go
@@ -92,6 +92,19 @@ func TestParsePayload(t *testing.T) {
 			expEvent:          ev1,
 			targetPipelinerun: "dummy",
 		},
+		{
+			name:              "good/comment cancel a pr",
+			eventType:         "pr:comment:added",
+			payloadEvent:      bbv1test.MakePREvent(ev1, "/cancel dummy"),
+			expEvent:          ev1,
+			targetPipelinerun: "dummy",
+		},
+		{
+			name:         "good/comment cancel all",
+			eventType:    "pr:comment:added",
+			payloadEvent: bbv1test.MakePREvent(ev1, "/cancel"),
+			expEvent:     ev1,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/provider/bitbucketserver/parse_payload_test.go
+++ b/pkg/provider/bitbucketserver/parse_payload_test.go
@@ -25,13 +25,14 @@ func TestParsePayload(t *testing.T) {
 	}
 
 	tests := []struct {
-		name              string
-		payloadEvent      interface{}
-		expEvent          *info.Event
-		eventType         string
-		wantErrSubstr     string
-		rawStr            string
-		targetPipelinerun string
+		name                    string
+		payloadEvent            interface{}
+		expEvent                *info.Event
+		eventType               string
+		wantErrSubstr           string
+		rawStr                  string
+		targetPipelinerun       string
+		canceltargetPipelinerun string
 	}{
 		{
 			name:          "bad/invalid event type",
@@ -93,11 +94,11 @@ func TestParsePayload(t *testing.T) {
 			targetPipelinerun: "dummy",
 		},
 		{
-			name:              "good/comment cancel a pr",
-			eventType:         "pr:comment:added",
-			payloadEvent:      bbv1test.MakePREvent(ev1, "/cancel dummy"),
-			expEvent:          ev1,
-			targetPipelinerun: "dummy",
+			name:                    "good/comment cancel a pr",
+			eventType:               "pr:comment:added",
+			payloadEvent:            bbv1test.MakePREvent(ev1, "/cancel dummy"),
+			expEvent:                ev1,
+			canceltargetPipelinerun: "dummy",
 		},
 		{
 			name:         "good/comment cancel all",
@@ -140,6 +141,9 @@ func TestParsePayload(t *testing.T) {
 
 			if tt.targetPipelinerun != "" {
 				assert.Equal(t, got.TargetTestPipelineRun, tt.targetPipelinerun)
+			}
+			if tt.canceltargetPipelinerun != "" {
+				assert.Equal(t, got.TargetCancelPipelineRun, tt.canceltargetPipelinerun)
 			}
 		})
 	}

--- a/pkg/provider/gitea/detect.go
+++ b/pkg/provider/gitea/detect.go
@@ -23,7 +23,7 @@ func (v *Provider) Detect(req *http.Request, payload string, logger *zap.Sugared
 	setLoggerAndProceed := func(processEvent bool, reason string, err error) (bool, bool, *zap.SugaredLogger,
 		string, error,
 	) {
-		logger = logger.With("provider", "gitea", "event-id", req.Header.Get("X-Request-Id"))
+		logger = logger.With("provider", "gitea", "event-id", req.Header.Get("X-Gitea-Delivery"))
 		return isGitea, processEvent, logger, reason, err
 	}
 

--- a/pkg/provider/gitea/detect.go
+++ b/pkg/provider/gitea/detect.go
@@ -44,6 +44,9 @@ func (v *Provider) Detect(req *http.Request, payload string, logger *zap.Sugared
 			if provider.IsOkToTestComment(gitEvent.Comment.Body) {
 				return setLoggerAndProceed(true, "", nil)
 			}
+			if provider.IsCancelComment(gitEvent.Comment.Body) {
+				return setLoggerAndProceed(true, "", nil)
+			}
 			return setLoggerAndProceed(false, "", nil)
 		}
 		return setLoggerAndProceed(false, "not a issue comment we care about", nil)

--- a/pkg/provider/gitea/detect_test.go
+++ b/pkg/provider/gitea/detect_test.go
@@ -162,6 +162,32 @@ func TestProviderDetect(t *testing.T) {
 			},
 			wantErrSubstr: "unexpected event type",
 		},
+		{
+			name: "good/cancel comment",
+			args: args{
+				req: &http.Request{
+					Header: http.Header{
+						"X-Gitea-Event-Type": []string{"issue_comment"},
+					},
+				},
+				payload: `{"action": "created", "comment":{"body": "/cancel"}, "issue":{"pull_request": {"merged": false}, "state": "open"}}`,
+			},
+			isGitea:      true,
+			processEvent: true,
+		},
+		{
+			name: "good/cancel comment single pr",
+			args: args{
+				req: &http.Request{
+					Header: http.Header{
+						"X-Gitea-Event-Type": []string{"issue_comment"},
+					},
+				},
+				payload: `{"action": "created", "comment":{"body": "/cancel pr"}, "issue":{"pull_request": {"merged": false}, "state": "open"}}`,
+			},
+			isGitea:      true,
+			processEvent: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/provider/gitea/parse_payload.go
+++ b/pkg/provider/gitea/parse_payload.go
@@ -81,6 +81,10 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 		if provider.IsTestRetestComment(gitEvent.Comment.Body) {
 			processedEvent.TargetTestPipelineRun = provider.GetPipelineRunFromTestComment(gitEvent.Comment.Body)
 		}
+		if provider.IsCancelComment(gitEvent.Comment.Body) {
+			processedEvent.CancelPipelineRuns = true
+			processedEvent.TargetCancelPipelineRun = provider.GetPipelineRunFromCancelComment(gitEvent.Comment.Body)
+		}
 		processedEvent.PullRequestNumber, err = convertPullRequestURLtoNumber(gitEvent.Issue.URL)
 		if err != nil {
 			return nil, err

--- a/pkg/provider/gitea/parse_payload.go
+++ b/pkg/provider/gitea/parse_payload.go
@@ -79,7 +79,7 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 		processedEvent.EventType = "pull_request"
 
 		if provider.IsTestRetestComment(gitEvent.Comment.Body) {
-			processedEvent.TargetTestPipelineRun = provider.GetPipelineRunFromComment(gitEvent.Comment.Body)
+			processedEvent.TargetTestPipelineRun = provider.GetPipelineRunFromTestComment(gitEvent.Comment.Body)
 		}
 		processedEvent.PullRequestNumber, err = convertPullRequestURLtoNumber(gitEvent.Issue.URL)
 		if err != nil {

--- a/pkg/provider/github/detect.go
+++ b/pkg/provider/github/detect.go
@@ -57,6 +57,9 @@ func (v *Provider) Detect(req *http.Request, payload string, logger *zap.Sugared
 			if provider.IsOkToTestComment(gitEvent.GetComment().GetBody()) {
 				return setLoggerAndProceed(true, "", nil)
 			}
+			if provider.IsCancelComment(gitEvent.GetComment().GetBody()) {
+				return setLoggerAndProceed(true, "", nil)
+			}
 			return setLoggerAndProceed(false, "", nil)
 		}
 		return setLoggerAndProceed(false, "issue: not a gitops pull request comment", nil)

--- a/pkg/provider/github/detect_test.go
+++ b/pkg/provider/github/detect_test.go
@@ -195,6 +195,44 @@ func TestProvider_Detect(t *testing.T) {
 			isGH:       true,
 			processReq: false,
 		},
+		{
+			name: "issue comment event with cancel comment",
+			event: github.IssueCommentEvent{
+				Action: github.String("created"),
+				Issue: &github.Issue{
+					PullRequestLinks: &github.PullRequestLinks{
+						URL: github.String("url"),
+					},
+					State: github.String("open"),
+				},
+				Installation: &github.Installation{
+					ID: github.Int64(123),
+				},
+				Comment: &github.IssueComment{Body: github.String("/cancel")},
+			},
+			eventType:  "issue_comment",
+			isGH:       true,
+			processReq: true,
+		},
+		{
+			name: "issue comment Event with retest",
+			event: github.IssueCommentEvent{
+				Action: github.String("created"),
+				Issue: &github.Issue{
+					PullRequestLinks: &github.PullRequestLinks{
+						URL: github.String("url"),
+					},
+					State: github.String("open"),
+				},
+				Installation: &github.Installation{
+					ID: github.Int64(123),
+				},
+				Comment: &github.IssueComment{Body: github.String("/cancel dummy")},
+			},
+			eventType:  "issue_comment",
+			isGH:       true,
+			processReq: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/provider/github/parse_payload.go
+++ b/pkg/provider/github/parse_payload.go
@@ -251,7 +251,7 @@ func (v *Provider) handleIssueCommentEvent(ctx context.Context, event *github.Is
 
 	// if it is a /test or /retest comment with pipelinerun name figure out the pipelinerun name
 	if provider.IsTestRetestComment(event.GetComment().GetBody()) {
-		runevent.TargetTestPipelineRun = provider.GetPipelineRunFromComment(event.GetComment().GetBody())
+		runevent.TargetTestPipelineRun = provider.GetPipelineRunFromTestComment(event.GetComment().GetBody())
 	}
 
 	// We are getting the full URL so we have to get the last part to get the PR number,

--- a/pkg/provider/github/parse_payload.go
+++ b/pkg/provider/github/parse_payload.go
@@ -253,7 +253,10 @@ func (v *Provider) handleIssueCommentEvent(ctx context.Context, event *github.Is
 	if provider.IsTestRetestComment(event.GetComment().GetBody()) {
 		runevent.TargetTestPipelineRun = provider.GetPipelineRunFromTestComment(event.GetComment().GetBody())
 	}
-
+	if provider.IsCancelComment(event.GetComment().GetBody()) {
+		runevent.CancelPipelineRuns = true
+		runevent.TargetTestPipelineRun = provider.GetPipelineRunFromCancelComment(event.GetComment().GetBody())
+	}
 	// We are getting the full URL so we have to get the last part to get the PR number,
 	// we don't have to care about URL query string/hash and other stuff because
 	// that comes up from the API.

--- a/pkg/provider/github/parse_payload_test.go
+++ b/pkg/provider/github/parse_payload_test.go
@@ -258,6 +258,45 @@ func TestParsePayLoad(t *testing.T) {
 			shaRet:            "samplePRsha",
 			targetPipelinerun: "dummy",
 		},
+		{
+			name:          "good/issue comment for cancel all",
+			eventType:     "issue_comment",
+			triggerTarget: "pull_request",
+			githubClient:  fakeclient,
+			payloadEventStruct: github.IssueCommentEvent{
+				Issue: &github.Issue{
+					PullRequestLinks: &github.PullRequestLinks{
+						HTMLURL: github.String("/999"),
+					},
+				},
+				Repo: sampleRepo,
+				Comment: &github.IssueComment{
+					Body: github.String("/cancel"),
+				},
+			},
+			muxReplies: map[string]interface{}{"/repos/owner/reponame/pulls/999": samplePR},
+			shaRet:     "samplePRsha",
+		},
+		{
+			name:          "good/issue comment for cancel a pr",
+			eventType:     "issue_comment",
+			triggerTarget: "pull_request",
+			githubClient:  fakeclient,
+			payloadEventStruct: github.IssueCommentEvent{
+				Issue: &github.Issue{
+					PullRequestLinks: &github.PullRequestLinks{
+						HTMLURL: github.String("/888"),
+					},
+				},
+				Repo: sampleRepo,
+				Comment: &github.IssueComment{
+					Body: github.String("/cancel dummy"),
+				},
+			},
+			muxReplies:        map[string]interface{}{"/repos/owner/reponame/pulls/888": samplePR},
+			shaRet:            "samplePRsha",
+			targetPipelinerun: "dummy",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/provider/github/parse_payload_test.go
+++ b/pkg/provider/github/parse_payload_test.go
@@ -79,16 +79,17 @@ func TestParsePayLoad(t *testing.T) {
 	defer teardown()
 
 	tests := []struct {
-		name               string
-		wantErrString      string
-		eventType          string
-		payloadEventStruct interface{}
-		jeez               string
-		triggerTarget      string
-		githubClient       *github.Client
-		muxReplies         map[string]interface{}
-		shaRet             string
-		targetPipelinerun  string
+		name                    string
+		wantErrString           string
+		eventType               string
+		payloadEventStruct      interface{}
+		jeez                    string
+		triggerTarget           string
+		githubClient            *github.Client
+		muxReplies              map[string]interface{}
+		shaRet                  string
+		targetPipelinerun       string
+		targetCancelPipelinerun string
 	}{
 		{
 			name:          "bad/unknow event",
@@ -293,9 +294,9 @@ func TestParsePayLoad(t *testing.T) {
 					Body: github.String("/cancel dummy"),
 				},
 			},
-			muxReplies:        map[string]interface{}{"/repos/owner/reponame/pulls/888": samplePR},
-			shaRet:            "samplePRsha",
-			targetPipelinerun: "dummy",
+			muxReplies:              map[string]interface{}{"/repos/owner/reponame/pulls/888": samplePR},
+			shaRet:                  "samplePRsha",
+			targetCancelPipelinerun: "dummy",
 		},
 	}
 	for _, tt := range tests {
@@ -334,6 +335,9 @@ func TestParsePayLoad(t *testing.T) {
 			assert.Equal(t, tt.shaRet, ret.SHA)
 			if tt.targetPipelinerun != "" {
 				assert.Equal(t, tt.targetPipelinerun, ret.TargetTestPipelineRun)
+			}
+			if tt.targetCancelPipelinerun != "" {
+				assert.Equal(t, tt.targetCancelPipelinerun, ret.TargetCancelPipelineRun)
 			}
 		})
 	}

--- a/pkg/provider/gitlab/detect.go
+++ b/pkg/provider/gitlab/detect.go
@@ -52,6 +52,9 @@ func (v *Provider) Detect(req *http.Request, payload string, logger *zap.Sugared
 			if provider.IsOkToTestComment(gitEvent.ObjectAttributes.Note) {
 				return setLoggerAndProceed(true, "", nil)
 			}
+			if provider.IsCancelComment(gitEvent.ObjectAttributes.Note) {
+				return setLoggerAndProceed(true, "", nil)
+			}
 		}
 		return setLoggerAndProceed(false, "not a gitops style merge comment event", nil)
 	default:

--- a/pkg/provider/gitlab/detect_test.go
+++ b/pkg/provider/gitlab/detect_test.go
@@ -84,6 +84,20 @@ func TestProvider_Detect(t *testing.T) {
 			processReq: true,
 		},
 		{
+			name:       "issue comment Event with cancel",
+			event:      sample.NoteEventAsJSON("/cancel"),
+			eventType:  gitlab.EventTypeNote,
+			isGL:       true,
+			processReq: true,
+		},
+		{
+			name:       "issue comment Event with cancel a pr",
+			event:      sample.NoteEventAsJSON("/cancel dummy"),
+			eventType:  gitlab.EventTypeNote,
+			isGL:       true,
+			processReq: true,
+		},
+		{
 			name:       "push event",
 			event:      sample.PushEventAsJSON(true),
 			eventType:  gitlab.EventTypePush,

--- a/pkg/provider/gitlab/parse_payload.go
+++ b/pkg/provider/gitlab/parse_payload.go
@@ -91,7 +91,7 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 			processedEvent.TargetTestPipelineRun = provider.GetPipelineRunFromTestComment(gitEvent.ObjectAttributes.Note)
 		}
 		if provider.IsCancelComment(gitEvent.ObjectAttributes.Note) {
-			processedEvent.TargetTestPipelineRun = provider.GetPipelineRunFromCancelComment(gitEvent.ObjectAttributes.Note)
+			processedEvent.TargetCancelPipelineRun = provider.GetPipelineRunFromCancelComment(gitEvent.ObjectAttributes.Note)
 		}
 
 		v.pathWithNamespace = gitEvent.Project.PathWithNamespace

--- a/pkg/provider/gitlab/parse_payload.go
+++ b/pkg/provider/gitlab/parse_payload.go
@@ -88,7 +88,10 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 		processedEvent.HeadBranch = gitEvent.MergeRequest.SourceBranch
 		// if it is a /test or /retest comment with pipelinerun name figure out the pipelineRun name
 		if provider.IsTestRetestComment(gitEvent.ObjectAttributes.Note) {
-			processedEvent.TargetTestPipelineRun = provider.GetPipelineRunFromComment(gitEvent.ObjectAttributes.Note)
+			processedEvent.TargetTestPipelineRun = provider.GetPipelineRunFromTestComment(gitEvent.ObjectAttributes.Note)
+		}
+		if provider.IsCancelComment(gitEvent.ObjectAttributes.Note) {
+			processedEvent.TargetTestPipelineRun = provider.GetPipelineRunFromCancelComment(gitEvent.ObjectAttributes.Note)
 		}
 
 		v.pathWithNamespace = gitEvent.Project.PathWithNamespace

--- a/pkg/provider/gitlab/parse_payload_test.go
+++ b/pkg/provider/gitlab/parse_payload_test.go
@@ -123,6 +123,33 @@ func TestParsePayload(t *testing.T) {
 				State:         info.State{TargetTestPipelineRun: "dummy"},
 			},
 		},
+		{
+			name: "note event cancel all",
+			args: args{
+				event:   gitlab.EventTypeNote,
+				payload: sample.NoteEventAsJSON("/cancel"),
+			},
+			want: &info.Event{
+				EventType:     "Note",
+				TriggerTarget: "pull_request",
+				Organization:  "hello-this-is-me-ze",
+				Repository:    "project",
+			},
+		},
+		{
+			name: "note event cancel a pr",
+			args: args{
+				event:   gitlab.EventTypeNote,
+				payload: sample.NoteEventAsJSON("/cancel dummy"),
+			},
+			want: &info.Event{
+				EventType:     "Note",
+				TriggerTarget: "pull_request",
+				Organization:  "hello-this-is-me-ze",
+				Repository:    "project",
+				State:         info.State{TargetTestPipelineRun: "dummy"},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/provider/gitlab/parse_payload_test.go
+++ b/pkg/provider/gitlab/parse_payload_test.go
@@ -147,7 +147,7 @@ func TestParsePayload(t *testing.T) {
 				TriggerTarget: "pull_request",
 				Organization:  "hello-this-is-me-ze",
 				Repository:    "project",
-				State:         info.State{TargetTestPipelineRun: "dummy"},
+				State:         info.State{TargetCancelPipelineRun: "dummy"},
 			},
 		},
 	}
@@ -184,6 +184,9 @@ func TestParsePayload(t *testing.T) {
 				assert.Equal(t, tt.want.Repository, got.Repository)
 				if tt.want.TargetTestPipelineRun != "" {
 					assert.Equal(t, tt.want.TargetTestPipelineRun, got.TargetTestPipelineRun)
+				}
+				if tt.want.TargetCancelPipelineRun != "" {
+					assert.Equal(t, tt.want.TargetCancelPipelineRun, got.TargetCancelPipelineRun)
 				}
 			}
 		})

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -10,12 +10,18 @@ var (
 	testRetestAllRegex    = regexp.MustCompile(`(?m)^(/retest|/test)\s*$`)
 	testRetestSingleRegex = regexp.MustCompile(`(?m)^(/test|/retest)[ \t]+\S+`)
 	oktotestRegex         = regexp.MustCompile(`(?m)^/ok-to-test\s*$`)
+	cancelAllRegex        = regexp.MustCompile(`(?m)^(/cancel)\s*$`)
+	cancelSingleRegex     = regexp.MustCompile(`(?m)^(/cancel)[ \t]+\S+`)
 )
 
 const (
-	ProviderGitHubApp     = "GitHubApp"
-	ProviderGitHubWebhook = "GitHubWebhook"
-	ProviderGitLabWebhook = "GitLabWebhook"
+	testComment   = "/test"
+	retestComment = "/retest"
+	cancelComment = "/cancel"
+)
+
+const (
+	ProviderGitHubApp = "GitHubApp"
 )
 
 func Valid(value string, validValues []string) bool {
@@ -35,13 +41,23 @@ func IsOkToTestComment(comment string) bool {
 	return oktotestRegex.MatchString(comment)
 }
 
-func GetPipelineRunFromComment(comment string) string {
-	var splitTest []string
-	if strings.Contains(comment, "/test") {
-		splitTest = strings.Split(comment, "/test")
-	} else {
-		splitTest = strings.Split(comment, "/retest")
+func IsCancelComment(comment string) bool {
+	return cancelAllRegex.MatchString(comment) || cancelSingleRegex.MatchString(comment)
+}
+
+func GetPipelineRunFromTestComment(comment string) string {
+	if strings.Contains(comment, testComment) {
+		return getNameFromComment(testComment, comment)
 	}
+	return getNameFromComment(retestComment, comment)
+}
+
+func GetPipelineRunFromCancelComment(comment string) string {
+	return getNameFromComment(cancelComment, comment)
+}
+
+func getNameFromComment(typeOfComment, comment string) string {
+	splitTest := strings.Split(comment, typeOfComment)
 	// now get the first line
 	getFirstLine := strings.Split(splitTest[1], "\n")
 	// trim spaces

--- a/pkg/reconciler/event.go
+++ b/pkg/reconciler/event.go
@@ -70,7 +70,7 @@ func buildEventFromPipelineRun(pr *v1beta1.PipelineRun) *info.Event {
 	event.SHATitle = prAnno[keys.ShaTitle]
 	event.SHAURL = prAnno[keys.ShaURL]
 
-	prNumber := prAnno[keys.PullRequest]
+	prNumber := prLabels[keys.PullRequest]
 	if prNumber != "" {
 		event.PullRequestNumber, _ = strconv.Atoi(prNumber)
 	}

--- a/pkg/reconciler/event_test.go
+++ b/pkg/reconciler/event_test.go
@@ -46,11 +46,11 @@ func TestBuildEventFromPipelineRun(t *testing.T) {
 						keys.EventType:     "push",
 						keys.Branch:        "branch",
 						keys.State:         kubeinteraction.StateStarted,
+						keys.PullRequest:   "1234",
 					},
 					Annotations: map[string]string{
-						keys.ShaTitle:    "sha-title",
-						keys.ShaURL:      "sha-url",
-						keys.PullRequest: "1234",
+						keys.ShaTitle: "sha-title",
+						keys.ShaURL:   "sha-url",
 
 						// github
 						keys.InstallationID: "12345678",

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -58,7 +58,9 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, pr *v1beta1.PipelineRun)
 		}
 	}
 
-	if state == kubeinteraction.StateQueued {
+	// queue pipelines which are in queued state and pending status
+	// if status is not pending, it could be canceled so let it be reported, even if state is queued
+	if state == kubeinteraction.StateQueued && pr.Spec.Status == v1beta1.PipelineRunSpecStatusPending {
 		return r.queuePipelineRun(ctx, logger, pr)
 	}
 


### PR DESCRIPTION
## Cancelling the PipelineRun

You can cancel a running PipelineRun by commenting on the PullRequest.

For example. you want to cancel all your pipeline you can add a comment starting
with `/cancel` and all PipelineRun attached to that pull or merge request will be cancelled.

Example :

```text
It seems the infra is down, so cancelling the pipelineruns.

/cancel
```

If you have multiple `PipelineRun` and you want to target a specific
`PipelineRun` you can use the `/cancel` comment with the PipelineRun name

Example:

```text
roses are red, violets are blue. why to run the pipeline when the infra is down.

/cancel <pipelinerun-name>
```

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
