### PR TITLE
Do not validate users when pull-request is from the same repository

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,4 @@
 approvers:
-    - dependabot[bot]
     - sm43
 
 # vim: ft=yaml

--- a/docs/content/docs/guide/running.md
+++ b/docs/content/docs/guide/running.md
@@ -18,6 +18,7 @@ with that PipelineRun, and it will run if the following conditions are met:
   - The author is the owner of the repository.
   - The author is a collaborator on the repository.
   - The author is a public member on the organization of the repository.
+  - The author has permissions to push to branches inside the repository.
   - The pull request author is inside an OWNER file located in the
   repository root on the main branch (the main branch as defined in the GitHub
   configuration for the repo) and added to either `approvers` or `reviewers`


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Though user is not owner/collaborator/public member or in owner files but has permission to push to branches inside repository then PAC should allow triggering CI for pull-request create in the same repository 

Fixes : https://issues.redhat.com/browse/SRVKP-2846



<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
