### PR TITLE
Fix tkn pac resolve with remote task

### DIFF
--- a/pkg/params/run.go
+++ b/pkg/params/run.go
@@ -57,7 +57,7 @@ func (r *Run) WatchConfigMapChanges(ctx context.Context, run *Run) error {
 }
 
 // getConfigFromConfigMapWatcher get config from configmap, we should remove all the
-// logics from cobra flags and just support configmap config and env config in the future.
+// logics from cobra flags and just support configmap config and environment config in the future.
 func (r *Run) getConfigFromConfigMapWatcher(ctx context.Context, eventChannel <-chan watch.Event) error {
 	for {
 		event, open := <-eventChannel

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -162,8 +162,13 @@ func (v *Provider) checkWebhookSecretValidity(ctx context.Context, cw clockwork.
 	rl, resp, err := v.Client.RateLimits(ctx)
 	// check if resp.TokenExpiration is after now
 	if resp.TokenExpiration.After(cw.Now()) {
-		return fmt.Errorf("token has expired at %s, err: %w", resp.TokenExpiration.Time.Format(time.RFC1123), err)
+		errm := fmt.Sprintf("token has expired at %s", resp.TokenExpiration.Time.Format(time.RFC1123))
+		if err != nil {
+			errm += fmt.Sprintf(" err: %s", err.Error())
+		}
+		return fmt.Errorf(errm)
 	}
+
 	if err != nil {
 		return fmt.Errorf("error using token to access API: %w", err)
 	}

--- a/pkg/resolve/resolve.go
+++ b/pkg/resolve/resolve.go
@@ -198,7 +198,7 @@ func Resolve(ctx context.Context, cs *params.Run, logger *zap.SugaredLogger, pro
 			originPipelinerunName = pipelinerun.ObjectMeta.GenerateName
 		}
 
-		// make sure we keep the originalPipelineRun in a label
+		// keep the originalPipelineRun in a label
 		// because we would need it later on when grouping by cleanups and we
 		// can attach that pr file from .tekton directory.
 

--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -19,8 +19,11 @@ import (
 	tknpacdesc "github.com/openshift-pipelines/pipelines-as-code/pkg/cmd/tknpac/describe"
 	tknpacgenerate "github.com/openshift-pipelines/pipelines-as-code/pkg/cmd/tknpac/generate"
 	tknpaclist "github.com/openshift-pipelines/pipelines-as-code/pkg/cmd/tknpac/list"
+	tknpacresolve "github.com/openshift-pipelines/pipelines-as-code/pkg/cmd/tknpac/resolve"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/git"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
 	tknpactest "github.com/openshift-pipelines/pipelines-as-code/test/pkg/cli"
 	tgitea "github.com/openshift-pipelines/pipelines-as-code/test/pkg/gitea"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
@@ -531,6 +534,10 @@ func TestGiteaWithCLIGeneratePipeline(t *testing.T) {
 				"--branch", topts.DefaultBranch, "--file-name", ".tekton/pr.yaml", "--overwrite")
 			assert.NilError(t, err)
 			assert.Assert(t, regexp.MustCompile(tt.generateOutputRegexp).MatchString(output))
+			topts.Clients.Info.Pac = &info.PacOpts{}
+			topts.Clients.Info.Pac.Settings = &settings.Settings{}
+			_, err = tknpactest.ExecCommand(topts.Clients, tknpacresolve.Command, "-f", ".tekton/pr.yaml", "-p", "revision=main")
+			assert.NilError(t, err)
 
 			// edit .tekton/pr.yaml file
 			pryaml, err := os.ReadFile(filepath.Join(tmpdir, ".tekton/pr.yaml"))


### PR DESCRIPTION
We were not getting the pac settings  properly to get the default hub
catalog name and it would fail.

Don't output log.Info on resolve, maybe we can add a flag in the feature
to enable it.

Plug into the e2e test as well that would detect this kind of defect.

Fixes #1039

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
