### PR TITLE
switches to listers for querying repositories

### DIFF
--- a/config/202-watcher-role.yaml
+++ b/config/202-watcher-role.yaml
@@ -70,7 +70,7 @@ rules:
     verbs: ["get", "delete"]
   - apiGroups: ["pipelinesascode.tekton.dev"]
     resources: ["repositories"]
-    verbs: ["get", "list", "update"]
+    verbs: ["get", "list", "update", "watch"]
   - apiGroups: ["tekton.dev"]
     resources: ["pipelineruns"]
     verbs: ["get", "delete", "list", "watch", "update", "patch"]

--- a/pkg/reconciler/controller.go
+++ b/pkg/reconciler/controller.go
@@ -7,6 +7,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/events"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/generated/injection/informers/pipelinesascode/v1alpha1/repository"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/metrics"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
@@ -50,6 +51,7 @@ func NewController() func(context.Context, configmap.Watcher) *controller.Impl {
 			run:               run,
 			kinteract:         kinteract,
 			pipelineRunLister: pipelineRunInformer.Lister(),
+			repoLister:        repository.Get(ctx).Lister(),
 			qm:                sync.NewQueueManager(run.Clients.Log),
 			metrics:           metrics,
 			eventEmitter:      events.NewEventEmitter(run.Clients.Kube, run.Clients.Log),

--- a/pkg/reconciler/finalizer.go
+++ b/pkg/reconciler/finalizer.go
@@ -26,9 +26,7 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, pr *v1beta1.PipelineRun) 
 		if !ok {
 			return nil
 		}
-		repo, err := r.run.Clients.PipelineAsCode.PipelinesascodeV1alpha1().
-			Repositories(pr.Namespace).Get(ctx, repoName, metav1.GetOptions{})
-
+		repo, err := r.repoLister.Repositories(pr.Namespace).Get(repoName)
 		// if repository is not found then remove the queue for that repository if exist
 		if errors.IsNotFound(err) {
 			r.qm.RemoveRepository(&v1alpha1.Repository{

--- a/pkg/reconciler/finalizer_test.go
+++ b/pkg/reconciler/finalizer_test.go
@@ -102,9 +102,10 @@ func TestReconciler_FinalizeKind(t *testing.T) {
 			if tt.skipAddingRepo {
 				testData.Repositories = []*v1alpha1.Repository{}
 			}
-			stdata, _ := testclient.SeedTestData(t, ctx, testData)
+			stdata, informers := testclient.SeedTestData(t, ctx, testData)
 			r := Reconciler{
-				qm: sync.NewQueueManager(fakelogger),
+				repoLister: informers.Repository.Lister(),
+				qm:         sync.NewQueueManager(fakelogger),
 				run: &params.Run{
 					Clients: clients.Clients{
 						PipelineAsCode: stdata.PipelineAsCode,

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -148,7 +148,7 @@ func TestReconciler_ReconcileKind(t *testing.T) {
 					},
 				},
 			}
-			stdata, _ := testclient.SeedTestData(t, ctx, testData)
+			stdata, informers := testclient.SeedTestData(t, ctx, testData)
 
 			testSetupGHReplies(t, mux, runEvent, tt.checkRunID, tt.finalStatus, tt.finalStatusText)
 
@@ -156,7 +156,8 @@ func TestReconciler_ReconcileKind(t *testing.T) {
 			assert.NilError(t, err)
 
 			r := Reconciler{
-				qm: sync.NewQueueManager(fakelogger),
+				repoLister: informers.Repository.Lister(),
+				qm:         sync.NewQueueManager(fakelogger),
 				run: &params.Run{
 					Clients: clients.Clients{
 						PipelineAsCode: stdata.PipelineAsCode,


### PR DESCRIPTION
reconciler now uses informers/listers to query repositories instead of doing api call to kube.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
