### PR TITLE
Fix tkn pac resolve

### DIFF
--- a/pkg/cmd/tknpac/resolve/resolve.go
+++ b/pkg/cmd/tknpac/resolve/resolve.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/resolve"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/templates"
 	"github.com/spf13/cobra"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"go.uber.org/zap"
 	"sigs.k8s.io/yaml"
 )
@@ -212,6 +213,8 @@ func resolveFilenames(ctx context.Context, cs *params.Run, filenames []string, p
 	}
 
 	for _, run := range prun {
+		run.APIVersion = tektonv1.SchemeGroupVersion.String()
+		run.Kind = "PipelineRun"
 		d, err := yaml.Marshal(run)
 		if err != nil {
 			return "", err


### PR DESCRIPTION
I can't figure out why the apiVersion and Kind is not getting populated
on CLI while working when generated from the controller.

let's add it manually which seems to generate proper PipelineRun

We do have [e2e tests](https://github.com/chmouel/pipelines-as-code/blob/main/test/gitea_test.go#L551) covering all of this code path but it seems to
occur only from a binary and not when launched from go code, so i guess
we can't do much about it.

Fixes #1178

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
