### PR TITLE
use github apps installation token to run the test 

### DIFF
--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -110,7 +110,7 @@ func (v *Provider) GetTaskURI(ctx context.Context, _ *params.Run, event *info.Ev
 
 func (v *Provider) InitAppClient(ctx context.Context, kube kubernetes.Interface, event *info.Event) error {
 	var err error
-	event.Provider.Token, err = v.getAppToken(ctx, kube, event.GHEURL, event.InstallationID)
+	event.Provider.Token, err = v.GetAppToken(ctx, kube, event.GHEURL, event.InstallationID)
 	if err != nil {
 		return err
 	}

--- a/pkg/provider/github/parse_payload.go
+++ b/pkg/provider/github/parse_payload.go
@@ -25,7 +25,7 @@ const (
 	secretName = "pipelines-as-code-secret"
 )
 
-func (v *Provider) getAppToken(ctx context.Context, kube kubernetes.Interface, gheURL string, installationID int64) (string, error) {
+func (v *Provider) GetAppToken(ctx context.Context, kube kubernetes.Interface, gheURL string, installationID int64) (string, error) {
 	// TODO: move this out of here
 	ns := os.Getenv("SYSTEM_NAMESPACE")
 	secret, err := kube.CoreV1().Secrets(ns).Get(ctx, secretName, v1.GetOptions{})
@@ -137,7 +137,7 @@ func (v *Provider) ParsePayload(ctx context.Context, run *params.Run, request *h
 	installationIDFrompayload := getInstallationIDFromPayload(payload)
 	if installationIDFrompayload != -1 {
 		var err error
-		if event.Provider.Token, err = v.getAppToken(ctx, run.Clients.Kube, event.Provider.URL, installationIDFrompayload); err != nil {
+		if event.Provider.Token, err = v.GetAppToken(ctx, run.Clients.Kube, event.Provider.URL, installationIDFrompayload); err != nil {
 			return nil, err
 		}
 	}
@@ -176,7 +176,7 @@ func (v *Provider) ParsePayload(ctx context.Context, run *params.Run, request *h
 			}
 		}
 		var err error
-		if processedEvent.Provider.Token, err = v.getAppToken(ctx, run.Clients.Kube, event.Provider.URL,
+		if processedEvent.Provider.Token, err = v.GetAppToken(ctx, run.Clients.Kube, event.Provider.URL,
 			installationIDFrompayload); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
let use a generated github apps token for github to run the tests which   has a much upper limit than PAT.

ghapp_token improvements and documentation
we don't need to create a app token and pass a installation_id if we
just want to generate a jwt token.

add a long description of how it works and how it can be used.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com><!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
