### PR TITLE
Don't error out when checking for token expiration on 404     

### DIFF
--- a/pkg/adapter/adapter_test.go
+++ b/pkg/adapter/adapter_test.go
@@ -14,21 +14,15 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
 	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
-	"go.uber.org/zap"
-	zapobserver "go.uber.org/zap/zaptest/observer"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/test/logger"
 	"gotest.tools/v3/assert"
 	rtesting "knative.dev/pkg/reconciler/testing"
 )
 
-func getLogger() *zap.SugaredLogger {
-	observer, _ := zapobserver.New(zap.InfoLevel)
-	logger := zap.New(observer).Sugar()
-	return logger
-}
-
 func TestHandleEvent(t *testing.T) {
 	ctx, _ := rtesting.SetupFakeContext(t)
 	cs, _ := testclient.SeedTestData(t, ctx, testclient.Data{})
+	logger, _ := logger.GetLogger()
 
 	l := listener{
 		run: &params.Run{
@@ -43,7 +37,7 @@ func TestHandleEvent(t *testing.T) {
 				},
 			},
 		},
-		logger: getLogger(),
+		logger: logger,
 	}
 
 	ts := httptest.NewServer(l.handleEvent())
@@ -128,8 +122,9 @@ func TestHandleEvent(t *testing.T) {
 }
 
 func TestWhichProvider(t *testing.T) {
+	logger, _ := logger.GetLogger()
 	l := listener{
-		logger: getLogger(),
+		logger: logger,
 	}
 	tests := []struct {
 		name          string

--- a/pkg/provider/bitbucketcloud/bitbucket_test.go
+++ b/pkg/provider/bitbucketcloud/bitbucket_test.go
@@ -10,8 +10,6 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	bbcloudtest "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketcloud/test"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketcloud/types"
-	"go.uber.org/zap"
-	zapobserver "go.uber.org/zap/zaptest/observer"
 	"gotest.tools/v3/assert"
 	rtesting "knative.dev/pkg/reconciler/testing"
 )
@@ -284,10 +282,4 @@ func TestCreateStatus(t *testing.T) {
 			assert.NilError(t, err)
 		})
 	}
-}
-
-func getLogger() *zap.SugaredLogger {
-	observer, _ := zapobserver.New(zap.InfoLevel)
-	logger := zap.New(observer).Sugar()
-	return logger
 }

--- a/pkg/provider/bitbucketcloud/detect_test.go
+++ b/pkg/provider/bitbucketcloud/detect_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketcloud/types"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/test/logger"
 	"gotest.tools/v3/assert"
 )
 
@@ -132,7 +133,7 @@ func TestProvider_Detect(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			bprovider := Provider{}
-			logger := getLogger()
+			logger, _ := logger.GetLogger()
 
 			jeez, err := json.Marshal(tt.event)
 			if err != nil {

--- a/pkg/provider/bitbucketserver/bitbucketserver_test.go
+++ b/pkg/provider/bitbucketserver/bitbucketserver_test.go
@@ -20,8 +20,6 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	bbtest "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketserver/test"
-	"go.uber.org/zap"
-	zapobserver "go.uber.org/zap/zaptest/observer"
 	"gotest.tools/v3/assert"
 	rtesting "knative.dev/pkg/reconciler/testing"
 )
@@ -336,12 +334,6 @@ func TestGetConfig(t *testing.T) {
 	v := &Provider{}
 	config := v.GetConfig()
 	assert.Equal(t, config.TaskStatusTMPL, taskStatusTemplate)
-}
-
-func getLogger() *zap.SugaredLogger {
-	observer, _ := zapobserver.New(zap.InfoLevel)
-	logger := zap.New(observer).Sugar()
-	return logger
 }
 
 func TestValidate(t *testing.T) {

--- a/pkg/provider/bitbucketserver/detect_test.go
+++ b/pkg/provider/bitbucketserver/detect_test.go
@@ -8,6 +8,7 @@ import (
 
 	bbv1 "github.com/gfleury/go-bitbucket-v1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketserver/types"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/test/logger"
 	"gotest.tools/v3/assert"
 )
 
@@ -115,7 +116,7 @@ func TestProvider_Detect(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			bprovider := Provider{}
-			logger := getLogger()
+			logger, _ := logger.GetLogger()
 
 			jeez, err := json.Marshal(tt.event)
 			if err != nil {

--- a/pkg/provider/github/detect_test.go
+++ b/pkg/provider/github/detect_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/go-github/v48/github"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/test/logger"
 	"gotest.tools/v3/assert"
 )
 
@@ -238,8 +239,7 @@ func TestProvider_Detect(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gprovider := Provider{}
-			logger := getLogger()
-
+			logger, _ := logger.GetLogger()
 			jeez, err := json.Marshal(tt.event)
 			if err != nil {
 				assert.NilError(t, err)

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
 	"sync"
@@ -180,11 +181,16 @@ func makeClient(ctx context.Context, apiURL, token string) (*github.Client, stri
 func (v *Provider) checkWebhookSecretValidity(ctx context.Context, cw clockwork.Clock) error {
 	rl, resp, err := v.Client.RateLimits(ctx)
 	if resp.Header.Get("GitHub-Authentication-Token-Expiration") != "" && cw.Now().After(resp.TokenExpiration.Time) {
-		errm := fmt.Sprintf("token has expired at %s", resp.TokenExpiration.Time.Format(time.RFC1123))
+		errm := fmt.Sprintf("token has expired at %s", resp.TokenExpiration.Format(time.RFC1123))
 		if err != nil {
 			errm += fmt.Sprintf(" err: %s", err.Error())
 		}
 		return fmt.Errorf(errm)
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		v.Logger.Info("skipping checking if token has expired, rate_limit api is not enabled on token")
+		return nil
 	}
 
 	// some other error happened that is not rate limited related
@@ -193,7 +199,7 @@ func (v *Provider) checkWebhookSecretValidity(ctx context.Context, cw clockwork.
 	}
 
 	if rl.SCIM.Remaining == 0 {
-		return fmt.Errorf("token is ratelimited, it will be available again at %s", rl.SCIM.Reset.Time.Format(time.RFC1123))
+		return fmt.Errorf("token is ratelimited, it will be available again at %s", rl.SCIM.Reset.Format(time.RFC1123))
 	}
 	return nil
 }

--- a/pkg/provider/github/github_test.go
+++ b/pkg/provider/github/github_test.go
@@ -21,18 +21,11 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	ghtesthelper "github.com/openshift-pipelines/pipelines-as-code/pkg/test/github"
-	"go.uber.org/zap"
-	zapobserver "go.uber.org/zap/zaptest/observer"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/test/logger"
 	"gotest.tools/v3/assert"
 	"knative.dev/pkg/ptr"
 	rtesting "knative.dev/pkg/reconciler/testing"
 )
-
-func getLogger() *zap.SugaredLogger {
-	observer, _ := zapobserver.New(zap.InfoLevel)
-	logger := zap.New(observer).Sugar()
-	return logger
-}
 
 func TestGithubSplitURL(t *testing.T) {
 	tests := []struct {
@@ -512,7 +505,7 @@ func TestValidate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			logger := getLogger()
+			logger, _ := logger.GetLogger()
 			v := &Provider{Logger: logger}
 
 			hm := hmac.New(tt.hashFunc, []byte(tt.secret))

--- a/pkg/provider/github/parse_payload_test.go
+++ b/pkg/provider/github/parse_payload_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
 	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
 	ghtesthelper "github.com/openshift-pipelines/pipelines-as-code/pkg/test/github"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/test/logger"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/env"
 	corev1 "k8s.io/api/core/v1"
@@ -313,7 +314,7 @@ func TestParsePayLoad(t *testing.T) {
 					fmt.Fprint(rw, string(bjeez))
 				})
 			}
-			logger := getLogger()
+			logger, _ := logger.GetLogger()
 			gprovider := Provider{
 				Client: tt.githubClient,
 				Logger: logger,
@@ -505,7 +506,7 @@ func TestAppTokenGeneration(t *testing.T) {
 			}
 
 			jeez, _ := json.Marshal(samplePRevent)
-			logger := getLogger()
+			logger, _ := logger.GetLogger()
 			gprovider := Provider{
 				Logger: logger,
 				Client: fakeghclient,

--- a/pkg/provider/github/status_test.go
+++ b/pkg/provider/github/status_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
 	ghtesthelper "github.com/openshift-pipelines/pipelines-as-code/pkg/test/github"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/test/logger"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"gotest.tools/v3/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -283,7 +284,7 @@ func TestGithubProviderCreateStatus(t *testing.T) {
 			ctx, _ := rtesting.SetupFakeContext(t)
 			gcvs := New()
 			gcvs.Client = fakeclient
-			gcvs.Logger = getLogger()
+			gcvs.Logger, _ = logger.GetLogger()
 			gcvs.Run = params.New()
 
 			mux.HandleFunc("/repos/check/run/statuses/sha", func(rw http.ResponseWriter, r *http.Request) {})

--- a/pkg/provider/gitlab/detect_test.go
+++ b/pkg/provider/gitlab/detect_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	thelp "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/gitlab/test"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/test/logger"
 	"github.com/xanzy/go-gitlab"
 	"gotest.tools/v3/assert"
 )
@@ -109,7 +110,7 @@ func TestProvider_Detect(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gprovider := Provider{}
-			logger := getLogger()
+			logger, _ := logger.GetLogger()
 
 			header := http.Header{}
 			header.Set("X-Gitlab-Event", string(tt.eventType))

--- a/pkg/provider/gitlab/gitlab_test.go
+++ b/pkg/provider/gitlab/gitlab_test.go
@@ -14,8 +14,6 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	thelp "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/gitlab/test"
 	"github.com/xanzy/go-gitlab"
-	"go.uber.org/zap"
-	zapobserver "go.uber.org/zap/zaptest/observer"
 	"gotest.tools/v3/assert"
 	rtesting "knative.dev/pkg/reconciler/testing"
 )
@@ -359,12 +357,6 @@ func TestGetFileInsideRepo(t *testing.T) {
 
 	_, err = v.GetFileInsideRepo(ctx, event, "notfound", "")
 	assert.Assert(t, err != nil)
-}
-
-func getLogger() *zap.SugaredLogger {
-	observer, _ := zapobserver.New(zap.InfoLevel)
-	logger := zap.New(observer).Sugar()
-	return logger
 }
 
 func TestValidate(t *testing.T) {

--- a/pkg/test/logger/logger.go
+++ b/pkg/test/logger/logger.go
@@ -1,0 +1,12 @@
+package logger
+
+import (
+	"go.uber.org/zap"
+	zapobserver "go.uber.org/zap/zaptest/observer"
+)
+
+func GetLogger() (*zap.SugaredLogger, *zapobserver.ObservedLogs) {
+	zapper, observer := zapobserver.New(zap.InfoLevel)
+	logger := zap.New(zapper).Sugar()
+	return logger, observer
+}


### PR DESCRIPTION

When checking for token expiration the rate_limit api may not enabled on that  token. Don't error out and just print a log message.
    
Fixes #1107

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
