### PR TITLE
Part of Force controller & watcher goroutine to start "early"

### DIFF
--- a/cmd/pipelines-as-code-controller/main.go
+++ b/cmd/pipelines-as-code-controller/main.go
@@ -32,7 +32,7 @@ func main() {
 	go func() {
 		log.Println("started goroutine to watch configmap changes for controller")
 		c <- struct{}{}
-		if err := run.WatchConfigMapChanges(ctx, run); err != nil {
+		if err := run.WatchConfigMapChanges(ctx); err != nil {
 			log.Fatal("error from WatchConfigMapChanges for controller : ", err)
 		}
 	}()

--- a/cmd/pipelines-as-code-controller/main.go
+++ b/cmd/pipelines-as-code-controller/main.go
@@ -30,9 +30,10 @@ func main() {
 
 	c := make(chan struct{})
 	go func() {
+		log.Println("started goroutine to watch configmap changes for controller")
 		c <- struct{}{}
 		if err := run.WatchConfigMapChanges(ctx, run); err != nil {
-			log.Fatal(err)
+			log.Fatal("error from WatchConfigMapChanges for controller : ", err)
 		}
 	}()
 	// Force WatchConfigMapChanges go routines to actually start

--- a/cmd/pipelines-as-code-watcher/main.go
+++ b/cmd/pipelines-as-code-watcher/main.go
@@ -28,6 +28,7 @@ func main() {
 
 	c := make(chan struct{})
 	go func() {
+		log.Println("started goroutine for watcher")
 		c <- struct{}{}
 		// start the web server on port and accept requests
 		log.Printf("Readiness and health check server listening on port %s", probesPort)

--- a/pkg/params/run.go
+++ b/pkg/params/run.go
@@ -39,6 +39,7 @@ func StringToBool(s string) bool {
 
 // WatchConfigMapChanges watches for provide configmap
 func (r *Run) WatchConfigMapChanges(ctx context.Context, run *Run) error {
+	r.Clients.Log.Info("Inside WatchConfigMapChanges function")
 	ns := os.Getenv("SYSTEM_NAMESPACE")
 	if ns == "" {
 		return fmt.Errorf("failed to find pipelines-as-code installation namespace")
@@ -64,7 +65,9 @@ func (r *Run) getConfigFromConfigMapWatcher(ctx context.Context, eventChannel <-
 		if open {
 			switch event.Type {
 			case watch.Added, watch.Modified:
+				r.Clients.Log.Info("added or modifies events are coming")
 				if err := r.UpdatePACInfo(ctx); err != nil {
+					r.Clients.Log.Info("failed to update PAC info", err)
 					return err
 				}
 			case watch.Deleted, watch.Bookmark, watch.Error:

--- a/pkg/params/run.go
+++ b/pkg/params/run.go
@@ -38,7 +38,7 @@ func StringToBool(s string) bool {
 }
 
 // WatchConfigMapChanges watches for provide configmap
-func (r *Run) WatchConfigMapChanges(ctx context.Context, run *Run) error {
+func (r *Run) WatchConfigMapChanges(ctx context.Context) error {
 	r.Clients.Log.Info("Inside WatchConfigMapChanges function")
 	ns := os.Getenv("SYSTEM_NAMESPACE")
 	if ns == "" {
@@ -51,7 +51,7 @@ func (r *Run) WatchConfigMapChanges(ctx context.Context, run *Run) error {
 	if err != nil {
 		return fmt.Errorf("unable to create watcher : %w", err)
 	}
-	if err := run.getConfigFromConfigMapWatcher(ctx, watcher.ResultChan()); err != nil {
+	if err := r.getConfigFromConfigMapWatcher(ctx, watcher.ResultChan()); err != nil {
 		return fmt.Errorf("failed to get defaults : %w", err)
 	}
 	return nil

--- a/pkg/reconciler/controller.go
+++ b/pkg/reconciler/controller.go
@@ -38,7 +38,7 @@ func NewController() func(context.Context, configmap.Watcher) *controller.Impl {
 		go func() {
 			log.Println("started goroutine to watch configmap changes inside controller reconciler")
 			c <- struct{}{}
-			if err := run.WatchConfigMapChanges(ctx, run); err != nil {
+			if err := run.WatchConfigMapChanges(ctx); err != nil {
 				log.Fatal("error from WatchConfigMapChanges from controller reconciler : ", err)
 			}
 		}()

--- a/pkg/reconciler/controller.go
+++ b/pkg/reconciler/controller.go
@@ -36,9 +36,10 @@ func NewController() func(context.Context, configmap.Watcher) *controller.Impl {
 
 		c := make(chan struct{})
 		go func() {
+			log.Println("started goroutine to watch configmap changes inside controller reconciler")
 			c <- struct{}{}
 			if err := run.WatchConfigMapChanges(ctx, run); err != nil {
-				log.Fatal(err)
+				log.Fatal("error from WatchConfigMapChanges from controller reconciler : ", err)
 			}
 		}()
 		<-c


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
1. Fixed : https://github.com/openshift-pipelines/pipelines-as-code/pull/1097#issuecomment-1378675836
2. Added some prints to verify the configmap watcher issue

Signed-off-by: Savita Ashture <sashture@redhat.com>

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
