### PR TITLE
Let User bypass GH enteprise question in cli bootstrap github-app

### DIFF
--- a/pkg/apis/pipelinesascode/keys/keys.go
+++ b/pkg/apis/pipelinesascode/keys/keys.go
@@ -49,7 +49,7 @@ const (
 	LogURL          = pipelinesascode.GroupName + "/log-url"
 	ExecutionOrder  = pipelinesascode.GroupName + "/execution-order"
 	// default is "https://api.github.com" but it can be overridden by X-GitHub-Enterprise-Host header
-	APIURL = "https://api.github.com"
+	PublicGithubAPIURL = "https://api.github.com"
 	// installationURL give us the Installation ID
 	InstallationURL = "/app/installations"
 )

--- a/pkg/cli/webhook/github.go
+++ b/pkg/cli/webhook/github.go
@@ -9,14 +9,13 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/google/go-github/v49/github"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli/prompt"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/random"
 	"golang.org/x/oauth2"
 )
-
-const apiPublicURL = "https://api.github.com/"
 
 type gitHubConfig struct {
 	Client              *github.Client
@@ -155,14 +154,14 @@ func (gh *gitHubConfig) create(ctx context.Context) error {
 		return err
 	}
 
-	if res.Response.StatusCode != http.StatusCreated {
+	if res.StatusCode != http.StatusCreated {
 		payload, err := io.ReadAll(res.Body)
 		if err != nil {
 			return fmt.Errorf("failed to read response body: %w", err)
 		}
 
 		return fmt.Errorf("failed to create webhook on repository %v/%v, status code: %v, error : %v",
-			gh.repoOwner, gh.repoName, res.Response.StatusCode, payload)
+			gh.repoOwner, gh.repoName, res.StatusCode, payload)
 	}
 
 	fmt.Fprintf(gh.IOStream.Out, "✓ Webhook has been created on repository %v/%v\n", gh.repoOwner, gh.repoName)
@@ -177,7 +176,7 @@ func (gh *gitHubConfig) newGHClientByToken(ctx context.Context) (*github.Client,
 		&oauth2.Token{AccessToken: gh.personalAccessToken},
 	)
 
-	if gh.APIURL == "" || gh.APIURL == apiPublicURL {
+	if gh.APIURL == "" || gh.APIURL == keys.PublicGithubAPIURL {
 		return github.NewClient(oauth2.NewClient(ctx, ts)), nil
 	}
 

--- a/pkg/cli/webhook/gitlab.go
+++ b/pkg/cli/webhook/gitlab.go
@@ -135,13 +135,13 @@ func (gl *gitLabConfig) create() error {
 		return err
 	}
 
-	if resp.Response.StatusCode != http.StatusCreated {
+	if resp.StatusCode != http.StatusCreated {
 		payload, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return fmt.Errorf("failed to read response body: %w", err)
 		}
 		return fmt.Errorf("failed to create webhook, status code: %v, error : %v",
-			resp.Response.StatusCode, payload)
+			resp.StatusCode, payload)
 	}
 
 	fmt.Fprintln(gl.IOStream.Out, "✓ Webhook has been created on your repository")

--- a/pkg/cmd/tknpac/webhook/add_test.go
+++ b/pkg/cmd/tknpac/webhook/add_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli/prompt"
@@ -124,7 +125,7 @@ func TestWebhookAdd(t *testing.T) {
 			as.StubOne("true")
 			as.StubOne("yes")
 			as.StubOne("c8978ebcd5407637a6da1c8d178654267fd66a3b")
-			as.StubOne("https://api.github.com")
+			as.StubOne(keys.PublicGithubAPIURL)
 		},
 		namespaces:   []*corev1.Namespace{namespace1},
 		repositories: []*v1alpha1.Repository{repo1},

--- a/pkg/provider/github/app/token.go
+++ b/pkg/provider/github/app/token.go
@@ -28,7 +28,7 @@ func GetAndUpdateInstallationID(ctx context.Context, req *http.Request, run *par
 		return "", "", 0, err
 	}
 
-	installationURL := keys.APIURL + keys.InstallationURL
+	installationURL := keys.PublicGithubAPIURL + keys.InstallationURL
 	enterpriseURL = req.Header.Get("X-GitHub-Enterprise-Host")
 	if enterpriseURL != "" {
 		installationURL = enterpriseURL + keys.InstallationURL

--- a/pkg/provider/github/github_test.go
+++ b/pkg/provider/github/github_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/google/go-github/v49/github"
 	"github.com/jonboulle/clockwork"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	ghtesthelper "github.com/openshift-pipelines/pipelines-as-code/pkg/test/github"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/test/logger"
@@ -445,7 +446,7 @@ func TestGithubSetClient(t *testing.T) {
 		},
 		{
 			name:        "default to public github",
-			expectedURL: "https://api.github.com/",
+			expectedURL: fmt.Sprintf("%s/", keys.PublicGithubAPIURL),
 			event:       info.NewEvent(),
 		},
 	}


### PR DESCRIPTION
If we specify the github-api-url when running tkn pac bootstrap
github-tapp then assume it's a enteprise url without asking unless the
url configure to github.com or api.github.com

refactor all references to api.github.com to keys.PublicGithubApiURL 

Fixes #1160

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com><!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
