### PR TITLE
Make our own parsing for token expiration

### DIFF
--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -52,6 +52,7 @@ func (p *PacRun) Run(ctx context.Context) error {
 			Text:       fmt.Sprintf("There was an issue validating the commit: %q", err),
 			DetailsURL: p.run.Clients.ConsoleUI.URL(),
 		})
+		p.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "RepositoryCreateStatus", fmt.Sprintf("There was an error while processing the payload: %s", err))
 		if createStatusErr != nil {
 			p.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "RepositoryCreateStatus", fmt.Sprintf("Cannot create status: %s: %s", err, createStatusErr))
 		}

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -173,6 +173,29 @@ func makeClient(ctx context.Context, apiURL, token string) (*github.Client, stri
 	return client, providerName, github.String(apiURL)
 }
 
+func parseTS(headerTS string) (time.Time, error) {
+	ts := time.Time{}
+	// Github go-github library as defined there
+	if t, err := time.Parse("2006-01-02 03:04:05 MST", headerTS); err == nil {
+		ts = t
+	}
+
+	// Normal UTC: 2023-01-31 23:00:00 UTC
+	if t, err := time.Parse("2006-01-02 15:04:05 MST", headerTS); err == nil {
+		ts = t
+	}
+
+	// With TZ(???), ie: a token from Christoph 2023-04-26 23:23:26 +2000
+	if t, err := time.Parse("2006-01-02 15:04:05 -0700", headerTS); err == nil {
+		ts = t
+	}
+	if ts.Year() == 1 {
+		return ts, fmt.Errorf("cannot parse token expiration date: %s", headerTS)
+	}
+
+	return ts, nil
+}
+
 // checkWebhookSecretValidity check the webhook secret is valid and not
 // ratelimited. we try to check first the header is set (unlimited life token  would
 // not have an expiration) we would anyway get a 401 error when trying to use it
@@ -180,12 +203,16 @@ func makeClient(ctx context.Context, apiURL, token string) (*github.Client, stri
 // the issue was
 func (v *Provider) checkWebhookSecretValidity(ctx context.Context, cw clockwork.Clock) error {
 	rl, resp, err := v.Client.RateLimits(ctx)
-	if resp.Header.Get("GitHub-Authentication-Token-Expiration") != "" && cw.Now().After(resp.TokenExpiration.Time) {
-		errm := fmt.Sprintf("token has expired at %s", resp.TokenExpiration.Format(time.RFC1123))
+	if resp.Header.Get("GitHub-Authentication-Token-Expiration") != "" {
+		ts, err := parseTS(resp.Header.Get("GitHub-Authentication-Token-Expiration"))
 		if err != nil {
-			errm += fmt.Sprintf(" err: %s", err.Error())
+			return fmt.Errorf("error parsing token expiration date: %w", err)
 		}
-		return fmt.Errorf(errm)
+
+		if cw.Now().After(ts) {
+			errm := fmt.Sprintf("token has expired at %s", resp.TokenExpiration.Format(time.RFC1123))
+			return fmt.Errorf(errm)
+		}
 	}
 
 	if resp.StatusCode == http.StatusNotFound {

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -175,11 +175,6 @@ func makeClient(ctx context.Context, apiURL, token string) (*github.Client, stri
 
 func parseTS(headerTS string) (time.Time, error) {
 	ts := time.Time{}
-	// Github go-github library as defined there
-	if t, err := time.Parse("2006-01-02 03:04:05 MST", headerTS); err == nil {
-		ts = t
-	}
-
 	// Normal UTC: 2023-01-31 23:00:00 UTC
 	if t, err := time.Parse("2006-01-02 15:04:05 MST", headerTS); err == nil {
 		ts = t

--- a/pkg/provider/github/github_test.go
+++ b/pkg/provider/github/github_test.go
@@ -708,3 +708,41 @@ func TestProvider_checkWebhookSecretValidity(t *testing.T) {
 		})
 	}
 }
+
+func TestParseTS(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr bool
+		expTS   string
+	}{
+		{
+			name:  "valid as defined by go-github",
+			expTS: "2023-01-31 03:30:00 UTC",
+		},
+		{
+			name:  "valid with UTC and eu time",
+			expTS: "2023-01-31 15:30:00 UTC",
+		},
+		{
+			name:  "valid with timezone inside",
+			expTS: "2023-04-26 23:23:26 +2000",
+		},
+
+		{
+			name:    "invalid",
+			expTS:   "Mon 2023-04-26 23:23:26 +2000",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseTS(tt.expTS)
+			if tt.wantErr {
+				assert.Assert(t, err != nil)
+			} else {
+				assert.NilError(t, err)
+				assert.Assert(t, got.Year() != 0o1)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Github servers time behave weirdly and fail or work sometime, see:

https://github.com/google/go-github/issues/2649

make our own parsing with all the different token expiration collected

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
