### PR TITLE
Makefile: replace /bin/bash to bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GO           = go
 TIMEOUT_UNIT = 20m
 TIMEOUT_E2E  = 20m
 GO_TEST_FLAGS +=
-SHELL := /bin/bash
+SHELL := bash
 
 
 PY_FILES := $(shell find . -type f -regex ".*py" -print)


### PR DESCRIPTION
So that it works on NixOS or system where /bin/bash doesn't exists.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>
