### PR TITLE
Reconciler: Retry reporting provider status if failed

### DIFF
--- a/pkg/kubeinteraction/labels.go
+++ b/pkg/kubeinteraction/labels.go
@@ -16,6 +16,7 @@ const (
 	StateStarted   = "started"
 	StateQueued    = "queued"
 	StateCompleted = "completed"
+	StateFailed    = "failed"
 )
 
 func AddLabelsAndAnnotations(event *info.Event, pipelineRun *tektonv1beta1.PipelineRun, repo *apipac.Repository, providerinfo *info.ProviderConfig) {

--- a/pkg/reconciler/status_test.go
+++ b/pkg/reconciler/status_test.go
@@ -1,0 +1,31 @@
+package reconciler
+
+import (
+	"context"
+	"testing"
+
+	provider2 "github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/test/provider"
+	"go.uber.org/zap"
+	zapobserver "go.uber.org/zap/zaptest/observer"
+	"gotest.tools/v3/assert"
+)
+
+func TestCreateStatusWithRetry(t *testing.T) {
+	observer, _ := zapobserver.New(zap.InfoLevel)
+	fakelogger := zap.New(observer).Sugar()
+	vcx := provider.TestProviderImp{}
+
+	err := createStatusWithRetry(context.TODO(), fakelogger, nil, &vcx, nil, nil, provider2.StatusOpts{})
+	assert.NilError(t, err)
+}
+
+func TestCreateStatusWithRetry_ErrorCase(t *testing.T) {
+	observer, _ := zapobserver.New(zap.InfoLevel)
+	fakelogger := zap.New(observer).Sugar()
+	vcx := provider.TestProviderImp{}
+	vcx.CreateStatusErorring = true
+
+	err := createStatusWithRetry(context.TODO(), fakelogger, nil, &vcx, nil, nil, provider2.StatusOpts{})
+	assert.Error(t, err, "failed to report status: some provider error occurred while reporting status")
+}

--- a/pkg/test/provider/testwebvcs.go
+++ b/pkg/test/provider/testwebvcs.go
@@ -63,7 +63,7 @@ func (v *TestProviderImp) GetTaskURI(ctx context.Context, params *params.Run, ev
 
 func (v *TestProviderImp) CreateStatus(ctx context.Context, _ versioned.Interface, event *info.Event, opts *info.PacOpts, statusOpts provider.StatusOpts) error {
 	if v.CreateStatusErorring {
-		return fmt.Errorf("you want me to error I error for you")
+		return fmt.Errorf("some provider error occurred while reporting status")
 	}
 	return nil
 }


### PR DESCRIPTION
reconciler will retry to report provider status if failed now with a backoff time. It will try 3 times. if it still fails for reporting the final status then it updates the `state` to `failed`. so that those pipelineruns can be queried.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
