### PR TITLE
Make sure coverage pipeline target the main branch

### DIFF
--- a/.tekton/generate-coverage-release.yaml
+++ b/.tekton/generate-coverage-release.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/task: "[git-clone]"
     pipelinesascode.tekton.dev/max-keep-runs: "2"
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push" && ("***/*.go".pathChanged() || "config/".pathChanged())
+      event == "push" && target_branch == "main" && ("***/*.go".pathChanged() || "config/".pathChanged())
 spec:
   params:
     - name: repo_url


### PR DESCRIPTION
The coverage/release.yaml create a push into the nightly branch, so we
were looping ourselves forever targetting all branches when generate
release.yaml which upload to the nightly and run it again and again.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [X] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [X] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [X] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [X] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [X] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
