### PR TITLE
Updates basic auth secret owner reference with pipelinerun

### DIFF
--- a/config/201-controller-role.yaml
+++ b/config/201-controller-role.yaml
@@ -67,7 +67,7 @@ rules:
     verbs: ["create"]
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "create"]
+    verbs: ["get", "create", "update"]
   - apiGroups: ["pipelinesascode.tekton.dev"]
     resources: ["repositories"]
     verbs: ["create", "list"]

--- a/pkg/kubeinteraction/kubeinteraction.go
+++ b/pkg/kubeinteraction/kubeinteraction.go
@@ -15,7 +15,7 @@ import (
 type Interface interface {
 	CleanupPipelines(context.Context, *zap.SugaredLogger, *v1alpha1.Repository, *v1beta1.PipelineRun, int) error
 	CreateSecret(ctx context.Context, ns string, secret *corev1.Secret) error
-	DeleteSecret(context.Context, *zap.SugaredLogger, string, string) error
+	UpdateSecretWithOwnerRef(context.Context, *zap.SugaredLogger, string, string, *v1beta1.PipelineRun) error
 	GetSecret(context.Context, ktypes.GetSecretOpt) (string, error)
 	GetPodLogs(context.Context, string, string, string, int64) (string, error)
 }

--- a/pkg/kubeinteraction/secrets_test.go
+++ b/pkg/kubeinteraction/secrets_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
 	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"go.uber.org/zap"
 	zapobserver "go.uber.org/zap/zaptest/observer"
 	"gotest.tools/v3/assert"
@@ -65,4 +66,45 @@ func TestDeleteSecret(t *testing.T) {
 			assert.NilError(t, err)
 		})
 	}
+}
+
+func TestUpdateSecretWithOwnerRef(t *testing.T) {
+	testNs := "there"
+	secrete := "dont-tell-anyone-its-a-secrete"
+	tdata := testclient.Data{
+		Secret: []*corev1.Secret{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNs,
+					Name:      secrete,
+				},
+			},
+		},
+	}
+	ctx, _ := rtesting.SetupFakeContext(t)
+	stdata, _ := testclient.SeedTestData(t, ctx, tdata)
+	observer, _ := zapobserver.New(zap.InfoLevel)
+	fakelogger := zap.New(observer).Sugar()
+	kint := Interaction{
+		Run: &params.Run{
+			Clients: clients.Clients{
+				Kube: stdata.Kube,
+			},
+		},
+	}
+	pr := &v1beta1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+			UID:  "uid",
+		},
+	}
+
+	err := kint.UpdateSecretWithOwnerRef(ctx, fakelogger, testNs, secrete, pr)
+	assert.NilError(t, err)
+
+	updatedSecret, err := stdata.Kube.CoreV1().Secrets(testNs).Get(ctx, secrete, metav1.GetOptions{})
+	assert.NilError(t, err)
+	assert.Assert(t, len(updatedSecret.OwnerReferences) != 0)
+	assert.Equal(t, updatedSecret.OwnerReferences[0].Kind, "PipelineRun")
+	assert.Equal(t, updatedSecret.OwnerReferences[0].Name, pr.Name)
 }

--- a/pkg/pipelineascode/pipelinesascode_github_test.go
+++ b/pkg/pipelineascode/pipelinesascode_github_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/google/go-github/v48/github"
 	apipac "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/consoleui"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
@@ -496,6 +497,13 @@ func TestRun(t *testing.T) {
 						logger.Fatalf("failed to find log-url label on pipelinerun: %v/%v", pr.GetNamespace(), pr.GetName())
 					}
 					assert.Equal(t, logURL, cs.Clients.ConsoleUI.DetailURL(pr.Namespace, pr.Name))
+
+					if cs.Info.Pac.SecretAutoCreation {
+						secretName := pr.GetAnnotations()[keys.GitAuthSecret]
+						secret, err := cs.Clients.Kube.CoreV1().Secrets(pr.Namespace).Get(ctx, secretName, metav1.GetOptions{})
+						assert.NilError(t, err)
+						assert.Assert(t, len(secret.OwnerReferences) != 0)
+					}
 				}
 			}
 		})

--- a/pkg/reconciler/cleanup.go
+++ b/pkg/reconciler/cleanup.go
@@ -2,7 +2,6 @@ package reconciler
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
@@ -10,21 +9,6 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"go.uber.org/zap"
 )
-
-func (r *Reconciler) cleanupSecrets(ctx context.Context, logger *zap.SugaredLogger, repo *v1alpha1.Repository, pr *v1beta1.PipelineRun) error {
-	var gitAuthSecretName string
-	if annotation, ok := pr.Annotations[keys.GitAuthSecret]; ok {
-		gitAuthSecretName = annotation
-	} else {
-		return fmt.Errorf("cannot get annotation %s as set on PR", keys.GitAuthSecret)
-	}
-
-	err := r.kinteract.DeleteSecret(ctx, logger, repo.GetNamespace(), gitAuthSecretName)
-	if err != nil {
-		return fmt.Errorf("deleting basic auth secret has failed: %w ", err)
-	}
-	return nil
-}
 
 func (r *Reconciler) cleanupPipelineRuns(ctx context.Context, logger *zap.SugaredLogger, repo *v1alpha1.Repository, pr *v1beta1.PipelineRun) error {
 	keepMaxPipeline, ok := pr.Annotations[keys.MaxKeepRuns]

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -151,12 +151,6 @@ func (r *Reconciler) reportFinalStatus(ctx context.Context, logger *zap.SugaredL
 		return repo, fmt.Errorf("cannot clean prs: %w", err)
 	}
 
-	if r.run.Info.Pac.SecretAutoCreation {
-		if err := r.cleanupSecrets(ctx, logger, repo, pr); err != nil {
-			return repo, fmt.Errorf("cannot clean secret: %w", err)
-		}
-	}
-
 	newPr, err := r.postFinalStatus(ctx, logger, provider, event, pr)
 	if err != nil {
 		return repo, fmt.Errorf("cannot post final status: %w", err)

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -191,10 +191,6 @@ func TestReconciler_ReconcileKind(t *testing.T) {
 			got, err := stdata.Pipeline.TektonV1beta1().PipelineRuns(pr.Namespace).Get(ctx, pr.Name, metav1.GetOptions{})
 			assert.NilError(t, err)
 
-			// make sure secret is deleted
-			_, err = stdata.Kube.CoreV1().Secrets(testRepo.Namespace).Get(ctx, secretName, metav1.GetOptions{})
-			assert.Error(t, err, fmt.Sprintf("secrets \"%s\" not found", secretName))
-
 			// state must be updated to completed
 			assert.Equal(t, got.Labels[keys.State], kubeinteraction.StateCompleted)
 		})

--- a/pkg/test/kubernetestint/kubernetesint.go
+++ b/pkg/test/kubernetestint/kubernetesint.go
@@ -36,6 +36,10 @@ func (k *KinterfaceTest) GetPodLogs(_ context.Context, ns, pod, cont string, _ i
 	return "", nil
 }
 
+func (k *KinterfaceTest) UpdateSecretWithOwnerRef(_ context.Context, _ *zap.SugaredLogger, _, _ string, _ *v1beta1.PipelineRun) error {
+	return nil
+}
+
 func (k *KinterfaceTest) GetSecret(ctx context.Context, secret ktypes.GetSecretOpt) (string, error) {
 	// check if secret exist in k.GetSecretResult
 	if k.GetSecretResult[secret.Name] == "" {

--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -85,6 +85,8 @@ func TestGiteaPullRequestPrivateRepository(t *testing.T) {
 		CheckForStatus: "success",
 	}
 	defer tgitea.TestPR(t, topts)()
+
+	tgitea.WaitForSecretDeletion(t, topts, topts.TargetRefName)
 }
 
 // TestGiteaBadYaml we can't check pr status but this shows up in the
@@ -526,7 +528,6 @@ func TestGiteaWithCLIGeneratePipeline(t *testing.T) {
 				assert.NilError(t, err)
 				_, err = newFile.WriteString(v)
 				assert.NilError(t, err)
-				defer newFile.Close()
 				_, err = git.RunGit(tmpdir, "add", k)
 				assert.NilError(t, err)
 			}


### PR DESCRIPTION
this updates the secreted basic auth secret owner ref with pipelinerun so that they get cleanedup with pipelinerun

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
