### PR TITLE
Don't error out when repo is not found

### DIFF
--- a/docs/content/docs/guide/repositorycrd.md
+++ b/docs/content/docs/guide/repositorycrd.md
@@ -41,6 +41,8 @@ If there is multiples CRD matching the same event, only the oldest one will
 match. If you need to match a specific namespace you would need to use the
 target-namespace feature in the pipeline annotation (see below).
 
+## Explicitely targetting a Target Namespace from a PipelineRun
+
 There is another optional layer of security where PipelineRun can have an
 annotation to explicitly target a specific
 namespace. It would still need to have a Repository CRD created in that

--- a/docs/content/docs/guide/running.md
+++ b/docs/content/docs/guide/running.md
@@ -35,21 +35,28 @@ If the pull request author does not meet these requirements,
 another user that does meet these requirements can comment `/ok-to-test` on the pull request
 to run the PipelineRun.
 
+{{< hint info >}}
+If you are using the Github Apps and have installed it on an Organization,
+Pipelines as Code will only be initiated when a Repo CR matching one of the
+repositories in a URL is detected on a repository belonging to the organization
+where the Github App has been installed.
+Otherwise, Pipelines as Code will not be triggered.
+{{< /hint >}}
+
 ## PipelineRun Execution
 
 The PipelineRun will always run in the namespace of the Repository CRD associated with the repo
 that generated the event.
 
-You can follow the execution of your pipeline with the
-[tkn pac](../cli/#install) cli :
+You can follow the execution of your PipelineRun with the [tkn pac](../cli/#install) cli :
 
 ```console
 tkn pac logs -n my-pipeline-ci -L
 ```
 
-If you need to show another pipelinerun than the last one you
-can use the `tkn pac` logs command and it will ask you to select a PipelineRun
-attached to the repository :
+If you need to show another pipelinerun than the last one you can use the `tkn
+pac` logs command and it will ask you to select a PipelineRun attached to the
+repository :
 
 ```console
 tkn pac logs -n my-pipeline-ci

--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -56,15 +56,6 @@ func (p *PacRun) verifyRepoAndUser(ctx context.Context) (*v1alpha1.Repository, e
 		msg := fmt.Sprintf("cannot find a namespace match for %s", p.event.URL)
 		p.eventEmitter.EmitMessage(nil, zap.WarnLevel, "RepositoryNamespaceMatch", msg)
 
-		status := provider.StatusOpts{
-			Status:     "completed",
-			Conclusion: "skipped",
-			Text:       msg,
-			DetailsURL: "https://tenor.com/search/sad-cat-gifs",
-		}
-		if err := p.vcx.CreateStatus(ctx, p.run.Clients.Tekton, p.event, p.run.Info.Pac, status); err != nil {
-			return nil, fmt.Errorf("failed to run create status on repo not found: %w", err)
-		}
 		return nil, nil
 	}
 


### PR DESCRIPTION
We only create a log error, we don't need to error things out.

When i wrote that i didn't take into account that folks can add the
whole app on a org and some repo would not have a repo cr yet.

This mimic other CI behaviours, i.e if you don't have a .github/workflows/
github actions will not bug you if you don't have one on your pull request.

https://issues.redhat.com/browse/SRVKP-2918

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
