### PR TITLE
add custom console driver

### DIFF
--- a/config/302-pac-configmap.yaml
+++ b/config/302-pac-configmap.yaml
@@ -110,6 +110,13 @@ data:
   # https://github.com/owner/repo will be `owner-repo-ci`
   auto-configure-repo-namespace-template: ""
 
+  # Configure a custom console here
+  #
+  # custom-console-name: Console Name
+  # custom-console-url: https://url
+  # custom-console-url-pr-details: https://url/ns/{{ namespace }}/{{ pr }}
+  # custom-console-url-pr-tasklog: https://url/ns/{{ namespace }}/{{ pr }}/logs/{{ task }}
+
 kind: ConfigMap
 metadata:
   name: pipelines-as-code

--- a/docs/content/docs/install/settings.md
+++ b/docs/content/docs/install/settings.md
@@ -70,12 +70,6 @@ There is a few things you can configure through the config map
 
   The [tekton hub](https://github.com/tektoncd/hub/) catalog name. default to `tekton`
 
-* `tekton-dashboard-url`
-
-   When you are not running on Openshift using the [tekton
-   dashboard](https://github.com/tektoncd/dashboard/) you will need to specify a
-   dashboard url to have the logs tnd the pipelinerun details linked.
-
 * `bitbucket-cloud-check-source-ip`
 
   Public bitbucket doesn't have the concept of Secret, we need to be
@@ -137,6 +131,11 @@ There is a few things you can configure through the config map
 
   `https://github.com/owner/repo` will be `owner-repo-ci`
 
+### Error Detection
+
+Pipelines as Code can show a snippet and optionally detect the error in the
+pipelinerun logs, you can configure the behaviour with these settings:
+
 * `error-log-snippet`
 
   Enable or disable the feature to show a log snippet of the failed task when
@@ -190,6 +189,51 @@ There is a few things you can configure through the config map
    You can configure the default regexp used for detection. You will need to
    keep the regexp groups: `<filename>`, `<line>`, `<error>` to make it works.
 
+### Reporting logs URL to Tekton Dashboard or custom Console
+
+Pipelines as Code have the ability to automatically detect the OpenShift Console and link the logs of the tasks to the
+public URL of the OpenShift Console. If you are using the Tekton Dashboard, you can configure this feature using the
+`tekton-dashboard-url` setting. Simply set this to your dashboard URL, and the pipelinerun status and tasklog will be
+displayed there.
+
+Alternatively, you can also configure a custom console with the following settings:
+
+* `custom-console-name`
+
+ Set this to the name of your custom console. example: `MyCorp Console`
+
+* `custom-console-url`
+
+ Set this to the root URL of your custom console. example: `https://mycorp.com`
+
+* `custom-console-url-pr-details`
+
+ Set this to the URL where to view the details of the `PipelineRun`. This is
+ shown when the PipelineRun is started so the user can follow execution on your
+ console or when to see more details about the pipelinerun ion result.
+
+ The URL suports templating for these value:
+
+* `{{ namespace }}`: The target namespace where the pipelinerun is executed
+* `{{ pr }}`: The PipelineRun name.
+
+ example: `https://mycorp.com/ns/{{ namespace }}/pipelienrun/{{ pr }}`
+
+* `custom-console-url-pr-tasklog`
+
+ Set this to the URL where to view the log of the taskrun of the `PipelineRun`. This is
+ shown when we post a result of the task breakdown to link to the logs of the taskrun.
+
+ The URL suports templating for these value:
+
+* `{{ namespace }}`: The target namespace where the pipelinerun is executed
+* `{{ pr }}`: The PipelineRun name.
+* `{{ task }}`: The Task name in the PR
+* `{{ pod }}`: The Pod name of the TaskRun
+* `{{ firstFailedStep }}`: The name of the first failed step in the TaskRun
+
+ example: `https://mycorp.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}#{{ pod }}-{{ firstFailedStep }}`
+
 ## Pipelines-As-Code Info
 
   There are a settings exposed through a config map for which any authenticated
@@ -204,10 +248,10 @@ There is a few things you can configure through the config map
   The controller URL as set by the `tkn pac bootstrap` command while setting up
   the GitHub App or if Pipelines as code is installed
 
-  When using OpenShift Pipelines Operator then the operator sets the route created
+  The OpenShift Pipelines Operator will automatically set the the route created
   for the controller.
 
-  This field is also used to detect the controller URL when using the `webhook add`
+  This field is also used to detect the controller URL when using the `tkn pac webhook add`
   commands.
 
 * `provider`

--- a/pkg/action/patch_test.go
+++ b/pkg/action/patch_test.go
@@ -47,7 +47,7 @@ func getLogURLMergePatch(clients clients.Clients, pr *pipelinev1.PipelineRun) ma
 	return map[string]interface{}{
 		"metadata": map[string]interface{}{
 			"annotations": map[string]string{
-				keys.LogURL: clients.ConsoleUI.DetailURL(pr.GetNamespace(), pr.GetName()),
+				keys.LogURL: clients.ConsoleUI.DetailURL(pr),
 			},
 		},
 	}

--- a/pkg/cli/status/status.go
+++ b/pkg/cli/status/status.go
@@ -63,9 +63,10 @@ func MixLivePRandRepoStatus(ctx context.Context, cs *params.Run, repository pacv
 		return sortrepostatus.RepositorySortRunStatus(repositorystatus)
 	}
 
-	for _, pr := range prs.Items {
+	for i := range prs.Items {
+		pr := prs.Items[i]
 		repositorystatus = RepositoryRunStatusRemoveSameSHA(repositorystatus, pr.GetLabels()["pipelinesascode.tekton.dev/sha"])
-		logurl := cs.Clients.ConsoleUI.DetailURL(pr.GetNamespace(), pr.GetName())
+		logurl := cs.Clients.ConsoleUI.DetailURL(&pr)
 		repositorystatus = append(repositorystatus, convertPrStatusToRepositoryStatus(ctx, cs, pr, logurl))
 	}
 	return sortrepostatus.RepositorySortRunStatus(repositorystatus)

--- a/pkg/cmd/tknpac/logs/logs.go
+++ b/pkg/cmd/tknpac/logs/logs.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/sort"
 	"github.com/spf13/cobra"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -161,7 +162,7 @@ func getTknPath() (string, error) {
 	return filepath.Abs(fname)
 }
 
-// getPipelineRunsToRepo returns all pipelinesruns running in a namespace
+// getPipelineRunsToRepo returns all PipelineRuns running in a namespace
 func getPipelineRunsToRepo(ctx context.Context, lopt *logOption, repoName string) ([]string, error) {
 	opts := metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("%s=%s",
@@ -248,13 +249,19 @@ func showLogsWithWebConsole(lo *logOption, pr string) error {
 		lo.cs.Clients.ConsoleUI = &consoleui.TektonDashboard{BaseURL: os.Getenv("PAC_TEKTON_DASHBOARD_URL")}
 	}
 
-	return browser.OpenWebBrowser(lo.cs.Clients.ConsoleUI.DetailURL(lo.cs.Info.Kube.Namespace, pr))
+	prObj := &tektonv1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pr,
+			Namespace: lo.cs.Info.Kube.Namespace,
+		},
+	}
+	return browser.OpenWebBrowser(lo.cs.Clients.ConsoleUI.DetailURL(prObj))
 }
 
 func showlogswithtkn(tknPath, pr, ns string) error {
 	//nolint: gosec
 	if err := syscall.Exec(tknPath, []string{tknPath, "pr", "logs", "-f", "-n", ns, pr}, os.Environ()); err != nil {
-		fmt.Fprintf(os.Stderr, "Command finished with error: %v", err)
+		_, _ = fmt.Fprintf(os.Stderr, "Command finished with error: %v", err)
 		os.Exit(127)
 	}
 	return nil

--- a/pkg/consoleui/custom.go
+++ b/pkg/consoleui/custom.go
@@ -60,8 +60,6 @@ func (o *CustomConsole) TaskLogURL(pr *tektonv1.PipelineRun, taskRunStatus *tekt
 	})
 }
 
-// UI use dynamic client to get the route of the openshift
-// console where we can point to.
 func (o *CustomConsole) UI(_ context.Context, _ dynamic.Interface) error {
 	return nil
 }

--- a/pkg/consoleui/custom.go
+++ b/pkg/consoleui/custom.go
@@ -1,0 +1,67 @@
+package consoleui
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/templates"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"k8s.io/client-go/dynamic"
+)
+
+type CustomConsole struct {
+	info *info.Info
+}
+
+func (o *CustomConsole) GetName() string {
+	if o.info.Pac.CustomConsoleName == "" {
+		return "Not configured"
+	}
+	return o.info.Pac.CustomConsoleName
+}
+
+func (o *CustomConsole) URL() string {
+	if o.info.Pac.CustomConsoleURL == "" {
+		return fmt.Sprintf("https://setting.%s.is.not.configured", settings.CustomConsoleURLKey)
+	}
+	return o.info.Pac.CustomConsoleURL
+}
+
+func (o *CustomConsole) DetailURL(pr *tektonv1.PipelineRun) string {
+	if o.info.Pac.CustomConsolePRdetail == "" {
+		return fmt.Sprintf("https://setting.%s.is.not.configured", settings.CustomConsolePRDetailKey)
+	}
+	return templates.ReplacePlaceHoldersVariables(o.info.Pac.CustomConsolePRdetail, map[string]string{
+		"namespace": pr.GetNamespace(),
+		"pr":        pr.GetName(),
+	})
+}
+
+func (o *CustomConsole) TaskLogURL(pr *tektonv1.PipelineRun, taskRunStatus *tektonv1.PipelineRunTaskRunStatus) string {
+	if o.info.Pac.CustomConsolePRTaskLog == "" {
+		return fmt.Sprintf("https://setting.%s.is.not.configured", settings.CustomConsolePRTaskLogKey)
+	}
+	firstFailedStep := ""
+	// search for the first failed steps in taskrunstatus
+	for _, step := range taskRunStatus.Status.Steps {
+		if step.Terminated != nil && step.Terminated.ExitCode != 0 {
+			firstFailedStep = step.Name
+			break
+		}
+	}
+	return templates.ReplacePlaceHoldersVariables(o.info.Pac.CustomConsolePRTaskLog, map[string]string{
+		"namespace":       pr.GetNamespace(),
+		"pr":              pr.GetName(),
+		"task":            taskRunStatus.PipelineTaskName,
+		"pod":             taskRunStatus.Status.PodName,
+		"firstFailedStep": firstFailedStep,
+	})
+}
+
+// UI use dynamic client to get the route of the openshift
+// console where we can point to.
+func (o *CustomConsole) UI(_ context.Context, _ dynamic.Interface) error {
+	return nil
+}

--- a/pkg/consoleui/custom_test.go
+++ b/pkg/consoleui/custom_test.go
@@ -1,0 +1,89 @@
+package consoleui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCustomGood(t *testing.T) {
+	consoleName := "MyCorp Console"
+	consoleURL := "https://mycorp.console"
+	consolePRdetail := "https://mycorp.console/{{ namespace }}/{{ pr }}"
+	consolePRtasklog := "https://mycorp.console/{{ namespace }}/{{ pr }}/{{ task }}/{{ pod }}/{{ firstFailedStep }}"
+
+	c := CustomConsole{
+		info: &info.Info{
+			Pac: &info.PacOpts{
+				Settings: &settings.Settings{
+					CustomConsoleName:      consoleName,
+					CustomConsoleURL:       consoleURL,
+					CustomConsolePRdetail:  consolePRdetail,
+					CustomConsolePRTaskLog: consolePRtasklog,
+				},
+			},
+		},
+	}
+	pr := &tektonv1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns",
+			Name:      "pr",
+		},
+	}
+	trStatus := &tektonv1.PipelineRunTaskRunStatus{
+		PipelineTaskName: "task",
+		Status: &tektonv1.TaskRunStatus{
+			TaskRunStatusFields: tektonv1.TaskRunStatusFields{
+				PodName: "pod",
+				Steps: []tektonv1.StepState{
+					{
+						Name: "failure",
+						ContainerState: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								ExitCode: 1,
+							},
+						},
+					},
+					{
+						Name: "nextFailure",
+						ContainerState: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								ExitCode: 1,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	assert.Equal(t, c.GetName(), consoleName)
+	assert.Equal(t, c.URL(), consoleURL)
+	assert.Equal(t, c.DetailURL(pr), "https://mycorp.console/ns/pr")
+	assert.Equal(t, c.TaskLogURL(pr, trStatus), "https://mycorp.console/ns/pr/task/pod/failure")
+}
+
+func TestCustomBad(t *testing.T) {
+	c := CustomConsole{
+		info: &info.Info{
+			Pac: &info.PacOpts{
+				Settings: &settings.Settings{},
+			},
+		},
+	}
+	pr := &tektonv1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns",
+			Name:      "pr",
+		},
+	}
+	assert.Assert(t, strings.Contains(c.GetName(), "Not configured"))
+	assert.Assert(t, strings.Contains(c.URL(), "is.not.configured"))
+	assert.Assert(t, strings.Contains(c.DetailURL(pr), "is.not.configured"))
+	assert.Assert(t, strings.Contains(c.TaskLogURL(pr, nil), "is.not.configured"))
+}

--- a/pkg/consoleui/interface.go
+++ b/pkg/consoleui/interface.go
@@ -4,14 +4,15 @@ import (
 	"context"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"k8s.io/client-go/dynamic"
 )
 
 const consoleIsnotConfiguredURL = "https://dashboard.is.not.configured"
 
 type Interface interface {
-	DetailURL(ns, pr string) string
-	TaskLogURL(ns, pr, task string) string
+	DetailURL(pr *tektonv1.PipelineRun) string
+	TaskLogURL(pr *tektonv1.PipelineRun, taskRunStatusstatus *tektonv1.PipelineRunTaskRunStatus) string
 	UI(ctx context.Context, kdyn dynamic.Interface) error
 	URL() string
 	GetName() string
@@ -23,15 +24,15 @@ func (f FallBackConsole) GetName() string {
 	return "Not configured"
 }
 
-func (f FallBackConsole) DetailURL(ns, pr string) string {
+func (f FallBackConsole) DetailURL(_ *tektonv1.PipelineRun) string {
 	return consoleIsnotConfiguredURL
 }
 
-func (f FallBackConsole) TaskLogURL(ns, pr, task string) string {
+func (f FallBackConsole) TaskLogURL(_ *tektonv1.PipelineRun, _ *tektonv1.PipelineRunTaskRunStatus) string {
 	return consoleIsnotConfiguredURL
 }
 
-func (f FallBackConsole) UI(ctx context.Context, kdyn dynamic.Interface) error {
+func (f FallBackConsole) UI(_ context.Context, _ dynamic.Interface) error {
 	return nil
 }
 

--- a/pkg/consoleui/interface_test.go
+++ b/pkg/consoleui/interface_test.go
@@ -3,7 +3,9 @@ package consoleui
 import (
 	"testing"
 
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
@@ -19,8 +21,18 @@ func TestFallbackConsole(t *testing.T) {
 		"kind":       "Random",
 	})
 	dynClient := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), unsf)
+
+	pr := &tektonv1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns",
+			Name:      "pr",
+		},
+	}
+	trStatus := &tektonv1.PipelineRunTaskRunStatus{
+		PipelineTaskName: "task",
+	}
 	assert.NilError(t, fbc.UI(ctx, dynClient))
 	assert.Assert(t, fbc.URL() != "")
-	assert.Assert(t, fbc.DetailURL("ns", "pr") != "")
-	assert.Assert(t, fbc.TaskLogURL("ns", "pr", "task") != "")
+	assert.Assert(t, fbc.DetailURL(pr) != "")
+	assert.Assert(t, fbc.TaskLogURL(pr, trStatus) != "")
 }

--- a/pkg/consoleui/openshift.go
+++ b/pkg/consoleui/openshift.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
@@ -32,12 +33,12 @@ func (o *OpenshiftConsole) URL() string {
 	return "https://" + o.host
 }
 
-func (o *OpenshiftConsole) DetailURL(ns, pr string) string {
-	return fmt.Sprintf(openShiftPipelineDetailViewURL, o.host, ns, pr)
+func (o *OpenshiftConsole) DetailURL(pr *tektonv1.PipelineRun) string {
+	return fmt.Sprintf(openShiftPipelineDetailViewURL, o.host, pr.GetNamespace(), pr.GetName())
 }
 
-func (o *OpenshiftConsole) TaskLogURL(ns, pr, task string) string {
-	return fmt.Sprintf(openShiftPipelineTaskLogURL, o.DetailURL(ns, pr), task)
+func (o *OpenshiftConsole) TaskLogURL(pr *tektonv1.PipelineRun, taskRunStatus *tektonv1.PipelineRunTaskRunStatus) string {
+	return fmt.Sprintf(openShiftPipelineTaskLogURL, o.DetailURL(pr), taskRunStatus.PipelineTaskName)
 }
 
 // UI use dynamic client to get the route of the openshift

--- a/pkg/consoleui/openshift_test.go
+++ b/pkg/consoleui/openshift_test.go
@@ -3,7 +3,9 @@ package consoleui
 import (
 	"testing"
 
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
@@ -99,8 +101,17 @@ func TestOpenshiftConsoleUI(t *testing.T) {
 }
 
 func TestOpenshiftConsoleURLs(t *testing.T) {
+	pr := &tektonv1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns",
+			Name:      "pr",
+		},
+	}
+	trStatus := &tektonv1.PipelineRunTaskRunStatus{
+		PipelineTaskName: "task",
+	}
 	o := OpenshiftConsole{host: "http://fakeconsole"}
 	assert.Assert(t, o.URL() != "")
-	assert.Assert(t, o.DetailURL("ns", "pr") != "")
-	assert.Assert(t, o.TaskLogURL("ns", "pr", "task") != "")
+	assert.Assert(t, o.DetailURL(pr) != "")
+	assert.Assert(t, o.TaskLogURL(pr, trStatus) != "")
 }

--- a/pkg/consoleui/tektondashboard.go
+++ b/pkg/consoleui/tektondashboard.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"k8s.io/client-go/dynamic"
 )
 
@@ -17,18 +18,18 @@ func (t *TektonDashboard) GetName() string {
 	return tektonDashboardName
 }
 
-func (t *TektonDashboard) DetailURL(ns, pr string) string {
-	return fmt.Sprintf("%s/#/namespaces/%s/pipelineruns/%s", t.BaseURL, ns, pr)
+func (t *TektonDashboard) DetailURL(pr *tektonv1.PipelineRun) string {
+	return fmt.Sprintf("%s/#/namespaces/%s/pipelineruns/%s", t.BaseURL, pr.GetNamespace(), pr.GetName())
 }
 
-func (t *TektonDashboard) TaskLogURL(ns, pr, task string) string {
-	return fmt.Sprintf("%s?pipelineTask=%s", t.DetailURL(ns, pr), task)
+func (t *TektonDashboard) TaskLogURL(pr *tektonv1.PipelineRun, taskRunStatus *tektonv1.PipelineRunTaskRunStatus) string {
+	return fmt.Sprintf("%s?pipelineTask=%s", t.DetailURL(pr), taskRunStatus.PipelineTaskName)
 }
 
 func (t *TektonDashboard) URL() string {
 	return t.BaseURL
 }
 
-func (t *TektonDashboard) UI(ctx context.Context, kdyn dynamic.Interface) error {
+func (t *TektonDashboard) UI(_ context.Context, _ dynamic.Interface) error {
 	return nil
 }

--- a/pkg/consoleui/tektondashboard_test.go
+++ b/pkg/consoleui/tektondashboard_test.go
@@ -4,7 +4,9 @@ import (
 	"strings"
 	"testing"
 
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
@@ -22,9 +24,19 @@ func TestTektonDashboard(t *testing.T) {
 		"apiVersion": "foo.io/v1",
 		"kind":       "Random",
 	})
+
+	pr := &tektonv1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns",
+			Name:      "pr",
+		},
+	}
+	trStatus := &tektonv1.PipelineRunTaskRunStatus{
+		PipelineTaskName: "task",
+	}
 	dynClient := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), unsf)
 	assert.NilError(t, tr.UI(ctx, dynClient))
-	assert.Assert(t, strings.Contains(tr.DetailURL("ns", "pr"), "namespaces/ns"))
-	assert.Assert(t, strings.Contains(tr.TaskLogURL("ns", "pr", "task"), "pipelineTask=task"))
+	assert.Assert(t, strings.Contains(tr.DetailURL(pr), "namespaces/ns"))
+	assert.Assert(t, strings.Contains(tr.TaskLogURL(pr, trStatus), "pipelineTask=task"))
 	assert.Assert(t, strings.Contains(tr.URL(), "test"))
 }

--- a/pkg/params/settings/config.go
+++ b/pkg/params/settings/config.go
@@ -21,6 +21,11 @@ const (
 	AutoConfigureNewGitHubRepoKey         = "auto-configure-new-github-repo"
 	AutoConfigureRepoNamespaceTemplateKey = "auto-configure-repo-namespace-template"
 
+	CustomConsoleNameKey      = "custom-console-name"
+	CustomConsoleURLKey       = "custom-console-url"
+	CustomConsolePRDetailKey  = "custom-console-url-pr-details"
+	CustomConsolePRTaskLogKey = "custom-console-url-pr-tasklog"
+
 	SecretAutoCreateKey                          = "secret-auto-create"
 	secretAutoCreateDefaultValue                 = "true"
 	SecretGhAppTokenRepoScopedKey                = "secret-github-app-token-scoped" //nolint: gosec
@@ -71,6 +76,11 @@ type Settings struct {
 	ErrorDetection              bool
 	ErrorDetectionNumberOfLines int
 	ErrorDetectionSimpleRegexp  string
+
+	CustomConsoleName      string
+	CustomConsoleURL       string
+	CustomConsolePRdetail  string
+	CustomConsolePRTaskLog string
 }
 
 func ConfigToSettings(logger *zap.SugaredLogger, setting *Settings, config map[string]string) error {
@@ -173,6 +183,26 @@ func ConfigToSettings(logger *zap.SugaredLogger, setting *Settings, config map[s
 		// replace double backslash with single backslash because kube configmap is giving us things double backslashes
 		logger.Infof("CONFIG: setting error detection regexp to %v", strings.TrimSpace(config[ErrorDetectionSimpleRegexpKey]))
 		setting.ErrorDetectionSimpleRegexp = strings.TrimSpace(config[ErrorDetectionSimpleRegexpKey])
+	}
+
+	if setting.CustomConsoleName != config[CustomConsoleNameKey] {
+		logger.Infof("CONFIG: setting custom console name to %v", config[CustomConsoleNameKey])
+		setting.CustomConsoleName = config[CustomConsoleNameKey]
+	}
+
+	if setting.CustomConsoleURL != config[CustomConsoleURLKey] {
+		logger.Infof("CONFIG: setting custom console url to %v", config[CustomConsoleURLKey])
+		setting.CustomConsoleURL = config[CustomConsoleURLKey]
+	}
+
+	if setting.CustomConsolePRdetail != config[CustomConsolePRDetailKey] {
+		logger.Infof("CONFIG: setting custom console pr detail URL to %v", config[CustomConsolePRDetailKey])
+		setting.CustomConsolePRdetail = config[CustomConsolePRDetailKey]
+	}
+
+	if setting.CustomConsolePRTaskLog != config[CustomConsolePRTaskLogKey] {
+		logger.Infof("CONFIG: setting custom console pr task log URL to %v", config[CustomConsolePRTaskLogKey])
+		setting.CustomConsolePRTaskLog = config[CustomConsolePRTaskLogKey]
 	}
 
 	return nil

--- a/pkg/params/settings/default.go
+++ b/pkg/params/settings/default.go
@@ -50,4 +50,17 @@ func SetDefaults(config map[string]string) {
 	if errorDetectionSimpleRegexp, ok := config[ErrorDetectionSimpleRegexpKey]; !ok || errorDetectionSimpleRegexp == "" {
 		config[ErrorDetectionSimpleRegexpKey] = errorDetectionSimpleRegexpValue
 	}
+
+	if v, ok := config[CustomConsoleNameKey]; !ok || v == "" {
+		config[CustomConsoleNameKey] = v
+	}
+	if v, ok := config[CustomConsoleURLKey]; !ok || v == "" {
+		config[CustomConsoleURLKey] = v
+	}
+	if v, ok := config[CustomConsolePRDetailKey]; !ok || v == "" {
+		config[CustomConsolePRDetailKey] = v
+	}
+	if v, ok := config[CustomConsolePRTaskLogKey]; !ok || v == "" {
+		config[CustomConsolePRTaskLogKey] = v
+	}
 }

--- a/pkg/params/settings/validation.go
+++ b/pkg/params/settings/validation.go
@@ -63,6 +63,24 @@ func Validate(config map[string]string) error {
 			return fmt.Errorf("cannot use %v as regexp for error detection: %w", config[ErrorDetectionSimpleRegexpKey], err)
 		}
 	}
+
+	if v, ok := config[CustomConsoleURLKey]; ok && v != "" {
+		if _, err := url.ParseRequestURI(v); err != nil {
+			return fmt.Errorf("invalid value for key %v, invalid url: %w", CustomConsoleURLKey, err)
+		}
+	}
+
+	if v, ok := config[CustomConsolePRTaskLogKey]; ok && v != "" {
+		if _, err := url.ParseRequestURI(v); err != nil {
+			return fmt.Errorf("invalid value for key %v, invalid url: %w", CustomConsolePRTaskLogKey, err)
+		}
+	}
+
+	if v, ok := config[CustomConsolePRDetailKey]; ok && v != "" {
+		if _, err := url.ParseRequestURI(v); err != nil {
+			return fmt.Errorf("invalid value for key %v, invalid url: %w", CustomConsolePRDetailKey, err)
+		}
+	}
 	return nil
 }
 

--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -147,7 +147,7 @@ func (p *PacRun) startPR(ctx context.Context, match matcher.Match) (*tektonv1.Pi
 	// Create status with the log url
 	p.logger.Infof("pipelinerun %s has been created in namespace %s for SHA: %s Target Branch: %s",
 		pr.GetName(), match.Repo.GetNamespace(), p.event.SHA, p.event.BaseBranch)
-	consoleURL := p.run.Clients.ConsoleUI.DetailURL(match.Repo.GetNamespace(), pr.GetName())
+	consoleURL := p.run.Clients.ConsoleUI.DetailURL(pr)
 	// Create status with the log url
 	msg := fmt.Sprintf(params.StartingPipelineRunText,
 		pr.GetName(), match.Repo.GetNamespace(),
@@ -175,7 +175,7 @@ func (p *PacRun) startPR(ctx context.Context, match matcher.Match) (*tektonv1.Pi
 		return nil, fmt.Errorf("cannot create a in_progress status on the provider platform: %w", err)
 	}
 
-	// Patch pipelineRun with logURL annotation, skips for GitHub App as we patch logURL while patching checkrunID
+	// Patch pipelineRun with logURL annotation, skips for GitHub App as we patch logURL while patching CheckrunID
 	if _, ok := pr.Annotations[keys.InstallationID]; !ok {
 		pr, err = action.PatchPipelineRun(ctx, p.logger, "logURL", p.run.Clients.Tekton, pr, getLogURLMergePatch(p.run.Clients, pr))
 		if err != nil {
@@ -194,7 +194,7 @@ func getLogURLMergePatch(clients clients.Clients, pr *tektonv1.PipelineRun) map[
 	return map[string]interface{}{
 		"metadata": map[string]interface{}{
 			"annotations": map[string]string{
-				keys.LogURL: clients.ConsoleUI.DetailURL(pr.GetNamespace(), pr.GetName()),
+				keys.LogURL: clients.ConsoleUI.DetailURL(pr),
 			},
 		},
 	}

--- a/pkg/pipelineascode/pipelinesascode_github_test.go
+++ b/pkg/pipelineascode/pipelinesascode_github_test.go
@@ -38,7 +38,7 @@ import (
 
 func replyString(mux *http.ServeMux, url, body string) {
 	mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, body)
+		_, _ = fmt.Fprint(w, body)
 	})
 }
 
@@ -67,7 +67,7 @@ func testSetupCommonGhReplies(t *testing.T, mux *http.ServeMux, runevent info.Ev
 
 	if !noReplyOrgPublicMembers {
 		mux.HandleFunc("/orgs/"+runevent.Organization+"/public_members", func(rw http.ResponseWriter, r *http.Request) {
-			fmt.Fprintf(rw, `[{"login": "%s"}]`, runevent.Sender)
+			_, _ = fmt.Fprintf(rw, `[{"login": "%s"}]`, runevent.Sender)
 		})
 	}
 
@@ -488,7 +488,8 @@ func TestRun(t *testing.T) {
 					t.Error("failed to create pipelineRun for case: ", tt.name)
 				}
 				// validate logURL label
-				for _, pr := range prs.Items {
+				for i := range prs.Items {
+					pr := prs.Items[i]
 					// skip existing seed pipelineRuns
 					if pr.GetName() == "force-me" {
 						continue
@@ -497,7 +498,7 @@ func TestRun(t *testing.T) {
 					if !ok {
 						logger.Fatalf("failed to find log-url label on pipelinerun: %v/%v", pr.GetNamespace(), pr.GetName())
 					}
-					assert.Equal(t, logURL, cs.Clients.ConsoleUI.DetailURL(pr.Namespace, pr.Name))
+					assert.Equal(t, logURL, cs.Clients.ConsoleUI.DetailURL(&pr))
 
 					if cs.Info.Pac.SecretAutoCreation {
 						secretName := pr.GetAnnotations()[keys.GitAuthSecret]

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -43,7 +43,7 @@ var (
 	_ pipelinerunreconciler.Finalizer = (*Reconciler)(nil)
 )
 
-// ReconCileKind is the main entry point for reconciling PipelineRun resources.
+// ReconcileKind is the main entry point for reconciling PipelineRun resources.
 func (r *Reconciler) ReconcileKind(ctx context.Context, pr *tektonv1.PipelineRun) pkgreconciler.Event {
 	logger := logging.FromContext(ctx)
 
@@ -177,7 +177,7 @@ func (r *Reconciler) updatePipelineRunToInProgress(ctx context.Context, logger *
 		return fmt.Errorf("cannot set client: %w", err)
 	}
 
-	consoleURL := r.run.Clients.ConsoleUI.DetailURL(repo.GetNamespace(), pr.GetName())
+	consoleURL := r.run.Clients.ConsoleUI.DetailURL(pr)
 	msg := fmt.Sprintf(params.StartingPipelineRunText,
 		pr.GetName(), repo.GetNamespace(),
 		r.run.Clients.ConsoleUI.GetName(), consoleURL,

--- a/pkg/reconciler/status.go
+++ b/pkg/reconciler/status.go
@@ -44,7 +44,7 @@ func (r *Reconciler) updateRepoRunStatus(ctx context.Context, logger *zap.Sugare
 		SHA:             &event.SHA,
 		SHAURL:          &event.SHAURL,
 		Title:           &event.SHATitle,
-		LogURL:          github.String(r.run.Clients.ConsoleUI.DetailURL(pr.GetNamespace(), pr.GetName())),
+		LogURL:          github.String(r.run.Clients.ConsoleUI.DetailURL(pr)),
 		EventType:       &event.EventType,
 		TargetBranch:    &refsanitized,
 	}
@@ -126,7 +126,7 @@ func (r *Reconciler) postFinalStatus(ctx context.Context, logger *zap.SugaredLog
 		Conclusion:              formatting.PipelineRunStatus(pr),
 		Text:                    taskStatusText,
 		PipelineRunName:         pr.Name,
-		DetailsURL:              r.run.Clients.ConsoleUI.DetailURL(pr.GetNamespace(), pr.GetName()),
+		DetailsURL:              r.run.Clients.ConsoleUI.DetailURL(pr),
 		OriginalPipelineRunName: pr.GetLabels()[apipac.OriginalPRName],
 	}
 

--- a/pkg/sort/task_status.go
+++ b/pkg/sort/task_status.go
@@ -37,7 +37,7 @@ func (trs taskrunList) Less(i, j int) bool {
 	return trs[j].Status.StartTime.Before(trs[i].Status.StartTime)
 }
 
-// TaskStatusTmpl generate a template of all status of a taskruns sorted to a statusTemplate as defined by the git provider
+// TaskStatusTmpl generate a template of all status of a TaskRuns sorted to a statusTemplate as defined by the git provider
 func TaskStatusTmpl(pr *tektonv1.PipelineRun, trStatus map[string]*tektonv1.PipelineRunTaskRunStatus, runs *params.Run, config *info.ProviderConfig) (string, error) {
 	trl := taskrunList{}
 	outputBuffer := bytes.Buffer{}
@@ -48,11 +48,7 @@ func TaskStatusTmpl(pr *tektonv1.PipelineRun, trStatus map[string]*tektonv1.Pipe
 
 	for _, taskrunStatus := range trStatus {
 		trl = append(trl, tkr{
-			taskLogURL: runs.Clients.ConsoleUI.TaskLogURL(
-				pr.GetNamespace(),
-				pr.GetName(),
-				taskrunStatus.PipelineTaskName,
-			),
+			taskLogURL:               runs.Clients.ConsoleUI.TaskLogURL(pr, taskrunStatus),
 			PipelineRunTaskRunStatus: taskrunStatus,
 		})
 	}
@@ -70,7 +66,7 @@ func TaskStatusTmpl(pr *tektonv1.PipelineRun, trStatus map[string]*tektonv1.Pipe
 	data := struct{ TaskRunList taskrunList }{TaskRunList: trl}
 	t := template.Must(template.New("Task Status").Funcs(funcMap).Parse(config.TaskStatusTMPL))
 	if err := t.Execute(&outputBuffer, data); err != nil {
-		fmt.Fprintf(&outputBuffer, "failed to execute template: ")
+		_, _ = fmt.Fprintf(&outputBuffer, "failed to execute template: ")
 		return "", err
 	}
 


### PR DESCRIPTION
let the user define a console endpoint which is replaced by template
for link showed on the pr results and others.

* `tekton-dashboard-url`

  Set this to your dashboard URL, and the pipelinerun and tasklog will be
  expander there.

You can configure a custom console with this settings:

* `custom-console-name`

 Set this to the name of your custom console. example: `MyCorp Console`

* `custom-console-url`

 Set this to the root URL of your custom console. example: `https://mycorp.com`

* `custom-console-url-pr-details`

 Set this to the URL where to view the details of the `PipelineRun`. This is
 shown when the PipelineRun is started so the user can follow execution on your
 console or when to see more details about the pipelinerun ion result.

 The URL suports templating for these value:

* `{{ namespace }}`: The target namespace where the pipelinerun is executed
* `{{ pr }}`: The PipelineRun name.

 example: `https://mycorp.com/ns/{{ namespace }}/pipelienrun/{{ pr }}`

* `custom-console-url-pr-tasklog`

 Set this to the URL where to view the log of the taskrun of the `PipelineRun`. This is
 shown when we post a result of the task breakdown to link to the logs of the taskrun.

 The URL suports templating for these value:

* `{{ namespace }}`: The target namespace where the pipelinerun is executed
* `{{ pr }}`: The PipelineRun name.
* `{{ task }}`: The Task name in the PR
* `{{ pod }}`: The Pod name of the TaskRun
* `{{ firstFailedStep }}`: The name of the first failed step in the TaskRun

 example: `https://mycorp.com/ns/{{ namespace }}/pipelienrun/{{ pr }}/logs/{{ task }}`

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
