### PR TITLE
More helpful error message when we cannot find task/pipeline

### DIFF
--- a/pkg/resolve/resolve.go
+++ b/pkg/resolve/resolve.go
@@ -105,7 +105,7 @@ func getTaskByName(name string, tasks []*tektonv1.Task) (*tektonv1.Task, error) 
 			return value, nil
 		}
 	}
-	return &tektonv1.Task{}, fmt.Errorf("cannot find task %s in input", name)
+	return &tektonv1.Task{}, fmt.Errorf("cannot find referenced task %s. if it's a remote task make sure to add it in the annotations", name)
 }
 
 func getPipelineByName(name string, tasks []*tektonv1.Pipeline) (*tektonv1.Pipeline, error) {
@@ -114,7 +114,7 @@ func getPipelineByName(name string, tasks []*tektonv1.Pipeline) (*tektonv1.Pipel
 			return value, nil
 		}
 	}
-	return &tektonv1.Pipeline{}, fmt.Errorf("cannot find pipeline %s in input", name)
+	return &tektonv1.Pipeline{}, fmt.Errorf("cannot find referenced pipeline %s. for a remote pipeline make sure to add it in the annotation", name)
 }
 
 func skippingTask(taskName string, skippedTasks []string) bool {

--- a/pkg/resolve/resolve_test.go
+++ b/pkg/resolve/resolve_test.go
@@ -212,12 +212,12 @@ func TestNoPipelineRuns(t *testing.T) {
 
 func TestReferencedTaskNotInRepo(t *testing.T) {
 	_, _, err := readTDfile(t, "referenced-task-not-in-repo", false, true)
-	assert.Error(t, err, "cannot find task nothere in input")
+	assert.Error(t, err, "cannot find referenced task nothere. if it's a remote task make sure to add it in the annotations")
 }
 
 func TestReferencedPipelineNotInRepo(t *testing.T) {
 	_, _, err := readTDfile(t, "referenced-pipeline-not-in-repo", false, true)
-	assert.Error(t, err, "cannot find pipeline pipeline-test1 in input")
+	assert.Error(t, err, "cannot find referenced pipeline pipeline-test1. for a remote pipeline make sure to add it in the annotation")
 }
 
 func TestIgnoreDocSpace(t *testing.T) {


### PR DESCRIPTION
When the user hasn't added their referenced task/pipeline, show a more
explicit error message explaining to check their annotations

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [x] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [x] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [x] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [x] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
