### PR TITLE
Error out if multiple pipelineruns with same name are found

### DIFF
--- a/test/pkg/payload/get_entries.go
+++ b/test/pkg/payload/get_entries.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"text/template"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/random"
 )
 
 func vinceMap(a, b map[string]string) map[string]string {
@@ -25,7 +27,8 @@ func GetEntries(yamlfile map[string]string, targetNS, targetBranch, targetEvent 
 	entries := map[string]string{}
 	for target, file := range yamlfile {
 		name := strings.TrimSuffix(filepath.Base(target), filepath.Ext(target))
-		extraParams["PipelineName"] = name
+		// add some random character to name so that each PR has different name
+		extraParams["PipelineName"] = name + "-" + strings.ToLower(random.AlphaString(4))
 		// PipelineName can be overridden by extraParams
 		newParams := vinceMap(params, extraParams)
 


### PR DESCRIPTION
if there are multiple pipelineruns with sama name in .tekton directory then return an error.

Closes #1192 

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
