### PR TITLE
Scope token creation to the repository by default

### DIFF
--- a/config/302-pac-configmap.yaml
+++ b/config/302-pac-configmap.yaml
@@ -30,7 +30,15 @@ data:
   # If you trust every users on your orgnisations to access any repos there or
   # not planning to install your github application globally on a Github Organisation
   # then you can safely set this option to false.
-  secret-github-apps-token-scopped: "true"
+  secret-github-app-token-scopped: "true"
+
+  # If you don't want to completely disable the scopping of the token, but still
+  # wants some other repos (on the same installation id) available from the
+  # token, then you can add an extra owner/repo here.
+  #
+  # You can have multiple owner/repositories separated by commas:
+  # i.e: "owner/private-repo1, org/repo2"
+  secret-github-app-scope-extra-repos: ""
 
   # Tekton HUB API urls
   hub-url: "https://api.hub.tekton.dev/v1"

--- a/config/302-pac-configmap.yaml
+++ b/config/302-pac-configmap.yaml
@@ -20,6 +20,18 @@ data:
   # Whether to automatically create a secret with the token to be use by git-clone
   secret-auto-create: "true"
 
+  # By default we only generate token scopped to the repository from where the
+  # payload come from.
+  # We do this because if the github apps is installed on an github organisation
+  #
+  # and there is a mix of public and private repositories in there
+  # where some users on that org does not have access.
+  #
+  # If you trust every users on your orgnisations to access any repos there or
+  # not planning to install your github application globally on a Github Organisation
+  # then you can safely set this option to false.
+  secret-github-apps-token-scopped: "true"
+
   # Tekton HUB API urls
   hub-url: "https://api.hub.tekton.dev/v1"
 

--- a/docs/content/docs/guide/authoringprs.md
+++ b/docs/content/docs/guide/authoringprs.md
@@ -204,9 +204,9 @@ tasks:
 Since we are using the dynamic variables we are able to reuse this on any
 PullRequest from any repositories.
 
-
 {{< hint info >}}
-* On GitHub apps the generated installation token [will be available for 8 hours](https://docs.github.com/en/developers/apps/building-github-apps/refreshing-user-to-server-access-tokens).
+
+* On GitHub apps the generated installation token [will be available for 8 hours](https://docs.github.com/en/developers/apps/building-github-apps/refreshing-user-to-server-access-tokens)
 * The token is scopped to the repository it target. On PullRequest it has the
   scope of the forked and target repository.
 {{< /hint >}}

--- a/docs/content/docs/guide/authoringprs.md
+++ b/docs/content/docs/guide/authoringprs.md
@@ -204,8 +204,12 @@ tasks:
 Since we are using the dynamic variables we are able to reuse this on any
 PullRequest from any repositories.
 
-Note that the generated token from the Github Apps
-[will be available for 8 hours](https://docs.github.com/en/developers/apps/building-github-apps/refreshing-user-to-server-access-tokens).
+
+{{< hint info >}}
+* On GitHub apps the generated installation token [will be available for 8 hours](https://docs.github.com/en/developers/apps/building-github-apps/refreshing-user-to-server-access-tokens).
+* The token is scopped to the repository it target. On PullRequest it has the
+  scope of the forked and target repository.
+{{< /hint >}}
 
 ## Example
 

--- a/docs/content/docs/guide/authoringprs.md
+++ b/docs/content/docs/guide/authoringprs.md
@@ -192,7 +192,7 @@ tasks:
         name: github-add-comment
       params:
         - name: REQUEST_URL
-          value: "https://github.com/{{ repo_owner }}/{{ repo_url }}/pull/{{ pull_request_number }}"
+          value: "{{ repo_url }}/pull/{{ pull_request_number }}"
         - name: COMMENT_OR_FILE
           value: "Pipelines as Code IS GREAT!"
         - name: GITHUB_TOKEN_SECRET_NAME

--- a/docs/content/docs/install/settings.md
+++ b/docs/content/docs/install/settings.md
@@ -19,7 +19,7 @@ There is a few things you can configure through the config map
   application to be used with private repositories. This feature is enabled by
   default.
 
-* `secret-github-apps-token-scopped`
+* `secret-github-app-token-scopped`
 
   When using a Github app, we generate a temporary installation token, we scope it
   to the repository from where the payload comes. We do this when the Github app
@@ -32,6 +32,22 @@ There is a few things you can configure through the config map
   If you trust every user on your organization to access any repository or you are
   not planning to install your Github app globally on a Github organization, then
   you can safely set this option to false.
+
+* `secret-github-app-scope-extra-repos`
+
+  If you don't want to completely disable the scopping of the token, but still
+  wants some other repos available, then you can add an extra owner/repo here.
+
+  This let you able fetch remote url on github from extra private repositories
+  in an organisation if you need it.
+
+  This only works when all the repos are added from the same installation IDs.
+  
+  You can have multiple owner/repository separated by commas:
+  
+  ```yaml
+  secret-github-app-token-scopped: "owner/private-repo1, org/repo2"
+  ```
 
 * `remote-tasks`
 

--- a/docs/content/docs/install/settings.md
+++ b/docs/content/docs/install/settings.md
@@ -19,6 +19,20 @@ There is a few things you can configure through the config map
   application to be used with private repositories. This feature is enabled by
   default.
 
+* `secret-github-apps-token-scopped`
+
+  When using a Github app, we generate a temporary installation token, we scope it
+  to the repository from where the payload comes. We do this when the Github app
+  is configured globally on a Github organization.
+
+  If the organization has a mix of public and private repositories and not every
+  user in the organization is trusted to have access to every repository, then the
+  scoped token would not allow them to access those.
+
+  If you trust every user on your organization to access any repository or you are
+  not planning to install your Github app globally on a Github organization, then
+  you can safely set this option to false.
+
 * `remote-tasks`
 
   Let allows remote tasks from pipelinerun annotations. This feature is enabled by
@@ -68,12 +82,14 @@ There is a few things you can configure through the config map
 
 * `auto-configure-new-github-repo`
 
-  Let you autoconfigure newly created GitHub repositories. On creation of a new repository, Pipelines As Code will set up a namespace
+  This setting let you autoconfigure newly created GitHub repositories. On creation of a new repository, Pipelines As Code will set up a namespace
   for your repository and create a Repository CR.
 
   This feature is disabled by default and is only supported with GitHub App.
 
-  ****NOTE****: If you have a GitHub App already setup then verify if `Repository` event is subscribed.
+{< hint info >}
+ If you have a GitHub App already setup then verify if `Repository` event is subscribed.
+{< /hint >}
 
 * `auto-configure-repo-namespace-template`
 

--- a/pkg/params/settings/config.go
+++ b/pkg/params/settings/config.go
@@ -9,19 +9,22 @@ import (
 )
 
 const (
-	ApplicationNameKey                      = "application-name"
-	SecretAutoCreateKey                     = "secret-auto-create"
-	HubURLKey                               = "hub-url"
-	HubCatalogNameKey                       = "hub-catalog-name"
-	MaxKeepRunUpperLimitKey                 = "max-keep-run-upper-limit"
-	DefaultMaxKeepRunsKey                   = "default-max-keep-runs"
-	RemoteTasksKey                          = "remote-tasks"
-	BitbucketCloudCheckSourceIPKey          = "bitbucket-cloud-check-source-ip"
-	BitbucketCloudAdditionalSourceIPKey     = "bitbucket-cloud-additional-source-ip"
-	TektonDashboardURLKey                   = "tekton-dashboard-url"
-	AutoConfigureNewGitHubRepoKey           = "auto-configure-new-github-repo"
-	AutoConfigureRepoNamespaceTemplateKey   = "auto-configure-repo-namespace-template"
-	secretAutoCreateDefaultValue            = "true"
+	ApplicationNameKey                    = "application-name"
+	SecretAutoCreateKey                   = "secret-auto-create"
+	HubURLKey                             = "hub-url"
+	HubCatalogNameKey                     = "hub-catalog-name"
+	MaxKeepRunUpperLimitKey               = "max-keep-run-upper-limit"
+	DefaultMaxKeepRunsKey                 = "default-max-keep-runs"
+	RemoteTasksKey                        = "remote-tasks"
+	BitbucketCloudCheckSourceIPKey        = "bitbucket-cloud-check-source-ip"
+	BitbucketCloudAdditionalSourceIPKey   = "bitbucket-cloud-additional-source-ip"
+	TektonDashboardURLKey                 = "tekton-dashboard-url"
+	AutoConfigureNewGitHubRepoKey         = "auto-configure-new-github-repo"
+	AutoConfigureRepoNamespaceTemplateKey = "auto-configure-repo-namespace-template"
+	secretAutoCreateDefaultValue          = "true"
+	//nolint: gosec
+	SecretGhAppTokenRepoScoppedKey          = "secret-github-apps-token-scopped"
+	secretGhAppTokenRepoScoppedDefaultValue = "true"
 	remoteTasksDefaultValue                 = "true"
 	bitbucketCloudCheckSourceIPDefaultValue = "true"
 	PACApplicationNameDefaultValue          = "Pipelines as Code CI"
@@ -54,6 +57,7 @@ type Settings struct {
 	TektonDashboardURL                 string
 	AutoConfigureNewGitHubRepo         bool
 	AutoConfigureRepoNamespaceTemplate string
+	SecretGHAppRepoScoped              bool
 
 	ErrorLogSnippet             bool
 	ErrorDetection              bool
@@ -78,6 +82,12 @@ func ConfigToSettings(logger *zap.SugaredLogger, setting *Settings, config map[s
 	if setting.SecretAutoCreation != secretAutoCreate {
 		logger.Infof("CONFIG: secret auto create set to %v", secretAutoCreate)
 		setting.SecretAutoCreation = secretAutoCreate
+	}
+
+	secretGHAppRepoScoped := StringToBool(config[SecretGhAppTokenRepoScoppedKey])
+	if setting.SecretGHAppRepoScoped != secretGHAppRepoScoped {
+		logger.Infof("CONFIG: not scopping the token generated from gh %v", secretGHAppRepoScoped)
+		setting.SecretGHAppRepoScoped = secretGHAppRepoScoped
 	}
 	if setting.HubURL != config[HubURLKey] {
 		logger.Infof("CONFIG: hub URL set to %v", config[HubURLKey])

--- a/pkg/params/settings/config.go
+++ b/pkg/params/settings/config.go
@@ -10,7 +10,6 @@ import (
 
 const (
 	ApplicationNameKey                    = "application-name"
-	SecretAutoCreateKey                   = "secret-auto-create"
 	HubURLKey                             = "hub-url"
 	HubCatalogNameKey                     = "hub-catalog-name"
 	MaxKeepRunUpperLimitKey               = "max-keep-run-upper-limit"
@@ -21,10 +20,14 @@ const (
 	TektonDashboardURLKey                 = "tekton-dashboard-url"
 	AutoConfigureNewGitHubRepoKey         = "auto-configure-new-github-repo"
 	AutoConfigureRepoNamespaceTemplateKey = "auto-configure-repo-namespace-template"
-	secretAutoCreateDefaultValue          = "true"
-	//nolint: gosec
-	SecretGhAppTokenRepoScoppedKey          = "secret-github-apps-token-scopped"
-	secretGhAppTokenRepoScoppedDefaultValue = "true"
+
+	SecretAutoCreateKey                           = "secret-auto-create"
+	secretAutoCreateDefaultValue                  = "true"
+	SecretGhAppTokenRepoScoppedKey                = "secret-github-app-token-scopped" //nolint: gosec
+	secretGhAppTokenRepoScoppedDefaultValue       = "true"
+	SecretGhAppTokenScoppedExtraReposKey          = "secret-github-app-scope-extra-repos" //nolint: gosec
+	secretGhAppTokenScoppedExtraReposDefaultValue = ""                                    //nolint: gosec
+
 	remoteTasksDefaultValue                 = "true"
 	bitbucketCloudCheckSourceIPDefaultValue = "true"
 	PACApplicationNameDefaultValue          = "Pipelines as Code CI"
@@ -46,7 +49,6 @@ const (
 
 type Settings struct {
 	ApplicationName                    string
-	SecretAutoCreation                 bool
 	HubURL                             string
 	HubCatalogName                     string
 	RemoteTasks                        bool
@@ -57,7 +59,10 @@ type Settings struct {
 	TektonDashboardURL                 string
 	AutoConfigureNewGitHubRepo         bool
 	AutoConfigureRepoNamespaceTemplate string
-	SecretGHAppRepoScoped              bool
+
+	SecretAutoCreation                bool
+	SecretGHAppRepoScoped             bool
+	SecretGhAppTokenScoppedExtraRepos string
 
 	ErrorLogSnippet             bool
 	ErrorDetection              bool
@@ -78,6 +83,7 @@ func ConfigToSettings(logger *zap.SugaredLogger, setting *Settings, config map[s
 		logger.Infof("CONFIG: application name set to %v", config[ApplicationNameKey])
 		setting.ApplicationName = config[ApplicationNameKey]
 	}
+
 	secretAutoCreate := StringToBool(config[SecretAutoCreateKey])
 	if setting.SecretAutoCreation != secretAutoCreate {
 		logger.Infof("CONFIG: secret auto create set to %v", secretAutoCreate)
@@ -89,6 +95,13 @@ func ConfigToSettings(logger *zap.SugaredLogger, setting *Settings, config map[s
 		logger.Infof("CONFIG: not scopping the token generated from gh %v", secretGHAppRepoScoped)
 		setting.SecretGHAppRepoScoped = secretGHAppRepoScoped
 	}
+
+	secretGHAppScoppedExtraRepos := config[SecretGhAppTokenScoppedExtraReposKey]
+	if setting.SecretGhAppTokenScoppedExtraRepos != secretGHAppScoppedExtraRepos {
+		logger.Infof("CONFIG: adding extra repositories for token scopping %v", secretGHAppRepoScoped)
+		setting.SecretGhAppTokenScoppedExtraRepos = secretGHAppScoppedExtraRepos
+	}
+
 	if setting.HubURL != config[HubURLKey] {
 		logger.Infof("CONFIG: hub URL set to %v", config[HubURLKey])
 		setting.HubURL = config[HubURLKey]

--- a/pkg/params/settings/default.go
+++ b/pkg/params/settings/default.go
@@ -11,6 +11,10 @@ func SetDefaults(config map[string]string) {
 		config[SecretAutoCreateKey] = secretAutoCreateDefaultValue
 	}
 
+	if ghScoppedToken, ok := config[SecretGhAppTokenRepoScoppedKey]; !ok || ghScoppedToken == "" {
+		config[SecretGhAppTokenRepoScoppedKey] = secretGhAppTokenRepoScoppedDefaultValue
+	}
+
 	if hubURL, ok := config[HubURLKey]; !ok || hubURL == "" {
 		config[HubURLKey] = HubURLDefaultValue
 	}

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -35,8 +35,10 @@ type Provider struct {
 	Token, APIURL *string
 	ApplicationID *int64
 	providerName  string
+	Run           *params.Run
+	repositoryIDs []int64
+
 	skippedRun
-	Run *params.Run
 }
 
 type skippedRun struct {
@@ -112,6 +114,7 @@ func (v *Provider) InitAppClient(ctx context.Context, kube kubernetes.Interface,
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -213,6 +216,7 @@ func (v *Provider) SetClient(ctx context.Context, run *params.Run, event *info.E
 			return fmt.Errorf("the webhook secret is not valid: %w", err)
 		}
 	}
+
 	return nil
 }
 
@@ -348,6 +352,11 @@ func (v *Provider) getPullRequest(ctx context.Context, runevent *info.Event) (*i
 	runevent.HeadBranch = pr.GetHead().GetRef()
 	runevent.BaseBranch = pr.GetBase().GetRef()
 	runevent.EventType = "pull_request"
+
+	v.repositoryIDs = []int64{
+		pr.GetBase().GetRepo().GetID(),
+		pr.GetHead().GetRepo().GetID(),
+	}
 	return runevent, nil
 }
 

--- a/pkg/provider/github/parse_payload.go
+++ b/pkg/provider/github/parse_payload.go
@@ -126,7 +126,7 @@ func getInstallationIDFromPayload(payload string) int64 {
 // Another thing: The payload is protected by the webhook signature so it cannot be tempered but even tho if it's
 // tempered with and somehow a malicious user found the token and set their own github endpoint to hijack and
 // exfiltrate the token, it would fail since the jwt token generation will fail, so we are safe here.
-// a bit too far fetched but i don't see any way this can be exploited.
+// a bit too far fetched but i don't see any way we can exploit this.
 func (v *Provider) ParsePayload(ctx context.Context, run *params.Run, request *http.Request, payload string) (*info.Event, error) {
 	event := info.NewEvent()
 
@@ -156,7 +156,7 @@ func (v *Provider) ParsePayload(ctx context.Context, run *params.Run, request *h
 	}
 
 	// regenerate token scoped to the repo IDs
-	if installationIDFrompayload != -1 && len(v.repositoryIDs) > 0 {
+	if run.Info.Pac.Settings.SecretGHAppRepoScoped && installationIDFrompayload != -1 && len(v.repositoryIDs) > 0 {
 		var err error
 		if processedEvent.Provider.Token, err = v.getAppToken(ctx, run.Clients.Kube, event.Provider.URL,
 			installationIDFrompayload); err != nil {

--- a/pkg/provider/github/parse_payload_test.go
+++ b/pkg/provider/github/parse_payload_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
 	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
 	ghtesthelper "github.com/openshift-pipelines/pipelines-as-code/pkg/test/github"
 	"gotest.tools/v3/assert"
@@ -280,7 +281,11 @@ func TestParsePayLoad(t *testing.T) {
 			request.Header.Set("X-GitHub-Event", tt.eventType)
 
 			run := &params.Run{
-				Info: info.Info{},
+				Info: info.Info{
+					Pac: &info.PacOpts{
+						Settings: &settings.Settings{},
+					},
+				},
 			}
 			bjeez, _ := json.Marshal(tt.payloadEventStruct)
 			jeez := string(bjeez)
@@ -462,7 +467,9 @@ func TestAppTokenGeneration(t *testing.T) {
 					Kube: tt.seedData.Kube,
 				},
 				Info: info.Info{
-					Pac: &info.PacOpts{},
+					Pac: &info.PacOpts{
+						Settings: &settings.Settings{},
+					},
 				},
 			}
 

--- a/pkg/provider/github/parse_payload_test.go
+++ b/pkg/provider/github/parse_payload_test.go
@@ -145,11 +145,13 @@ func TestParsePayLoad(t *testing.T) {
 			eventType:     "issue_comment",
 			triggerTarget: "pull_request",
 			githubClient:  fakeclient,
-			payloadEventStruct: github.IssueCommentEvent{Issue: &github.Issue{
-				PullRequestLinks: &github.PullRequestLinks{
-					HTMLURL: github.String("/bad"),
+			payloadEventStruct: github.IssueCommentEvent{
+				Issue: &github.Issue{
+					PullRequestLinks: &github.PullRequestLinks{
+						HTMLURL: github.String("/bad"),
+					},
 				},
-			}},
+			},
 			wantErrString: "bad pull request number",
 		},
 		{
@@ -356,13 +358,14 @@ func TestAppTokenGeneration(t *testing.T) {
 
 	fakeGithubAuthURL := "https://fake.gitub.auth/api/v3/"
 	tests := []struct {
-		ctx           context.Context
-		name          string
-		wantErr       bool
-		nilClient     bool
-		seedData      testclient.Clients
-		envs          map[string]string
-		resultBaseURL string
+		ctx             context.Context
+		name            string
+		wantErr         bool
+		nilClient       bool
+		seedData        testclient.Clients
+		envs            map[string]string
+		resultBaseURL   string
+		checkInstallIDs []int64
 	}{
 		{
 			name: "secret not found",
@@ -384,6 +387,17 @@ func TestAppTokenGeneration(t *testing.T) {
 			nilClient:     false,
 		},
 		{
+			ctx:  ctx,
+			name: "check installation ids are set",
+			envs: map[string]string{
+				"SYSTEM_NAMESPACE": testNamespace,
+			},
+			seedData:        vaildSecret,
+			resultBaseURL:   "https://fake.gitub.auth/api/v3/",
+			nilClient:       false,
+			checkInstallIDs: []int64{123, 456},
+		},
+		{
 			ctx:  ctxInvalidAppID,
 			name: "invalid app id in secret",
 			envs: map[string]string{
@@ -394,7 +408,7 @@ func TestAppTokenGeneration(t *testing.T) {
 		},
 		{
 			ctx:  ctxInvalidPrivateKey,
-			name: "invalid app id in secret",
+			name: "invalid private key in secret",
 			envs: map[string]string{
 				"SYSTEM_NAMESPACE": testNamespace,
 			},
@@ -418,6 +432,22 @@ func TestAppTokenGeneration(t *testing.T) {
 			// adding installation id to event to enforce client creation
 			samplePRevent.Installation = &github.Installation{
 				ID: &testInstallationID,
+			}
+
+			if len(tt.checkInstallIDs) > 0 {
+				samplePRevent.PullRequest = &github.PullRequest{
+					// order is important here for the check later
+					Base: &github.PullRequestBranch{
+						Repo: &github.Repository{
+							ID: github.Int64(tt.checkInstallIDs[0]),
+						},
+					},
+					Head: &github.PullRequestBranch{
+						Repo: &github.Repository{
+							ID: github.Int64(tt.checkInstallIDs[1]),
+						},
+					},
+				}
 			}
 
 			jeez, _ := json.Marshal(samplePRevent)
@@ -446,6 +476,13 @@ func TestAppTokenGeneration(t *testing.T) {
 				assert.Assert(t, gprovider.Client == nil)
 				return
 			}
+
+			for k, id := range tt.checkInstallIDs {
+				if gprovider.repositoryIDs[k] != id {
+					t.Errorf("got %d, want %d", gprovider.repositoryIDs[k], id)
+				}
+			}
+
 			assert.Assert(t, gprovider.Client != nil)
 			assert.Equal(t, gprovider.Client.BaseURL.String(), tt.resultBaseURL)
 		})


### PR DESCRIPTION
Let scope the token to the repoID from where the payload come from
(Base) and on PullRequest the target it belongs to.

Copying the larger comment from the code here:

```
+// ParsePayload will parse the payload and return the event
+// it generate the github app token targeting the installation id
+// this pieces of code is a bit messy because we need first getting a token to
+// before parsing the payload.
+//
+// We need to get the token at first because in some case when coming from pull request
+// comment (or recheck from the UI) we will use that token to get
+// information about the PR that is not part of the payload.
+//
+// We then regenerate a second time the token scoped to the repo where the
+// payload come from so we can avoid the scenario where an admin install the
+// app on a github org which has a mixed of private and public repos and some of
+// the public users should not have access to the private repos.
+//
+// Another thing: The payload is protected by the webhook signature so it cannot be tempered but even tho if it's
+// tempered with and somehow a malicious user found the webhook secrets and then set their own github endpoint to hijack and
+// exfiltrate the token, it would fail since the jwt token generation will fail, so we are safe here.
+// a bit too far fetched but i don't see any way this can be exploited.
```
Add a setting as well to disable that behavior if the user would like so.
Add a setting to keep the repo scopping but add extra repository if they want so.


Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com><!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
