### PR TITLE
Support custom params on CR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,12 @@ lint-md: ${MD_FILES} ## runs markdownlint and vale on all markdown files
 	@echo "Grammar check with vale of documentation..."
 	@vale docs/content --minAlertLevel=error --output=line
 
+.PHONY: fix-markdownlint
+fix-markdownlint: ${MD_FILES} ## run markdownlint and fix on all markdown file
+	@echo "Fixing markdown files..."
+	@markdownlint --fix $(MD_FILES)
+	@[[ -n `git status --porcelain $(MD_FILES)` ]] && { echo "Markdowns has been cleaned 🧹. Cleaned Files: ";git status --porcelain $(MD_FILES) ;} || echo "Markdown is clean ✨"
+
 .PHONY: lint-py
 lint-py: ${PY_FILES} ## runs pylint on all python files
 	@echo "Linting python files..."

--- a/config/300-repositories.yaml
+++ b/config/300-repositories.yaml
@@ -81,6 +81,36 @@ spec:
                     - bitbucket
                     - gitlab
                     - bitbucket-enteprise
+                params:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - name
+                    properties:
+                      name:
+                        description: The name of the params for the pipelinerun variable
+                        type: string
+                      value:
+                        description: The value of the params as injected into pipelinerun
+                        type: string
+                      filter:
+                        description: A CEL filter to set condition on param
+                        type: string
+                      secret_ref:
+                        description: The value as coming from secret
+                        type: object
+                        required:
+                          - name
+                          - key
+                        properties:
+                          key:
+                            description: Key of the secret
+                            type: string
+                            default: "secret"
+                          name:
+                            description: Name of the secret
+                            type: string
                 incoming:
                   type: array
                   items:

--- a/docs/content/docs/guide/authoringprs.md
+++ b/docs/content/docs/guide/authoringprs.md
@@ -14,7 +14,7 @@ weight: 3
   but PipelineRuns will only be triggered by events in the repository containing
   the `.tekton` directory.
 
-* Using its [resolver](./resolver) Pipelines as Code will try to bundle the
+* Using its [resolver](../resolver/) Pipelines as Code will try to bundle the
   PipelineRun with all its Task as a single PipelineRun with no external
   dependencies.
 
@@ -29,6 +29,7 @@ weight: 3
   like this `{{ var }}` and those are the one you can use:
 
   * `{{repo_owner}}`: The repository owner.
+  * `{{event_type}}`: The event type (eg: `pull_request` or `push`)
   * `{{repo_name}}`: The repository name.
   * `{{repo_url}}`: The repository full URL.
   * `{{target_namespace}}`: The target namespace where the Repository has matched and the PipelineRun will be created.

--- a/docs/content/docs/guide/repositorycrd.md
+++ b/docs/content/docs/guide/repositorycrd.md
@@ -1,22 +1,25 @@
 ---
-title: Repository CRD
+title: Repository CR
 weight: 1
 ---
-# Repository CRD
+# Repository CR
 
-The purposes of the Repository CRD  is:
+The Repository CR serves the following purposes:
 
-- To let _Pipelines as Code_ know that this event from this URL needs to be handled.
-- To let _Pipelines as Code_ know on which namespace the PipelineRuns are going to be executed.
-- To reference an api secret, username or api URL if needed for the Git provider
-  platforms that requires it (ie: when you are using webhooks method and not
-  the GitHub application).
-- To give the last Pipelinerun status for that Repository (5 by default).
+- Informing Pipelines as Code that an event from a specific URL needs to be handled.
+- Specifying the namespace where the `PipelineRuns` will be executed.
+- Referencing an API secret, username, or API URL if necessary for Git provider
+  platforms that require it (e.g., when using webhooks instead of the GitHub
+  application).
+- Providing the last `PipelineRun`statuses for that repository (5 by default).
+- Allowing for configuration of custom parameters within the `PipelineRun`that
+  can be expanded based on certain filters.
 
-The flow looks like this :
+The process involves creating a Repository CR inside the target namespace
+my-pipeline-ci, using the tkn pac CLI or another method.
 
-Using the tkn pac CLI or other method the user creates a `Repository` CR
-inside the target namespace `my-pipeline-ci` :
+For example, this will create a Repo CR for the github repository
+<https://github.com/linda/project>
 
 ```yaml
 cat <<EOF|kubectl create -n my-pipeline-ci -f-
@@ -29,35 +32,45 @@ spec:
 EOF
 ```
 
-Whenever there is an event coming from `github.com/linda/project` Pipelines as
-Code will match it and starts checking out the content of the `linda/project`
-for pipelinerun to match in the `.tekton/` directory.
+With this configuration when an event from the `linda/project` repository
+occurs, Pipelines as Code will know it needs to be handled and begin checking
+out the contents of linda/project to match with the PipelineRun in the .tekton/
+directory.
 
-The Repository CRD needs to be created in the namespace where Tekton Pipelines
-associated with the source code repository would be executed, it cannot target
-another namespace.
+If the `PipelineRun` matches via its annotations the event, for example on a
+specific branch and event like a `push` or `pull_request`. It wil start the
+`PipelineRun` where the `Repository` CR has been created. You can only start the
+`PipelineRun` in the namespace where the Repository CR is located.
 
-If there is multiples CRD matching the same event, only the oldest one will
-match. If you need to match a specific namespace you would need to use the
-target-namespace feature in the pipeline annotation (see below).
+## Additional Repository CR Security
 
-## Explicitely targetting a Target Namespace from a PipelineRun
+An additional layer of security can be added by using a PipelineRun annotation
+to explicitly target a specific namespace. However, a Repository CRD must still
+be created in that namespace for it to be matched.
 
-There is another optional layer of security where PipelineRun can have an
-annotation to explicitly target a specific
-namespace. It would still need to have a Repository CRD created in that
-namespace to be able to be matched.
+This annotation helps prevent bad actors on a cluster from hijacking
+PipelineRun execution to a namespace they don't have access to. It let the user
+specify the ownership of a repo matching the access of a specific namespace on
+a cluster
 
-With this annotation a bad actor on a cluster cannot hijack the pipelineRun
-execution to a namespace they don't have access to. To use that feature you
-need to add this annotation to the pipeline annotation :
+To use this feature, add the following annotation to the pipeline:
 
 ```yaml
 pipelinesascode.tekton.dev/target-namespace: "mynamespace"
 ```
 
-and Pipelines as Code will only match the repository in the mynamespace
-Namespace rather than trying to match it from all available repository on cluster.
+Pipelines as Code will then only match the repository in the mynamespace
+namespace instead of trying to match it from all available repositories on the
+cluster.
+
+{{< hint info >}}
+Pipelines as Code installs a Kubernetes Mutating Admission Webhook to ensure
+that only one Repository CRD is created per URL on a cluster.
+
+If you disable this webhook, multiple Repository CRDs can be created for the
+same URL. However, only the oldest created Repository CRD will be matched,
+unless you use the `target-namespace` annotation.
+{{< /hint >}}
 
 ## Concurrency
 
@@ -78,3 +91,117 @@ request with a `concurrency_limit` of 1 in the repository configuration, then al
 of the pipelineruns will be executed in alphabetical order, one after the
 other. At any given time, only one pipeline run will be in the running state,
 while the rest will be queued.
+
+## Custom Parameter Expansion
+
+Using the `{{ param }}` syntax, Pipelines as Code let you expand a variable
+inside a template directly within your PipelineRuns.
+
+By default, there are
+several variables exposed according to the event. To view all the variables
+exposed by default, refer to the documentation on [Authoring
+PipelineRuns](../authoringprs).
+
+With the custom Parameter expansion, you can specify some custom values to be
+replaced inside the template.
+
+{{< hint warning >}}
+Utilizing the Tekton PipelineRun parameters feature may generally be the
+preferable approach, and custom params expansion should only be used in specific
+scenarios where Tekton params cannot be used.
+{{< /hint >}}
+
+As an example here is a custom variable in the Repository CR `spec`:
+
+```yaml
+spec:
+  params:
+    - name: company
+      value: "My Beautiful Company"
+```
+
+The variable name `{{ company }}` will be replaced by `My Beautiful Company`
+anywhere inside your `PipelineRun` (including the remotely fetched task).
+
+Alternatively, the value can be retrieved from a Kubernetes Secret.
+For instance, the following code will retrieve the value for the company
+`parameter` from a secret named `my-secret` and the key `companyname`:
+
+```yaml
+spec:
+  params:
+    - name: company
+      secretRef:
+        name: my-secret
+        key: companyname
+```
+
+{{< hint info >}}
+
+- If you have a `value` and a `secretRef` defined, the `value` will be used.
+- If you don't have a `value` or a `secretRef` the parameter will not be
+  parsed, it will be shown as `{{ param }}` in the `PipelineRun`.
+- If you don't have a `name` in the `params` the parameter will not parsed.
+- If you have multiple `params` with the same `name` the last one will be used.
+{{< /hint >}}
+
+### CEL filtering on custom parameters
+
+You can define a `param` to only apply the custom parameters expansion when some
+conditions has been matched on a `filter`:
+
+```yaml
+spec:
+  params:
+    - name: company
+      value: "My Beautiful Company"
+      filter:
+        - name: event
+          value: |
+      pac.event_type == "pull_request"
+```
+
+The `pac` prefix contains all the values as set by default in the templates
+variables. Refer to the [Authoring PipelineRuns](../authoringprs) documentation
+for all the variable exposed by default.
+
+The body of the payload is exposed inside the `body` prefix.
+
+For example if you are running a Pull Request on Github pac will receive a
+payload which has this kind of json:
+
+```json
+{
+  "action": "opened",
+  "number": 79,
+  // .... more data
+}
+```
+
+The filter can then do something like this:
+
+```yaml
+spec:
+  params:
+    - name: company
+      value: "My Beautiful Company"
+      filter:
+        - name: event
+          value: |
+      body.action == "opened" && pac.event_type == "pull_request"
+```
+
+The payload of the event contains much more information that can be used with
+the CEL filter. To see the specific payload content for your provider, refer to
+the API documentation
+
+You can have multiple `params` with the same name and different filters, the
+first param that matches the filter will be picked up. This let you have
+different output according to different event, and for example combine a push
+and a pull request event.
+
+{{< hint info >}}
+
+- [Github Documentation for webhook events](https://docs.github.com/webhooks-and-events/webhooks/webhook-events-and-payloads?actionType=auto_merge_disabled#pull_request)
+- [Gitlab Documentation for webhook events](https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html)
+{{< /hint >}}

--- a/pkg/apis/pipelinesascode/v1alpha1/types.go
+++ b/pkg/apis/pipelinesascode/v1alpha1/types.go
@@ -74,6 +74,14 @@ type RepositorySpec struct {
 	URL              string       `json:"url"`
 	GitProvider      *GitProvider `json:"git_provider,omitempty"`
 	Incomings        *[]Incoming  `json:"incoming,omitempty"`
+	Params           *[]Params    `json:"params,omitempty"`
+}
+
+type Params struct {
+	Name      string  `json:"name"`
+	Value     string  `json:"value,omitempty"`
+	SecretRef *Secret `json:"secret_ref,omitempty"`
+	Filter    string  `json:"filter,omitempty"`
 }
 
 type Incoming struct {

--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -153,7 +153,7 @@ func (p *PacRun) getPipelineRunsFromRepo(ctx context.Context, repo *v1alpha1.Rep
 	}
 
 	// Replace those {{var}} placeholders user has in her template to the run.Info variable
-	allTemplates := templates.Process(p.event, repo, rawTemplates)
+	allTemplates := p.makeTemplate(ctx, repo, rawTemplates)
 	pipelineRuns, err := resolve.Resolve(ctx, p.run, p.logger, p.vcx, p.event, allTemplates, &resolve.Opts{
 		GenerateName: true,
 		RemoteTasks:  p.run.Info.Pac.RemoteTasks,

--- a/pkg/pipelineascode/template.go
+++ b/pkg/pipelineascode/template.go
@@ -1,0 +1,181 @@
+package pipelineascode
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/checker/decls"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
+	sectypes "github.com/openshift-pipelines/pipelines-as-code/pkg/secrets/types"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/templates"
+	"go.uber.org/zap"
+)
+
+func celEvaluate(expr string, env *cel.Env, data map[string]interface{}) (ref.Val, error) {
+	parsed, issues := env.Parse(expr)
+	if issues != nil && issues.Err() != nil {
+		return nil, fmt.Errorf("failed to parse expression %#v: %w", expr, issues.Err())
+	}
+
+	checked, issues := env.Check(parsed)
+	if issues != nil && issues.Err() != nil {
+		return nil, fmt.Errorf("expression %#v check failed: %w", expr, issues.Err())
+	}
+
+	prg, err := env.Program(checked, cel.EvalOptions(cel.OptOptimize))
+	if err != nil {
+		return nil, fmt.Errorf("expression %#v failed to create a Program: %w", expr, err)
+	}
+
+	out, _, err := prg.Eval(data)
+	if err != nil {
+		return nil, fmt.Errorf("expression %#v failed to evaluate: %w", expr, err)
+	}
+
+	return out, nil
+}
+
+// celFilter filters a query with cel, it sets two variables for the user to use
+// in the cel filter. body and pac.
+// body is the payload of the event, since it's already casted we un-marshall/and
+// marshall it as a map[string]interface{}
+func celFilter(query string, body any, pacParams map[string]string) (bool, error) {
+	nbody, err := json.Marshal(body)
+	if err != nil {
+		return false, err
+	}
+	var jsonMap map[string]interface{}
+	err = json.Unmarshal(nbody, &jsonMap)
+	if err != nil {
+		return false, err
+	}
+
+	mapStrDyn := decls.NewMapType(decls.String, decls.Dyn)
+	celDec, _ := cel.NewEnv(
+		cel.Declarations(
+			decls.NewVar("body", mapStrDyn),
+			decls.NewVar("pac", mapStrDyn),
+		))
+	val, err := celEvaluate(query, celDec, map[string]any{
+		"body": jsonMap,
+		"pac":  pacParams,
+	})
+	if err != nil {
+		return false, err
+	}
+
+	//nolint: gocritic
+	switch val.(type) {
+	case types.Bool:
+		if val.Value() == true {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// processParams will process the parameters as set in the repo.Spec CR.
+// value can come from a string or from a secretKeyRef or from a string value
+// if both is set we pick the value and issue a warning in the user namespace
+// we let the user specify a cel filter. If false then we skip the parameters.
+// if multiple params name has a filter we pick up the first one that has
+// matched true.
+func (p *PacRun) processParams(ctx context.Context, repo *v1alpha1.Repository, maptemplate map[string]string) error {
+	mapFilters := map[string]string{}
+	if repo.Spec.Params == nil {
+		return nil
+	}
+	for index, value := range *repo.Spec.Params {
+		// if the name is empty we skip it
+		if value.Name == "" {
+			p.eventEmitter.EmitMessage(repo, zap.ErrorLevel,
+				"ParamsFilterSkipped", fmt.Sprintf("no name has been set in params[%d] of repo %s", index, repo.GetName()))
+			continue
+		}
+		if value.Filter != "" {
+			// if we already have a filter that has matched we skip it
+			if _, ok := mapFilters[value.Name]; ok {
+				p.eventEmitter.EmitMessage(repo, zap.WarnLevel,
+					"ParamsFilterSkipped", fmt.Sprintf("skipping params name %s, filter has already been matched previously", value.Name))
+				continue
+			}
+
+			// if the cel filter condition is false we skip it
+			cond, err := celFilter(value.Filter, p.event.Event, maptemplate)
+			if err != nil {
+				return err
+			}
+			if !cond {
+				p.eventEmitter.EmitMessage(repo, zap.InfoLevel,
+					"ParamsFilterSkipped", fmt.Sprintf("skipping params name %s, filter condition is false", value.Name))
+				continue
+			}
+			mapFilters[value.Name] = value.Value
+		}
+
+		if value.SecretRef != nil && value.Value != "" {
+			p.eventEmitter.EmitMessage(repo, zap.InfoLevel,
+				"ParamsFilterUsedValue",
+				fmt.Sprintf("repo %s, param name %s has a value and secretref, picking value", repo.GetName(), value.Name))
+		}
+		if value.Value != "" {
+			maptemplate[value.Name] = value.Value
+		} else if value.SecretRef != nil {
+			secretValue, err := p.k8int.GetSecret(ctx, sectypes.GetSecretOpt{
+				Namespace: repo.GetNamespace(),
+				Name:      value.SecretRef.Name,
+				Key:       value.SecretRef.Key,
+			})
+			if err != nil {
+				return err
+			}
+			maptemplate[value.Name] = secretValue
+		}
+	}
+	return nil
+}
+
+// makeTemplate will process all templates replacing the value from the event and from the
+// params as set on Repo CR
+func (p *PacRun) makeTemplate(ctx context.Context, repo *v1alpha1.Repository, template string) string {
+	repoURL := p.event.URL
+	// On bitbucket server you are have a special url for checking it out, they
+	// seemed to fix it in 2.0 but i guess we have to live with this until then.
+	if p.event.CloneURL != "" {
+		repoURL = p.event.CloneURL
+	}
+
+	if p.event.CloneURL == "" {
+		p.event.AccountID = ""
+	}
+
+	maptemplate := map[string]string{
+		"revision":         p.event.SHA,
+		"repo_url":         repoURL,
+		"repo_owner":       strings.ToLower(p.event.Organization),
+		"repo_name":        strings.ToLower(p.event.Repository),
+		"target_branch":    formatting.SanitizeBranch(p.event.BaseBranch),
+		"source_branch":    formatting.SanitizeBranch(p.event.HeadBranch),
+		"sender":           strings.ToLower(p.event.Sender),
+		"target_namespace": repo.GetNamespace(),
+		"event_type":       p.event.EventType,
+	}
+
+	if err := p.processParams(ctx, repo, maptemplate); err != nil {
+		p.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "ParamsError",
+			fmt.Sprintf("error processing repository CR custom params: %s", err.Error()))
+	}
+
+	// convert to string
+	if p.event.PullRequestNumber != 0 {
+		maptemplate["pull_request_number"] = fmt.Sprintf("%d", p.event.PullRequestNumber)
+	}
+
+	return templates.ReplacePlaceHoldersVariables(template, maptemplate)
+}

--- a/pkg/pipelineascode/template_test.go
+++ b/pkg/pipelineascode/template_test.go
@@ -1,0 +1,368 @@
+package pipelineascode
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-github/v50/github"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/events"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
+	kitesthelper "github.com/openshift-pipelines/pipelines-as-code/pkg/test/kubernetestint"
+	"go.uber.org/zap"
+	zapobserver "go.uber.org/zap/zaptest/observer"
+	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	rtesting "knative.dev/pkg/reconciler/testing"
+)
+
+func TestProcessTemplates(t *testing.T) {
+	ns := "there"
+	tests := []struct {
+		name               string
+		event              *info.Event
+		template           string
+		expected           string
+		repository         *v1alpha1.Repository
+		secretData         map[string]string
+		expectedLogSnippet string
+	}{
+		{
+			name: "test process templates",
+			event: &info.Event{
+				SHA:          "abcd",
+				URL:          "http://chmouel.com",
+				Organization: "owner",
+				Repository:   "repository",
+				HeadBranch:   "ohyeah",
+				BaseBranch:   "ohno",
+				Sender:       "apollo",
+			},
+			template: `{{ revision }} {{ repo_owner }} {{ repo_name }} {{ repo_url }} {{ source_branch }} {{ target_branch }} {{ sender }}`,
+			expected: "abcd owner repository http://chmouel.com ohyeah ohno apollo",
+		},
+		{
+			name: "strip refs head from branches",
+			event: &info.Event{
+				HeadBranch: "refs/heads/ohyeah",
+				BaseBranch: "refs/heads/ohno",
+				Sender:     "apollo",
+			},
+			template: `{{ source_branch }} {{ target_branch }}`,
+			expected: "ohyeah ohno",
+		},
+		{
+			name: "process pull request number",
+			event: &info.Event{
+				PullRequestNumber: 666,
+			},
+			template: `{{ pull_request_number }}`,
+			expected: "666",
+		},
+		{
+			name:     "no pull request no nothing",
+			event:    &info.Event{},
+			template: `{{ pull_request_number }}`,
+			expected: `{{ pull_request_number }}`,
+		},
+		{
+			name: "test process templates lowering owner and repository",
+			event: &info.Event{
+				Organization: "OWNER",
+				Repository:   "REPOSITORY",
+			},
+			template: `{{ repo_owner }} {{ repo_name }}`,
+			expected: "owner repository",
+		},
+		{
+			name: "test process use cloneurl",
+			event: &info.Event{
+				CloneURL: "https://cloneurl",
+				URL:      "http://chmouel.com",
+			},
+			template: `{{ repo_url }}`,
+			expected: "https://cloneurl",
+		},
+		{
+			name:     "replace target_namespace",
+			template: `ns {{ target_namespace }}`,
+			expected: fmt.Sprintf("ns %s", ns),
+			repository: &v1alpha1.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns,
+				},
+			},
+		},
+		{
+			name:     "params/basic",
+			template: `I am {{ params }}`,
+			expected: "I am batman",
+			repository: &v1alpha1.Repository{
+				Spec: v1alpha1.RepositorySpec{
+					Params: &[]v1alpha1.Params{
+						{
+							Name:  "params",
+							Value: "batman",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "params/from secret",
+			template: `ain't no sunshine when she {{ params }}`,
+			expected: "ain't no sunshine when she gone",
+			secretData: map[string]string{
+				"name": "gone",
+			},
+			repository: &v1alpha1.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns,
+				},
+				Spec: v1alpha1.RepositorySpec{
+					Params: &[]v1alpha1.Params{
+						{
+							Name: "params",
+							SecretRef: &v1alpha1.Secret{
+								Name: "name",
+								Key:  "key",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "params/use last params when two values of the same name",
+			template: `I am {{ params }}`,
+			expected: "I am robin",
+			repository: &v1alpha1.Repository{
+				Spec: v1alpha1.RepositorySpec{
+					Params: &[]v1alpha1.Params{
+						{
+							Name:  "params",
+							Value: "batman",
+						},
+						{
+							Name:  "params",
+							Value: "robin",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "params/use last params when two values of the same name",
+			template: `I am {{ params }}`,
+			expected: "I am robin",
+			repository: &v1alpha1.Repository{
+				Spec: v1alpha1.RepositorySpec{
+					Params: &[]v1alpha1.Params{
+						{
+							Name:  "params",
+							Value: "batman",
+						},
+						{
+							Name:  "params",
+							Value: "robin",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:               "params/skip with no name",
+			template:           `I am {{ params }}`,
+			expected:           "I am {{ params }}",
+			expectedLogSnippet: "no name has been set in params[0] of repo",
+			repository: &v1alpha1.Repository{
+				Spec: v1alpha1.RepositorySpec{
+					Params: &[]v1alpha1.Params{
+						{
+							Value: "batman",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:               "params/pick value when value and secret set",
+			template:           `I am {{ params }}`,
+			expected:           "I am batman",
+			expectedLogSnippet: "repo repo, param name params has a value and secretref, picking value",
+			repository: &v1alpha1.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "repo",
+				},
+				Spec: v1alpha1.RepositorySpec{
+					Params: &[]v1alpha1.Params{
+						{
+							Name:  "params",
+							Value: "batman",
+							SecretRef: &v1alpha1.Secret{
+								Name: "name",
+								Key:  "key",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "params/filter",
+			template: `I am {{ params }}`,
+			expected: "I am batman",
+			event:    &info.Event{EventType: "pull_request"},
+			repository: &v1alpha1.Repository{
+				Spec: v1alpha1.RepositorySpec{
+					Params: &[]v1alpha1.Params{
+						{
+							Name:   "params",
+							Value:  "batman",
+							Filter: `pac.event_type == "pull_request"`,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "params/filter on body",
+			template: `I am {{ params }}`,
+			expected: "I am batman",
+			event:    &info.Event{EventType: "pull_request", Event: github.PullRequestEvent{Number: github.Int(42)}},
+			repository: &v1alpha1.Repository{
+				Spec: v1alpha1.RepositorySpec{
+					Params: &[]v1alpha1.Params{
+						{
+							Name:   "params",
+							Value:  "batman",
+							Filter: `body.number == 42`,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "params/filter on body with bad filter",
+			template: `I am {{ params }}`,
+			expected: "I am {{ params }}",
+			event:    &info.Event{EventType: "pull_request", Event: github.PullRequestEvent{Number: github.Int(42)}},
+			repository: &v1alpha1.Repository{
+				Spec: v1alpha1.RepositorySpec{
+					Params: &[]v1alpha1.Params{
+						{
+							Name:   "params",
+							Value:  "batman",
+							Filter: `body.BADDDADA == 42`,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "params/bad filter skipped",
+			template: `I am {{ params }}`,
+			expected: "I am {{ params }}",
+			event:    &info.Event{EventType: "push"},
+			repository: &v1alpha1.Repository{
+				Spec: v1alpha1.RepositorySpec{
+					Params: &[]v1alpha1.Params{
+						{
+							Name:   "params",
+							Value:  "batman",
+							Filter: `BADDADADDADA`,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "params/bad payload skipped",
+			template: `I am {{ params }}`,
+			expected: "I am {{ params }}",
+			event:    &info.Event{EventType: "push", Event: "BADADDADA"},
+			repository: &v1alpha1.Repository{
+				Spec: v1alpha1.RepositorySpec{
+					Params: &[]v1alpha1.Params{
+						{
+							Name:   "params",
+							Value:  "batman",
+							Filter: `body.number == 42`,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:               "params/no filter match",
+			template:           `I am {{ params }}`,
+			expected:           "I am {{ params }}",
+			expectedLogSnippet: "skipping params name params, filter condition is false",
+			event:              &info.Event{EventType: "push"},
+			repository: &v1alpha1.Repository{
+				Spec: v1alpha1.RepositorySpec{
+					Params: &[]v1alpha1.Params{
+						{
+							Name:   "params",
+							Value:  "batman",
+							Filter: `pac.event_type == "pull_request"`,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:               "params/two filters same name, match first",
+			template:           `I am {{ params }}`,
+			expected:           "I am batman",
+			event:              &info.Event{EventType: "pull_request"},
+			expectedLogSnippet: "skipping params name params, filter has already been matched previously",
+			repository: &v1alpha1.Repository{
+				Spec: v1alpha1.RepositorySpec{
+					Params: &[]v1alpha1.Params{
+						{
+							Name:   "params",
+							Value:  "batman",
+							Filter: `pac.event_type == "pull_request"`,
+						},
+						{
+							Name:   "params",
+							Value:  "batman",
+							Filter: `pac.event_type == "push"`,
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			observer, log := zapobserver.New(zap.InfoLevel)
+			logger := zap.New(observer).Sugar()
+			repo := tt.repository
+			if repo == nil {
+				repo = &v1alpha1.Repository{}
+			}
+			ctx, _ := rtesting.SetupFakeContext(t)
+			run := &params.Run{Clients: clients.Clients{}}
+			if tt.event == nil {
+				tt.event = &info.Event{}
+			}
+			p := NewPacs(tt.event, nil, run, &kitesthelper.KinterfaceTest{GetSecretResult: tt.secretData}, nil)
+			p.logger = logger
+			stdata, _ := testclient.SeedTestData(t, ctx, testclient.Data{})
+			p.eventEmitter = events.NewEventEmitter(stdata.Kube, logger)
+			processed := p.makeTemplate(ctx, repo, tt.template)
+			assert.Equal(t, tt.expected, processed)
+
+			if tt.expectedLogSnippet != "" {
+				logmsg := log.FilterMessageSnippet(tt.expectedLogSnippet).TakeAll()
+				assert.Assert(t, len(logmsg) > 0, "log message filtered %s expected %s alllogs: %+v", logmsg,
+					tt.expectedLogSnippet, log.TakeAll())
+			}
+		})
+	}
+}

--- a/pkg/templates/templating.go
+++ b/pkg/templates/templating.go
@@ -1,13 +1,8 @@
 package templates
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
-
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 )
 
 var reTemplate = regexp.MustCompile(`{{([^}]{2,})}}`)
@@ -22,30 +17,4 @@ func ReplacePlaceHoldersVariables(template string, dico map[string]string) strin
 		}
 		return dico[key]
 	})
-}
-
-// Process process all templates replacing
-func Process(event *info.Event, repo *v1alpha1.Repository, template string) string {
-	repoURL := event.URL
-	// On bitbucket server you are have a special url for checking it out, they
-	// seemed to fix it in 2.0 but i guess we have to live with this until then.
-	if event.CloneURL != "" {
-		repoURL = event.CloneURL
-	}
-
-	maptemplate := map[string]string{
-		"revision":         event.SHA,
-		"repo_url":         repoURL,
-		"repo_owner":       strings.ToLower(event.Organization),
-		"repo_name":        strings.ToLower(event.Repository),
-		"target_branch":    formatting.SanitizeBranch(event.BaseBranch),
-		"source_branch":    formatting.SanitizeBranch(event.HeadBranch),
-		"sender":           strings.ToLower(event.Sender),
-		"target_namespace": repo.GetNamespace(),
-	}
-	// we don't want to get a 0 replaced
-	if event.PullRequestNumber != 0 {
-		maptemplate["pull_request_number"] = fmt.Sprintf("%d", event.PullRequestNumber)
-	}
-	return ReplacePlaceHoldersVariables(template, maptemplate)
 }

--- a/pkg/templates/templating_test.go
+++ b/pkg/templates/templating_test.go
@@ -4,10 +4,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
-	"gotest.tools/v3/assert"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestReplacePlaceHoldersVariables(t *testing.T) {
@@ -33,97 +29,6 @@ func TestReplacePlaceHoldersVariables(t *testing.T) {
 			if d := cmp.Diff(got, tt.expected); d != "" {
 				t.Fatalf("-got, +want: %v", d)
 			}
-		})
-	}
-}
-
-func TestProcessTemplates(t *testing.T) {
-	tests := []struct {
-		name       string
-		event      *info.Event
-		template   string
-		expected   string
-		repository *v1alpha1.Repository
-	}{
-		{
-			name: "test process templates",
-			event: &info.Event{
-				SHA:          "abcd",
-				URL:          "http://chmouel.com",
-				Organization: "owner",
-				Repository:   "repository",
-				HeadBranch:   "ohyeah",
-				BaseBranch:   "ohno",
-				Sender:       "apollo",
-			},
-			template: `{{ revision }} {{ repo_owner }} {{ repo_name }} {{ repo_url }} {{ source_branch }} {{ target_branch }} {{ sender }}`,
-			expected: "abcd owner repository http://chmouel.com ohyeah ohno apollo",
-		},
-		{
-			name: "strip refs head from branches",
-			event: &info.Event{
-				HeadBranch: "refs/heads/ohyeah",
-				BaseBranch: "refs/heads/ohno",
-				Sender:     "apollo",
-			},
-			template: `{{ source_branch }} {{ target_branch }}`,
-			expected: "ohyeah ohno",
-		},
-		{
-			name: "process pull request number",
-			event: &info.Event{
-				PullRequestNumber: 666,
-			},
-			template: `{{ pull_request_number }}`,
-			expected: "666",
-		},
-		{
-			name:     "no pull request no nothing",
-			event:    &info.Event{},
-			template: `{{ pull_request_number }}`,
-			expected: `{{ pull_request_number }}`,
-		},
-		{
-			name: "test process templates lowering owner and repository",
-			event: &info.Event{
-				Organization: "OWNER",
-				Repository:   "REPOSITORY",
-			},
-			template: `{{ repo_owner }} {{ repo_name }}`,
-			expected: "owner repository",
-		},
-		{
-			name: "test process use cloneurl",
-			event: &info.Event{
-				CloneURL: "https://cloneurl",
-				URL:      "http://chmouel.com",
-			},
-			template: `{{ repo_url }}`,
-			expected: "https://cloneurl",
-		},
-		{
-			name: "replace target_namespace",
-			event: &info.Event{
-				CloneURL: "https://cloneurl",
-				URL:      "http://chmouel.com",
-			},
-			template: `Install in {{ target_namespace }}`,
-			expected: "Install in the_namespace",
-			repository: &v1alpha1.Repository{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "the_namespace",
-				},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			repo := tt.repository
-			if repo == nil {
-				repo = &v1alpha1.Repository{}
-			}
-			processed := Process(tt.event, repo, tt.template)
-			assert.Equal(t, tt.expected, processed)
 		})
 	}
 }

--- a/test/pkg/gitea/crd.go
+++ b/test/pkg/gitea/crd.go
@@ -27,7 +27,7 @@ func CreateCRD(ctx context.Context, topts *TestOpts) error {
 		return err
 	}
 
-	if err := secret.Create(ctx, topts.Params, map[string]string{"token": token}, topts.TargetNS, "gitea-secret"); err != nil {
+	if err := secret.Create(ctx, topts.ParamsRun, map[string]string{"token": token}, topts.TargetNS, "gitea-secret"); err != nil {
 		return err
 	}
 	repository := &v1alpha1.Repository{
@@ -44,8 +44,9 @@ func CreateCRD(ctx context.Context, topts *TestOpts) error {
 				Secret: &v1alpha1.Secret{Name: "gitea-secret", Key: "token"},
 			},
 			ConcurrencyLimit: topts.ConcurrencyLimit,
+			Params:           topts.RepoCRParams,
 		},
 	}
 
-	return pacrepo.CreateRepo(ctx, topts.TargetNS, topts.Params, repository)
+	return pacrepo.CreateRepo(ctx, topts.TargetNS, topts.ParamsRun, repository)
 }

--- a/test/pkg/gitea/scm.go
+++ b/test/pkg/gitea/scm.go
@@ -71,7 +71,7 @@ func PushFilesToRefGit(t *testing.T, topts *TestOpts, entries map[string]string,
 	_, err = git.RunGit(path, "push", "origin", topts.TargetRefName)
 	assert.NilError(t, err)
 	// parse url topts.GitURL
-	topts.Params.Clients.Log.Infof("Pushed files to repo %s branch %s", topts.GitHTMLURL, topts.TargetRefName)
+	topts.ParamsRun.Clients.Log.Infof("Pushed files to repo %s branch %s", topts.GitHTMLURL, topts.TargetRefName)
 }
 
 // Make a clone url with username and password
@@ -136,7 +136,7 @@ type Timelines []struct {
 func GetIssueTimeline(ctx context.Context, topts *TestOpts) (Timelines, error) {
 	timelineURL := fmt.Sprintf("%s/api/v1/repos/%s/issues/%d/timeline", topts.GiteaAPIURL,
 		topts.PullRequest.Base.Repository.FullName, topts.PullRequest.Index)
-	resp, err := MakeRequest(ctx, topts.Params.Clients.HTTP, timelineURL, topts.Opts.Organization, topts.GiteaPassword)
+	resp, err := MakeRequest(ctx, topts.ParamsRun.Clients.HTTP, timelineURL, topts.Opts.Organization, topts.GiteaPassword)
 	if err != nil {
 		return nil, fmt.Errorf("error on URL %s: %w", timelineURL, err)
 	}
@@ -207,7 +207,7 @@ func CreateForkPullRequest(t *testing.T, topts *TestOpts, secondcnx pgitea.Provi
 	cloneURL, err := MakeGitCloneURL(forkrepo.CloneURL, topts.TargetRefName, topts.GiteaPassword)
 	assert.NilError(t, err)
 	newopts := &TestOpts{
-		GitCloneURL: cloneURL, TargetRefName: topts.TargetRefName, Params: topts.Params,
+		GitCloneURL: cloneURL, TargetRefName: topts.TargetRefName, ParamsRun: topts.ParamsRun,
 	}
 	processed, err := payload.ApplyTemplate("testdata/pipelinerun-alt.yaml", map[string]string{
 		"TargetNamespace": topts.TargetNS,
@@ -231,7 +231,7 @@ func CreateForkPullRequest(t *testing.T, topts *TestOpts, secondcnx pgitea.Provi
 			Title: fmt.Sprintf("New PR from %s", topts.TargetRefName),
 		})
 	assert.NilError(t, err)
-	topts.Params.Clients.Log.Infof("Created pr %s", pr.HTMLURL)
+	topts.ParamsRun.Clients.Log.Infof("Created pr %s", pr.HTMLURL)
 	return pr
 }
 

--- a/test/pkg/gitea/setup.go
+++ b/test/pkg/gitea/setup.go
@@ -76,7 +76,7 @@ func Setup(ctx context.Context) (*params.Run, options.E2E, gitea.Provider, error
 }
 
 func TearDown(ctx context.Context, t *testing.T, topts *TestOpts) {
-	repository.NSTearDown(ctx, t, topts.Params, topts.TargetNS)
+	repository.NSTearDown(ctx, t, topts.ParamsRun, topts.TargetNS)
 	_, err := topts.GiteaCNX.Client.DeleteRepo(topts.Opts.Organization, topts.TargetRefName)
 	assert.NilError(t, err)
 }

--- a/test/pkg/logs/pod.go
+++ b/test/pkg/logs/pod.go
@@ -11,15 +11,27 @@ import (
 	corev1i "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
-func GetPodLog(ctx context.Context, kclient corev1i.CoreV1Interface, labelselector, containerName string) (string, error) {
-	ns, err := kclient.Namespaces().Get(ctx, "pipelines-as-code", metav1.GetOptions{})
-	if err != nil {
-		ns, err = kclient.Namespaces().Get(ctx, "openshift-pipelines", metav1.GetOptions{})
+func GetControllerLog(ctx context.Context, kclient corev1i.CoreV1Interface, labelselector, containerName string) (string, error) {
+	_, err := kclient.Namespaces().Get(ctx, "pipelines-as-code", metav1.GetOptions{})
+	var ns string
+	if err == nil {
+		ns = "pipelines-as-code"
+	} else {
+		_, err = kclient.Namespaces().Get(ctx, "openshift-pipelines", metav1.GetOptions{})
 		if err != nil {
 			return "", err
 		}
+		ns = "openshift-pipelines"
 	}
-	items, err := kclient.Pods(ns.GetName()).List(ctx, metav1.ListOptions{
+	return GetPodLog(ctx, kclient, ns, labelselector, containerName)
+}
+
+func GetPodLog(ctx context.Context, kclient corev1i.CoreV1Interface, ns, labelselector, containerName string) (string, error) {
+	nsO, err := kclient.Namespaces().Get(ctx, ns, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	items, err := kclient.Pods(nsO.GetName()).List(ctx, metav1.ListOptions{
 		LabelSelector: labelselector,
 	})
 	if err != nil {
@@ -29,7 +41,7 @@ func GetPodLog(ctx context.Context, kclient corev1i.CoreV1Interface, labelselect
 		return "", fmt.Errorf("could not match any pod to label selector: %s", labelselector)
 	}
 	// maybe one day there is going to be multiple controller containers and then we would need to handle it here
-	ios, err := kclient.Pods(ns.GetName()).GetLogs(items.Items[0].GetName(), &v1.PodLogOptions{
+	ios, err := kclient.Pods(nsO.GetName()).GetLogs(items.Items[0].GetName(), &v1.PodLogOptions{
 		Container: containerName,
 		TailLines: github.Int64(10),
 	}).Stream(ctx)

--- a/test/testdata/params.yaml
+++ b/test/testdata/params.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: "\\ .PipelineName //"
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
+    pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: params
+        taskSpec:
+          steps:
+            - name: test-params-value
+              image: registry.access.redhat.com/ubi9/ubi-micro
+              script: |
+                echo "{{ event_type_match }}"
+                echo "{{ secret value }}"
+                echo "{{ no_filter }}"
+                echo "{{ no_match }}"
+                echo "{{ filter_on_body }}"


### PR DESCRIPTION
We are now supporting injecting template variable as params from CR.
This let you add some filtering based on payload body condition and
event variable.

See documentation in this commit for more description on how it works.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com><!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
