### PR TITLE
Reword error message when failing to match pr

### DIFF
--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -143,7 +143,7 @@ is that what you want? make sure you use -n when generating the secret, eg: echo
 		RemoteTasks:  p.run.Info.Pac.RemoteTasks,
 	})
 	if err != nil {
-		p.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "RepositoryFailedToResolve", fmt.Sprintf("failed to resolve pipelineRuns: %s", err.Error()))
+		p.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "RepositoryFailedToMatch", fmt.Sprintf("failed to match pipelineRuns: %s", err.Error()))
 		return nil, repo, err
 	}
 	if pipelineRuns == nil {

--- a/pkg/resolve/resolve.go
+++ b/pkg/resolve/resolve.go
@@ -2,7 +2,6 @@ package resolve
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -119,7 +118,7 @@ type Opts struct {
 func Resolve(ctx context.Context, cs *params.Run, logger *zap.SugaredLogger, providerintf provider.Interface, event *info.Event, data string, ropt *Opts) ([]*tektonv1beta1.PipelineRun, error) {
 	types := readTypes(logger, data)
 	if len(types.PipelineRuns) == 0 {
-		return []*tektonv1beta1.PipelineRun{}, errors.New("we need at least one pipelinerun to start with")
+		return []*tektonv1beta1.PipelineRun{}, fmt.Errorf("could not find any PipelineRun in your .tekton/ directory")
 	}
 
 	// First resolve Annotations Tasks

--- a/pkg/resolve/resolve_test.go
+++ b/pkg/resolve/resolve_test.go
@@ -192,7 +192,7 @@ func TestInRepoShouldNotEmbedIfNoAnnotations(t *testing.T) {
 
 func TestNoPipelineRuns(t *testing.T) {
 	_, _, err := readTDfile(t, "no-pipelinerun", false, true)
-	assert.Error(t, err, "we need at least one pipelinerun to start with")
+	assert.Error(t, err, "could not find any PipelineRun in your .tekton/ directory")
 }
 
 func TestReferencedTaskNotInRepo(t *testing.T) {


### PR DESCRIPTION
Resolve is only something internal to PAC that user don't necessary understand.

Change it to match instead which is a bit more understable i guess.

Fixes #967

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
