### PR TITLE
Fix extra spacing in gitea comments

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -8,14 +8,15 @@ An opinionated CI based on OpenShift Pipelines / Tekton.
 
 ## Introduction
 
-Pipelines as Code let you use
-the [Pipelines as Code flow](https://www.thoughtworks.com/radar/techniques/pipelines-as-code)
-directly with OpenShift Pipelines.
+Pipelines as code refers to the practice of defining, versioning, and managing
+the entire workflow of a software project, including the build, test, and
+deployment processes, using [Tekton](https://tekton.dev) PipelineRuns and
+Tasks from a web-based Git repository managers that provide source code
+management  like [Github](https://github.com), [Gitlab](https://gitlab.com) and
+others..
 
-The goal of Pipelines as Code is to let you define your
-[Tekton](https://tekton.dev) templates inside your source code repository and
-have the pipeline run and report the status
-of the execution when triggered by a `Pull Request` or a `Push`.
+This approach enables automation, repeatability, collaboration, and change
+tracking using a Git workflow.
 
 ## Features
 

--- a/docs/content/docs/install/installation.md
+++ b/docs/content/docs/install/installation.md
@@ -29,7 +29,7 @@ on your OpenShift cluster you can apply the template with kubectl :
 
 ```shell
 # OpenShift
-kubectl patch tektonconfig config --type="merge" -p '{"spec": {"addon":{"enablePipelinesAsCode": false}}}'
+kubectl patch tektonconfig config --type="merge" -p '{"spec": {"platforms": {"openshift":{"pipelinesAsCode": {"enable": false}}}}}'
 kubectl apply -f https://raw.githubusercontent.com/openshift-pipelines/pipelines-as-code/stable/release.yaml
 
 # Kubernetes

--- a/hack/dev/kind/install.sh
+++ b/hack/dev/kind/install.sh
@@ -53,6 +53,7 @@ function start_registry() {
         docker rm -f kind-registry || true
         docker run \
                -d --restart=always -p "127.0.0.1:${REG_PORT}:5000" \
+               -e REGISTRY_HTTP_SECRET=secret \
                --name "${REG_NAME}" \
                registry:2
     fi
@@ -143,7 +144,7 @@ function install_pac() {
         oldPwd=${PWD}
         cd ${PAC_DIR}
         echo "Deploying PAC from ${PAC_DIR}"
-        env KO_DOCKER_REPO=localhost:5000 ko apply -f config --sbom=none -B >/dev/null
+        [[ -n ${PAC_DEPLOY_SCRIPT:-""} ]] && ${PAC_DEPLOY_SCRIPT} || env KO_DOCKER_REPO=localhost:5000 ko apply -f config --sbom=none -B >/dev/null
         cd ${oldPwd}
     fi
     configure_pac

--- a/pkg/provider/gitea/gitea.go
+++ b/pkg/provider/gitea/gitea.go
@@ -150,9 +150,7 @@ func (v *Provider) createStatusCommit(event *info.Event, pacopts *info.PacOpts, 
 	}
 
 	if status.Text != "" && event.EventType == "pull_request" {
-		// insanity!! I am not even sure how to explain it but try to remove
-		// this and you get a failure when posting the text.
-		status.Text = strings.ReplaceAll(status.Text, "\n", "<br>")
+		status.Text = strings.TrimSpace(status.Text)
 		_, _, err := v.Client.CreateIssueComment(event.Organization, event.Repository,
 			int64(event.PullRequestNumber), gitea.CreateIssueCommentOption{
 				Body: fmt.Sprintf("%s\n%s", status.Summary, status.Text),


### PR DESCRIPTION
* it's now fixed in gitea and don't 422 anymore Fixes #1047 

![image](https://user-images.githubusercontent.com/98980/213653494-77f0361b-a6f4-4ca7-9c25-6e8444a4d64c.png)

* Rephrase pac introduction to explain better pac

* some small modification to the install script to workaround https://github.com/ko-build/ko/issues/939

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
