### PR TITLE
Always use latest ubi-minimal to build image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /src
 RUN \
     make /tmp/${BINARY_NAME} LDFLAGS="-s -w" OUTPUT_DIR=/tmp
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:ecebade89b064d33e6e1405e4ec6e9b904e7c573a52b52d0f38026bb8d1db1f8
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 
 ARG BINARY_NAME=pipelines-as-code-controller
 LABEL com.redhat.component=${BINARY_NAME} \


### PR DESCRIPTION
We were pinning and getting out of band security update from the base
image.

Rather get latest security fixes than reproducibly i guess

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
