### PR TITLE
Separate slow e2e test to nightly

### DIFF
--- a/.github/workflows/kind-nightly.yaml
+++ b/.github/workflows/kind-nightly.yaml
@@ -1,26 +1,19 @@
-name: E2E Tests on Kind
+name: Nightly E2E Tests on Kind
 
 on:
-  workflow_dispatch: # yamllint disable-line
-  push: # yamllint disable-line
-  pull_request_target:
-    types: [opened, synchronize, reopened]
+  schedule:
+    - cron: "0 5 * * *"
 jobs:
   e2e-tests:
     name: e2e tests
     runs-on: ubuntu-latest
     env:
-      # https://github.com/google/go-containerregistry/pull/125 allows insecure registry for
-      # '*.local' hostnames. This works both for `ko` and our own tag-to-digest resolution logic,
-      # thus allowing us to test without bypassing tag-to-digest resolution.
       REGISTRY_NAME: registry.local
       REGISTRY_PORT: 5000
       KO_DOCKER_REPO: registry.local:5000/ko
       CONTROLLER_DOMAIN_URL: controller.paac-127-0-0-1.nip.io
       TEST_GITHUB_REPO_OWNER_GITHUBAPP: openshift-pipelines/pipelines-as-code-e2e-tests
-      # TEST_GITHUB_REPO_OWNER_WEBHOOK: pac/pac-test-webhooks
       KUBECONFIG: /home/runner/.kube/config.kind
-
     steps:
       - uses: actions/checkout@v3
         with:
@@ -92,8 +85,6 @@ jobs:
           export TEST_GITHUB_PRIVATE_TASK_URL="https://github.com/openshift-pipelines/pipelines-as-code-e2e-tests-private/blob/main/remote_task.yaml"
           export TEST_GITHUB_PRIVATE_TASK_NAME="task-remote"
 
-          export GO_TEST_FLAGS="-v -race -failfast"
-
           export TEST_BITBUCKET_CLOUD_API_URL=https://api.bitbucket.org/2.0
           export TEST_BITBUCKET_CLOUD_E2E_REPOSITORY=cboudjna/pac-e2e-tests
           export TEST_BITBUCKET_CLOUD_TOKEN=${{ secrets.BITBUCKET_CLOUD_TOKEN }}
@@ -121,8 +112,37 @@ jobs:
           export TEST_GITLAB_PROJECT_ID="34405323"
           export TEST_GITLAB_TOKEN=${{ secrets.GITLAB_TOKEN }}
           # https://gitlab.com/gitlab-com/alliances/ibm-red-hat/sandbox/openshift-pipelines/pac-e2e-tests
-          make test-e2e
+          export GO_TEST_FLAGS="-v -race -failfast"
+          export NIGHTLY_E2E_TEST="true"
+          make test-e2e-nightly
 
+      - name: Install wine
+        run: |
+          sudo dpkg --add-architecture i386
+          wget -qO - https://dl.winehq.org/wine-builds/winehq.key | sudo apt-key add -
+          sudo apt-add-repository 'deb https://dl.winehq.org/wine-builds/ubuntu/ jammy main'
+          sudo apt-get update
+          sudo apt install --install-recommends winehq-stable
+
+      - name: Compile tkn-pac for windows
+        run: |
+          mkdir -p bin/
+          make windows
+
+      - name: Run a simple tkn-pac on wine test
+        run: |
+          set -e
+          wine ./bin/tkn-pac.exe ls -A
+
+      - name: Compile tkn-pac for linux
+        run: |
+          mkdir -p bin/
+          make bin/tkn-pac
+
+      - name: Run a simple tkn-pac test
+        run: |
+          set -e
+          ./bin/tkn-pac ls -A
       # - name: Setup tmate session
       #   uses: mxschmitt/action-tmate@v3
       - name: Collect logs
@@ -143,3 +163,12 @@ jobs:
         with:
           name: logs
           path: /tmp/logs
+
+      - name: Report Status
+        if: ${{ always() }}
+        uses: ravsamhq/notify-slack-action@v1
+        with:
+          status: ${{ job.status }}
+          notify_when: 'failure'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,12 @@ test-e2e-cleanup: ## cleanup test e2e namespace/pr left open
 test-e2e:  test-e2e-cleanup ## run e2e tests
 	@go test $(GO_TEST_FLAGS) -timeout $(TIMEOUT_E2E)  -failfast -count=1 -tags=e2e $(GO_TEST_FLAGS) ./test
 
+.PHONY: test-e2e-nightly
+test-e2e-nightly: test-e2e-cleanup ## run e2e tests
+	@env NIGHTLY_E2E_TEST="true" \
+		go test $(GO_TEST_FLAGS) -timeout $(TIMEOUT_E2E) -failfast -count=1 -tags=e2e \
+		-run "TestGithub" $(GO_TEST_FLAGS) ./test # Add more to -run if we have more e2e to run
+
 .PHONY: lint
 lint: lint-go lint-yaml lint-md lint-py ## run all linters
 

--- a/test/README.md
+++ b/test/README.md
@@ -70,3 +70,25 @@ You can specify only a subsets of test to run with :
 ```
 
 same goes for `TestGitlab` or other methods.
+
+## Running nightly tests
+
+Some tests are set as nightly which mean not run on every PR, because exposing rate limitation often.
+We run those as nightly via github action on kind.
+
+You can use `make test-e2e-nightly` if you want to run those manually as long
+as you have all the env variables set.
+
+If you are writing a test targetting a nightly test you need to check for the env variable:
+
+```go
+    if os.Getenv("NIGHTLY_E2E_TEST") != "true" {
+        t.Skip("Skipping test since only enabled for nightly")
+    }
+```
+
+and maybe add to the test-e2e-nightly Makefile target to the -run argument :
+
+```bash
+-run '(TestGithub|TestOtherPrefixOfTest)'
+```

--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -396,7 +396,7 @@ func TestGiteaClusterTasks(t *testing.T) {
 	assert.NilError(t, err)
 	ct := v1beta1.ClusterTask{}
 	assert.NilError(t, yaml.Unmarshal([]byte(entries[ctname]), &ct))
-	ct.ObjectMeta.Name = "clustertask-" + topts.TargetNS
+	ct.Name = "clustertask-" + topts.TargetNS
 
 	run := &params.Run{}
 	ctx := context.Background()
@@ -406,7 +406,7 @@ func TestGiteaClusterTasks(t *testing.T) {
 	assert.NilError(t, pacrepo.CreateNS(ctx, topts.TargetNS, run))
 	run.Clients.Log.Infof("%s has been created", ct.GetName())
 	defer (func() {
-		assert.NilError(t, topts.Params.Clients.Tekton.TektonV1beta1().ClusterTasks().Delete(context.TODO(), ct.ObjectMeta.Name, metav1.DeleteOptions{}))
+		assert.NilError(t, topts.Params.Clients.Tekton.TektonV1beta1().ClusterTasks().Delete(context.TODO(), ct.Name, metav1.DeleteOptions{}))
 		run.Clients.Log.Infof("%s is deleted", ct.GetName())
 	})()
 
@@ -530,12 +530,12 @@ func TestGiteaWithCLIGeneratePipeline(t *testing.T) {
 			assert.NilError(t, err)
 
 			for k, v := range tt.fileToAdd {
-				newFile, err := os.Create(filepath.Join(tmpdir, k))
-				assert.NilError(t, err)
-				_, err = newFile.WriteString(v)
-				assert.NilError(t, err)
-				_, err = git.RunGit(tmpdir, "add", k)
-				assert.NilError(t, err)
+				newFile, err2 := os.Create(filepath.Join(tmpdir, k))
+				assert.NilError(t, err2)
+				_, err2 = newFile.WriteString(v)
+				assert.NilError(t, err2)
+				_, err2 = git.RunGit(tmpdir, "add", k)
+				assert.NilError(t, err2)
 			}
 
 			output, err := tknpactest.ExecCommand(topts.Params, tknpacgenerate.Command, "--event-type", topts.TargetEvent,

--- a/test/github_pullrequest_concurrency_test.go
+++ b/test/github_pullrequest_concurrency_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
@@ -29,6 +30,10 @@ func contains(s []string, e string) bool {
 }
 
 func TestGithubPullRequestConcurrency(t *testing.T) {
+	if os.Getenv("NIGHTLY_E2E_TEST") != "true" {
+		t.Skip("Skipping test since only enabled for nightly")
+	}
+
 	ctx := context.Background()
 	label := "Github PullRequest Concurrent"
 	numberOfPipelineRuns := 10
@@ -43,7 +48,7 @@ func TestGithubPullRequestConcurrency(t *testing.T) {
 
 	repoinfo, resp, err := ghcnx.Client.Repositories.Get(ctx, opts.Organization, opts.Repo)
 	assert.NilError(t, err)
-	if resp != nil && resp.Response.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
 	}
 

--- a/test/github_pullrequest_oktotest_test.go
+++ b/test/github_pullrequest_oktotest_test.go
@@ -22,6 +22,9 @@ import (
 )
 
 func TestGithubPullRequestOkToTest(t *testing.T) {
+	if os.Getenv("NIGHTLY_E2E_TEST") != "true" {
+		t.Skip("Skipping test since only enabled for nightly")
+	}
 	ctx := context.TODO()
 	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, sha := tgithub.RunPullRequest(ctx, t,
 		"Github OkToTest comment", []string{"testdata/pipelinerun.yaml"}, false)
@@ -29,7 +32,7 @@ func TestGithubPullRequestOkToTest(t *testing.T) {
 
 	repoinfo, resp, err := ghcnx.Client.Repositories.Get(ctx, opts.Organization, opts.Repo)
 	assert.NilError(t, err)
-	if resp != nil && resp.Response.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
 	}
 

--- a/test/github_pullrequest_privaterepository_test.go
+++ b/test/github_pullrequest_privaterepository_test.go
@@ -5,12 +5,16 @@ package test
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	tgithub "github.com/openshift-pipelines/pipelines-as-code/test/pkg/github"
 )
 
 func TestGithubPullRequestPrivateRepository(t *testing.T) {
+	if os.Getenv("NIGHTLY_E2E_TEST") != "true" {
+		t.Skip("Skipping test since only enabled for nightly")
+	}
 	ctx := context.TODO()
 	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, _ := tgithub.RunPullRequest(ctx, t,
 		"Github Private Repo", []string{"testdata/pipelinerun_git_clone_private.yaml"}, false)
@@ -18,6 +22,9 @@ func TestGithubPullRequestPrivateRepository(t *testing.T) {
 }
 
 func TestGithubPullRequestPrivateRepositoryOnWebhook(t *testing.T) {
+	if os.Getenv("NIGHTLY_E2E_TEST") != "true" {
+		t.Skip("Skipping test since only enabled for nightly")
+	}
 	ctx := context.TODO()
 	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, _ := tgithub.RunPullRequest(ctx, t,
 		"Github Private Repo OnWebhook", []string{"testdata/pipelinerun_git_clone_private.yaml"}, true)

--- a/test/github_pullrequest_remote_task_annotations_test.go
+++ b/test/github_pullrequest_remote_task_annotations_test.go
@@ -24,6 +24,9 @@ import (
 )
 
 func TestGithubPullRequestRemoteTaskAnnotations(t *testing.T) {
+	if os.Getenv("NIGHTLY_E2E_TEST") != "true" {
+		t.Skip("Skipping test since only enabled for nightly")
+	}
 	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
 	ctx := context.Background()
 	runcnx, opts, ghcnx, err := tgithub.Setup(ctx, false)
@@ -50,7 +53,7 @@ func TestGithubPullRequestRemoteTaskAnnotations(t *testing.T) {
 
 	repoinfo, resp, err := ghcnx.Client.Repositories.Get(ctx, opts.Organization, opts.Repo)
 	assert.NilError(t, err)
-	if resp != nil && resp.Response.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
 	}
 

--- a/test/github_pullrequest_rerequest_test.go
+++ b/test/github_pullrequest_rerequest_test.go
@@ -21,6 +21,9 @@ import (
 )
 
 func TestGithubPullRerequest(t *testing.T) {
+	if os.Getenv("NIGHTLY_E2E_TEST") != "true" {
+		t.Skip("Skipping test since only enabled for nightly")
+	}
 	ctx := context.TODO()
 	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, sha := tgithub.RunPullRequest(ctx, t, "Github Rerequest",
 		[]string{"testdata/pipelinerun.yaml"}, false)
@@ -28,7 +31,7 @@ func TestGithubPullRerequest(t *testing.T) {
 
 	repoinfo, resp, err := ghcnx.Client.Repositories.Get(ctx, opts.Organization, opts.Repo)
 	assert.NilError(t, err)
-	if resp != nil && resp.Response.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
 	}
 

--- a/test/github_pullrequest_retest_test.go
+++ b/test/github_pullrequest_retest_test.go
@@ -5,6 +5,7 @@ package test
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/google/go-github/v49/github"
@@ -16,6 +17,9 @@ import (
 )
 
 func TestGithubPullRequestRetest(t *testing.T) {
+	if os.Getenv("NIGHTLY_E2E_TEST") != "true" {
+		t.Skip("Skipping test since only enabled for nightly")
+	}
 	ctx := context.TODO()
 	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, sha := tgithub.RunPullRequest(ctx, t,
 		"Github Retest comment", []string{"testdata/pipelinerun.yaml"}, false)

--- a/test/github_pullrequest_test.go
+++ b/test/github_pullrequest_test.go
@@ -19,6 +19,9 @@ func TestGithubPullRequest(t *testing.T) {
 }
 
 func TestGithubPullRequestMultiples(t *testing.T) {
+	if os.Getenv("NIGHTLY_E2E_TEST") != "true" {
+		t.Skip("Skipping test since only enabled for nightly")
+	}
 	ctx := context.Background()
 	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, _ := tgithub.RunPullRequest(ctx, t, "Github PullRequest",
 		[]string{"testdata/pipelinerun.yaml", "testdata/pipelinerun-clone.yaml"}, false)
@@ -26,6 +29,9 @@ func TestGithubPullRequestMultiples(t *testing.T) {
 }
 
 func TestGithubPullRequestMatchOnCEL(t *testing.T) {
+	if os.Getenv("NIGHTLY_E2E_TEST") != "true" {
+		t.Skip("Skipping test since only enabled for nightly")
+	}
 	ctx := context.Background()
 	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, _ := tgithub.RunPullRequest(ctx, t, "Github PullRequest",
 		[]string{"testdata/pipelinerun-cel-annotation.yaml"}, false)
@@ -33,6 +39,9 @@ func TestGithubPullRequestMatchOnCEL(t *testing.T) {
 }
 
 func TestGithubPullRequestWebhook(t *testing.T) {
+	if os.Getenv("NIGHTLY_E2E_TEST") != "true" {
+		t.Skip("Skipping test since only enabled for nightly")
+	}
 	if os.Getenv("TEST_GITHUB_REPO_OWNER_WEBHOOK") == "" {
 		t.Skip("TEST_GITHUB_REPO_OWNER_WEBHOOK is not set")
 		return

--- a/test/github_pullrequest_test_comment_test.go
+++ b/test/github_pullrequest_test_comment_test.go
@@ -5,6 +5,7 @@ package test
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/google/go-github/v49/github"
@@ -16,6 +17,9 @@ import (
 )
 
 func TestGithubPullRequestTest(t *testing.T) {
+	if os.Getenv("NIGHTLY_E2E_TEST") != "true" {
+		t.Skip("Skipping test since only enabled for nightly")
+	}
 	ctx := context.TODO()
 	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, sha := tgithub.RunPullRequest(ctx, t, "Github test comment",
 		[]string{"testdata/pipelinerun.yaml", "testdata/pipelinerun-clone.yaml"}, false)

--- a/test/github_push_test.go
+++ b/test/github_push_test.go
@@ -20,6 +20,9 @@ import (
 )
 
 func TestGithubPush(t *testing.T) {
+	if os.Getenv("NIGHTLY_E2E_TEST") != "true" {
+		t.Skip("Skipping test since only enabled for nightly")
+	}
 	for _, onWebhook := range []bool{false, true} {
 		targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-push")
 		targetBranch := targetNS
@@ -40,7 +43,7 @@ func TestGithubPush(t *testing.T) {
 		}
 		repoinfo, resp, err := gprovider.Client.Repositories.Get(ctx, opts.Organization, opts.Repo)
 		assert.NilError(t, err)
-		if resp != nil && resp.Response.StatusCode == http.StatusNotFound {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
 		}
 		err = tgithub.CreateCRD(ctx, t, repoinfo, runcnx, opts, targetNS)

--- a/test/github_tkn_pac_cli_test.go
+++ b/test/github_tkn_pac_cli_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 
@@ -24,6 +25,9 @@ import (
 )
 
 func TestGithubPacCli(t *testing.T) {
+	if os.Getenv("NIGHTLY_E2E_TEST") != "true" {
+		t.Skip("Skipping test since only enabled for nightly")
+	}
 	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
 	ctx := context.Background()
 	runcnx, opts, ghprovider, err := tgithub.Setup(ctx, false)
@@ -53,7 +57,7 @@ spec:
 
 	repoinfo, resp, err := ghprovider.Client.Repositories.Get(ctx, opts.Organization, opts.Repo)
 	assert.NilError(t, err)
-	if resp != nil && resp.Response.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
 	}
 

--- a/test/gitlab_incoming_webhook_test.go
+++ b/test/gitlab_incoming_webhook_test.go
@@ -32,7 +32,7 @@ func TestGitlabIncomingWebhook(t *testing.T) {
 	runcnx.Clients.Log.Info("Testing with Gitlab")
 	projectinfo, resp, err := glprovider.Client.Projects.GetProject(opts.ProjectID, nil)
 	assert.NilError(t, err)
-	if resp != nil && resp.Response.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
 	}
 

--- a/test/gitlab_merge_request_test.go
+++ b/test/gitlab_merge_request_test.go
@@ -25,7 +25,7 @@ func TestGitlabMergeRequest(t *testing.T) {
 
 	projectinfo, resp, err := glprovider.Client.Projects.GetProject(opts.ProjectID, nil)
 	assert.NilError(t, err)
-	if resp != nil && resp.Response.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
 	}
 


### PR DESCRIPTION
Some e2e tests are slow (like tkn-pac on wine) or expose rate limit often.

Move those e2e tests to a new github action which un nightly

Add a blob in README documenting it.

Fix some warnings along the way...

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
