### PR TITLE
Properly report error when the PipelineRun could not get created

### DIFF
--- a/pkg/reconciler/status_test.go
+++ b/pkg/reconciler/status_test.go
@@ -4,28 +4,66 @@ import (
 	"context"
 	"testing"
 
-	provider2 "github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/test/provider"
+	"github.com/jonboulle/clockwork"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/consoleui"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
+	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
+	tprovider "github.com/openshift-pipelines/pipelines-as-code/pkg/test/provider"
+	tektontest "github.com/openshift-pipelines/pipelines-as-code/pkg/test/tekton"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"go.uber.org/zap"
 	zapobserver "go.uber.org/zap/zaptest/observer"
 	"gotest.tools/v3/assert"
+	"knative.dev/pkg/apis"
+	rtesting "knative.dev/pkg/reconciler/testing"
 )
 
 func TestCreateStatusWithRetry(t *testing.T) {
 	observer, _ := zapobserver.New(zap.InfoLevel)
 	fakelogger := zap.New(observer).Sugar()
-	vcx := provider.TestProviderImp{}
+	vcx := tprovider.TestProviderImp{}
 
-	err := createStatusWithRetry(context.TODO(), fakelogger, nil, &vcx, nil, nil, provider2.StatusOpts{})
+	err := createStatusWithRetry(context.TODO(), fakelogger, nil, &vcx, nil, nil, provider.StatusOpts{})
 	assert.NilError(t, err)
 }
 
 func TestCreateStatusWithRetry_ErrorCase(t *testing.T) {
 	observer, _ := zapobserver.New(zap.InfoLevel)
 	fakelogger := zap.New(observer).Sugar()
-	vcx := provider.TestProviderImp{}
+	vcx := tprovider.TestProviderImp{}
 	vcx.CreateStatusErorring = true
 
-	err := createStatusWithRetry(context.TODO(), fakelogger, nil, &vcx, nil, nil, provider2.StatusOpts{})
+	err := createStatusWithRetry(context.TODO(), fakelogger, nil, &vcx, nil, nil, provider.StatusOpts{})
 	assert.Error(t, err, "failed to report status: some provider error occurred while reporting status")
+}
+
+func TestPostFinalStatus(t *testing.T) {
+	observer, _ := zapobserver.New(zap.InfoLevel)
+	fakelogger := zap.New(observer).Sugar()
+	vcx := &tprovider.TestProviderImp{}
+
+	labels := map[string]string{}
+	ns := "namespace"
+	clock := clockwork.NewFakeClock()
+	pr1 := tektontest.MakePRCompletion(clock, "pipeline-newest", ns, tektonv1.PipelineRunReasonSuccessful.String(), labels, 10)
+	pr1.Status.Conditions = append(pr1.Status.Conditions, apis.Condition{Status: "False", Message: "Hello not good", Type: "Succeeded", Reason: "CouldntGetTask"})
+	ctx, _ := rtesting.SetupFakeContext(t)
+	tdata := testclient.Data{PipelineRuns: []*tektonv1.PipelineRun{pr1}}
+	stdata, _ := testclient.SeedTestData(t, ctx, tdata)
+
+	run := params.New()
+	run.Clients = clients.Clients{
+		Kube:   stdata.Kube,
+		Tekton: stdata.Pipeline,
+	}
+	run.Clients.ConsoleUI = consoleui.FallBackConsole{}
+
+	r := &Reconciler{
+		run: run,
+	}
+	_, err := r.postFinalStatus(ctx, fakelogger, vcx, info.NewEvent(), pr1)
+	assert.NilError(t, err)
 }

--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -672,6 +672,22 @@ func TestGiteaErrorSnippetWithSecret(t *testing.T) {
 	tgitea.WaitForPullRequestCommentMatch(context.Background(), t, topts)
 }
 
+// TestGiteaNotExistingClusterTask checks that the pipeline run fails if the clustertask does not exist
+// This willl test properly if we error the reason in UI see bug #1160
+func TestGiteaNotExistingClusterTask(t *testing.T) {
+	topts := &tgitea.TestOpts{
+		Regexp:      regexp.MustCompile(`.*clustertasks.tekton.dev "foo-bar" not found`),
+		TargetEvent: options.PullRequestEvent,
+		YAMLFiles: map[string]string{
+			".tekton/pr.yaml": "testdata/failures/not-existing-clustertask.yaml",
+		},
+		NoCleanup:      true,
+		CheckForStatus: "failure",
+		ExpectEvents:   false,
+	}
+	defer tgitea.TestPR(t, topts)()
+}
+
 // Local Variables:
 // compile-command: "go test -tags=e2e -v -run TestGiteaPush ."
 // End:

--- a/test/testdata/failures/not-existing-clustertask.yaml
+++ b/test/testdata/failures/not-existing-clustertask.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: "\\.PipelineName//"
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
+    pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: task
+        taskRef:
+          kind: ClusterTask
+          name: foo-bar


### PR DESCRIPTION
When there is no task status (ie: pipeline creation error from
tekton/pipelines) we would report "no taskrun" we now properly report
the error.

Unit test is not great since there was not any to stat with :((( but e2e
should covered it properly

Fixes #1160 [SRVKP](https://issues.redhat.com/browse/SRVKP-2898)

## Screenshot

screenshot how it look like now on github and as comment

![image](https://user-images.githubusercontent.com/98980/223700522-bdf55ad2-7718-4b02-9738-da9aefe061c8.png)
![image](https://user-images.githubusercontent.com/98980/223700585-8fdf6f85-5ecc-490a-82a3-820b8b607d9d.png)


Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [X] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [X] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [X] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [X] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [X] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
