### PR TITLE
Fix custom console dashboard issue and added e2e

### DIFF
--- a/config/302-pac-configmap.yaml
+++ b/config/302-pac-configmap.yaml
@@ -27,7 +27,7 @@ data:
   # and there is a mix of public and private repositories in there
   # where some users on that org does not have access.
   #
-  # If you trust every users on your orgnisations to access any repos there or
+  # If you trust every users on your organisations to access any repos there or
   # not planning to install your github application globally on a Github Organisation
   # then you can safely set this option to false.
   secret-github-app-token-scoped: "true"

--- a/pkg/consoleui/custom.go
+++ b/pkg/consoleui/custom.go
@@ -12,36 +12,36 @@ import (
 )
 
 type CustomConsole struct {
-	info *info.Info
+	Info *info.Info
 }
 
 func (o *CustomConsole) GetName() string {
-	if o.info.Pac.CustomConsoleName == "" {
+	if o.Info.Pac.CustomConsoleName == "" {
 		return "Not configured"
 	}
-	return o.info.Pac.CustomConsoleName
+	return o.Info.Pac.CustomConsoleName
 }
 
 func (o *CustomConsole) URL() string {
-	if o.info.Pac.CustomConsoleURL == "" {
-		return fmt.Sprintf("https://setting.%s.is.not.configured", settings.CustomConsoleURLKey)
+	if o.Info.Pac.CustomConsoleURL == "" {
+		return fmt.Sprintf("https://url.setting.%s.is.not.configured", settings.CustomConsoleURLKey)
 	}
-	return o.info.Pac.CustomConsoleURL
+	return o.Info.Pac.CustomConsoleURL
 }
 
 func (o *CustomConsole) DetailURL(pr *tektonv1.PipelineRun) string {
-	if o.info.Pac.CustomConsolePRdetail == "" {
-		return fmt.Sprintf("https://setting.%s.is.not.configured", settings.CustomConsolePRDetailKey)
+	if o.Info.Pac.CustomConsolePRdetail == "" {
+		return fmt.Sprintf("https://detailurl.setting.%s.is.not.configured", settings.CustomConsolePRDetailKey)
 	}
-	return templates.ReplacePlaceHoldersVariables(o.info.Pac.CustomConsolePRdetail, map[string]string{
+	return templates.ReplacePlaceHoldersVariables(o.Info.Pac.CustomConsolePRdetail, map[string]string{
 		"namespace": pr.GetNamespace(),
 		"pr":        pr.GetName(),
 	})
 }
 
 func (o *CustomConsole) TaskLogURL(pr *tektonv1.PipelineRun, taskRunStatus *tektonv1.PipelineRunTaskRunStatus) string {
-	if o.info.Pac.CustomConsolePRTaskLog == "" {
-		return fmt.Sprintf("https://setting.%s.is.not.configured", settings.CustomConsolePRTaskLogKey)
+	if o.Info.Pac.CustomConsolePRTaskLog == "" {
+		return fmt.Sprintf("https://tasklogurl.setting.%s.is.not.configured", settings.CustomConsolePRTaskLogKey)
 	}
 	firstFailedStep := ""
 	// search for the first failed steps in taskrunstatus
@@ -51,7 +51,7 @@ func (o *CustomConsole) TaskLogURL(pr *tektonv1.PipelineRun, taskRunStatus *tekt
 			break
 		}
 	}
-	return templates.ReplacePlaceHoldersVariables(o.info.Pac.CustomConsolePRTaskLog, map[string]string{
+	return templates.ReplacePlaceHoldersVariables(o.Info.Pac.CustomConsolePRTaskLog, map[string]string{
 		"namespace":       pr.GetNamespace(),
 		"pr":              pr.GetName(),
 		"task":            taskRunStatus.PipelineTaskName,

--- a/pkg/consoleui/custom_test.go
+++ b/pkg/consoleui/custom_test.go
@@ -19,7 +19,7 @@ func TestCustomGood(t *testing.T) {
 	consolePRtasklog := "https://mycorp.console/{{ namespace }}/{{ pr }}/{{ task }}/{{ pod }}/{{ firstFailedStep }}"
 
 	c := CustomConsole{
-		info: &info.Info{
+		Info: &info.Info{
 			Pac: &info.PacOpts{
 				Settings: &settings.Settings{
 					CustomConsoleName:      consoleName,
@@ -70,7 +70,7 @@ func TestCustomGood(t *testing.T) {
 
 func TestCustomBad(t *testing.T) {
 	c := CustomConsole{
-		info: &info.Info{
+		Info: &info.Info{
 			Pac: &info.PacOpts{
 				Settings: &settings.Settings{},
 			},

--- a/pkg/params/run.go
+++ b/pkg/params/run.go
@@ -104,6 +104,18 @@ func (r *Run) UpdatePACInfo(ctx context.Context) error {
 		r.Clients.Log.Infof("using tekton dashboard url on: %s", os.Getenv("PAC_TEKTON_DASHBOARD_URL"))
 		r.Clients.ConsoleUI = &consoleui.TektonDashboard{BaseURL: os.Getenv("PAC_TEKTON_DASHBOARD_URL")}
 	}
+	if r.Info.Pac.Settings.CustomConsoleURL != "" {
+		r.Clients.Log.Infof("updating console url to: %s", r.Info.Pac.Settings.CustomConsoleURL)
+		r.Clients.ConsoleUI = &consoleui.CustomConsole{Info: &r.Info}
+	}
+
+	// This is the case when reverted settings for CustomConsole and TektonDashboard then URL should point to OpenshiftConsole for Openshift platform
+	if r.Info.Pac.Settings.CustomConsoleURL == "" &&
+		(r.Info.Pac.Settings.TektonDashboardURL == "" && os.Getenv("PAC_TEKTON_DASHBOARD_URL") == "") {
+		r.Clients.ConsoleUI = &consoleui.OpenshiftConsole{}
+		_ = r.Clients.ConsoleUI.UI(ctx, r.Clients.Dynamic)
+	}
+
 	return nil
 }
 

--- a/test/gitea_custom_console_dashboard_test.go
+++ b/test/gitea_custom_console_dashboard_test.go
@@ -1,0 +1,115 @@
+//go:build e2e
+// +build e2e
+
+package test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	tgitea "github.com/openshift-pipelines/pipelines-as-code/test/pkg/gitea"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
+	twait "github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
+	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	customConsoleDashboardName        = "custom-console-name"
+	customConsoleDashboardURL         = "custom-console-url"
+	customConsoleDashboardPRDetailURL = "custom-console-url-pr-details"
+	customConsoleDashboardPRTaskLog   = "custom-console-url-pr-tasklog"
+)
+
+func revertCM(ctx context.Context, t *testing.T, runcnx *params.Run) {
+	cmList, err := runcnx.Clients.Kube.CoreV1().ConfigMaps("").List(ctx, metav1.ListOptions{})
+	assert.NilError(t, err)
+	for _, v := range cmList.Items {
+		if v.Name == "pipelines-as-code" {
+			cmData, err := runcnx.Clients.Kube.CoreV1().ConfigMaps(v.Namespace).Get(ctx, v.Name, metav1.GetOptions{})
+			assert.NilError(t, err)
+			delete(cmData.Data, customConsoleDashboardName)
+			delete(cmData.Data, customConsoleDashboardURL)
+			delete(cmData.Data, customConsoleDashboardPRDetailURL)
+			delete(cmData.Data, customConsoleDashboardPRTaskLog)
+			_, err = runcnx.Clients.Kube.CoreV1().ConfigMaps(v.Namespace).Update(ctx, cmData, metav1.UpdateOptions{})
+			assert.NilError(t, err)
+		}
+	}
+}
+
+func TestGiteaCustomConsoleDashboard(t *testing.T) {
+	ctx := context.TODO()
+	topts := &tgitea.TestOpts{
+		Regexp:      successRegexp,
+		TargetEvent: options.PullRequestEvent,
+		YAMLFiles: map[string]string{
+			".tekton/pr.yaml": "testdata/pipelinerun-max-keep-run-1.yaml",
+		},
+		NoCleanup:      true,
+		CheckForStatus: "success",
+		ExpectEvents:   false,
+	}
+	defer tgitea.TestPR(t, topts)()
+
+	prs, err := topts.Params.Clients.Tekton.TektonV1().PipelineRuns(topts.TargetNS).List(ctx, metav1.ListOptions{})
+
+	assert.NilError(t, err)
+	// asserting with non empty because we are not sure the URL for K8S and Openshift
+	assert.Assert(t, prs.Items[0].Annotations["pipelinesascode.tekton.dev/log-url"] != "")
+
+	// update config map with console dashboard information
+	cmList, er := topts.Params.Clients.Kube.CoreV1().ConfigMaps("").List(ctx, metav1.ListOptions{})
+	assert.NilError(t, er)
+	for _, v := range cmList.Items {
+		if v.Name == "pipelines-as-code" {
+			cmData, err := topts.Params.Clients.Kube.CoreV1().ConfigMaps(v.Namespace).Get(ctx, v.Name, metav1.GetOptions{})
+			assert.NilError(t, err)
+			cmData.Data[customConsoleDashboardName] = "My custom console"
+			cmData.Data[customConsoleDashboardURL] = "https://custom-console.ospqa.com"
+			cmData.Data[customConsoleDashboardPRDetailURL] = "https://custom-console.ospqa.com/foo-pr"
+			cmData.Data[customConsoleDashboardPRTaskLog] = "https://custom-console.ospqa.com/foo-pr/logs/task"
+			_, err = topts.Params.Clients.Kube.CoreV1().ConfigMaps(v.Namespace).Update(ctx, cmData, metav1.UpdateOptions{})
+			assert.NilError(t, err)
+		}
+	}
+
+	tgitea.PostCommentOnPullRequest(t, topts, "/retest")
+	tgitea.WaitForStatus(t, topts, topts.TargetRefName)
+
+	waitOpts := twait.Opts{
+		RepoName:        topts.TargetNS,
+		Namespace:       topts.TargetNS,
+		MinNumberStatus: 1, // 1 means 2 🙃
+		PollTimeout:     twait.DefaultTimeout,
+		TargetSHA:       topts.PullRequest.Head.Sha,
+	}
+	err = twait.UntilRepositoryUpdated(ctx, topts.Params.Clients, waitOpts)
+	assert.NilError(t, err)
+
+	time.Sleep(15 * time.Second) // “Evil does not sleep. It waits.” - Galadriel
+
+	prs, err = topts.Params.Clients.Tekton.TektonV1().PipelineRuns(topts.TargetNS).List(ctx, metav1.ListOptions{})
+	assert.NilError(t, err)
+
+	assert.Equal(t, len(prs.Items), 1, "should have only one pipelinerun, but we have: %d", len(prs.Items))
+
+	prs, err = topts.Params.Clients.Tekton.TektonV1().PipelineRuns(topts.TargetNS).List(ctx, metav1.ListOptions{})
+	assert.NilError(t, err)
+
+	logURL := map[string]string{}
+	for _, v := range prs.Items {
+		logURL[v.Annotations["pipelinesascode.tekton.dev/log-url"]] = v.Annotations["pipelinesascode.tekton.dev/log-url"]
+	}
+	// Check that latest create Pipeline Run will have the console dashboard URL
+	assert.Assert(t, logURL["https://custom-console.ospqa.com/foo-pr"] == "https://custom-console.ospqa.com/foo-pr")
+
+	// Resetting back by removing console dashboard information
+	defer revertCM(ctx, t, topts.Params)
+}
+
+// Local Variables:
+// compile-command: "go test -tags=e2e -v -run TestGiteaCustomConsoleDashboard$ ."
+// End:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
**Issue:** When custom console configuration set the logURL still points to Openshift Console URL
**Fix:** 
1. Initialized client for custom console so that if configurations `custom-console-url` set in CM then log URL should use custom console 
2. If configurations for custom console is removed from configmap then it should point to Openshift Console
3. Added e2e 

Fixes : https://github.com/openshift-pipelines/pipelines-as-code/issues/1149


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
