### PR TITLE
Properly test resolve with golden output

### DIFF
--- a/pkg/cmd/tknpac/resolve/resolve.go
+++ b/pkg/cmd/tknpac/resolve/resolve.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
@@ -212,6 +213,9 @@ func resolveFilenames(ctx context.Context, cs *params.Run, filenames []string, p
 		return "", err
 	}
 
+	// cleanedup regexp do as much as we can but really it's a lost game to try this
+	cleanRe := regexp.MustCompile(`\n(\t|\s)*(creationTimestamp|spec|taskRunTemplate|metadata|computeResources):\s*(null|{})\n`)
+
 	for _, run := range prun {
 		run.APIVersion = tektonv1.SchemeGroupVersion.String()
 		run.Kind = "PipelineRun"
@@ -219,7 +223,8 @@ func resolveFilenames(ctx context.Context, cs *params.Run, filenames []string, p
 		if err != nil {
 			return "", err
 		}
-		ret += fmt.Sprintf("---\n%s\n", d)
+		cleaned := cleanRe.ReplaceAllString(string(d), "\n")
+		ret += fmt.Sprintf("---\n%s\n", cleaned)
 	}
 	return ret, nil
 }

--- a/pkg/cmd/tknpac/resolve/resolve_test.go
+++ b/pkg/cmd/tknpac/resolve/resolve_test.go
@@ -16,6 +16,7 @@ import (
 	zapobserver "go.uber.org/zap/zaptest/observer"
 	"gotest.tools/v3/assert"
 	assertfs "gotest.tools/v3/fs"
+	"gotest.tools/v3/golden"
 	rtesting "knative.dev/pkg/reconciler/testing"
 )
 
@@ -32,8 +33,7 @@ spec:
 		  steps:
 			- name: hello-moto
 			  image: alpine:3.7
-			  script: "echo hello moto"
-`
+			  script: "echo hello moto"`
 
 func TestSplitArgsInMap(t *testing.T) {
 	args := []string{"ride=bike", "be=free", "of=car"}
@@ -106,6 +106,7 @@ func TestResolveFilenames(t *testing.T) {
 				t.Errorf("resolveFilenames() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			} else if !tt.wantErr {
+				golden.Assert(t, string(got), strings.ReplaceAll(fmt.Sprintf("%s.golden", t.Name()), "/", "-"))
 				assert.Assert(t, got != "")
 			}
 		})

--- a/pkg/cmd/tknpac/resolve/testdata/TestResolveFilenames-Resolve_templates_no_prefix.golden
+++ b/pkg/cmd/tknpac/resolve/testdata/TestResolveFilenames-Resolve_templates_no_prefix.golden
@@ -1,0 +1,20 @@
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  generateName: test-
+  labels:
+    pipelinesascode.tekton.dev/original-prname: test
+spec:
+  pipelineSpec:
+    tasks:
+    - name: bar
+      taskSpec:
+        spec: null
+        steps:
+        - computeResources: {}
+          image: alpine:3.7
+          name: hello-moto
+          script: echo hello moto
+status: {}
+

--- a/pkg/cmd/tknpac/resolve/testdata/TestResolveFilenames-Resolve_templates_with_prefix.golden
+++ b/pkg/cmd/tknpac/resolve/testdata/TestResolveFilenames-Resolve_templates_with_prefix.golden
@@ -1,0 +1,20 @@
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  generateName: test-
+  labels:
+    pipelinesascode.tekton.dev/original-prname: test
+spec:
+  pipelineSpec:
+    tasks:
+    - name: bar
+      taskSpec:
+        spec: null
+        steps:
+        - computeResources: {}
+          image: alpine:3.7
+          name: hello-moto
+          script: echo hello moto
+status: {}
+


### PR DESCRIPTION
Followup from fe40c180105b7a9e5299e11174c2f083bd2565cd, update tkn pac resolve unittest to use golden so we know it output properly the apiVersion and kind in Template

cleaned up some null field along the way but that's a loose battle, ie see https://github.com/kubernetes-sigs/kustomize/issues/4740

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
