### PR TITLE
Add client side URL validation for Tekton Dashboard URL

### DIFF
--- a/pkg/cmd/tknpac/bootstrap/install.go
+++ b/pkg/cmd/tknpac/bootstrap/install.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 	"strings"
@@ -101,6 +102,9 @@ func getDashboardURL(ctx context.Context, opts *bootstrapOpts, run *params.Run) 
 	}
 	if err := prompt.SurveyAskOne(qs, &ans); err != nil {
 		return err
+	}
+	if _, err := url.ParseRequestURI(ans); err != nil {
+		return fmt.Errorf("invalid url: %w", err)
 	}
 	opts.dashboardURL = ans
 	return nil


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Add URL validation for Tekton Dashboard URL

**Before change: When user provides invalid URL**
```
$ tkn-pac bootstrap
🏃 Checking if Pipelines as Code is installed.
🕵️ Pipelines as Code doesn't seems to be installed in pipelines-as-code namespace
? Do you want me to install Pipelines as Code v0.17.2? Yes
✓ Pipelines-as-Code v0.17.2 has been installed
Pipelines as Code does not install a Ingress object to make the controller accessing from the internet
we can install a webhook forwarder called gosmee (https://github.com/chmouel/gosmee) using a https://smee.io URL
this will let your git platform provider (ie: Github) to reach the controller without having to be having public access
? Do you want me to install the gosmee forwarder? Yes
💡 Your gosmee forward URL has been generated: https://smee.io/qSbQHqMCPwdSDqSb
? Enter your Tekton Dashboard URL:  localhost
? Enter the name of your GitHub application:  testurl
🌍 Starting a web browser on http://localhost:8080, click on the button to create your GitHub APP
🔑 Secret pipelines-as-code-secret has been created in the pipelines-as-code namespace
🚀 You can now add your newly created application on your repository by going to this URL:

https://github.com/apps/testurl11

💡 Don't forget to run the "tkn pac create repo" to create a new Repository CRD on your cluster.
```
and PAC watcher pod started failing with
```
$ kubectl logs -f pipelines-as-code-watcher-65fcd866cd-ksc4q -n pipelines-as-code

{"level":"info","ts":1680590304.3347425,"caller":"params/run.go:68","msg":"failed to update PAC infoconfig validation failed: invalid value for key tekton-dashboard-url, invalid url: parse \"localhost\": invalid URI for request"}
2023/04/04 06:38:24 error from WatchConfigMapChanges from watcher reconciler : failed to get defaults : config validation failed: invalid value for key tekton-dashboard-url, invalid url: parse "localhost": invalid URI for request
```
and end user will not get the info

**After change: When user provides invalid URL**

```
$ ./tkn-pac bootstrap
🏃 Checking if Pipelines as Code is installed.
🕵️ Pipelines as Code doesn't seems to be installed in pipelines-as-code namespace
? Do you want me to install Pipelines as Code v0.17.2? Yes
✓ Pipelines-as-Code v0.17.2 has been installed
Pipelines as Code does not install a Ingress object to make the controller accessing from the internet
we can install a webhook forwarder called gosmee (https://github.com/chmouel/gosmee) using a https://hook.pipelinesascode.com URL
this will let your git platform provider (ie: Github) to reach the controller without having to be having public access
? Do you want me to install the gosmee forwarder? Yes
💡 Your gosmee forward URL has been generated: https://hook.pipelinesascode.com/LKJWjZZxKLKa
? Enter your Tekton Dashboard URL:  localhost
Error: invalid url: parse "localhost": invalid URI for request
```

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
