### PR TITLE
Fixing git command to restart CI from docs

### DIFF
--- a/docs/content/docs/install/github_webhook.md
+++ b/docs/content/docs/install/github_webhook.md
@@ -19,7 +19,7 @@ commit. You can make it quick with this command line snippet (adjust branchname 
 the branch) :
 
 ```console
-git amend -a --no-edit && git push --force-with-lease origin branchname
+git commit --amend -a --no-edit && git push --force-with-lease origin branchname
 ```
 
 ## Create GitHub Personal Access Token


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

This PR adjusts the git command shown in the documentation to restart the CI, so it works and does not fail https://pipelinesascode.com/docs/install/github_webhook/

Fixes #1110. 

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
