### PR TITLE
Fix getting remote task uri from another branch

### DIFF
--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -101,6 +101,7 @@ func (v *Provider) GetTaskURI(ctx context.Context, _ *params.Run, event *info.Ev
 	nEvent := info.NewEvent()
 	nEvent.Organization = spOrg
 	nEvent.Repository = spRepo
+	nEvent.BaseBranch = spRef
 	ret, err := v.GetFileInsideRepo(ctx, nEvent, spPath, spRef)
 	if err != nil {
 		return false, "", err


### PR DESCRIPTION
the ref/branch would not be set properly, v.GetFileInsideRepo is a bit buggy but rather not have bad side effect fixing it in there.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
