### PR TITLE
Add target_namespace env variable

### DIFF
--- a/.tekton/doc.yaml
+++ b/.tekton/doc.yaml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: pipeline-as-code-doc-generation
+  name: doc-generation
   annotations:
     pipelinesascode.tekton.dev/max-keep-runs: "2"
     pipelinesascode.tekton.dev/on-cel-expression: |

--- a/.tekton/go.yaml
+++ b/.tekton/go.yaml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: go-ninja-go
+  name: go-testing
   annotations:
     pipelinesascode.tekton.dev/max-keep-runs: "2"
     pipelinesascode.tekton.dev/on-cel-expression: |

--- a/.tekton/linter.yaml
+++ b/.tekton/linter.yaml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: pull-request
+  name: linters
   annotations:
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-target-branch: "[main]"

--- a/docs/content/docs/guide/authoringprs.md
+++ b/docs/content/docs/guide/authoringprs.md
@@ -31,6 +31,7 @@ weight: 3
   * `{{repo_owner}}`: The repository owner.
   * `{{repo_name}}`: The repository name.
   * `{{repo_url}}`: The repository full URL.
+  * `{{target_namespace}}`: The target namespace where the Repository has matched and the PipelineRun will be created.
   * `{{revision}}`: The commit full sha revision.
   * `{{sender}}`: The sender username (or accountid on some providers) of the commit.
   * `{{source_branch}}`: The branch name where the event come from.

--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -162,7 +162,7 @@ func (p *PacRun) getPipelineRunsFromRepo(ctx context.Context, repo *v1alpha1.Rep
 	}
 
 	// Replace those {{var}} placeholders user has in her template to the run.Info variable
-	allTemplates := templates.Process(p.event, rawTemplates)
+	allTemplates := templates.Process(p.event, repo, rawTemplates)
 	pipelineRuns, err := resolve.Resolve(ctx, p.run, p.logger, p.vcx, p.event, allTemplates, &resolve.Opts{
 		GenerateName: true,
 		RemoteTasks:  p.run.Info.Pac.RemoteTasks,

--- a/pkg/templates/templating.go
+++ b/pkg/templates/templating.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 )
@@ -24,7 +25,7 @@ func ReplacePlaceHoldersVariables(template string, dico map[string]string) strin
 }
 
 // Process process all templates replacing
-func Process(event *info.Event, template string) string {
+func Process(event *info.Event, repo *v1alpha1.Repository, template string) string {
 	repoURL := event.URL
 	// On bitbucket server you are have a special url for checking it out, they
 	// seemed to fix it in 2.0 but i guess we have to live with this until then.
@@ -33,13 +34,14 @@ func Process(event *info.Event, template string) string {
 	}
 
 	maptemplate := map[string]string{
-		"revision":      event.SHA,
-		"repo_url":      repoURL,
-		"repo_owner":    strings.ToLower(event.Organization),
-		"repo_name":     strings.ToLower(event.Repository),
-		"target_branch": formatting.SanitizeBranch(event.BaseBranch),
-		"source_branch": formatting.SanitizeBranch(event.HeadBranch),
-		"sender":        strings.ToLower(event.Sender),
+		"revision":         event.SHA,
+		"repo_url":         repoURL,
+		"repo_owner":       strings.ToLower(event.Organization),
+		"repo_name":        strings.ToLower(event.Repository),
+		"target_branch":    formatting.SanitizeBranch(event.BaseBranch),
+		"source_branch":    formatting.SanitizeBranch(event.HeadBranch),
+		"sender":           strings.ToLower(event.Sender),
+		"target_namespace": repo.GetNamespace(),
 	}
 	// we don't want to get a 0 replaced
 	if event.PullRequestNumber != 0 {


### PR DESCRIPTION
It's useful for user who move templates around between namespace which has namespace information (ie: to  be able to push to their current namespace registry).

See https://issues.redhat.com/browse/SRVKP-2792 for more details

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
