### PR TITLE
Only execute the e2e tests on pullreq

### DIFF
--- a/.github/workflows/kind-e2e-tests.yaml
+++ b/.github/workflows/kind-e2e-tests.yaml
@@ -2,7 +2,6 @@ name: E2E Tests on Kind
 
 on:
   workflow_dispatch: # yamllint disable-line
-  push: # yamllint disable-line
   pull_request_target:
     types: [opened, synchronize, reopened]
 jobs:

--- a/.github/workflows/kind-nightly.yaml
+++ b/.github/workflows/kind-nightly.yaml
@@ -114,7 +114,7 @@ jobs:
           # https://gitlab.com/gitlab-com/alliances/ibm-red-hat/sandbox/openshift-pipelines/pac-e2e-tests
           export GO_TEST_FLAGS="-v -race -failfast"
           export NIGHTLY_E2E_TEST="true"
-          make test-e2e-nightly
+          make test-e2e
 
       - name: Install wine
         run: |

--- a/Makefile
+++ b/Makefile
@@ -62,12 +62,6 @@ test-e2e-cleanup: ## cleanup test e2e namespace/pr left open
 test-e2e:  test-e2e-cleanup ## run e2e tests
 	@go test $(GO_TEST_FLAGS) -timeout $(TIMEOUT_E2E)  -failfast -count=1 -tags=e2e $(GO_TEST_FLAGS) ./test
 
-.PHONY: test-e2e-nightly
-test-e2e-nightly: test-e2e-cleanup ## run e2e tests
-	@env NIGHTLY_E2E_TEST="true" \
-		go test $(GO_TEST_FLAGS) -timeout $(TIMEOUT_E2E) -failfast -count=1 -tags=e2e \
-		-run "TestGithub" $(GO_TEST_FLAGS) ./test # Add more to -run if we have more e2e to run
-
 .PHONY: lint
 lint: lint-go lint-yaml lint-md lint-py ## run all linters
 


### PR DESCRIPTION
Make nightly run all tests not just github so we get some sort of
reporting.

This will save token rate limitation and well crazyness when we push a
release since pushing to multiple branches..

Fixes #867

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
