### PR TITLE
Fix issue related to repository URL if it contains '/' at the end

### DIFF
--- a/pkg/matcher/repo_runinfo_matcher.go
+++ b/pkg/matcher/repo_runinfo_matcher.go
@@ -2,6 +2,7 @@ package matcher
 
 import (
 	"context"
+	"strings"
 
 	apipac "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
@@ -17,6 +18,7 @@ func MatchEventURLRepo(ctx context.Context, cs *params.Run, event *info.Event, n
 	}
 	for i := len(repositories.Items) - 1; i >= 0; i-- {
 		repo := repositories.Items[i]
+		repo.Spec.URL = strings.TrimSuffix(repo.Spec.URL, "/")
 		if repo.Spec.URL == event.URL {
 			return &repo, nil
 		}

--- a/pkg/matcher/repo_runinfo_matcher_test.go
+++ b/pkg/matcher/repo_runinfo_matcher_test.go
@@ -52,6 +52,25 @@ func Test_getRepoByCR(t *testing.T) {
 			wantErr:      false,
 		},
 		{
+			name: "test-match-url-slash-at-the-end",
+			args: args{
+				data: testclient.Data{
+					Repositories: []*v1alpha1.Repository{
+						testnewrepo.NewRepo(
+							testnewrepo.RepoTestcreationOpts{
+								Name:             "test-good",
+								URL:              "https//nowhere.togo/",
+								InstallNamespace: targetNamespace,
+							},
+						),
+					},
+				},
+				runevent: info.Event{URL: targetURL, BaseBranch: mainBranch, EventType: "pull_request"},
+			},
+			wantTargetNS: targetNamespace,
+			wantErr:      false,
+		},
+		{
 			name: "test-nomatch-url",
 			args: args{
 				data: testclient.Data{


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Issue
Repository with spec.url ending with '/' is not matching URL coming from Github.

# Changes
Removed slashes from the repo.spec.url in order to match with the URL coming from Github

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
