### PR TITLE
more helpful errors on parsing

### DIFF
--- a/.tekton/generate-coverage-release.yaml
+++ b/.tekton/generate-coverage-release.yaml
@@ -4,7 +4,7 @@ kind: PipelineRun
 metadata:
   name: push-generate-coverage-releaseyaml
   annotations:
-    pipelinesascode.tekton.dev/task-1: "[https://git.io/Jn9Ee]" # send slack notification on failure
+    pipelinesascode.tekton.dev/task-1: "[https://git.io/Jn9Ee]"  # send slack message on failure
     pipelinesascode.tekton.dev/max-keep-runs: "2"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" && ("***/*.go".pathChanged() || "config/".pathChanged())

--- a/.tekton/go.yaml
+++ b/.tekton/go.yaml
@@ -4,6 +4,7 @@ kind: PipelineRun
 metadata:
   name: go-testing
   annotations:
+    pipelinesascode.tekton.dev/task: "[git-clone]"
     pipelinesascode.tekton.dev/max-keep-runs: "2"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" && "***/*.go".pathChanged()
@@ -25,7 +26,6 @@ spec:
           - name: revision
             value: $(params.revision)
         taskRef:
-          kind: ClusterTask
           name: git-clone
         workspaces:
           - name: output

--- a/.tekton/linter.yaml
+++ b/.tekton/linter.yaml
@@ -7,6 +7,7 @@ metadata:
     pipelinesascode.tekton.dev/on-event: "[push, pull_request]"
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/max-keep-runs: "2"
+    pipelinesascode.tekton.dev/task: "[git-clone]"
 spec:
   params:
     - name: repo_url
@@ -25,7 +26,6 @@ spec:
           - name: revision
             value: $(params.revision)
         taskRef:
-          kind: ClusterTask
           name: git-clone
         workspaces:
           - name: output

--- a/pkg/matcher/annotation_tasks_install.go
+++ b/pkg/matcher/annotation_tasks_install.go
@@ -53,7 +53,7 @@ func (rt RemoteTasks) convertToPipeline(ctx context.Context, uri, data string) (
 		// o.SetDefaults(ctx)
 		// ctx2 := features.SetFeatureFlag(context.Background())
 		// if err := o.Validate(ctx2); err != nil {
-		// 	return nil, fmt.Errorf("remote pipeline %s cannot be validated properly: err: %w", o.GetName(), err)
+		// return nil, fmt.Errorf("remote pipeline from uri: %s with name %s cannot be validated: %w", uri, o.GetName(), err)
 		// }
 		if err := o.ConvertTo(ctx, c); err != nil {
 			return nil, fmt.Errorf("remote pipeline from uri: %s with name %s cannot be converted to v1beta1: %w", uri, o.GetName(), err)
@@ -85,6 +85,7 @@ func (rt RemoteTasks) convertTotask(ctx context.Context, uri, data string) (*tek
 		// o.SetDefaults(ctx)
 		// if err := o.Validate(ctx); err != nil {
 		// 	return nil, fmt.Errorf("remote task %s cannot be validated properly: err: %w", o.GetName(), err)
+		// return nil, fmt.Errorf("remote task from uri: %s with name %s cannot be validated: %w", uri, o.GetName(), err)
 		// }
 		if err := o.ConvertTo(ctx, c); err != nil {
 			return nil, fmt.Errorf("remote task from uri: %s with name %s cannot be converted to v1beta1: %w", uri, o.GetName(), err)

--- a/pkg/matcher/annotation_tasks_install_test.go
+++ b/pkg/matcher/annotation_tasks_install_test.go
@@ -297,7 +297,6 @@ func TestGetPipelineFromAnnotations(t *testing.T) {
 				},
 			},
 		},
-<<<<<<< HEAD
 		// TODO: to uncomment in the future when fixing the Valdiate bug issue
 		// {
 		// 	name: "invalid-pipeline-validaton-failed",
@@ -310,7 +309,7 @@ func TestGetPipelineFromAnnotations(t *testing.T) {
 		// 			"code": "200",
 		// 		},
 		// 	},
-		// 	wantErr: "cannot be validated properly",
+		// 	wantErr: "remote pipeline from uri: http://remote.pipeline with name pipeline-test1 cannot be validated:",
 		// },
 		// {
 		// 	name: "invalid-remote-pipeline",
@@ -323,36 +322,8 @@ func TestGetPipelineFromAnnotations(t *testing.T) {
 		// 			"code": "200",
 		// 		},
 		// 	},
-		// 	wantErr: "cannot be validated properly",
+		// 	wantErr: "emote pipeline from uri: http://remote.pipeline with name pipeline cannot be validated: expected at least one, got none:",
 		// },
-=======
-		{
-			name: "invalid-pipeline-validaton-failed",
-			annotations: map[string]string{
-				keys.Pipeline: "[http://remote.pipeline]",
-			},
-			remoteURLS: map[string]map[string]string{
-				"http://remote.pipeline": {
-					"body": readTDfile(t, "pipeline-invalid-bundle"),
-					"code": "200",
-				},
-			},
-			wantErr: "remote pipeline from uri: http://remote.pipeline with name pipeline-test1 cannot be validated:",
-		},
-		{
-			name: "invalid-remote-pipeline",
-			annotations: map[string]string{
-				keys.Pipeline: "[http://remote.pipeline]",
-			},
-			remoteURLS: map[string]map[string]string{
-				"http://remote.pipeline": {
-					"body": readTDfile(t, "pipeline-invalid"),
-					"code": "200",
-				},
-			},
-			wantErr: "emote pipeline from uri: http://remote.pipeline with name pipeline cannot be validated: expected at least one, got none:",
-		},
->>>>>>> 2ad64cab (more helpful error about which remote ressource has failed to be parsed)
 		{
 			name: "bad/error getting pipeline",
 			annotations: map[string]string{

--- a/pkg/matcher/annotation_tasks_install_test.go
+++ b/pkg/matcher/annotation_tasks_install_test.go
@@ -297,6 +297,7 @@ func TestGetPipelineFromAnnotations(t *testing.T) {
 				},
 			},
 		},
+<<<<<<< HEAD
 		// TODO: to uncomment in the future when fixing the Valdiate bug issue
 		// {
 		// 	name: "invalid-pipeline-validaton-failed",
@@ -324,6 +325,34 @@ func TestGetPipelineFromAnnotations(t *testing.T) {
 		// 	},
 		// 	wantErr: "cannot be validated properly",
 		// },
+=======
+		{
+			name: "invalid-pipeline-validaton-failed",
+			annotations: map[string]string{
+				keys.Pipeline: "[http://remote.pipeline]",
+			},
+			remoteURLS: map[string]map[string]string{
+				"http://remote.pipeline": {
+					"body": readTDfile(t, "pipeline-invalid-bundle"),
+					"code": "200",
+				},
+			},
+			wantErr: "remote pipeline from uri: http://remote.pipeline with name pipeline-test1 cannot be validated:",
+		},
+		{
+			name: "invalid-remote-pipeline",
+			annotations: map[string]string{
+				keys.Pipeline: "[http://remote.pipeline]",
+			},
+			remoteURLS: map[string]map[string]string{
+				"http://remote.pipeline": {
+					"body": readTDfile(t, "pipeline-invalid"),
+					"code": "200",
+				},
+			},
+			wantErr: "emote pipeline from uri: http://remote.pipeline with name pipeline cannot be validated: expected at least one, got none:",
+		},
+>>>>>>> 2ad64cab (more helpful error about which remote ressource has failed to be parsed)
 		{
 			name: "bad/error getting pipeline",
 			annotations: map[string]string{
@@ -347,7 +376,7 @@ func TestGetPipelineFromAnnotations(t *testing.T) {
 					"code": "200",
 				},
 			},
-			wantErr: "this doesn't seem to be a proper pipeline",
+			wantErr: "remote pipeline from uri: http://remote.pipeline has not been recognized as a tekton pipeline",
 		},
 		{
 			name: "bad/could not get remote",


### PR DESCRIPTION
- more helpful error about which remote ressource has failed to be parsed, this now show the annoation value when echoing the parsing error.
- don't use clustertasks since they are broken on operator nightly with v1

Fixes #1157