### PR TITLE
Don't scope token to the base repo on gh pull request

### DIFF
--- a/.github/workflows/kind-e2e-tests.yaml
+++ b/.github/workflows/kind-e2e-tests.yaml
@@ -85,7 +85,7 @@ jobs:
           # Add an extra Repository ID to the token scope to fetch private url
           # This goes with the variable TEST_GITHUB_PRIVATE_TASK_NAME and tested with
           # the TestGithubPullRequestRemoteTaskAnnotations test
-          kubectl patch configmap -n pipelines-as-code -p "{\"data\":{\"secret-github-app-scope-extra-repos\": \"openshift-pipelines/pipelines-as-code-e2e-tests-webhook\"}}" \
+          kubectl patch configmap -n pipelines-as-code -p "{\"data\":{\"secret-github-app-scope-extra-repos\": \"openshift-pipelines/pipelines-as-code-e2e-tests-private\"}}" \
           --type merge pipelines-as-code
 
           # restart controller
@@ -106,7 +106,7 @@ jobs:
       - name: Run E2E Tests
         run: |
           # Nothing specific to webhook here it  just that repo is private in that org and that's what we want to test
-          export TEST_GITHUB_PRIVATE_TASK_URL="https://github.com/openshift-pipelines/pipelines-as-code-e2e-tests-webhook/blob/main/testdatas/remote_task.yaml"
+          export TEST_GITHUB_PRIVATE_TASK_URL="https://github.com/openshift-pipelines/pipelines-as-code-e2e-tests-private/blob/main/remote_task.yaml"
           export TEST_GITHUB_PRIVATE_TASK_NAME="task-remote"
 
           export GO_TEST_FLAGS="-v -race -failfast"

--- a/pkg/provider/github/parse_payload.go
+++ b/pkg/provider/github/parse_payload.go
@@ -248,7 +248,6 @@ func (v *Provider) processEvent(ctx context.Context, event *info.Event, eventInt
 		// to scope the token to
 		v.repositoryIDs = []int64{
 			gitEvent.GetPullRequest().GetBase().GetRepo().GetID(),
-			gitEvent.GetPullRequest().GetHead().GetRepo().GetID(),
 		}
 	default:
 		return nil, errors.New("this event is not supported")

--- a/pkg/provider/github/parse_payload_test.go
+++ b/pkg/provider/github/parse_payload_test.go
@@ -445,7 +445,7 @@ func TestAppTokenGeneration(t *testing.T) {
 			seedData:        vaildSecret,
 			resultBaseURL:   "https://fake.gitub.auth/api/v3/",
 			nilClient:       false,
-			checkInstallIDs: []int64{123, 456},
+			checkInstallIDs: []int64{123},
 		},
 		{
 			ctx:  ctx,
@@ -455,7 +455,7 @@ func TestAppTokenGeneration(t *testing.T) {
 			},
 			seedData:            vaildSecret,
 			nilClient:           false,
-			checkInstallIDs:     []int64{123, 456},
+			checkInstallIDs:     []int64{123},
 			extraRepoInstallIds: map[string]string{"another/one": "789", "andanother/two": "10112"},
 		},
 		{
@@ -499,11 +499,6 @@ func TestAppTokenGeneration(t *testing.T) {
 					Base: &github.PullRequestBranch{
 						Repo: &github.Repository{
 							ID: github.Int64(tt.checkInstallIDs[0]),
-						},
-					},
-					Head: &github.PullRequestBranch{
-						Repo: &github.Repository{
-							ID: github.Int64(tt.checkInstallIDs[1]),
 						},
 					},
 				}


### PR DESCRIPTION
On Github Pull Request with scopped token, we were scopping it to the base pull request but that's not necessary and fails when user didn't add the app to their own repo (which they don't have to)..

Fixes #1072

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
