### PR TITLE
Add NO_COLOR to vale

### DIFF
--- a/.tekton/linter.yaml
+++ b/.tekton/linter.yaml
@@ -125,6 +125,7 @@ spec:
               image: quay.io/eclipse/che-docs
               workingDir: $(workspaces.source.path)
               script: |
+                export NO_COLOR=1
                 vale docs/content --minAlertLevel=error --output=line
         workspaces:
           - name: source


### PR DESCRIPTION
So we don't get colouring when outputing to the openshift console. Which
still don't support term chars

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
