### PR TITLE
Ordered execution during concurrency

### DIFF
--- a/pkg/action/patch.go
+++ b/pkg/action/patch.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/client-go/util/retry"
 )
 
-func PatchPipelineRun(ctx context.Context, logger *zap.SugaredLogger, tekton versioned.Interface, pr *v1beta1.PipelineRun, mergePatch map[string]interface{}) error {
+func PatchPipelineRun(ctx context.Context, logger *zap.SugaredLogger, whatPatching string, tekton versioned.Interface, pr *v1beta1.PipelineRun, mergePatch map[string]interface{}) error {
 	if pr == nil {
 		return nil
 	}
@@ -24,14 +24,14 @@ func PatchPipelineRun(ctx context.Context, logger *zap.SugaredLogger, tekton ver
 		}
 		patchedPR, err := tekton.TektonV1beta1().PipelineRuns(pr.GetNamespace()).Patch(ctx, pr.GetName(), types.MergePatchType, patch, metav1.PatchOptions{})
 		if err != nil {
-			logger.Infof("could not patch Pipelinerun, retrying %v/%v: %v", pr.GetNamespace(), pr.GetName(), err)
+			logger.Infof("could not patch Pipelinerun with %v, retrying %v/%v: %v", whatPatching, pr.GetNamespace(), pr.GetName(), err)
 			return err
 		}
-		logger.Infof("patched pipelinerun: %v/%v", patchedPR.Namespace, patchedPR.Name)
+		logger.Infof("patched pipelinerun with %v: %v/%v", whatPatching, patchedPR.Namespace, patchedPR.Name)
 		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("failed to patch pipelinerun %v/%v: %w", pr.Namespace, pr.Name, err)
+		return fmt.Errorf("failed to patch pipelinerun %v/%v with %v: %w", pr.Namespace, whatPatching, pr.Name, err)
 	}
 	return nil
 }

--- a/pkg/action/patch_test.go
+++ b/pkg/action/patch_test.go
@@ -39,7 +39,7 @@ func TestPatchPipelineRun(t *testing.T) {
 		ConsoleUI: &consoleui.TektonDashboard{BaseURL: "https://localhost.console"},
 	}
 
-	err := PatchPipelineRun(ctx, logger, fakeClients.Tekton, testPR, getLogURLMergePatch(fakeClients, testPR))
+	err := PatchPipelineRun(ctx, logger, "log URL", fakeClients.Tekton, testPR, getLogURLMergePatch(fakeClients, testPR))
 	assert.NilError(t, err)
 
 	pr, err := fakeClients.Tekton.TektonV1beta1().PipelineRuns("namespace").Get(ctx, "force-me", metav1.GetOptions{})

--- a/pkg/apis/pipelinesascode/keys/keys.go
+++ b/pkg/apis/pipelinesascode/keys/keys.go
@@ -47,4 +47,5 @@ const (
 	TargetNamespace = pipelinesascode.GroupName + "/target-namespace"
 	MaxKeepRuns     = pipelinesascode.GroupName + "/max-keep-runs"
 	LogURL          = pipelinesascode.GroupName + "/log-url"
+	ExecutionOrder  = pipelinesascode.GroupName + "/execution-order"
 )

--- a/pkg/pipelineascode/cancel_pipelineruns.go
+++ b/pkg/pipelineascode/cancel_pipelineruns.go
@@ -67,8 +67,7 @@ func (p *PacRun) cancelPipelineRuns(ctx context.Context, repo *v1alpha1.Reposito
 		wg.Add(1)
 		go func(ctx context.Context, pr v1beta1.PipelineRun) {
 			defer wg.Done()
-			p.logger.Infof("patching pipelinerun %v/%v with cancel patch", pr.Namespace, pr.Name)
-			if err := action.PatchPipelineRun(ctx, p.logger, p.run.Clients.Tekton, &pr, cancelMergePatch); err != nil {
+			if err := action.PatchPipelineRun(ctx, p.logger, "cancel patch", p.run.Clients.Tekton, &pr, cancelMergePatch); err != nil {
 				errMsg := fmt.Sprintf("failed to cancel pipelineRun %s/%s: %s", pr.GetNamespace(), pr.GetName(), err.Error())
 				p.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "RepositoryPipelineRun", errMsg)
 			}

--- a/pkg/pipelineascode/concurrency.go
+++ b/pkg/pipelineascode/concurrency.go
@@ -1,0 +1,74 @@
+package pipelineascode
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/sort"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+const namePath = "{.metadata.name}"
+
+type ConcurrencyManager struct {
+	enabled      bool
+	pipelineRuns []*v1beta1.PipelineRun
+	mutex        *sync.Mutex
+}
+
+func NewConcurrencyManager() *ConcurrencyManager {
+	return &ConcurrencyManager{
+		pipelineRuns: []*v1beta1.PipelineRun{},
+		mutex:        &sync.Mutex{},
+	}
+}
+
+func (c *ConcurrencyManager) AddPipelineRun(pr *v1beta1.PipelineRun) {
+	if !c.enabled {
+		return
+	}
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	c.pipelineRuns = append(c.pipelineRuns, pr)
+}
+
+func (c *ConcurrencyManager) Enable() {
+	c.enabled = true
+}
+
+func (c *ConcurrencyManager) GetExecutionOrder() (string, []*v1beta1.PipelineRun) {
+	if !c.enabled {
+		return "", nil
+	}
+
+	runtimeObjs := []runtime.Object{}
+	for _, pr := range c.pipelineRuns {
+		runtimeObjs = append(runtimeObjs, pr)
+	}
+
+	// sort runs by name
+	sort.ByField(namePath, runtimeObjs)
+
+	sortedPipelineRuns := []*v1beta1.PipelineRun{}
+	for _, run := range runtimeObjs {
+		pr, _ := run.(*v1beta1.PipelineRun)
+		sortedPipelineRuns = append(sortedPipelineRuns, pr)
+	}
+	c.pipelineRuns = sortedPipelineRuns
+
+	return getOrderByName(c.pipelineRuns), c.pipelineRuns
+}
+
+func getOrderByName(runs []*v1beta1.PipelineRun) string {
+	var order string
+	for _, run := range runs {
+		if order == "" {
+			order = fmt.Sprintf("%s/%s", run.GetNamespace(), run.GetName())
+			continue
+		}
+		order = order + "," + fmt.Sprintf("%s/%s", run.GetNamespace(), run.GetName())
+	}
+	return order
+}

--- a/pkg/pipelineascode/concurrency_test.go
+++ b/pkg/pipelineascode/concurrency_test.go
@@ -1,0 +1,31 @@
+package pipelineascode
+
+import (
+	"testing"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestExecutionOrder(t *testing.T) {
+	cm := NewConcurrencyManager()
+
+	testNs := "test"
+	abcPR := &v1beta1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: testNs}}
+	defPR := &v1beta1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Name: "def", Namespace: testNs}}
+	mnoPR := &v1beta1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Name: "mno", Namespace: testNs}}
+	pqrPR := &v1beta1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Name: "pqr", Namespace: testNs}}
+
+	cm.Enable()
+
+	// add pipelineRuns in random order
+	cm.AddPipelineRun(pqrPR)
+	cm.AddPipelineRun(abcPR)
+	cm.AddPipelineRun(mnoPR)
+	cm.AddPipelineRun(defPR)
+
+	order, runs := cm.GetExecutionOrder()
+	assert.Equal(t, order, "test/abc,test/def,test/mno,test/pqr")
+	assert.Equal(t, len(runs), 4)
+}

--- a/pkg/provider/github/status.go
+++ b/pkg/provider/github/status.go
@@ -204,8 +204,7 @@ func (v *Provider) getOrUpdateCheckRunStatus(ctx context.Context, tekton version
 			}
 		}
 		if statusOpts.PipelineRun != nil {
-			v.Logger.Infof("patching pipelinerun %v/%v with checkRunID and logURL", statusOpts.PipelineRun.Namespace, statusOpts.PipelineRun.Name)
-			if err := action.PatchPipelineRun(ctx, v.Logger, tekton, statusOpts.PipelineRun, metadataPatch(checkRunID, statusOpts.DetailsURL)); err != nil {
+			if err := action.PatchPipelineRun(ctx, v.Logger, "checkRunID and logURL", tekton, statusOpts.PipelineRun, metadataPatch(checkRunID, statusOpts.DetailsURL)); err != nil {
 				return err
 			}
 		}

--- a/pkg/reconciler/emit_metrics.go
+++ b/pkg/reconciler/emit_metrics.go
@@ -1,0 +1,23 @@
+package reconciler
+
+import (
+	"strings"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+)
+
+func (r *Reconciler) emitMetrics(pr *v1beta1.PipelineRun) error {
+	gitProvider := pr.GetLabels()[keys.GitProvider]
+	eventType := pr.GetLabels()[keys.EventType]
+
+	if strings.HasPrefix(gitProvider, "github") {
+		if _, ok := pr.GetAnnotations()[keys.InstallationID]; ok {
+			gitProvider += "-app"
+		} else {
+			gitProvider += "-webhook"
+		}
+	}
+
+	return r.metrics.Count(gitProvider, eventType)
+}

--- a/pkg/reconciler/finalizer_test.go
+++ b/pkg/reconciler/finalizer_test.go
@@ -115,7 +115,7 @@ func TestReconciler_FinalizeKind(t *testing.T) {
 
 			if len(tt.addToQueue) != 0 {
 				for _, pr := range tt.addToQueue {
-					_, _, err := r.qm.AddToQueue(finalizeTestRepo, pr)
+					_, err := r.qm.AddListToQueue(finalizeTestRepo, []string{pr.GetNamespace() + "/" + pr.GetName()})
 					assert.NilError(t, err)
 				}
 			}

--- a/pkg/reconciler/queue_pipelineruns.go
+++ b/pkg/reconciler/queue_pipelineruns.go
@@ -1,0 +1,65 @@
+package reconciler
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (r *Reconciler) queuePipelineRun(ctx context.Context, logger *zap.SugaredLogger, pr *v1beta1.PipelineRun) error {
+	order, exist := pr.GetAnnotations()[keys.ExecutionOrder]
+	if !exist {
+		// if the pipelineRun doesn't have order label then wait
+		return nil
+	}
+
+	repoName := pr.GetLabels()[keys.Repository]
+	repo, err := r.repoLister.Repositories(pr.Namespace).Get(repoName)
+	if err != nil {
+		// if repository is not found, then skip processing the pipelineRun and return nil
+		if errors.IsNotFound(err) {
+			r.qm.RemoveRepository(&v1alpha1.Repository{ObjectMeta: metav1.ObjectMeta{
+				Name:      repoName,
+				Namespace: pr.Namespace,
+			}})
+			return nil
+		}
+		return fmt.Errorf("updateError: %w", err)
+	}
+
+	// if concurrency was set and later removed or changed to zero
+	// then remove pipelineRun from Queue and update pending state to running
+	if repo.Spec.ConcurrencyLimit != nil && *repo.Spec.ConcurrencyLimit == 0 {
+		_ = r.qm.RemoveFromQueue(repo, pr)
+		if err := r.updatePipelineRunToInProgress(ctx, logger, repo, pr); err != nil {
+			return fmt.Errorf("failed to update PipelineRun to in_progress: %w", err)
+		}
+		return nil
+	}
+
+	orderedList := strings.Split(order, ",")
+	acquired, err := r.qm.AddListToQueue(repo, orderedList)
+	if err != nil {
+		return fmt.Errorf("failed to add to queue: %s: %w", pr.GetName(), err)
+	}
+
+	for _, prKeys := range acquired {
+		nsName := strings.Split(prKeys, "/")
+		pr, err = r.run.Clients.Tekton.TektonV1beta1().PipelineRuns(nsName[0]).Get(ctx, nsName[1], metav1.GetOptions{})
+		if err != nil {
+			logger.Info("failed to get pr with namespace and name: ", nsName[0], nsName[1])
+			return err
+		}
+		if err := r.updatePipelineRunToInProgress(ctx, logger, repo, pr); err != nil {
+			return fmt.Errorf("failed to update pipelineRun to in_progress: %w", err)
+		}
+	}
+	return nil
+}

--- a/pkg/sync/common.go
+++ b/pkg/sync/common.go
@@ -10,7 +10,7 @@ type Semaphore interface {
 	tryAcquire(string) (bool, string)
 	release(string) bool
 	resize(int) bool
-	addToQueue(string, time.Time)
+	addToQueue(string, time.Time) bool
 	removeFromQueue(string)
 	getName() string
 	getLimit() int

--- a/pkg/sync/priority_queue.go
+++ b/pkg/sync/priority_queue.go
@@ -19,15 +19,18 @@ type priorityQueue struct {
 	itemByKey map[string]*item
 }
 
-func (pq *priorityQueue) add(key key, priority int64) {
-	if res, ok := pq.itemByKey[key]; ok {
-		if res.priority != priority {
-			res.priority = priority
-			heap.Fix(pq, res.index)
-		}
-	} else {
-		heap.Push(pq, &item{key: key, priority: priority})
+func (pq *priorityQueue) isPending(key key) bool {
+	if _, ok := pq.itemByKey[key]; ok {
+		return true
 	}
+	return false
+}
+
+func (pq *priorityQueue) add(key key, priority int64) {
+	if _, ok := pq.itemByKey[key]; ok {
+		return
+	}
+	heap.Push(pq, &item{key: key, priority: priority})
 }
 
 func (pq *priorityQueue) remove(key key) {

--- a/pkg/sync/priority_queue_test.go
+++ b/pkg/sync/priority_queue_test.go
@@ -49,5 +49,5 @@ func TestPriorityQueue(t *testing.T) {
 	pq.add("item-a", 1)
 
 	// check the top most
-	assert.Equal(t, pq.peek().key, "item-a")
+	assert.Equal(t, pq.peek().key, "item-c")
 }

--- a/pkg/sync/semaphore.go
+++ b/pkg/sync/semaphore.go
@@ -116,14 +116,18 @@ func (s *prioritySemaphore) release(key string) bool {
 	return true
 }
 
-func (s *prioritySemaphore) addToQueue(key string, creationTime time.Time) {
+func (s *prioritySemaphore) addToQueue(key string, creationTime time.Time) bool {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
 	if _, ok := s.running[key]; ok {
-		return
+		return false
 	}
-	s.pending.add(key, creationTime.Unix())
+	if s.pending.isPending(key) {
+		return false
+	}
+	s.pending.add(key, creationTime.UnixNano())
+	return true
 }
 
 func (s *prioritySemaphore) tryAcquire(key string) (bool, string) {

--- a/pkg/sync/semaphore_test.go
+++ b/pkg/sync/semaphore_test.go
@@ -18,9 +18,9 @@ func TestNewSemaphore(t *testing.T) {
 	// add elements
 	// randomly adding elements, the element with the less priority
 	// must execute first
-	repo.addToQueue("C", cw.Now().Add(5*time.Second))
-	repo.addToQueue("A", cw.Now())
-	repo.addToQueue("B", cw.Now().Add(1*time.Second))
+	assert.Equal(t, repo.addToQueue("C", cw.Now().Add(5*time.Second)), true)
+	assert.Equal(t, repo.addToQueue("A", cw.Now()), true)
+	assert.Equal(t, repo.addToQueue("B", cw.Now().Add(1*time.Second)), true)
 
 	// start the topmost, which would be A
 	acquired, msg := repo.tryAcquire("A")
@@ -44,7 +44,7 @@ func TestNewSemaphore(t *testing.T) {
 
 	// adding element to Queue which is running
 	// nothing should happen
-	repo.addToQueue("A", cw.Now().Add(5*time.Second))
+	assert.Equal(t, repo.addToQueue("A", cw.Now().Add(5*time.Second)), false)
 
 	// A is done
 	repo.release("A")
@@ -67,9 +67,9 @@ func TestNewSemaphore(t *testing.T) {
 	repo.resize(2)
 
 	// now add new elements
-	repo.addToQueue("D", cw.Now().Add(8*time.Second))
-	repo.addToQueue("E", cw.Now().Add(6*time.Second))
-	repo.addToQueue("F", cw.Now().Add(7*time.Second))
+	assert.Equal(t, repo.addToQueue("D", cw.Now().Add(8*time.Second)), true)
+	assert.Equal(t, repo.addToQueue("E", cw.Now().Add(6*time.Second)), true)
+	assert.Equal(t, repo.addToQueue("F", cw.Now().Add(7*time.Second)), true)
 
 	// queue already have C in it
 	// now the queue must have C > E > F > D

--- a/test/testdata/pipelineruns-ordered-execution.yaml
+++ b/test/testdata/pipelineruns-ordered-execution.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: abc
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
+    pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: task
+        taskSpec:
+          steps:
+            - name: task
+              image: registry.access.redhat.com/ubi9/ubi-micro
+              command: ["/bin/echo", "HELLOMOTO"]
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: pqr
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
+    pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: task
+        taskSpec:
+          steps:
+            - name: task
+              image: registry.access.redhat.com/ubi9/ubi-micro
+              command: ["/bin/echo", "HELLOMOTO"]
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: xyz
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
+    pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: task
+        taskSpec:
+          steps:
+            - name: task
+              image: registry.access.redhat.com/ubi9/ubi-micro
+              command: ["/bin/echo", "HELLOMOTO"]


### PR DESCRIPTION
Previously if concurrency is enabled then order of execution of pipelineruns was random
this is to address that and now pipelineruns will be executed in alphabetical order.

how?
* controller after creating pipelineruns get all pipelineruns together and sort them by name
* it generated a execution order by name of pipelineruns after sorting
eg.
```
pipelinesascode.tekton.dev/execution-order: pac-app-pipelines/abc-6svcd,pac-app-pipelines/def-g45hj,pac-app-pipelines/ghi-t6445
```
* it patch all the pipelineruns with the order as annotation.
 
Now,
* watcher checks if pipelines is in pending state and its spec.status is pending
* then check if the order annotation is available, otherwise waits for it
* after getting the order it creates a queue for repository and add all the pipelineruns from the order
* first pipelinerun which will be reconciled will add all pipelineruns keys in queue 
* reconciling other pipelineruns will have no effect on the queue
* after adding in queue based on concurency limit, it tries to move that many pipelineruns to running state

what if watcher restarts?

* if watcher restarts it will rebuild queues
* it will first fetch all running pipelineruns for a repo which has concurrency enabled
* adds to the queues, and then fetch queued and add to the queues
* before working on pipelineruns, it sorts them by creation time stamp so that we don't requeue new before old

TODO:
* we no longer use priority queue in sync package as controller now defines order of execution
* we need to cleanup that but we need to rework on better architecture for concurreny, this is not going to work for advanced concurrency usecases we have in jira


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [x] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [x] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [x] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [x] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
