### PR TITLE
Fix gitea e2e test getting log of bad yaml

### DIFF
--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -106,7 +106,7 @@ func TestGiteaBadYaml(t *testing.T) {
 	ctx := context.Background()
 
 	assert.NilError(t, twait.RegexpMatchingInPodLog(ctx, topts.Params, "app.kubernetes.io/component=controller", "pac-controller", *regexp.MustCompile(
-		"pipelinerun .* cannot be validated properly: err: expected exactly one, got neither:"), 10))
+		"pipelinerun.*has failed.*expected exactly one, got neither: spec.pipelineRef, spec.pipelineSpec"), 10))
 }
 
 // don't test concurrency limit here, just parallel pipeline


### PR DESCRIPTION
since we changed the format of the log we didn't fix the e2e run to
match it...

fixing it
