### PR TITLE
fix controller not having sa role to list secret in its own namespace

### DIFF
--- a/config/201-controller-role.yaml
+++ b/config/201-controller-role.yaml
@@ -34,6 +34,9 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
pac would not start otherwise:

```
💡 08:07:28   skipping event: issue: not a gitops pull request comment
🚨 08:36:12   failed to parse event: secrets "pipelines-as-code-secret" is forbidden: User "system:serviceaccount:pipelines-as-code:pipelines-as-code-controller" cannot get resource "secrets" in API group "" in the namespace "pipelines-as-code"
🚨 08:36:12   an error occurred: secrets "pipelines-as-code-secret" is forbidden: User "system:serviceaccount:pipelines-as-code:pipelines-as-code-controller" cannot get resource "secrets" in API group "" in the namespace "pipelines-as-code"
```

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
