### PR TITLE
Handle ref/heads/* for both base branch and target branch

### DIFF
--- a/pkg/matcher/annotation_matcher.go
+++ b/pkg/matcher/annotation_matcher.go
@@ -40,6 +40,15 @@ func branchMatch(prunBranch, baseBranch string) bool {
 		}
 	}
 
+	// if base is refs/heads/.. and target is without ref (for push rerequested action)
+	if strings.HasPrefix(baseBranch, "refs/heads") && !strings.Contains(prunBranch, "/") {
+		prunRef := "refs/heads/" + prunBranch
+		g := glob.MustCompile(prunRef)
+		if g.Match(baseBranch) {
+			return true
+		}
+	}
+
 	// match globs like refs/tags/0.*
 	g := glob.MustCompile(prunBranch)
 	return g.Match(baseBranch)

--- a/pkg/matcher/annotation_matcher_test.go
+++ b/pkg/matcher/annotation_matcher_test.go
@@ -911,6 +911,14 @@ func TestMatchPipelinerunByAnnotation(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "ref-heads-main-push-rerequested-case",
+			args: args{
+				pruns:    []*tektonv1beta1.PipelineRun{pipelineGood},
+				runevent: info.Event{TriggerTarget: "pull_request", EventType: "pull_request", BaseBranch: "refs/heads/main"},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
if base branch has refs/heads but target annotation only has branch name, it use to fails
for eg. target annotation is main and for push rerequested action the base branch would be refs/heads/main
not this checks both ways if any of base branch or taget branch has refs/heads and then matches.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
