### PR TITLE
Set CI env to "" in goreleaser task 

### DIFF
--- a/.tekton/tasks/goreleaser.yaml
+++ b/.tekton/tasks/goreleaser.yaml
@@ -51,6 +51,8 @@ spec:
         git config --global --add safe.directory $(workspaces.source.path)
         goreleaser release $(params.flags)
       env:
+        - name: CI
+          value: ""
         - name: GOPATH
           value: /workspace
         - name: AUR_PRIVATE_KEY


### PR DESCRIPTION
or it will show a bunch of ansi char in openshift-console

this should works https://github.com/goreleaser/goreleaser/blob/571cde5d9ec09a99d7e39e48579056770cb804b8/main.go#L24

Fixes #1114

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
