### PR TITLE
Update commands of create repo, webhook add and generate

### DIFF
--- a/docs/content/docs/install/bitbucket_cloud.md
+++ b/docs/content/docs/install/bitbucket_cloud.md
@@ -54,7 +54,6 @@ $ tkn pac create repo
 ! Namespace repo-pipelines is not found
 ? Would you like me to create the namespace repo-pipelines? Yes
 ✓ Repository workspace-repo has been created in repo-pipelines namespace
-? Please enter the provider name to setup the webhook: bitbucket-cloud
 ✓ Setting up Bitbucket Webhook for Repository https://bitbucket.org/workspace/repo
 ? Please enter your bitbucket cloud username:  <username>
 ℹ ️You now need to create a Bitbucket Cloud app password, please checkout the docs at https://is.gd/fqMHiJ for the required permissions
@@ -67,6 +66,7 @@ $ tkn pac create repo
 ℹ Directory .tekton has been created.
 ✓ A basic template has been created in /home/Go/src/bitbucket/repo/.tekton/pipelinerun.yaml, feel free to customize it.
 ℹ You can test your pipeline manually with: tkn-pac resolve -f .tekton/pipelinerun.yaml | kubectl create -f-
+ℹ You can test your pipeline by pushing generated template to your git repository
 
 ```
 
@@ -170,7 +170,6 @@ Below is the sample format for `tkn pac webhook add`
 ```shell script
 $ tkn pac webhook add -n repo-pipelines
 
-? Please enter the provider name to setup the webhook: bitbucket-cloud
 ✓ Setting up Bitbucket Webhook for Repository https://bitbucket.org/workspace/repo
 ? Please enter your bitbucket cloud username:  <username>
 👀 I have detected a controller url: https://pipelines-as-code-controller-openshift-pipelines.apps.awscl2.aws.ospqa.com

--- a/docs/content/docs/install/github_webhook.md
+++ b/docs/content/docs/install/github_webhook.md
@@ -62,7 +62,6 @@ $ tkn pac create repo
 ! Namespace repo-pipelines is not found
 ? Would you like me to create the namespace repo-pipelines? Yes
 ✓ Repository owner-repo has been created in repo-pipelines namespace
-? Please enter the provider name to setup the webhook: github
 ✓ Setting up GitHub Webhook for Repository https://github.com/owner/repo
 👀 I have detected a controller url: https://pipelines-as-code-controller-openshift-pipelines.apps.awscl2.aws.ospqa.com
 ? Do you want me to use it? Yes
@@ -76,6 +75,7 @@ $ tkn pac create repo
 ✓ We have detected your repository using the programming language Go.
 ✓ A basic template has been created in /home/Go/src/github.com/owner/repo/.tekton/pipelinerun.yaml, feel free to customize it.
 ℹ You can test your pipeline manually with: tkn-pac resolve -f .tekton/pipelinerun.yaml | kubectl create -f-
+ℹ You can test your pipeline by pushing generated template to your git repository
 
 ```
 
@@ -159,7 +159,6 @@ Below is the sample format for `tkn pac webhook add`
 ```shell script
 $ tkn pac webhook add -n repo-pipelines
 
-? Please enter the provider name to setup the webhook: github
 ✓ Setting up GitHub Webhook for Repository https://github.com/owner/repo
 👀 I have detected a controller url: https://pipelines-as-code-controller-openshift-pipelines.apps.awscl2.aws.ospqa.com
 ? Do you want me to use it? Yes

--- a/docs/content/docs/install/gitlab.md
+++ b/docs/content/docs/install/gitlab.md
@@ -38,20 +38,19 @@ Below is the sample format for `tkn pac create repo`
 ```shell script
 $ tkn pac create repo
 
-? Enter the Git repository url (default: https://gitlab.com/repositories/project):  
-? Please enter the namespace where the pipeline should run (default: project-pipelines): 
+? Enter the Git repository url (default: https://gitlab.com/repositories/project):
+? Please enter the namespace where the pipeline should run (default: project-pipelines):
 ! Namespace project-pipelines is not found
 ? Would you like me to create the namespace project-pipelines? Yes
 ✓ Repository repositories-project has been created in project-pipelines namespace
-? Please enter the provider name to setup the webhook: gitlab
 ✓ Setting up GitLab Webhook for Repository https://gitlab.com/repositories/project
-? Please enter the project ID for the repository you want to be configured, 
+? Please enter the project ID for the repository you want to be configured,
   project ID refers to an unique ID (e.g. 34405323) shown at the top of your GitLab project : 17103
 👀 I have detected a controller url: https://pipelines-as-code-controller-openshift-pipelines.apps.awscl2.aws.ospqa.com
 ? Do you want me to use it? Yes
-? Please enter the secret to configure the webhook for payload validation (default: ISpmebVvMMIS):  ISpmebVvMMIS
+? Please enter the secret to configure the webhook for payload validation (default: lFjHIEcaGFlF):  lFjHIEcaGFlF
 ℹ ️You now need to create a GitLab personal access token with `api` scope
-ℹ ️Go to this URL to generate one https://gitlab.com/-/profile/personal_access_tokens, see https://is.gd/rOEo9B for documentation 
+ℹ ️Go to this URL to generate one https://gitlab.com/-/profile/personal_access_tokens, see https://is.gd/rOEo9B for documentation
 ? Please enter the GitLab access token:  **************************
 ? Please enter your GitLab API URL::  https://gitlab.com
 ✓ Webhook has been created on your repository
@@ -60,6 +59,7 @@ $ tkn pac create repo
 ℹ Directory .tekton has been created.
 ✓ A basic template has been created in /home/Go/src/gitlab.com/repositories/project/.tekton/pipelinerun.yaml, feel free to customize it.
 ℹ You can test your pipeline manually with: tkn-pac resolve -f .tekton/pipelinerun.yaml | kubectl create -f-
+ℹ You can test your pipeline by pushing generated template to your git repository
 ```
 
 ### Create a `Repository` and configure webhook manually
@@ -149,7 +149,6 @@ Below is the sample format for `tkn pac webhook add`
 ```shell script
 $ tkn pac webhook add -n project-pipelines
 
-? Please enter the provider name to setup the webhook: gitlab
 ✓ Setting up GitLab Webhook for Repository https://gitlab.com/repositories/project
 ? Please enter the project ID for the repository you want to be configured, 
   project ID refers to an unique ID (e.g. 34405323) shown at the top of your GitLab project : 17103

--- a/pkg/cmd/tknpac/create/repository.go
+++ b/pkg/cmd/tknpac/create/repository.go
@@ -88,32 +88,14 @@ func repositoryCommand(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command
 
 			if pacCMInfo.Provider == provider.ProviderGitHubApp {
 				if strings.Contains(createOpts.Event.URL, "github") {
-					msg := "👌 A GitHub App is configured for your cluster, Would you like to setup webhook for your repository?"
-					var setupWebhook bool
-					if err := prompt.SurveyAskOne(&survey.Confirm{Message: msg, Default: false}, &setupWebhook); err != nil {
+					if err := createOpts.generateTemplate(nil); err != nil {
 						return err
 					}
-					if !setupWebhook {
-						fmt.Fprintln(ioStreams.Out, "✓ Skipped webhook setup")
-						if err := createOpts.generateTemplate(nil); err != nil {
-							return err
-						}
-						return nil
-					}
+					return nil
 				}
 			}
 
-			msg := "Please enter the provider name to setup the webhook:"
-			providerLabels := make([]string, 0, len(webhook.ProviderTypes))
-			for _, label := range webhook.ProviderTypes {
-				providerLabels = append(providerLabels, label)
-			}
-			if err := prompt.SurveyAskOne(
-				&survey.Select{
-					Message: msg,
-					Options: providerLabels,
-					Default: 0,
-				}, &providerName); err != nil {
+			if providerName, err = webhook.GetProviderName(createOpts.Event.URL); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/tknpac/generate/generate.go
+++ b/pkg/cmd/tknpac/generate/generate.go
@@ -246,6 +246,7 @@ func (o *Opts) samplePipeline(recreateTemplate bool) error {
 	)
 	fmt.Fprintf(o.IOStreams.Out, "%s You can test your pipeline manually with: ", cs.InfoIcon())
 	fmt.Fprintf(o.IOStreams.Out, "tkn-pac resolve -f %s | kubectl create -f-\n", relpath)
+	fmt.Fprintf(o.IOStreams.Out, "%s You can test your pipeline by pushing generated template to your git repository\n", cs.InfoIcon())
 
 	return nil
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Updated 
1. tkn-pac create repo
2. tkn-pac webhook add
3. tkn-pac generate

**Scenarios:**
1. Add webhook when **GithubApp is configured**
- tkn-pac create repo won't add **Github** webhook when GithubApp is configured
- tkn-pac create repo add **Gitlab** webhook when GithubApp is configured
- tkn-pac create repo add **Bitbucket Cloud** webhook when GithubApp is configured

2. Add webhook when **GithubApp is not configured**
- tkn-pac create repo add **Github** webhook successfully and detect provider by command itself
- tkn-pac create repo add **Gitlab** webhook successfully and configured and detect provider by command itself
- tkn-pac create repo add **Bitbucket Cloud** webhook successfully and configured and detect provider by command itself

3. tkn-pac webhook add
- Add webhook to existing repository
- Re-add a webhook to existing repo because the webhook was deleted on the Git provider


Added more details in [hackmd.io@savita](https://hackmd.io/0pxZ1HP8SmObPrenl-611A)  and [google doc](https://docs.google.com/document/d/1Na0bNvGlBzqt9RJU00u6l2orMxbEsn5wERvADJb7PAA/edit)
with command output
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
