### PR TITLE
Fix: watcher was breaking when taskref was used in pipelinerun

### DIFF
--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -21,6 +21,9 @@ func GetSecretsAttachedToPipelineRun(ctx context.Context, k kubeinteraction.Inte
 	}
 
 	for _, pt := range append(pr.Spec.PipelineSpec.Finally, pr.Spec.PipelineSpec.Tasks...) {
+		if pt.TaskSpec == nil || pt.TaskSpec.Steps == nil {
+			continue
+		}
 		for _, step := range pt.TaskSpec.Steps {
 			for _, ev := range step.Env {
 				if ev.ValueFrom == nil {

--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -27,6 +27,12 @@ func TestGetSecretsAttachedToPipelineRun(t *testing.T) {
 							},
 						},
 					},
+					{
+						TaskRef: &tektonv1beta1.TaskRef{
+							Name: "git-clone",
+							Kind: "ClusterTask",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
in case when in the pipelinerun, task was referred using taskref instead of taskspec, watcher was breaking as we were trying to access `for _, step := range pt.TaskSpec.Steps`
which was nil. this fixes it.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
