### PR TITLE
Report pipelinerun error properly

### DIFF
--- a/docs/content/docs/guide/statuses.md
+++ b/docs/content/docs/guide/statuses.md
@@ -11,12 +11,23 @@ tabs, along with a concise overview of the duration of each task in the
 pipeline. If any step fails, a small portion of the log from that step will
 also be included in the output.
 
+In case an error is encountered while creating the `PipelineRun` on the cluster,
+the error message reported by the Pipeline Controller will be conveyed to the
+GitHub user interface. This facilitates the user to swiftly identify and
+troubleshoot the issue, without having to navigate to the underlying
+infrastructure.
+
+Any other error that may arise during the execution of the pipeline will also
+be reported to the GitHub user interface. However, if there was no match for the
+namespace, the error will be logged in the Pipeline as Code Controller's logs.
+
 ## Statuses for other providers (Webhook based)
 
-When the webhook event is a pull request, the event will be added as a comment
-to the pull or merge request. However, for push events, it is not possible to
-display the status of the PipelineRun since there is no specific location to
-show it. In such cases, you can use other methods as listed below.
+If the webhook event pertains to a pull request, it will be included as a
+comment to the corresponding pull or merge request. However, when it comes to
+push events, it is not feasible to exhibit the status of the PipelineRun as
+there is no dedicated space to showcase it. In such scenarios, you can employ
+alternate methods as enumerated below.
 
 ## Log Snippet when reporting error
 

--- a/test/pkg/wait/logs.go
+++ b/test/pkg/wait/logs.go
@@ -10,7 +10,9 @@ import (
 	tlogs "github.com/openshift-pipelines/pipelines-as-code/test/pkg/logs"
 )
 
-func RegexpMatchingInControllerLog(ctx context.Context, clients *params.Run, labelselector, containerName string, reg regexp.Regexp, maxNumberOfLoop int) error {
+func RegexpMatchingInControllerLog(ctx context.Context, clients *params.Run, reg regexp.Regexp, maxNumberOfLoop int) error {
+	labelselector := "app.kubernetes.io/component=controller"
+	containerName := "pac-controller"
 	for i := 0; i <= maxNumberOfLoop; i++ {
 		output, err := tlogs.GetControllerLog(ctx, clients.Clients.Kube.CoreV1(), labelselector, containerName)
 		if err != nil {

--- a/test/testdata/failures/bad-runafter-task.yaml
+++ b/test/testdata/failures/bad-runafter-task.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: "\\.PipelineName//"
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
+    pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: noexist
+        runAfter:
+          - donotexist
+        taskSpec:
+          steps:
+            - name: noop-task
+              image: registry.access.redhat.com/ubi9/ubi-micro
+              script: |
+                exit 0

--- a/test/testdata/pipelinerun_remote_pipeline_annotations.yaml
+++ b/test/testdata/pipelinerun_remote_pipeline_annotations.yaml
@@ -7,7 +7,7 @@ metadata:
     pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
     pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
     pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
-    pipelinesascode.tekton.dev/pipeline: "[https://raw.githubusercontent.com/chmouel/scratchmyback/main/pipelinerun-http.yaml]"
+    pipelinesascode.tekton.dev/pipeline: "[https://raw.githubusercontent.com/chmouel/scratchmyback/b33592ca2572b8f32be19576b2b3f31244c0479a/pipelinerun-http.yaml]"
 spec:
   pipelineRef:
     name: pipeline-from-remote


### PR DESCRIPTION
We didn't previously reported the startPR erros onto the user interface.
We now do it properly which would give an indication to the user why the
pipelinerun wasn't started.

Could not figure out how to fake a validation error from tekton
controller in unittest, but the added e2e covers it for the gitea comment
interface and on the controller.

Improved the error reports all over this function, to let know exactly
what action caused this error. 

Improved docs section on error reporting.	

Fixes #1224
https://issues.redhat.com/browse/SRVKP-2992

how it look like in gitea:

![image](https://user-images.githubusercontent.com/98980/230568271-b389a5cb-6ae5-4781-8ae7-f41f19655373.png)

how it look like in github:

![image](https://user-images.githubusercontent.com/98980/230568547-f6aee7ff-c515-440a-a91f-35fb954d7fe0.png)

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [x] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [x] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [x] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [x] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
