### PR TITLE
Added a check to watch on secret pipelines-as-code-secret to decide GithubApp or Webhook

### DIFF
--- a/pkg/cli/info/configmap.go
+++ b/pkg/cli/info/configmap.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/pipelineascode"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -13,6 +14,13 @@ type Options struct {
 	TargetNamespace string
 	ControllerURL   string
 	Provider        string
+}
+
+func IsGithubAppInstalled(ctx context.Context, run *params.Run, targetNamespace string) bool {
+	if _, err := run.Clients.Kube.CoreV1().Secrets(targetNamespace).Get(ctx, pipelineascode.DefaultPipelinesAscodeSecretName, metav1.GetOptions{}); err != nil {
+		return false
+	}
+	return true
 }
 
 func GetPACInfo(ctx context.Context, run *params.Run, targetNamespace string) (*Options, error) {

--- a/pkg/cmd/tknpac/bootstrap/bootstrap.go
+++ b/pkg/cmd/tknpac/bootstrap/bootstrap.go
@@ -9,7 +9,6 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	"github.com/spf13/cobra"
 	kapierror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -150,13 +149,8 @@ func Command(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
 				}
 			}
 
-			pacInfo, err := info.GetPACInfo(ctx, run, opts.targetNamespace)
-			if err != nil {
-				return err
-			}
-
 			if !opts.forceGitHubApp {
-				if pacInfo.Provider == provider.ProviderGitHubApp {
+				if info.IsGithubAppInstalled(ctx, run, opts.targetNamespace) {
 					fmt.Fprintln(opts.ioStreams.Out, "👌 Skips bootstrapping GitHub App, as one is already configured. Please pass --force-configure to override existing")
 					return nil
 				}
@@ -213,13 +207,8 @@ func GithubApp(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
 				return err
 			}
 
-			pacInfo, err := info.GetPACInfo(ctx, run, opts.targetNamespace)
-			if err != nil {
-				return err
-			}
-
 			if !opts.forceGitHubApp {
-				if pacInfo.Provider == provider.ProviderGitHubApp {
+				if info.IsGithubAppInstalled(ctx, run, opts.targetNamespace) {
 					fmt.Fprintln(opts.ioStreams.Out, "👌 Skips bootstrapping GitHub App, as one is already configured. Please pass --force-configure to override existing")
 					return nil
 				}

--- a/pkg/cmd/tknpac/bootstrap/kubestuff.go
+++ b/pkg/cmd/tknpac/bootstrap/kubestuff.go
@@ -22,6 +22,9 @@ func createPacSecret(ctx context.Context, run *params.Run, opts *bootstrapOpts, 
 	_, err := run.Clients.Kube.CoreV1().Secrets(opts.targetNamespace).Create(ctx, &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: secretName,
+			Labels: map[string]string{
+				"app.kubernetes.io/part-of": "pipelines-as-code",
+			},
 		},
 		Data: map[string][]byte{
 			"github-application-id": []byte(fmt.Sprintf("%d", manifest.GetID())),

--- a/pkg/cmd/tknpac/create/repository.go
+++ b/pkg/cmd/tknpac/create/repository.go
@@ -20,7 +20,6 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/git"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	"github.com/spf13/cobra"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -81,12 +80,8 @@ func repositoryCommand(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command
 			if err != nil {
 				return err
 			}
-			pacCMInfo, err := pacInfo.GetPACInfo(ctx, run, installationNS)
-			if err != nil {
-				return err
-			}
 
-			if pacCMInfo.Provider == provider.ProviderGitHubApp {
+			if pacInfo.IsGithubAppInstalled(ctx, run, installationNS) {
 				if strings.Contains(createOpts.Event.URL, "github") {
 					if err := createOpts.generateTemplate(nil); err != nil {
 						return err


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Fixes: https://issues.redhat.com/browse/SRVKP-2885

`tkn-pac create repo` should not configure webhook when GithubApp is installed but right now PAC relaying on `pipelines-as-code-info` configmap for Provider key [here](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/pkg/cli/info/configmap.go#L26) and if Provider is "" even though secret `pipelines-as-code-secret` present tkn-pac create repo does not know about secret info and it tries for Webhook

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
