### PR TITLE
Skip Tekton Resolver types in PAC Resolver

### DIFF
--- a/docs/content/docs/guide/resolver.md
+++ b/docs/content/docs/guide/resolver.md
@@ -23,6 +23,7 @@ The resolver will skip resolving if it sees these type of tasks:
 
 * a reference to a [`ClusterTask`](https://github.com/tektoncd/pipeline/blob/main/docs/tasks.md#task-vs-clustertask)
 * a `Task` or `Pipeline` [`Bundle`](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#tekton-bundles)
+* a reference to a [`Resolver`](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#tekton-bundles)
 * a [Custom Task](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#using-custom-tasks) with an apiVersion that doesn't have a `tekton.dev/` prefix.
 
 It just uses them "as is" and will not try to do anything with it.

--- a/pkg/resolve/resolve.go
+++ b/pkg/resolve/resolve.go
@@ -88,7 +88,9 @@ func isTektonAPIVersion(apiVersion string) bool {
 func inlineTasks(tasks []tektonv1beta1.PipelineTask, ropt *Opts, types Types) ([]tektonv1beta1.PipelineTask, error) {
 	pipelineTasks := []tektonv1beta1.PipelineTask{}
 	for _, task := range tasks {
-		if task.TaskRef != nil && task.TaskRef.Bundle == "" &&
+		if task.TaskRef != nil &&
+			task.TaskRef.Bundle == "" &&
+			task.TaskRef.Resolver == "" &&
 			isTektonAPIVersion(task.TaskRef.APIVersion) &&
 			string(task.TaskRef.Kind) != "ClusterTask" &&
 			!skippingTask(task.TaskRef.Name, ropt.SkipInlining) {
@@ -177,7 +179,7 @@ func Resolve(ctx context.Context, cs *params.Run, logger *zap.SugaredLogger, pro
 		}
 
 		// Resolve PipelineRef inside PipelineRef
-		if pipelinerun.Spec.PipelineRef != nil && pipelinerun.Spec.PipelineRef.Bundle == "" {
+		if pipelinerun.Spec.PipelineRef != nil && pipelinerun.Spec.PipelineRef.Bundle == "" && pipelinerun.Spec.PipelineRef.Resolver == "" {
 			pipelineResolved, err := getPipelineByName(pipelinerun.Spec.PipelineRef.Name, types.Pipelines)
 			if err != nil {
 				return []*tektonv1beta1.PipelineRun{}, err

--- a/pkg/resolve/resolve_test.go
+++ b/pkg/resolve/resolve_test.go
@@ -96,6 +96,19 @@ func TestTaskBundlesSkipped(t *testing.T) {
 	assert.Equal(t, resolved.Spec.PipelineSpec.Tasks[0].TaskRef.Bundle, "reg.io/ruben/barichello@sha256:1234")
 }
 
+func TestTaskResolverSkipped(t *testing.T) {
+	resolved, _, err := readTDfile(t, "pipelinerun-task-resolver", false, true)
+	assert.NilError(t, err)
+	assert.Assert(t, resolved.Spec.PipelineSpec.Tasks[0].TaskRef.Resolver == "resolver")
+}
+
+func TestPipelineResolverSkipped(t *testing.T) {
+	resolved, _, err := readTDfile(t, "pipelinerun-pipelinerun-resolver", false, true)
+	assert.NilError(t, err)
+	assert.Equal(t, string(resolved.Spec.PipelineRef.Resolver), "resolver")
+	assert.Equal(t, resolved.Spec.PipelineRef.Params[0].Value.StringVal, "task")
+}
+
 func TestClusterTasksSkipped(t *testing.T) {
 	resolved, _, err := readTDfile(t, "pipelinerun-with-a-clustertasks", false, true)
 	assert.NilError(t, err)

--- a/pkg/resolve/testdata/pipelinerun-pipelinerun-resolver.yaml
+++ b/pkg/resolve/testdata/pipelinerun-pipelinerun-resolver.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: pr-bundle
+spec:
+  pipelineRef:
+    resolver: resolver
+    params:
+      - name: kind
+        value: task
+      - name: name
+        value: task

--- a/pkg/resolve/testdata/pipelinerun-task-resolver.yaml
+++ b/pkg/resolve/testdata/pipelinerun-task-resolver.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: pr-test1
+spec:
+  pipelineRef:
+    name: pipeline-resolver1
+  params:
+    - name: key
+      value: "{{value}}"
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: pipeline-resolver1
+spec:
+  params:
+    - name: repo_url
+    - name: revision
+  tasks:
+    - name: bundled
+      taskRef:
+        resolver: resolver
+  steps:
+    - name: first-step
+      image: image


### PR DESCRIPTION
don't try to inline them and let the tekton resolver do its thing

Fixes #1125

Jira: https://issues.redhat.com/browse/SRVKP-2791

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
