### PR TITLE
Fixes logURL for GitHub App PipelineRuns

### DIFF
--- a/cmd/pipelines-as-code-controller/main.go
+++ b/cmd/pipelines-as-code-controller/main.go
@@ -34,7 +34,5 @@ func main() {
 		}
 	}()
 
-	run.Info.Pac.LogURL = run.Clients.ConsoleUI.URL()
-
 	evadapter.MainWithContext(ctx, PACControllerLogKey, adapter.NewEnvConfig, adapter.New(run, kinteract))
 }

--- a/pkg/params/info/pac.go
+++ b/pkg/params/info/pac.go
@@ -10,7 +10,6 @@ import (
 
 type PacOpts struct {
 	*settings.Settings
-	LogURL             string
 	WebhookType        string
 	PayloadFile        string
 	TektonDashboardURL string

--- a/pkg/provider/github/status.go
+++ b/pkg/provider/github/status.go
@@ -102,7 +102,7 @@ func (v *Provider) createCheckRunStatus(ctx context.Context, runevent *info.Even
 		Name:       getCheckName(status, pacopts),
 		HeadSHA:    runevent.SHA,
 		Status:     github.String("in_progress"),
-		DetailsURL: github.String(pacopts.LogURL),
+		DetailsURL: github.String(status.DetailsURL),
 		ExternalID: github.String(status.PipelineRunName),
 		StartedAt:  &now,
 	}
@@ -205,7 +205,7 @@ func (v *Provider) getOrUpdateCheckRunStatus(ctx context.Context, tekton version
 				return err
 			}
 		}
-		if err := v.patchPipelinerunWithMetadata(ctx, tekton, statusOpts.PipelineRun, checkRunID, pacopts.LogURL); err != nil {
+		if err := v.patchPipelinerunWithMetadata(ctx, tekton, statusOpts.PipelineRun, checkRunID, statusOpts.DetailsURL); err != nil {
 			return err
 		}
 	}
@@ -232,10 +232,6 @@ func (v *Provider) getOrUpdateCheckRunStatus(ctx context.Context, tekton version
 	if statusOpts.PipelineRunName != "" {
 		opts.ExternalID = github.String(statusOpts.PipelineRunName)
 	}
-	if pacopts.LogURL != "" {
-		opts.DetailsURL = github.String(pacopts.LogURL)
-	}
-
 	if statusOpts.DetailsURL != "" {
 		opts.DetailsURL = &statusOpts.DetailsURL
 	}

--- a/pkg/provider/github/status_test.go
+++ b/pkg/provider/github/status_test.go
@@ -45,7 +45,7 @@ func TestGithubProviderCreateCheckRun(t *testing.T) {
 		SHA:          "createCheckRunSHA",
 	}
 
-	err := cnx.getOrUpdateCheckRunStatus(ctx, nil, event, &info.PacOpts{LogURL: "http://nowhere", Settings: &settings.Settings{}}, provider.StatusOpts{
+	err := cnx.getOrUpdateCheckRunStatus(ctx, nil, event, &info.PacOpts{Settings: &settings.Settings{}}, provider.StatusOpts{
 		PipelineRunName: "pr1",
 		Status:          "hello moto",
 	})
@@ -337,7 +337,6 @@ func TestGithubProviderCreateStatus(t *testing.T) {
 				status.PipelineRun = tt.pr
 			}
 			pacopts := &info.PacOpts{
-				LogURL:   "https://log",
 				Settings: &settings.Settings{},
 			}
 			if tt.notoken {

--- a/pkg/reconciler/controller.go
+++ b/pkg/reconciler/controller.go
@@ -39,8 +39,6 @@ func NewController() func(context.Context, configmap.Watcher) *controller.Impl {
 			}
 		}()
 
-		run.Info.Pac.LogURL = run.Clients.ConsoleUI.URL()
-
 		pipelineRunInformer := pipelineruninformer.Get(ctx)
 
 		metrics, err := metrics.NewRecorder()


### PR DESCRIPTION
we were using LogURL from PACOpts but it was not the actual pipelinerun url but the console url.
logURL is pipelinerun specific so we don't need a pac level field in PacOpts, hence removed the field.
we use details url now.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
