### PR TITLE
Fixes the condition in watcher when to user repo secret

### DIFF
--- a/docs/content/docs/guide/resolver.md
+++ b/docs/content/docs/guide/resolver.md
@@ -100,7 +100,7 @@ pipelinesascode.tekton.dev/task: "[git-clone:0.1]" # this will install git-clone
 
 ### Remote HTTP URL
 
-If you have a string starting with http:// or https://, `Pipelines as Code`
+If you have a string starting with `http://` or `https://`, `Pipelines as Code`
 will fetch the task directly from that remote URL :
 
 ```yaml

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -96,12 +96,12 @@ func (r *Reconciler) reportFinalStatus(ctx context.Context, logger *zap.SugaredL
 		return nil, fmt.Errorf("reportFinalStatus: %w", err)
 	}
 
-	if repo.Spec.GitProvider != nil {
+	if event.InstallationID > 0 {
+		event.Provider.WebhookSecret, _ = pipelineascode.GetCurrentNSWebhookSecret(ctx, r.kinteract)
+	} else {
 		if err := pipelineascode.SecretFromRepository(ctx, r.run, r.kinteract, provider.GetConfig(), event, repo, logger); err != nil {
 			return repo, fmt.Errorf("cannot get secret from repository: %w", err)
 		}
-	} else {
-		event.Provider.WebhookSecret, _ = pipelineascode.GetCurrentNSWebhookSecret(ctx, r.kinteract)
 	}
 
 	err = provider.SetClient(ctx, r.run, event)
@@ -161,12 +161,12 @@ func (r *Reconciler) updatePipelineRunToInProgress(ctx context.Context, logger *
 		return nil
 	}
 
-	if repo.Spec.GitProvider != nil {
+	if event.InstallationID > 0 {
+		event.Provider.WebhookSecret, _ = pipelineascode.GetCurrentNSWebhookSecret(ctx, r.kinteract)
+	} else {
 		if err := pipelineascode.SecretFromRepository(ctx, r.run, r.kinteract, p.GetConfig(), event, repo, logger); err != nil {
 			return fmt.Errorf("cannot get secret from repo: %w", err)
 		}
-	} else {
-		event.Provider.WebhookSecret, _ = pipelineascode.GetCurrentNSWebhookSecret(ctx, r.kinteract)
 	}
 
 	err = p.SetClient(ctx, r.run, event)


### PR DESCRIPTION
we fixed this bug in controller but not in watcher, where we look for secret in repo cr only if the event is not from github app. this fixes the conditions for watcher.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
