### PR TITLE
Fix github user collaborator check

### DIFF
--- a/pkg/provider/github/acl.go
+++ b/pkg/provider/github/acl.go
@@ -129,21 +129,12 @@ func (v *Provider) checkSenderOrgMembership(ctx context.Context, runevent *info.
 
 // checkSenderRepoMembership check if user is allowed to run CI
 func (v *Provider) checkSenderRepoMembership(ctx context.Context, runevent *info.Event) (bool, error) {
-	users, _, err := v.Client.Repositories.ListCollaborators(ctx,
+	isCollab, _, err := v.Client.Repositories.IsCollaborator(ctx,
 		runevent.Organization,
 		runevent.Repository,
-		&github.ListCollaboratorsOptions{})
-	if err != nil {
-		return false, err
-	}
+		runevent.Sender)
 
-	for _, v := range users {
-		if v.GetLogin() == runevent.Sender {
-			return true, nil
-		}
-	}
-
-	return false, nil
+	return isCollab, err
 }
 
 // getFileFromDefaultBranch will get a file directly from the Default BaseBranch as

--- a/pkg/provider/github/acl_test.go
+++ b/pkg/provider/github/acl_test.go
@@ -177,8 +177,8 @@ func TestAclCheckAll(t *testing.T) {
 		fmt.Fprintf(rw, `{"content": "%s"}`, base64.RawStdEncoding.EncodeToString([]byte("approvers:\n  - approved\n")))
 	})
 
-	mux.HandleFunc(fmt.Sprintf("/repos/%v/%v/collaborators", collabOwner, collabRepo), func(rw http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(rw, `[{"login": "%s"}]`, collaborator)
+	mux.HandleFunc(fmt.Sprintf("/repos/%v/%v/collaborators/%v", collabOwner, collabRepo, collaborator), func(rw http.ResponseWriter, r *http.Request) {
+		rw.WriteHeader(204)
 	})
 
 	ctx, _ := rtesting.SetupFakeContext(t)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

If the number of collaborators is greater than the default page size of `ListCollaborators` request, it was possible for a pipeline not to run for a collaborator.  Instead of paginating the request use `IsCollaborator`.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
