### PR TITLE
Show Tekton Dashboard string if configured

### DIFF
--- a/docs/content/docs/guide/running.md
+++ b/docs/content/docs/guide/running.md
@@ -40,23 +40,24 @@ The PipelineRun will always run in the namespace of the Repository CRD associate
 that generated the event.
 
 You can follow the execution of your pipeline with the
-[tkn](https://github.com/tektoncd/cli) cli :
+[tkn pac](../cli/#install) cli :
 
 ```console
 tkn pac logs -n my-pipeline-ci -L
 ```
 
 If you need to show another pipelinerun than the last one you
-can use the `tkn pac` logs command :
+can use the `tkn pac` logs command and it will ask you to select a PipelineRun
+attached to the repository :
 
 ```console
 tkn pac logs -n my-pipeline-ci
 ```
 
-If you have connected Pipelines as Code to the tekton dashboard or the
-OpenShift console. Pipelines as Code will post a URL in the Checks tab for
-GitHub apps to let you click on it and follow the pipeline execution directly
-there.
+If you have set-up Pipelines as Code with the [Tekton Dashboard](https://github.com/tektoncd/dashboard/)
+or on OpenShift using the Openshift Console.
+Pipelines as Code will post a URL in the Checks tab for GitHub apps to let you
+click on it and follow the pipeline execution directly there.
 
 ## Restarting the PipelineRun
 

--- a/pkg/cmd/tknpac/describe/testdata/TestDescribe-live_run_and_repository_run.golden
+++ b/pkg/cmd/tknpac/describe/testdata/TestDescribe-live_run_and_repository_run.golden
@@ -4,7 +4,7 @@ URL:         https://anurl.com
 
 Last Run:
 Status:         Running
-Log:            https://giphy.com/search/random-dogs
+Log:            https://dashboard.is.not.configured
 Commit URL:     
 PipelineRun:    running
 Event:          papayolo

--- a/pkg/cmd/tknpac/describe/testdata/TestDescribe-multiple_live_runs.golden
+++ b/pkg/cmd/tknpac/describe/testdata/TestDescribe-multiple_live_runs.golden
@@ -2,7 +2,7 @@ Name:           test-run
 Namespace:      ns
 URL:            https://anurl.com
 Status:         Running
-Log:            https://giphy.com/search/random-dogs
+Log:            https://dashboard.is.not.configured
 Commit URL:     
 PipelineRun:    running2
 Event:          

--- a/pkg/cmd/tknpac/describe/testdata/TestDescribe-one_live_run.golden
+++ b/pkg/cmd/tknpac/describe/testdata/TestDescribe-one_live_run.golden
@@ -2,7 +2,7 @@ Name:           test-run
 Namespace:      ns
 URL:            https://anurl.com
 Status:         Running
-Log:            https://giphy.com/search/random-dogs
+Log:            https://dashboard.is.not.configured
 Commit URL:     
 PipelineRun:    running
 Event:          

--- a/pkg/cmd/tknpac/describe/testdata/TestDescribe-target_a_pipelinerun.golden
+++ b/pkg/cmd/tknpac/describe/testdata/TestDescribe-target_a_pipelinerun.golden
@@ -2,7 +2,7 @@ Name:           test-run
 Namespace:      ns
 URL:            https://anurl.com
 Status:         Running
-Log:            https://giphy.com/search/random-dogs
+Log:            https://dashboard.is.not.configured
 Commit URL:     
 PipelineRun:    running2
 Event:          

--- a/pkg/consoleui/interface.go
+++ b/pkg/consoleui/interface.go
@@ -7,21 +7,28 @@ import (
 	"k8s.io/client-go/dynamic"
 )
 
+const consoleIsnotConfiguredURL = "https://dashboard.is.not.configured"
+
 type Interface interface {
 	DetailURL(ns, pr string) string
 	TaskLogURL(ns, pr, task string) string
 	UI(ctx context.Context, kdyn dynamic.Interface) error
 	URL() string
+	GetName() string
 }
 
 type FallBackConsole struct{}
 
+func (f FallBackConsole) GetName() string {
+	return "Not configured"
+}
+
 func (f FallBackConsole) DetailURL(ns, pr string) string {
-	return "https://giphy.com/search/random-dogs"
+	return consoleIsnotConfiguredURL
 }
 
 func (f FallBackConsole) TaskLogURL(ns, pr, task string) string {
-	return "https://giphy.com/search/random-cats"
+	return consoleIsnotConfiguredURL
 }
 
 func (f FallBackConsole) UI(ctx context.Context, kdyn dynamic.Interface) error {
@@ -29,14 +36,15 @@ func (f FallBackConsole) UI(ctx context.Context, kdyn dynamic.Interface) error {
 }
 
 func (f FallBackConsole) URL() string {
-	return "https://giphy.com/explore/random"
+	return consoleIsnotConfiguredURL
 }
 
-func New(ctx context.Context, kdyn dynamic.Interface, runinfo *info.Info) Interface {
+func New(ctx context.Context, kdyn dynamic.Interface, _ *info.Info) Interface {
 	oc := &OpenshiftConsole{}
 	if err := oc.UI(ctx, kdyn); err == nil {
 		return oc
 	}
 
+	// TODO: Try to detect TektonDashboard somehow by ingress?
 	return FallBackConsole{}
 }

--- a/pkg/consoleui/openshift.go
+++ b/pkg/consoleui/openshift.go
@@ -17,10 +17,15 @@ const (
 	openShiftRouteGroup            = "route.openshift.io"
 	openShiftRouteVersion          = "v1"
 	openShiftRouteResource         = "routes"
+	openshiftConsoleName           = "OpenShift console"
 )
 
 type OpenshiftConsole struct {
 	host string
+}
+
+func (o *OpenshiftConsole) GetName() string {
+	return openshiftConsoleName
 }
 
 func (o *OpenshiftConsole) URL() string {

--- a/pkg/consoleui/tektondashboard.go
+++ b/pkg/consoleui/tektondashboard.go
@@ -11,6 +11,12 @@ type TektonDashboard struct {
 	BaseURL string
 }
 
+const tektonDashboardName = "Tekton Dashboard"
+
+func (t *TektonDashboard) GetName() string {
+	return tektonDashboardName
+}
+
 func (t *TektonDashboard) DetailURL(ns, pr string) string {
 	return fmt.Sprintf("%s/#/namespaces/%s/pipelineruns/%s", t.BaseURL, ns, pr)
 }

--- a/pkg/params/run.go
+++ b/pkg/params/run.go
@@ -17,7 +17,7 @@ import (
 const (
 	PACConfigmapName        = "pipelines-as-code"
 	StartingPipelineRunText = `Starting Pipelinerun <b>%s</b> in namespace
-  <b>%s</b><br><br>You can follow the execution on the [OpenShift console](%s) pipelinerun viewer or via
+  <b>%s</b><br><br>You can follow the execution on the [%s](%s) PipelineRun viewer or via
   the command line with :
 	<br><code>tkn pac logs -L -n %s %s</code>`
 	QueuingPipelineRunText = `PipelineRun <b>%s</b> has been queued Queuing in namespace

--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -122,7 +122,7 @@ func (p *PacRun) startPR(ctx context.Context, match matcher.Match) error {
 		pr.GetName(), match.Repo.GetNamespace(), p.event.SHA, p.event.BaseBranch)
 	consoleURL := p.run.Clients.ConsoleUI.DetailURL(match.Repo.GetNamespace(), pr.GetName())
 	// Create status with the log url
-	msg := fmt.Sprintf(params.StartingPipelineRunText, pr.GetName(), match.Repo.GetNamespace(), consoleURL,
+	msg := fmt.Sprintf(params.StartingPipelineRunText, pr.GetName(), match.Repo.GetNamespace(), p.run.Clients.ConsoleUI.GetName(), consoleURL,
 		match.Repo.GetNamespace(), match.Repo.GetName())
 	status := provider.StatusOpts{
 		Status:                  "in_progress",

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -226,8 +226,8 @@ func (r *Reconciler) updatePipelineRunToInProgress(ctx context.Context, logger *
 	}
 
 	consoleURL := r.run.Clients.ConsoleUI.DetailURL(repo.GetNamespace(), pr.GetName())
-	// Create status with the log url
-	msg := fmt.Sprintf(params.StartingPipelineRunText, pr.GetName(), repo.GetNamespace(), consoleURL,
+	// Create a status with the log url
+	msg := fmt.Sprintf(params.StartingPipelineRunText, pr.GetName(), repo.GetNamespace(), r.run.Clients.ConsoleUI.GetName(), consoleURL,
 		repo.GetNamespace(), repo.GetName())
 	status := provider.StatusOpts{
 		Status:                  "in_progress",

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -42,14 +42,14 @@ var (
 <td>✅ Succeeded</td>
 <td>42 seconds</td><td>
 
-[fetch-repository](https://giphy.com/search/random-cats)
+[fetch-repository](https://dashboard.is.not.configured)
 
 </td></tr>
 <tr>
 <td>✅ Succeeded</td>
 <td>18 seconds</td><td>
 
-[noop-task](https://giphy.com/search/random-cats)
+[noop-task](https://dashboard.is.not.configured)
 
 </td></tr>
 </table>`
@@ -62,14 +62,14 @@ var (
 <td>✅ Succeeded</td>
 <td>42 seconds</td><td>
 
-[fetch-repository](https://giphy.com/search/random-cats)
+[fetch-repository](https://dashboard.is.not.configured)
 
 </td></tr>
 <tr>
 <td>❌ Failed</td>
 <td>19 seconds</td><td>
 
-[noop-task](https://giphy.com/search/random-cats)
+[noop-task](https://dashboard.is.not.configured)
 
 </td></tr>
 </table>`


### PR DESCRIPTION
When the user has configured the tekton dashboard we would be showing the
string Openshift console instead of Tekton Dashboard which would be confusing.

We are not using the cat easter eggs anymore since it's a bit silly, we just
specify that it wasn't configured.

Fixes #988
Partial #1021

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
