### PR TITLE
fix checking token expiration

### DIFF
--- a/hack/dev/ghapp_token.py
+++ b/hack/dev/ghapp_token.py
@@ -82,7 +82,9 @@ class GitHub:
             headers.update({"Authorization": "Bearer " + self.token})
         if not url.startswith("http"):
             url = f"{self.github_api_url}{url}"
-        return requests.request(method, url, headers=headers, data=json.dumps(data))
+        return requests.request(
+            method, url, timeout=300, headers=headers, data=json.dumps(data)
+        )
 
 
 def get_private_key(ns):

--- a/hack/dev/kind/gitea/deploy.py
+++ b/hack/dev/kind/gitea/deploy.py
@@ -71,6 +71,7 @@ class ProvisionGitea:
                 r = requests.get(
                     f"{self.gitea_url}/api/v1/version",
                     verify=not OPENSHIFT_ROUTE_FORCE_HTTP,
+                    timeout=300,
                 )
                 if r.status_code == 200:
                     # wait a bit more that it finishes
@@ -105,6 +106,7 @@ class ProvisionGitea:
             data=data_user,
             headers=self.headers,
             verify=not OPENSHIFT_ROUTE_FORCE_HTTP,
+            timeout=300,
         )
         resp.raise_for_status()
 
@@ -113,6 +115,7 @@ class ProvisionGitea:
         resp = requests.post(
             url=f"{self.gitea_url}/api/v1/user/repos",
             headers=self.headers,
+            timeout=300,
             auth=(GITEA_USER, GITEA_PASSWORD),
             verify=not OPENSHIFT_ROUTE_FORCE_HTTP,
             data=jeez,
@@ -129,6 +132,7 @@ class ProvisionGitea:
             headers=self.headers,
             verify=not OPENSHIFT_ROUTE_FORCE_HTTP,
             auth=(GITEA_USER, GITEA_PASSWORD),
+            timeout=300,
             data=jeez,
         )
         resp.raise_for_status()
@@ -138,6 +142,7 @@ class ProvisionGitea:
             url=f"{self.gitea_url}/api/v1/users/{GITEA_USER}/tokens/{self.token_name}",
             headers=self.headers,
             verify=not OPENSHIFT_ROUTE_FORCE_HTTP,
+            timeout=300,
             auth=(GITEA_USER, GITEA_PASSWORD),
         )
         jeez = """{"name": "%s"}""" % (self.token_name)
@@ -146,6 +151,7 @@ class ProvisionGitea:
             headers=self.headers,
             auth=(GITEA_USER, GITEA_PASSWORD),
             verify=not OPENSHIFT_ROUTE_FORCE_HTTP,
+            timeout=300,
             data=jeez,
         )
         resp.raise_for_status()


### PR DESCRIPTION
We were inverted the logic so that was wrong and would fail.

We would not be able to reproduce it when the header was not set since
the header would not be set by Github on unlimited life token and not set other cases i am not
totally sure about (fine grained token?)

Add more test to handle all use cases

(fix some pylint latest linter warning along the way)

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [x] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [x] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [x] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [x] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
