### PR TITLE
add more gitea  workaround and reenable e2e tests

### DIFF
--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -118,7 +118,7 @@ func (p *PacRun) startPR(ctx context.Context, match matcher.Match) error {
 	consoleURL := p.run.Clients.ConsoleUI.DetailURL(match.Repo.GetNamespace(), pr.GetName())
 	// Create status with the log url
 	msg := fmt.Sprintf(params.StartingPipelineRunText, pr.GetName(), match.Repo.GetNamespace(), consoleURL,
-		match.Repo.GetNamespace(), pr.GetName())
+		match.Repo.GetNamespace(), match.Repo.GetName())
 	status := provider.StatusOpts{
 		Status:                  "in_progress",
 		Conclusion:              "pending",

--- a/pkg/provider/gitea/gitea.go
+++ b/pkg/provider/gitea/gitea.go
@@ -150,9 +150,9 @@ func (v *Provider) createStatusCommit(event *info.Event, pacopts *info.PacOpts, 
 	}
 
 	if status.Text != "" && event.EventType == "pull_request" {
-		// insane? yes, but gitea has some issues and need some random number
-		// to update the comment or we get a 422, may need to be removed
-		status.Text = fmt.Sprintf(status.Text, "\n", " \n ")
+		// insanity!! I am not even sure how to explain it but try to remove
+		// this and you get a failure when posting the text.
+		status.Text = strings.ReplaceAll(status.Text, "\n", "<br>")
 		_, _, err := v.Client.CreateIssueComment(event.Organization, event.Repository,
 			int64(event.PullRequestNumber), gitea.CreateIssueCommentOption{
 				Body: fmt.Sprintf("%s\n%s", status.Summary, status.Text),

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -234,7 +234,7 @@ func (r *Reconciler) updatePipelineRunToInProgress(ctx context.Context, logger *
 	consoleURL := r.run.Clients.ConsoleUI.DetailURL(repo.GetNamespace(), pr.GetName())
 	// Create status with the log url
 	msg := fmt.Sprintf(params.StartingPipelineRunText, pr.GetName(), repo.GetNamespace(), consoleURL,
-		repo.GetNamespace(), pr.GetName())
+		repo.GetNamespace(), repo.GetName())
 	status := provider.StatusOpts{
 		Status:                  "in_progress",
 		Conclusion:              "pending",

--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -139,7 +139,6 @@ func TestGiteaConcurrencyExclusivenessMultiplePipelines(t *testing.T) {
 
 // multiple push to the same  repo, concurrency should q them
 func TestGiteaConcurrencyExclusivenessMultipleRuns(t *testing.T) {
-	t.SkipNow()
 	numPipelines := 1
 	topts := &tgitea.TestOpts{
 		TargetEvent:          options.PullRequestEvent,
@@ -242,7 +241,6 @@ func TestGiteaACLOrgAllowed(t *testing.T) {
 }
 
 func TestGiteaACLOrgSkipped(t *testing.T) {
-	t.SkipNow()
 	topts := &tgitea.TestOpts{
 		TargetEvent: options.PullRequestEvent,
 		YAMLFiles: map[string]string{
@@ -258,12 +256,11 @@ func TestGiteaACLOrgSkipped(t *testing.T) {
 	topts.PullRequest = tgitea.CreateForkPullRequest(t, topts, secondcnx, "", "echo Hello from user "+topts.TargetRefName)
 	topts.CheckForStatus = "success"
 	tgitea.WaitForStatus(t, topts, topts.PullRequest.Head.Sha)
-	topts.Regexp = regexp.MustCompile(`.*is skipping this commit.*is not allowed.*`)
+	topts.Regexp = regexp.MustCompile(`.*is skipping this commit.*`)
 	tgitea.WaitForPullRequestCommentMatch(context.Background(), t, topts)
 }
 
 func TestGiteaACLCommentsAllowing(t *testing.T) {
-	t.SkipNow()
 	tests := []struct {
 		name, comment string
 	}{
@@ -297,7 +294,7 @@ func TestGiteaACLCommentsAllowing(t *testing.T) {
 			topts.PullRequest = tgitea.CreateForkPullRequest(t, topts, secondcnx, "", "echo Hello from user "+topts.TargetRefName)
 			topts.CheckForStatus = "success"
 			tgitea.WaitForStatus(t, topts, topts.PullRequest.Head.Sha)
-			topts.Regexp = regexp.MustCompile(`.*is skipping this commit.*is not allowed.*`)
+			topts.Regexp = regexp.MustCompile(`.*is skipping this commit.*`)
 			tgitea.WaitForPullRequestCommentMatch(context.Background(), t, topts)
 
 			tgitea.PostCommentOnPullRequest(t, topts, tt.comment)
@@ -370,8 +367,8 @@ func TestGiteaPush(t *testing.T) {
 }
 
 func TestGiteaClusterTasks(t *testing.T) {
-	// we need to make sure to create clustertask before pushing the files
-	// so we have to create a new client and do a lot of manual things we get for free in TestPR
+	// we need to verify sure to create clustertask before pushing the files
+	// so we have to create a new client and do more manual things we get for free in TestPR
 	topts := &tgitea.TestOpts{
 		TargetEvent: "pull_request, push",
 		YAMLFiles: map[string]string{
@@ -409,7 +406,7 @@ func TestGiteaClusterTasks(t *testing.T) {
 		RepoName:  topts.TargetNS,
 		Namespace: topts.TargetNS,
 		// 0 means 1 🙃 (we test for >, while we actually should do >=, but i
-		// need to go all over the code to make sure it's not going to break
+		// need to go all over the code to verify it's not going to break
 		// anything else)
 		MinNumberStatus: 0,
 		PollTimeout:     twait.DefaultTimeout,


### PR DESCRIPTION
# Changes

renable e2e tests and fix the acl** check test with latest gitea API
fixes statusString showing pr instead of the repoName

Fixes #1026

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
