### PR TITLE
[WIP] Extend scope of a GithubApp token to multiple repos in a particular namespace

### DIFF
--- a/config/300-repositories.yaml
+++ b/config/300-repositories.yaml
@@ -170,6 +170,9 @@ spec:
                         name:
                           type: string
                           description: "The secret name"
+                scope_token_to_namespace:
+                  description: scope token to a namespace
+                  type: string
 
               type: object
           type: object

--- a/docs/content/docs/guide/repositorycrd.md
+++ b/docs/content/docs/guide/repositorycrd.md
@@ -205,3 +205,18 @@ and a pull request event.
 - [Github Documentation for webhook events](https://docs.github.com/webhooks-and-events/webhooks/webhook-events-and-payloads?actionType=auto_merge_disabled#pull_request)
 - [Gitlab Documentation for webhook events](https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html)
 {{< /hint >}}
+
+## ScopeTokenToNamespace
+
+`scope_token_to_namespace` allows you to scope GithubApp token to a particular namespace when GithubApp is configured across Organization.
+
+When Repository custom resource created in a namespace with below info
+
+```yaml
+spec:
+  scope_token_to_namespace: "true"
+```
+
+Then token will be scoped to all the Repository CR's present in that particular namespace.
+
+The default value of `scope_token_to_namespace` is `false`.

--- a/pkg/apis/pipelinesascode/v1alpha1/types.go
+++ b/pkg/apis/pipelinesascode/v1alpha1/types.go
@@ -75,6 +75,7 @@ type RepositorySpec struct {
 	GitProvider      *GitProvider `json:"git_provider,omitempty"`
 	Incomings        *[]Incoming  `json:"incoming,omitempty"`
 	Params           *[]Params    `json:"params,omitempty"`
+        ScopeTokenToNamespace string       `json:"scope_token_to_namespace,omitempty"`
 }
 
 type Params struct {

--- a/pkg/provider/bitbucketcloud/bitbucket.go
+++ b/pkg/provider/bitbucketcloud/bitbucket.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ktrysmt/go-bitbucket"
 	"github.com/mitchellh/mapstructure"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
@@ -251,4 +252,8 @@ func (v *Provider) getBlob(runevent *info.Event, ref, path string) (string, erro
 
 func (v *Provider) GetFiles(_ context.Context, _ *info.Event) ([]string, error) {
 	return []string{}, nil
+}
+
+func (v *Provider) ListRepository(_ context.Context, _ []v1alpha1.Repository, _ *params.Run, _ *info.Event) (string, error) {
+	return "", nil
 }

--- a/pkg/provider/bitbucketserver/bitbucketserver.go
+++ b/pkg/provider/bitbucketserver/bitbucketserver.go
@@ -9,6 +9,7 @@ import (
 	bbv1 "github.com/gfleury/go-bitbucket-v1"
 	"github.com/google/go-github/v50/github"
 	"github.com/mitchellh/mapstructure"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
@@ -255,4 +256,8 @@ func (v *Provider) GetConfig() *info.ProviderConfig {
 
 func (v *Provider) GetFiles(_ context.Context, _ *info.Event) ([]string, error) {
 	return []string{}, nil
+}
+
+func (v *Provider) ListRepository(_ context.Context, _ []v1alpha1.Repository, _ *params.Run, _ *info.Event) (string, error) {
+	return "", nil
 }

--- a/pkg/provider/gitea/gitea.go
+++ b/pkg/provider/gitea/gitea.go
@@ -10,6 +10,7 @@ import (
 
 	"code.gitea.io/sdk/gitea"
 
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
@@ -290,4 +291,8 @@ func (v *Provider) GetCommitInfo(_ context.Context, runevent *info.Event) error 
 func (v *Provider) GetFiles(_ context.Context, _ *info.Event) ([]string, error) {
 	// TODO: figure out a way
 	return []string{}, fmt.Errorf("GetFiles is not supported on Gitea")
+}
+
+func (v *Provider) ListRepository(_ context.Context, _ []v1alpha1.Repository, _ *params.Run, _ *info.Event) (string, error) {
+	return "", nil
 }

--- a/pkg/provider/github/parse_payload.go
+++ b/pkg/provider/github/parse_payload.go
@@ -55,7 +55,7 @@ func (v *Provider) GetAppToken(ctx context.Context, kube kubernetes.Interface, g
 		return "", err
 	}
 	itr.InstallationTokenOptions = &github.InstallationTokenOptions{
-		RepositoryIDs: v.repositoryIDs,
+		RepositoryIDs: v.RepositoryIDs,
 	}
 
 	if gheURL != "" {
@@ -162,7 +162,7 @@ func (v *Provider) ParsePayload(ctx context.Context, run *params.Run, request *h
 	}
 
 	// regenerate token scoped to the repo IDs
-	if run.Info.Pac.SecretGHAppRepoScoped && installationIDFrompayload != -1 && len(v.repositoryIDs) > 0 {
+	if run.Info.Pac.SecretGHAppRepoScoped && installationIDFrompayload != -1 && len(v.RepositoryIDs) > 0 {
 		if run.Info.Pac.SecretGhAppTokenScopedExtraRepos != "" {
 			// this is going to show up a lot in the logs but i guess that
 			// would make people fix the value instead of being lost into
@@ -178,7 +178,7 @@ func (v *Provider) ParsePayload(ctx context.Context, run *params.Run, request *h
 					v.Logger.Warn("we have an invalid repository: `%s` in configmap key or no access to it: %v", configValueS, err)
 					continue
 				}
-				v.repositoryIDs = append(v.repositoryIDs, info.GetID())
+				v.RepositoryIDs = append(v.RepositoryIDs, info.GetID())
 			}
 		}
 		var err error
@@ -233,7 +233,7 @@ func (v *Provider) processEvent(ctx context.Context, event *info.Event, eventInt
 		processedEvent.Repository = gitEvent.GetRepo().GetName()
 		processedEvent.DefaultBranch = gitEvent.GetRepo().GetDefaultBranch()
 		processedEvent.URL = gitEvent.GetRepo().GetHTMLURL()
-		v.repositoryIDs = []int64{gitEvent.GetRepo().GetID()}
+		v.RepositoryIDs = []int64{gitEvent.GetRepo().GetID()}
 		processedEvent.SHA = gitEvent.GetHeadCommit().GetID()
 		// on push event we may not get a head commit but only
 		if processedEvent.SHA == "" {
@@ -259,7 +259,7 @@ func (v *Provider) processEvent(ctx context.Context, event *info.Event, eventInt
 		processedEvent.PullRequestNumber = gitEvent.GetPullRequest().GetNumber()
 		// getting the repository ids of the base and head of the pull request
 		// to scope the token to
-		v.repositoryIDs = []int64{
+		v.RepositoryIDs = []int64{
 			gitEvent.GetPullRequest().GetBase().GetRepo().GetID(),
 		}
 	default:

--- a/pkg/provider/github/parse_payload_test.go
+++ b/pkg/provider/github/parse_payload_test.go
@@ -584,8 +584,8 @@ func TestAppTokenGeneration(t *testing.T) {
 			}
 
 			for k, id := range tt.checkInstallIDs {
-				if gprovider.repositoryIDs[k] != id {
-					t.Errorf("got %d, want %d", gprovider.repositoryIDs[k], id)
+				if gprovider.RepositoryIDs[k] != id {
+					t.Errorf("got %d, want %d", gprovider.RepositoryIDs[k], id)
 				}
 			}
 
@@ -593,7 +593,7 @@ func TestAppTokenGeneration(t *testing.T) {
 				// checkInstallIDs and extraRepoInstallIds are merged and extraRepoInstallIds is after
 				found := false
 				extraIDInt, _ := strconv.ParseInt(extraid, 10, 64)
-				for _, rid := range gprovider.repositoryIDs {
+				for _, rid := range gprovider.RepositoryIDs {
 					if extraIDInt == rid {
 						found = true
 					}

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
@@ -319,4 +320,8 @@ func (v *Provider) GetFiles(_ context.Context, runevent *info.Event) ([]string, 
 		return result, nil
 	}
 	return []string{}, nil
+}
+
+func (v *Provider) ListRepository(_ context.Context, _ []v1alpha1.Repository, _ *params.Run, _ *info.Event) (string, error) {
+	return "", nil
 }

--- a/pkg/provider/interface.go
+++ b/pkg/provider/interface.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
@@ -37,6 +38,7 @@ type Interface interface {
 	GetConfig() *info.ProviderConfig
 	GetFiles(context.Context, *info.Event) ([]string, error)
 	GetTaskURI(ctx context.Context, params *params.Run, event *info.Event, uri string) (bool, string, error)
+	ListRepository(context.Context, []v1alpha1.Repository, *params.Run, *info.Event) (string, error)
 }
 
 const DefaultProviderAPIUser = "git"

--- a/pkg/test/provider/testwebvcs.go
+++ b/pkg/test/provider/testwebvcs.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
@@ -80,5 +81,9 @@ func (v *TestProviderImp) GetFileInsideRepo(_ context.Context, _ *info.Event, fi
 }
 
 func (v *TestProviderImp) GetFiles(_ context.Context, _ *info.Event) ([]string, error) {
+	return []string{}, nil
+}
+
+func (v *TestProviderImp) ListRepository(_ context.Context, _ []v1alpha1.Repository, _ *info.Event) ([]string, error) {
 	return []string{}, nil
 }


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Fixes: https://issues.redhat.com/browse/SRVKP-2911

PAC now support to extend scope of a GithubApp token to multiple repos in a particular namespace when `scope_token_to_namespace` set to `true`

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
