### PR TITLE
Ask for a token when detecting a git_auth_secret in template for tkn pac resolve

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -53,7 +53,7 @@ linters:
     - goprintffuncname
     - nilerr
     - noctx
-    - nolintlint
+      # - nolintlint (gofumpt conflict with it, create space all the time so :shrug:)
     - prealloc
     - promlinter
     # - rowserrcheck

--- a/docs/content/docs/guide/cli.md
+++ b/docs/content/docs/guide/cli.md
@@ -256,17 +256,20 @@ or [Kubernetes Kind](https://kind.sigs.k8s.io/docs/user/quick-start/) ) you can
 see your run in action without having to generate a new commit.
 
 If you run the command from your source code repository it will try to detect
-the current Git information and resolve the parameters like current revision or
-branch. You can override those params with the `-p` option. For example if you
-want to use a Git branch as revision and another repo name than the current repo
-name you can just use :
+the parameters (like the revision or branch_name) using the information from the
+Git repository.
+
+You can override the parameters with the `-p` flag.
+
+For example if you want to use a Git branch as revision and another repo name
+than the current repo name you can just use :
 
 `tkn pac resolve -f .tekton/pr.yaml -p revision=main -p repo_name=othername`
 
 `-f` can as well accept a directory path rather than just a filename and grab
-every `yaml`/`yml` from the directory.
+every `yaml` or `yml` files from that directory.
 
-You can specify multiple `-f` on the command line.
+Multiple `-f` arguments are accepted to provide multiple files on the command line.
 
 You need to verify that `git-clone` task (if you use it) can access the
 repository to the SHA. Which mean if you test your current source code you need
@@ -274,6 +277,15 @@ to push it first before using `tkn pac resolve|kubectl create -`.
 
 Compared with running directly on CI, you need to explicitly specify the list of
 filenames or directory where you have the templates.
+
+When you run `tkn pac resolve` it will try to detect if you have a `{{ git_auth_secret }}` inside your template and if you have it will ask  and will ask you to provide a Git provider token.
+
+You can explicitely provide on the command line with the `-t` or `--token` flag,
+or you can set the environment variable `PAC_PROVIDER_TOKEN` and it will use it
+instead of asking you.
+
+There is no clean-up of the secret after the run.
+
 {{< /details >}}
 
 {{< details "tkn pac webhook add" >}}

--- a/docs/content/docs/guide/cli.md
+++ b/docs/content/docs/guide/cli.md
@@ -278,11 +278,18 @@ to push it first before using `tkn pac resolve|kubectl create -`.
 Compared with running directly on CI, you need to explicitly specify the list of
 filenames or directory where you have the templates.
 
-When you run `tkn pac resolve` it will try to detect if you have a `{{ git_auth_secret }}` inside your template and if you have it will ask  and will ask you to provide a Git provider token.
+When you run the resolver it will try to detect if you have a `{{
+git_auth_secret }}` string inside your template and if there is a match it will
+ask you to provide a Git provider token.
 
-You can explicitely provide on the command line with the `-t` or `--token` flag,
-or you can set the environment variable `PAC_PROVIDER_TOKEN` and it will use it
-instead of asking you.
+If you already have an existing secret created in your namespace matching your
+repository URL it will use it.
+
+You can explicitely provide a token on the command line with the `-t` or
+`--providerToken` flag, or you can set the environment variable
+`PAC_PROVIDER_TOKEN` and it will use it instead of asking you.
+
+With the `--no-secret` flag you can completely skip any secret generation.
 
 There is no clean-up of the secret after the run.
 

--- a/docs/content/docs/guide/privaterepo.md
+++ b/docs/content/docs/guide/privaterepo.md
@@ -18,6 +18,10 @@ The secret contains a `.gitconfig` and Git credentials `.git-credentials` with
 the https URL using the token it discovered from the GitHub application or
 attached to the secret.
 
+The secret has as well the key `git-provider-token` which is the plain
+token, it can be reused directly but note that on the github apps provider the
+token has a very short  lifetime and is not refreshed.
+
 As documented :
 
 <https://github.com/tektoncd/catalog/blob/main/task/git-clone/0.4/README.md>

--- a/pkg/cmd/tknpac/resolve/basic_auth_secret.go
+++ b/pkg/cmd/tknpac/resolve/basic_auth_secret.go
@@ -2,19 +2,26 @@ package resolve
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli/prompt"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/secrets"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 )
 
 // nolint: gosec
-const basicAuthSecretString = `secretName: "{{ git_auth_secret }}"`
+const (
+	basicAuthSecretString = `secretName: "{{ git_auth_secret }}"`
+	gitProviderTokenKey   = "git-provider-token"
+)
 
 func detectWebhookSecret(filenames []string) bool {
 	for _, filename := range filenames {
@@ -38,15 +45,30 @@ func detectWebhookSecret(filenames []string) bool {
 	return false
 }
 
-func makeGitAuthSecret(filenames []string, token string, params map[string]string) (string, string, error) {
+func makeGitAuthSecret(ctx context.Context, cs *params.Run, filenames []string, token string, params map[string]string) (string, string, error) {
 	var ret, basicAuthsecretName string
 	if !detectWebhookSecret(filenames) {
 		return "", "", nil
 	}
+
+	if cs.Clients.Kube != nil {
+		list, _ := cs.Clients.Kube.CoreV1().Secrets(cs.Info.Kube.Namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("%s=%s,%s=%s", keys.URLOrg, params["repo_owner"], keys.URLRepository, params["repo_name"]),
+		})
+
+		if len(list.Items) > 0 {
+			if tokendata := list.Items[0].Data[gitProviderTokenKey]; string(tokendata) != "" {
+				return "", list.Items[0].GetName(), nil
+			}
+		}
+	}
+
+	// try first from env (unless passed on command line)
 	if token == "" {
 		token = os.Getenv("PAC_PROVIDER_TOKEN")
 	}
 
+	// try from running cluster
 	if token == "" {
 		provideSecret := false
 		msg := "We have detected a git_auth_secret in your Pipelinerun. Would you like to provide a token for the git_clone task?"
@@ -63,7 +85,9 @@ func makeGitAuthSecret(filenames []string, token string, params map[string]strin
 
 	if token != "" {
 		runevent := &info.Event{
-			URL: params["repo_url"],
+			URL:          params["repo_url"],
+			Organization: params["repo_owner"],
+			Repository:   params["repo_name"],
 			Provider: &info.Provider{
 				Token: token,
 			},

--- a/pkg/cmd/tknpac/resolve/basic_auth_secret.go
+++ b/pkg/cmd/tknpac/resolve/basic_auth_secret.go
@@ -1,0 +1,85 @@
+package resolve
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli/prompt"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/secrets"
+	"sigs.k8s.io/yaml"
+)
+
+// nolint: gosec
+const basicAuthSecretString = `secretName: "{{ git_auth_secret }}"`
+
+func detectWebhookSecret(filenames []string) bool {
+	for _, filename := range filenames {
+		file, err := os.Open(filename)
+		if err != nil {
+			return false
+		}
+		defer file.Close()
+		// check if we have the string secretName: "{{ git_auth_secret }}" and
+		// return true if it does
+		scanner := bufio.NewScanner(file)
+		for scanner.Scan() {
+			if strings.Contains(scanner.Text(), basicAuthSecretString) {
+				if err := scanner.Err(); err != nil {
+					return false
+				}
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func makeGitAuthSecret(filenames []string, token string, params map[string]string) (string, string, error) {
+	var ret, basicAuthsecretName string
+	if !detectWebhookSecret(filenames) {
+		return "", "", nil
+	}
+	if token == "" {
+		token = os.Getenv("PAC_PROVIDER_TOKEN")
+	}
+
+	if token == "" {
+		provideSecret := false
+		msg := "We have detected a git_auth_secret in your Pipelinerun. Would you like to provide a token for the git_clone task?"
+		if err := prompt.SurveyAskOne(&survey.Confirm{Message: msg, Default: true}, &provideSecret); err != nil {
+			return "", "", fmt.Errorf("canceled")
+		}
+		if provideSecret {
+			msg := `Enter a token to be used for the git_auth_secret`
+			if err := prompt.SurveyAskOne(&survey.Password{Message: msg}, &token); err != nil {
+				return "", "", fmt.Errorf("canceled")
+			}
+		}
+	}
+
+	if token != "" {
+		runevent := &info.Event{
+			URL: params["repo_url"],
+			Provider: &info.Provider{
+				Token: token,
+			},
+			SHA: params["revision"],
+		}
+		basicAuthsecretName = secrets.GenerateBasicAuthSecretName()
+		basicAuthSecret, err := secrets.MakeBasicAuthSecret(runevent, basicAuthsecretName)
+		if err != nil {
+			return "", "", err
+		}
+		out, err := yaml.Marshal(basicAuthSecret)
+		if err != nil {
+			return "", "", err
+		}
+		ret += fmt.Sprintf("---\n%s\n", out)
+	}
+
+	return ret, basicAuthsecretName, nil
+}

--- a/pkg/cmd/tknpac/resolve/basic_auth_secret_test.go
+++ b/pkg/cmd/tknpac/resolve/basic_auth_secret_test.go
@@ -1,0 +1,133 @@
+package resolve
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli/prompt"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/env"
+	"gotest.tools/v3/fs"
+)
+
+func TestDetectWebhookSecret(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{
+			name:    "detects webhook secret",
+			content: basicAuthSecretString,
+			want:    true,
+		},
+
+		{
+			name:    "not webhook secret detected",
+			content: "foobar",
+			want:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpfile := fs.NewFile(t, t.Name(), fs.WithContent(tt.content))
+			defer tmpfile.Remove()
+			filenames := []string{tmpfile.Path()}
+			if got := detectWebhookSecret(filenames); got != tt.want {
+				t.Errorf("detectWebhookSecret() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMakeGitAuthSecret(t *testing.T) {
+	type args struct {
+		filenames        []string
+		token            string
+		params, fakeEnvs map[string]string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		want     string
+		wantErr  bool
+		askStubs func(*prompt.AskStubber)
+	}{
+		{
+			name: "ask for provider token",
+			args: args{
+				filenames: []string{"testdata/pipelinerun.yaml"},
+				params: map[string]string{
+					"repo_url": "https://forge/owner/repo",
+					"revision": "https://forge/owner/12345",
+				},
+			},
+			askStubs: func(as *prompt.AskStubber) {
+				as.StubOne(true)
+				as.StubOne("SHH_IAM_HIDDEN")
+			},
+			want: `.*git-credentials.*SHH_IAM_HIDDEN`,
+		},
+		{
+			name: "do not care about token stuff",
+			args: args{
+				filenames: []string{"testdata/pipelinerun.yaml"},
+				params: map[string]string{
+					"repo_url": "https://forge/owner/repo",
+					"revision": "https://forge/owner/12345",
+				},
+			},
+			askStubs: func(as *prompt.AskStubber) {
+				as.StubOne("n")
+			},
+			wantErr: false,
+		},
+		{
+			name: "provided a token on flag",
+			args: args{
+				filenames: []string{"testdata/pipelinerun.yaml"},
+				params: map[string]string{
+					"repo_url": "https://forge/owner/repo",
+					"revision": "https://forge/owner/12345",
+				},
+				token: "SOMUCHFUN",
+			},
+			want: `.*git-credentials.*SOMUCHFUN`,
+		},
+		{
+			name: "provided a token via env",
+			args: args{
+				filenames: []string{"testdata/pipelinerun.yaml"},
+				params: map[string]string{
+					"repo_url": "https://forge/owner/repo",
+					"revision": "https://forge/owner/12345",
+				},
+				fakeEnvs: map[string]string{
+					"PAC_PROVIDER_TOKEN": "TOKENARETHEBEST",
+				},
+			},
+			want: `.*git-credentials.*TOKENARETHEBEST`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			envRemove := env.PatchAll(t, tt.args.fakeEnvs)
+			defer envRemove()
+
+			as, teardown := prompt.InitAskStubber()
+			defer teardown()
+			if tt.askStubs != nil {
+				tt.askStubs(as)
+			}
+
+			got, _, err := makeGitAuthSecret(tt.args.filenames, tt.args.token, tt.args.params)
+			if tt.wantErr {
+				assert.Assert(t, err != nil)
+				return
+			}
+			assert.NilError(t, err)
+			reg := regexp.MustCompile(tt.want)
+			assert.Assert(t, reg.MatchString(got), "want: %s, got: %s", tt.want, got)
+		})
+	}
+}

--- a/pkg/cmd/tknpac/resolve/resolve_test.go
+++ b/pkg/cmd/tknpac/resolve/resolve_test.go
@@ -100,7 +100,8 @@ func TestResolveFilenames(t *testing.T) {
 			dir := assertfs.NewDir(t, "test-name",
 				assertfs.WithFile("file.yaml", strings.ReplaceAll(tt.tmpl, "\t", "    ")))
 			defer dir.Remove()
-			got, err := resolveFilenames(cs, []string{dir.Path()}, map[string]string{"foo": "bar"})
+			ctx, _ := rtesting.SetupFakeContext(t)
+			got, err := resolveFilenames(ctx, cs, []string{dir.Path()}, map[string]string{"foo": "bar"})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("resolveFilenames() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/cmd/tknpac/resolve/testdata/pipelinerun.yaml
+++ b/pkg/cmd/tknpac/resolve/testdata/pipelinerun.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: pac-me-up-before-you-go-go
+spec:
+  pipelineRef:
+    name: foobar
+  workspaces:
+    - name: basic-auth
+      secret:
+        secretName: "{{ git_auth_secret }}"

--- a/pkg/kubeinteraction/kubeinteraction.go
+++ b/pkg/kubeinteraction/kubeinteraction.go
@@ -5,17 +5,17 @@ import (
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
 
 	ktypes "github.com/openshift-pipelines/pipelines-as-code/pkg/secrets/types"
 )
 
 type Interface interface {
 	CleanupPipelines(context.Context, *zap.SugaredLogger, *v1alpha1.Repository, *v1beta1.PipelineRun, int) error
-	CreateBasicAuthSecret(context.Context, *zap.SugaredLogger, *info.Event, string, string) error
-	DeleteBasicAuthSecret(context.Context, *zap.SugaredLogger, string, string) error
+	CreateSecret(ctx context.Context, ns string, secret *corev1.Secret) error
+	DeleteSecret(context.Context, *zap.SugaredLogger, string, string) error
 	GetSecret(context.Context, ktypes.GetSecretOpt) (string, error)
 	GetPodLogs(context.Context, string, string, string, int64) (string, error)
 }

--- a/pkg/kubeinteraction/secrets.go
+++ b/pkg/kubeinteraction/secrets.go
@@ -2,95 +2,13 @@ package kubeinteraction
 
 import (
 	"context"
-	"fmt"
-	"net/url"
-	"strings"
 
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/random"
 	ktypes "github.com/openshift-pipelines/pipelines-as-code/pkg/secrets/types"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-const (
-	//nolint:gosec
-	basicAuthSecretName    = `pac-gitauth-%s`
-	basicAuthGitConfigData = `
-	[credential "%s"]
-	helper=store
-	`
-)
-
-func (k Interaction) createSecret(ctx context.Context, secretData map[string]string, targetNamespace,
-	secretName string, annotations map[string]string,
-) error {
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        secretName,
-			Labels:      map[string]string{"app.kubernetes.io/managed-by": "pipelines-as-code"},
-			Annotations: annotations,
-		},
-	}
-	secret.StringData = secretData
-	_, err := k.Run.Clients.Kube.CoreV1().Secrets(targetNamespace).Create(ctx, secret, metav1.CreateOptions{})
-	return err
-}
-
-// CreateBasicAuthSecret Create a secret for git-clone basic-auth workspace
-func (k Interaction) CreateBasicAuthSecret(ctx context.Context, logger *zap.SugaredLogger, runevent *info.Event,
-	targetNamespace, secretName string,
-) error {
-	// Bitbucket Server have a different Clone URL than it's Repository URL, so we
-	// have to separate them 👨‍🏭
-	cloneURL := runevent.URL
-	if runevent.CloneURL != "" {
-		cloneURL = runevent.CloneURL
-	}
-
-	repoURL, err := url.Parse(cloneURL)
-	if err != nil {
-		return fmt.Errorf("cannot parse url %s: %w", cloneURL, err)
-	}
-
-	gitUser := provider.DefaultProviderAPIUser
-	if runevent.Provider.User != "" {
-		gitUser = runevent.Provider.User
-	}
-
-	// Bitbucket server token have / into it, so unless we quote the URL them it's
-	// impossible to use it🤡
-	//
-	// It supposed not working on GitHub according to
-	// https://stackoverflow.com/a/24719496 but arguably GitHub have a better
-	// product and would not do such things.
-	//
-	// maybe we could patch the git-clone task too but that probably be a pain
-	// in the tuchus to do it in shell.
-	token := url.QueryEscape(runevent.Provider.Token)
-
-	urlWithToken := fmt.Sprintf("%s://%s:%s@%s%s", repoURL.Scheme, gitUser, token, repoURL.Host, repoURL.Path)
-	secretData := map[string]string{
-		".gitconfig":       fmt.Sprintf(basicAuthGitConfigData, cloneURL),
-		".git-credentials": urlWithToken,
-	}
-	annotations := map[string]string{
-		"pipelinesascode.tekton.dev/url": cloneURL,
-		"pipelinesascode.tekton.dev/sha": runevent.SHA,
-	}
-
-	err = k.createSecret(ctx, secretData, targetNamespace, secretName, annotations)
-	// this should not happen since each secret  is unique with a random string
-	if err != nil {
-		return fmt.Errorf("cannot create git auth secret %s: %w", secretName, err)
-	}
-
-	logger.Infof("Secret %s has been generated in namespace %s", secretName, targetNamespace)
-	return nil
-}
 
 func (k Interaction) GetSecret(ctx context.Context, secretopt ktypes.GetSecretOpt) (string, error) {
 	secret, err := k.Run.Clients.Kube.CoreV1().Secrets(secretopt.Namespace).Get(
@@ -101,13 +19,8 @@ func (k Interaction) GetSecret(ctx context.Context, secretopt ktypes.GetSecretOp
 	return string(secret.Data[secretopt.Key]), nil
 }
 
-func GetBasicAuthSecretName() string {
-	return strings.ToLower(
-		fmt.Sprintf(basicAuthSecretName, random.AlphaString(4)))
-}
-
-// DeleteBasicAuthSecret deletes the secret created for git-clone basic-auth
-func (k Interaction) DeleteBasicAuthSecret(ctx context.Context, logger *zap.SugaredLogger, targetNamespace, secretName string) error {
+// DeleteSecret deletes the secret created for git-clone basic-auth
+func (k Interaction) DeleteSecret(ctx context.Context, logger *zap.SugaredLogger, targetNamespace, secretName string) error {
 	err := k.Run.Clients.Kube.CoreV1().Secrets(targetNamespace).Delete(ctx, secretName, metav1.DeleteOptions{})
 	if err != nil && !errors.IsNotFound(err) {
 		return err
@@ -117,4 +30,7 @@ func (k Interaction) DeleteBasicAuthSecret(ctx context.Context, logger *zap.Suga
 	return nil
 }
 
-// TODO: support envSource
+func (k Interaction) CreateSecret(ctx context.Context, ns string, secret *corev1.Secret) error {
+	_, err := k.Run.Clients.Kube.CoreV1().Secrets(ns).Create(ctx, secret, metav1.CreateOptions{})
+	return err
+}

--- a/pkg/kubeinteraction/secrets_test.go
+++ b/pkg/kubeinteraction/secrets_test.go
@@ -1,12 +1,10 @@
 package kubeinteraction
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
 	"go.uber.org/zap"
 	zapobserver "go.uber.org/zap/zaptest/observer"
@@ -16,34 +14,21 @@ import (
 	rtesting "knative.dev/pkg/reconciler/testing"
 )
 
-func TestCreateBasicAuthSecret(t *testing.T) {
-	nsNotThere := "not_there"
-	nsthere := "there"
-	secrete := "verysecrete"
+func TestDeleteSecret(t *testing.T) {
+	ns := "there"
 
 	tdata := testclient.Data{
 		Namespaces: []*corev1.Namespace{
 			{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: nsNotThere,
-				},
-			},
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: nsthere,
+					Name: ns,
 				},
 			},
 		},
 		Secret: []*corev1.Secret{
 			{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: nsNotThere,
-					Name:      "foo-bar-linux-bar",
-				},
-			},
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: nsthere,
+					Namespace: ns,
 					Name:      "pac-git-basic-auth-owner-repo",
 				},
 				StringData: map[string]string{
@@ -52,44 +37,15 @@ func TestCreateBasicAuthSecret(t *testing.T) {
 			},
 		},
 	}
-	event := info.NewEvent()
-	event.Organization = "owner"
-	event.Repository = "repo"
-	event.URL = "https://forge/owner/repo"
-
-	lowercaseEvent := info.NewEvent()
-	lowercaseEvent.Organization = "UPPER"
-	lowercaseEvent.Repository = "CASE"
-	lowercaseEvent.URL = "https://forge/UPPER/CASE"
 
 	tests := []struct {
-		name                    string
-		targetNS                string
-		event                   *info.Event
-		expectedGitCredentials  string
-		expectedStartSecretName string
-		expectedError           bool
+		name string
 	}{
 		{
-			name:                    "Target secret not there",
-			targetNS:                nsNotThere,
-			event:                   event,
-			expectedGitCredentials:  "https://git:verysecrete@forge/owner/repo",
-			expectedStartSecretName: "pac-gitauth-owner-repo",
+			name: "auth basic secret there",
 		},
 		{
-			name:                    "Target secret already there",
-			targetNS:                nsthere,
-			event:                   event,
-			expectedGitCredentials:  "https://git:verysecrete@forge/owner/repo",
-			expectedStartSecretName: "pac-gitauth-owner-repo",
-		},
-		{
-			name:                    "Lowercase secrets",
-			targetNS:                nsthere,
-			event:                   lowercaseEvent,
-			expectedGitCredentials:  "https://git:verysecrete@forge/UPPER/CASE",
-			expectedStartSecretName: "pac-gitauth-upper-case",
+			name: "auth basic secret not there",
 		},
 	}
 	for _, tt := range tests {
@@ -105,99 +61,8 @@ func TestCreateBasicAuthSecret(t *testing.T) {
 					},
 				},
 			}
-			tt.event.Provider.Token = secrete
-			err := kint.CreateBasicAuthSecret(ctx, fakelogger, tt.event, tt.targetNS, tt.expectedStartSecretName)
+			err := kint.DeleteSecret(ctx, fakelogger, "", ns)
 			assert.NilError(t, err)
-
-			slist, err := kint.Run.Clients.Kube.CoreV1().Secrets(tt.targetNS).List(ctx, metav1.ListOptions{})
-			assert.NilError(t, err)
-			assert.Assert(t, len(slist.Items) > 0, "Secret has not been created")
-
-			found := false
-			for _, s := range slist.Items {
-				if strings.HasPrefix(s.GetName(), tt.expectedStartSecretName) && s.StringData[".git-credentials"] == tt.expectedGitCredentials {
-					found = true
-				}
-			}
-			if !found {
-				t.Fatalf("we could not find the secret %s out of secrets created: %+v", tt.expectedStartSecretName, slist.Items)
-			}
 		})
 	}
-}
-
-func TestDeleteBasicAuthSecret(t *testing.T) {
-	nsthere := "there"
-
-	tdata := testclient.Data{
-		Namespaces: []*corev1.Namespace{
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: nsthere,
-				},
-			},
-		},
-		Secret: []*corev1.Secret{
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: nsthere,
-					Name:      "pac-git-basic-auth-owner-repo",
-				},
-				StringData: map[string]string{
-					".git-credentials": "https://whateveryousayboss",
-				},
-			},
-		},
-	}
-
-	tests := []struct {
-		name     string
-		targetNS string
-	}{
-		{
-			name:     "auth basic secret there",
-			targetNS: nsthere,
-		},
-		{
-			name:     "auth basic secret not there",
-			targetNS: nsthere,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctx, _ := rtesting.SetupFakeContext(t)
-			stdata, _ := testclient.SeedTestData(t, ctx, tdata)
-			observer, _ := zapobserver.New(zap.InfoLevel)
-			fakelogger := zap.New(observer).Sugar()
-			kint := Interaction{
-				Run: &params.Run{
-					Clients: clients.Clients{
-						Kube: stdata.Kube,
-					},
-				},
-			}
-			err := kint.DeleteBasicAuthSecret(ctx, fakelogger, "", tt.targetNS)
-			assert.NilError(t, err)
-
-			slist, err := kint.Run.Clients.Kube.CoreV1().Secrets(tt.targetNS).List(ctx, metav1.ListOptions{})
-			assert.NilError(t, err)
-
-			found := false
-			secretName := GetBasicAuthSecretName()
-			for _, s := range slist.Items {
-				if s.Name == secretName {
-					found = true
-				}
-			}
-			if found {
-				t.Fatal("failed to delete secret ", secretName)
-			}
-		})
-	}
-}
-
-func TestGetBasicAuthSecret(t *testing.T) {
-	t1 := GetBasicAuthSecretName()
-	t2 := GetBasicAuthSecretName()
-	assert.Assert(t, t1 != t2)
 }

--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -9,10 +9,10 @@ import (
 
 	apipac "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/matcher"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/resolve"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/secrets"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/templates"
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"go.uber.org/zap"
@@ -200,7 +200,7 @@ func changeSecret(prs []*tektonv1beta1.PipelineRun) error {
 			return err
 		}
 
-		name := kubeinteraction.GetBasicAuthSecretName()
+		name := secrets.GenerateBasicAuthSecretName()
 		processed := templates.ReplacePlaceHoldersVariables(string(b), map[string]string{
 			"git_auth_secret": name,
 		})
@@ -225,7 +225,7 @@ func changeSecret(prs []*tektonv1beta1.PipelineRun) error {
 // checks are deprecated/removed to n+1 release of OSP.
 // each check should give a good error message on how to update.
 func (p *PacRun) checkNeedUpdate(tmpl string) (string, bool) {
-	//nolint: gosec
+	// nolint: gosec
 	oldBasicAuthSecretName := `\W*secretName: "pac-git-basic-auth-{{repo_owner}}-{{repo_name}}"`
 	if matched, _ := regexp.MatchString(oldBasicAuthSecretName, tmpl); matched {
 		return `!Update needed! you have a old basic auth secret name, you need to modify your pipelinerun and change the string "secret: pac-git-basic-auth-{{repo_owner}}-{{repo_name}}" to "secret: {{ git_auth_secret }}"`, true

--- a/pkg/reconciler/cleanup.go
+++ b/pkg/reconciler/cleanup.go
@@ -19,7 +19,7 @@ func (r *Reconciler) cleanupSecrets(ctx context.Context, logger *zap.SugaredLogg
 		return fmt.Errorf("cannot get annotation %s as set on PR", keys.GitAuthSecret)
 	}
 
-	err := r.kinteract.DeleteBasicAuthSecret(ctx, logger, repo.GetNamespace(), gitAuthSecretName)
+	err := r.kinteract.DeleteSecret(ctx, logger, repo.GetNamespace(), gitAuthSecretName)
 	if err != nil {
 		return fmt.Errorf("deleting basic auth secret has failed: %w ", err)
 	}

--- a/pkg/resolve/resolve.go
+++ b/pkg/resolve/resolve.go
@@ -106,9 +106,10 @@ func inlineTasks(tasks []tektonv1beta1.PipelineTask, ropt *Opts, types Types) ([
 }
 
 type Opts struct {
-	GenerateName bool     // whether to GenerateName
-	RemoteTasks  bool     // whether to parse annotation to fetch tasks from remote
-	SkipInlining []string // task to skip inlining
+	GenerateName  bool     // whether to GenerateName
+	RemoteTasks   bool     // whether to parse annotation to fetch tasks from remote
+	SkipInlining  []string // task to skip inlining
+	ProviderToken string
 }
 
 // Resolve gets a large string which is a yaml multi documents containing

--- a/pkg/secrets/basic_auth.go
+++ b/pkg/secrets/basic_auth.go
@@ -1,0 +1,81 @@
+package secrets
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/random"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	basicAuthGitConfigData = `
+	[credential "%s"]
+	helper=store
+	`
+	//nolint:gosec
+	basicAuthSecretName = `pac-gitauth-%s`
+)
+
+// MakeBasicAuthSecret Make a secret for git-clone basic-auth workspace
+func MakeBasicAuthSecret(runevent *info.Event, secretName string) (*corev1.Secret, error) {
+	// Bitbucket Server have a different Clone URL than it's Repository URL, so we
+	// have to separate them 👨‍🏭
+	cloneURL := runevent.URL
+	if runevent.CloneURL != "" {
+		cloneURL = runevent.CloneURL
+	}
+
+	repoURL, err := url.Parse(cloneURL)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse url %s: %w", cloneURL, err)
+	}
+
+	gitUser := provider.DefaultProviderAPIUser
+	if runevent.Provider.User != "" {
+		gitUser = runevent.Provider.User
+	}
+
+	// Bitbucket server token have / into it, so unless we quote the URL them it's
+	// impossible to use it🤡
+	//
+	// It supposed not working on GitHub according to
+	// https://stackoverflow.com/a/24719496 but arguably GitHub have a better
+	// product and would not do such things.
+	//
+	// maybe we could patch the git-clone task too but that probably be a pain
+	// in the *** to do it in shell.
+	token := url.QueryEscape(runevent.Provider.Token)
+
+	urlWithToken := fmt.Sprintf("%s://%s:%s@%s%s", repoURL.Scheme, gitUser, token, repoURL.Host, repoURL.Path)
+	secretData := map[string]string{
+		".gitconfig":       fmt.Sprintf(basicAuthGitConfigData, cloneURL),
+		".git-credentials": urlWithToken,
+	}
+	annotations := map[string]string{
+		"pipelinesascode.tekton.dev/url": cloneURL,
+		"pipelinesascode.tekton.dev/sha": runevent.SHA,
+	}
+
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        secretName,
+			Labels:      map[string]string{"app.kubernetes.io/managed-by": "pipelines-as-code"},
+			Annotations: annotations,
+		},
+		StringData: secretData,
+	}, nil
+}
+
+func GenerateBasicAuthSecretName() string {
+	return strings.ToLower(
+		fmt.Sprintf(basicAuthSecretName, random.AlphaString(4)))
+}

--- a/pkg/secrets/basic_auth_test.go
+++ b/pkg/secrets/basic_auth_test.go
@@ -1,0 +1,110 @@
+package secrets
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"gotest.tools/v3/assert"
+)
+
+func TestCreateBasicAuthSecret(t *testing.T) {
+	nsNotThere := "not_there"
+	nsthere := "there"
+	secrete := "verysecrete"
+
+	event := info.Event{
+		Organization: "owner",
+		Repository:   "repo",
+		URL:          "https://forge/owner/repo",
+	}
+
+	tests := []struct {
+		name                    string
+		targetNS                string
+		event                   info.Event
+		expectedGitCredentials  string
+		expectedStartSecretName string
+		expectedError           bool
+	}{
+		{
+			name:                    "Target secret not there",
+			targetNS:                nsNotThere,
+			event:                   event,
+			expectedGitCredentials:  "https://git:verysecrete@forge/owner/repo",
+			expectedStartSecretName: "pac-gitauth-owner-repo",
+		},
+		{
+			name:                    "Use clone URL",
+			targetNS:                nsNotThere,
+			event:                   event,
+			expectedGitCredentials:  "https://git:verysecrete@forge/owner/repo",
+			expectedStartSecretName: "pac-gitauth-owner-repo",
+		},
+		{
+			name:                    "Target secret already there",
+			targetNS:                nsthere,
+			event:                   event,
+			expectedGitCredentials:  "https://git:verysecrete@forge/owner/repo",
+			expectedStartSecretName: "pac-gitauth-owner-repo",
+		},
+		{
+			name:     "Lowercase secrets",
+			targetNS: nsthere,
+			event: info.Event{
+				Organization: "UPPER",
+				Repository:   "CASE",
+				URL:          "https://forge/UPPER/CASE",
+			},
+			expectedGitCredentials:  "https://git:verysecrete@forge/UPPER/CASE",
+			expectedStartSecretName: "pac-gitauth-upper-case",
+		},
+		{
+			name:     "Use clone URL",
+			targetNS: nsthere,
+			event: info.Event{
+				Organization: "hello",
+				Repository:   "moto",
+				URL:          "https://forge/hello/moto",
+				CloneURL:     "https://forge/miss/robinson",
+			},
+			expectedGitCredentials:  "https://git:verysecrete@forge/miss/robinson",
+			expectedStartSecretName: "pac-gitauth-upper-case",
+		},
+		{
+			name:     "different git user",
+			targetNS: nsthere,
+			event: info.Event{
+				Organization: "hello",
+				Repository:   "moto",
+				URL:          "https://forge/bat/cave",
+				Provider: &info.Provider{
+					User:  "superman",
+					Token: "supersecrete",
+				},
+			},
+			expectedGitCredentials:  "https://superman:supersecrete@forge/bat/cave",
+			expectedStartSecretName: "pac-gitauth-upper-case",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.event.Provider == nil {
+				tt.event.Provider = &info.Provider{
+					Token: secrete,
+				}
+			}
+			secret, err := MakeBasicAuthSecret(&tt.event, tt.expectedStartSecretName)
+			assert.NilError(t, err)
+
+			assert.Assert(t, strings.HasPrefix(secret.GetName(), tt.expectedStartSecretName))
+			assert.Equal(t, secret.StringData[".git-credentials"], tt.expectedGitCredentials)
+		})
+	}
+}
+
+func TestGetBasicAuthSecret(t *testing.T) {
+	t1 := GenerateBasicAuthSecretName()
+	t2 := GenerateBasicAuthSecretName()
+	assert.Assert(t, t1 != t2)
+}

--- a/pkg/test/kubernetestint/kubernetesint.go
+++ b/pkg/test/kubernetestint/kubernetesint.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
 	ktypes "github.com/openshift-pipelines/pipelines-as-code/pkg/secrets/types"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
 )
 
 type KinterfaceTest struct {
@@ -18,6 +19,8 @@ type KinterfaceTest struct {
 	GetSecretResult          map[string]string
 	GetPodLogsOutput         map[string]string
 }
+
+var _ kubeinteraction.Interface = (*KinterfaceTest)(nil)
 
 func (k *KinterfaceTest) GetConsoleUI(_ context.Context, _, _ string) (string, error) {
 	if k.ConsoleURLErorring {
@@ -31,14 +34,6 @@ func (k *KinterfaceTest) GetPodLogs(_ context.Context, ns, pod, cont string, _ i
 		return k.GetPodLogsOutput[pod], nil
 	}
 	return "", nil
-}
-
-func (k *KinterfaceTest) CreateBasicAuthSecret(context.Context, *zap.SugaredLogger, *info.Event, string, string) error {
-	return nil
-}
-
-func (k *KinterfaceTest) DeleteBasicAuthSecret(_ context.Context, _ *zap.SugaredLogger, _, _ string) error {
-	return nil
 }
 
 func (k *KinterfaceTest) GetSecret(ctx context.Context, secret ktypes.GetSecretOpt) (string, error) {
@@ -55,5 +50,13 @@ func (k *KinterfaceTest) CleanupPipelines(_ context.Context, _ *zap.SugaredLogge
 	if k.ExpectedNumberofCleanups != limitnumber {
 		return fmt.Errorf("we wanted %d and we got %d", k.ExpectedNumberofCleanups, limitnumber)
 	}
+	return nil
+}
+
+func (k *KinterfaceTest) CreateSecret(_ context.Context, _ string, _ *corev1.Secret) error {
+	return nil
+}
+
+func (k *KinterfaceTest) DeleteSecret(_ context.Context, _ *zap.SugaredLogger, _, _ string) error {
 	return nil
 }

--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/names"
 	"gopkg.in/yaml.v2"
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/env"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -534,6 +535,9 @@ func TestGiteaWithCLIGeneratePipeline(t *testing.T) {
 				"--branch", topts.DefaultBranch, "--file-name", ".tekton/pr.yaml", "--overwrite")
 			assert.NilError(t, err)
 			assert.Assert(t, regexp.MustCompile(tt.generateOutputRegexp).MatchString(output))
+
+			envRemove := env.PatchAll(t, map[string]string{"PAC_PROVIDER_TOKEN": "NOWORRIESBEHAPPY"})
+			defer envRemove()
 			topts.Clients.Info.Pac = &info.PacOpts{}
 			topts.Clients.Info.Pac.Settings = &settings.Settings{}
 			_, err = tknpactest.ExecCommand(topts.Clients, tknpacresolve.Command, "-f", ".tekton/pr.yaml", "-p", "revision=main")

--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -571,7 +571,7 @@ func TestGiteaWithCLIGeneratePipeline(t *testing.T) {
 				LabelSelector: pacapi.EventType + "=pull_request",
 			})
 			assert.NilError(t, err)
-			assert.Assert(t, len(prs.Items) >= 2, "should have at least 2 pipelineruns")
+			assert.Assert(t, len(prs.Items) >= 1, "should have at least 1 pipelineruns")
 		})
 	}
 }


### PR DESCRIPTION
# Changes

* If we detect the string in template, we ask the user to provide one and generate a basic
auth Secret referencing it

* We reuses the existing secret in the current namespace matching via labels  if there is already one

* Refactor all basicauthdata secrets to pkkg/secrets instead of
pkg/kubeinteraction, keep only the stuff that touches directly kube
operation in there for testing.

* Improve testing and doc on TestGetBasicAuthSecret to cover different cases

Demo:


https://user-images.githubusercontent.com/98980/205111077-926b4c1c-f8c9-42f9-8ec9-67d5e130f110.mp4



Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>


