### PR TITLE
Move pipelinerun labels to pipelinerun annotation

### DIFF
--- a/pkg/cmd/tknpac/logs/logs.go
+++ b/pkg/cmd/tknpac/logs/logs.go
@@ -166,7 +166,7 @@ func getTknPath() (string, error) {
 func getPipelineRunsToRepo(ctx context.Context, lopt *logOption, repoName string) ([]string, error) {
 	opts := metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("%s=%s",
-			keys.Repository, repoName),
+			keys.Repository, formatting.CleanValueKubernetes(repoName)),
 	}
 	runs, err := lopt.cs.Clients.Tekton.TektonV1().PipelineRuns(lopt.opts.Namespace).List(ctx, opts)
 	if err != nil {

--- a/pkg/cmd/tknpac/resolve/basic_auth_secret.go
+++ b/pkg/cmd/tknpac/resolve/basic_auth_secret.go
@@ -10,6 +10,7 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli/prompt"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/secrets"
@@ -53,7 +54,8 @@ func makeGitAuthSecret(ctx context.Context, cs *params.Run, filenames []string, 
 
 	if cs.Clients.Kube != nil {
 		list, _ := cs.Clients.Kube.CoreV1().Secrets(cs.Info.Kube.Namespace).List(ctx, metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("%s=%s,%s=%s", keys.URLOrg, params["repo_owner"], keys.URLRepository, params["repo_name"]),
+			LabelSelector: fmt.Sprintf("%s=%s,%s=%s", keys.URLOrg, formatting.CleanValueKubernetes(params["repo_owner"]),
+				keys.URLRepository, formatting.CleanValueKubernetes(params["repo_name"])),
 		})
 
 		if len(list.Items) > 0 {

--- a/pkg/cmd/tknpac/resolve/testdata/TestResolveFilenames-Resolve_templates_no_prefix.golden
+++ b/pkg/cmd/tknpac/resolve/testdata/TestResolveFilenames-Resolve_templates_no_prefix.golden
@@ -2,6 +2,8 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
+  annotations:
+    pipelinesascode.tekton.dev/original-prname: test
   generateName: test-
   labels:
     pipelinesascode.tekton.dev/original-prname: test

--- a/pkg/cmd/tknpac/resolve/testdata/TestResolveFilenames-Resolve_templates_with_prefix.golden
+++ b/pkg/cmd/tknpac/resolve/testdata/TestResolveFilenames-Resolve_templates_with_prefix.golden
@@ -2,6 +2,8 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
+  annotations:
+    pipelinesascode.tekton.dev/original-prname: test
   generateName: test-
   labels:
     pipelinesascode.tekton.dev/original-prname: test

--- a/pkg/events/emit.go
+++ b/pkg/events/emit.go
@@ -6,6 +6,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	v1 "k8s.io/api/core/v1"
@@ -56,6 +57,9 @@ func makeEvent(repo *v1alpha1.Repository, loggerLevel zapcore.Level, reason, mes
 			GenerateName: repo.Name + "-",
 			Namespace:    repo.Namespace,
 			Labels: map[string]string{
+				keys.Repository: formatting.CleanValueKubernetes(repo.Name),
+			},
+			Annotations: map[string]string{
 				keys.Repository: repo.Name,
 			},
 		},

--- a/pkg/kubeinteraction/cleanups_test.go
+++ b/pkg/kubeinteraction/cleanups_test.go
@@ -26,6 +26,10 @@ func TestCleanupPipelines(t *testing.T) {
 		"pipelinesascode.tekton.dev/original-prname": cleanupPRName,
 		"pipelinesascode.tekton.dev/repository":      cleanupRepoName,
 	}
+	cleanupAnnotation := map[string]string{
+		"pipelinesascode.tekton.dev/original-prname": cleanupPRName,
+		"pipelinesascode.tekton.dev/repository":      cleanupRepoName,
+	}
 
 	clock := clockwork.NewFakeClock()
 
@@ -51,7 +55,7 @@ func TestCleanupPipelines(t *testing.T) {
 				repositoryName: cleanupRepoName,
 				maxKeep:        1,
 				kept:           1,
-				prunCurrent:    &tektonv1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Labels: cleanupLabels}},
+				prunCurrent:    &tektonv1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Labels: cleanupLabels, Annotations: cleanupAnnotation}},
 				pruns: []*tektonv1.PipelineRun{
 					tektontest.MakePRCompletion(clock, "pipeline-newest", ns, tektonv1.PipelineRunReasonSuccessful.String(), cleanupLabels, 10),
 					tektontest.MakePRCompletion(clock, "pipeline-middest", ns, tektonv1.PipelineRunReasonSuccessful.String(), cleanupLabels, 20),
@@ -67,7 +71,7 @@ func TestCleanupPipelines(t *testing.T) {
 				repositoryName: cleanupRepoName,
 				maxKeep:        1,
 				kept:           1, // see my comment in code why only 1 is kept.
-				prunCurrent:    &tektonv1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Labels: cleanupLabels}},
+				prunCurrent:    &tektonv1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Labels: cleanupLabels, Annotations: cleanupAnnotation}},
 				pruns: []*tektonv1.PipelineRun{
 					tektontest.MakePRCompletion(clock, "pipeline-running", ns, tektonv1.PipelineRunReasonRunning.String(), cleanupLabels, 10),
 					tektontest.MakePRCompletion(clock, "pipeline-toclean", ns, tektonv1.PipelineRunReasonSuccessful.String(), cleanupLabels, 30),

--- a/pkg/kubeinteraction/labels.go
+++ b/pkg/kubeinteraction/labels.go
@@ -23,27 +23,42 @@ func AddLabelsAndAnnotations(event *info.Event, pipelineRun *tektonv1.PipelineRu
 	// Add labels on the soon to be created pipelinerun so UI/CLI can easily
 	// query them.
 	labels := map[string]string{
+		// These keys are used in LabelSelector query so we are keeping in Labels as it is.
+		// But adding same keys to Annotations so UI/CLI can fetch the actual value instead of modified value
 		"app.kubernetes.io/managed-by": pipelinesascode.GroupName,
 		"app.kubernetes.io/version":    version.Version,
 		keys.URLOrg:                    formatting.CleanValueKubernetes(event.Organization),
 		keys.URLRepository:             formatting.CleanValueKubernetes(event.Repository),
 		keys.SHA:                       formatting.CleanValueKubernetes(event.SHA),
-		keys.Sender:                    formatting.CleanValueKubernetes(event.Sender),
-		keys.EventType:                 formatting.CleanValueKubernetes(event.EventType),
-		keys.Branch:                    formatting.CleanValueKubernetes(event.BaseBranch),
 		keys.Repository:                formatting.CleanValueKubernetes(repo.GetName()),
-		keys.GitProvider:               providerinfo.Name,
 		keys.State:                     StateStarted,
+		keys.EventType:                 formatting.CleanValueKubernetes(event.EventType),
+
+		// We are deprecating these below keys from labels and adding it to Annotations
+		// In PAC v0.20.x releases we will remove these keys from Labels
+		keys.Sender:      formatting.CleanValueKubernetes(event.Sender),
+		keys.Branch:      formatting.CleanValueKubernetes(event.BaseBranch),
+		keys.GitProvider: providerinfo.Name,
 	}
 
 	annotations := map[string]string{
-		keys.ShaTitle: event.SHATitle,
-		keys.ShaURL:   event.SHAURL,
-		keys.RepoURL:  event.URL,
+		keys.ShaTitle:      event.SHATitle,
+		keys.ShaURL:        event.SHAURL,
+		keys.RepoURL:       event.URL,
+		keys.URLOrg:        event.Organization,
+		keys.URLRepository: event.Repository,
+		keys.SHA:           event.SHA,
+		keys.Sender:        event.Sender,
+		keys.EventType:     event.EventType,
+		keys.Branch:        event.BaseBranch,
+		keys.Repository:    repo.GetName(),
+		keys.GitProvider:   providerinfo.Name,
+		keys.State:         StateStarted,
 	}
 
 	if event.PullRequestNumber != 0 {
 		labels[keys.PullRequest] = strconv.Itoa(event.PullRequestNumber)
+		annotations[keys.PullRequest] = strconv.Itoa(event.PullRequestNumber)
 	}
 
 	// TODO: move to provider specific function

--- a/pkg/kubeinteraction/labels_test.go
+++ b/pkg/kubeinteraction/labels_test.go
@@ -53,6 +53,8 @@ func TestAddLabelsAndAnnotations(t *testing.T) {
 			AddLabelsAndAnnotations(tt.args.event, tt.args.pipelineRun, tt.args.repo, &info.ProviderConfig{})
 			assert.Assert(t, tt.args.pipelineRun.Labels[keys.URLOrg] == tt.args.event.Organization, "'%s' != %s",
 				tt.args.pipelineRun.Labels[keys.URLOrg], tt.args.event.Organization)
+			assert.Assert(t, tt.args.pipelineRun.Annotations[keys.URLOrg] == tt.args.event.Organization, "'%s' != %s",
+				tt.args.pipelineRun.Annotations[keys.URLOrg], tt.args.event.Organization)
 			assert.Assert(t, tt.args.pipelineRun.Annotations[keys.ShaURL] == tt.args.event.SHAURL)
 		})
 	}

--- a/pkg/pipelineascode/cancel_pipelinerun_test.go
+++ b/pkg/pipelineascode/cancel_pipelinerun_test.go
@@ -37,9 +37,20 @@ var (
 		keys.SHA:           formatting.CleanValueKubernetes("foosha"),
 		keys.PullRequest:   strconv.Itoa(11),
 	}
+	fooRepoAnnotations = map[string]string{
+		keys.URLRepository: "foo",
+		keys.SHA:           "foosha",
+		keys.PullRequest:   strconv.Itoa(11),
+	}
 	fooRepoLabelsPrFooAbc = map[string]string{
 		keys.URLRepository:  formatting.CleanValueKubernetes("foo"),
 		keys.SHA:            formatting.CleanValueKubernetes("foosha"),
+		keys.PullRequest:    strconv.Itoa(11),
+		keys.OriginalPRName: "pr-foo-abc",
+	}
+	fooRepoAnnotationsPrFooAbc = map[string]string{
+		keys.URLRepository:  "foo",
+		keys.SHA:            "foosha",
 		keys.PullRequest:    strconv.Itoa(11),
 		keys.OriginalPRName: "pr-foo-abc",
 	}
@@ -117,25 +128,28 @@ func TestCancelPipelinerun(t *testing.T) {
 			pipelineRuns: []*pipelinev1.PipelineRun{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pr-foo",
-						Namespace: "foo",
-						Labels:    fooRepoLabels,
+						Name:        "pr-foo",
+						Namespace:   "foo",
+						Labels:      fooRepoLabels,
+						Annotations: fooRepoAnnotations,
 					},
 					Spec: pipelinev1.PipelineRunSpec{},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pr-foo-abc-123",
-						Namespace: "foo",
-						Labels:    fooRepoLabelsPrFooAbc,
+						Name:        "pr-foo-abc-123",
+						Namespace:   "foo",
+						Labels:      fooRepoLabelsPrFooAbc,
+						Annotations: fooRepoAnnotationsPrFooAbc,
 					},
 					Spec: pipelinev1.PipelineRunSpec{},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pr-foo-pqr",
-						Namespace: "foo",
-						Labels:    fooRepoLabels,
+						Name:        "pr-foo-pqr",
+						Namespace:   "foo",
+						Labels:      fooRepoLabels,
+						Annotations: fooRepoAnnotations,
 					},
 					Spec: pipelinev1.PipelineRunSpec{},
 				},

--- a/pkg/pipelineascode/cancel_pipelineruns.go
+++ b/pkg/pipelineascode/cancel_pipelineruns.go
@@ -51,7 +51,7 @@ func (p *PacRun) cancelPipelineRuns(ctx context.Context, repo *v1alpha1.Reposito
 	var wg sync.WaitGroup
 	for _, pr := range prs.Items {
 		if p.event.TargetCancelPipelineRun != "" {
-			if prName, ok := pr.GetLabels()[keys.OriginalPRName]; !ok || prName != p.event.TargetCancelPipelineRun {
+			if prName, ok := pr.GetAnnotations()[keys.OriginalPRName]; !ok || prName != p.event.TargetCancelPipelineRun {
 				continue
 			}
 		}

--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -197,7 +197,7 @@ func filterRunningPipelineRunOnTargetTest(testPipeline string, prs []*tektonv1.P
 		return prs
 	}
 	for _, pr := range prs {
-		if prName, ok := pr.GetLabels()[apipac.OriginalPRName]; ok {
+		if prName, ok := pr.GetAnnotations()[apipac.OriginalPRName]; ok {
 			if prName == testPipeline {
 				return []*tektonv1.PipelineRun{pr}
 			}

--- a/pkg/pipelineascode/match_test.go
+++ b/pkg/pipelineascode/match_test.go
@@ -63,7 +63,7 @@ func TestFilterRunningPipelineRunOnTargetTest(t *testing.T) {
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "pipelinerun-" + testPipeline,
-				Labels: map[string]string{
+				Annotations: map[string]string{
 					apipac.OriginalPRName: testPipeline,
 				},
 			},

--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -143,6 +143,7 @@ func (p *PacRun) startPR(ctx context.Context, match matcher.Match) (*tektonv1.Pi
 		match.PipelineRun.Spec.Status = tektonv1.PipelineRunSpecStatusPending
 		// pac state as queued
 		match.PipelineRun.Labels[keys.State] = kubeinteraction.StateQueued
+		match.PipelineRun.Annotations[keys.State] = kubeinteraction.StateQueued
 	}
 
 	// Create the actual pipeline
@@ -172,7 +173,7 @@ func (p *PacRun) startPR(ctx context.Context, match matcher.Match) (*tektonv1.Pi
 		DetailsURL:              consoleURL,
 		PipelineRunName:         pr.GetName(),
 		PipelineRun:             pr,
-		OriginalPipelineRunName: pr.GetLabels()[keys.OriginalPRName],
+		OriginalPipelineRunName: pr.GetAnnotations()[keys.OriginalPRName],
 	}
 
 	// if pipelineRun is in pending state then report status as queued

--- a/pkg/provider/github/status.go
+++ b/pkg/provider/github/status.go
@@ -187,7 +187,7 @@ func (v *Provider) getOrUpdateCheckRunStatus(ctx context.Context, tekton version
 	// check if pipelineRun has the label with checkRun-id
 	if statusOpts.PipelineRun != nil {
 		var id string
-		id, found = statusOpts.PipelineRun.GetLabels()[keys.CheckRunID]
+		id, found = statusOpts.PipelineRun.GetAnnotations()[keys.CheckRunID]
 		if found {
 			checkID, err := strconv.Atoi(id)
 			if err != nil {
@@ -266,7 +266,8 @@ func metadataPatch(checkRunID *int64, logURL string) map[string]interface{} {
 				keys.CheckRunID: strconv.FormatInt(*checkRunID, 10),
 			},
 			"annotations": map[string]string{
-				keys.LogURL: logURL,
+				keys.LogURL:     logURL,
+				keys.CheckRunID: strconv.FormatInt(*checkRunID, 10),
 			},
 		},
 	}

--- a/pkg/provider/github/status_test.go
+++ b/pkg/provider/github/status_test.go
@@ -139,7 +139,7 @@ func TestGithubProviderCreateStatus(t *testing.T) {
 	pr := &tektonv1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: prname,
-			Labels: map[string]string{
+			Annotations: map[string]string{
 				keys.CheckRunID: strconv.Itoa(int(checkrunid)),
 			},
 		},

--- a/pkg/reconciler/cleanup_test.go
+++ b/pkg/reconciler/cleanup_test.go
@@ -31,9 +31,16 @@ func TestCleanupPipelineRuns(t *testing.T) {
 		"pipelinesascode.tekton.dev/repository":      cleanupRepoName,
 	}
 
+	cleanupAnnotation := map[string]string{
+		"pipelinesascode.tekton.dev/original-prname": cleanupPRName,
+		"pipelinesascode.tekton.dev/repository":      cleanupRepoName,
+	}
+
 	maxRunsAnno := func(run int) map[string]string {
 		return map[string]string{
-			"pipelinesascode.tekton.dev/max-keep-runs": strconv.Itoa(run),
+			"pipelinesascode.tekton.dev/max-keep-runs":   strconv.Itoa(run),
+			"pipelinesascode.tekton.dev/original-prname": cleanupPRName,
+			"pipelinesascode.tekton.dev/repository":      cleanupRepoName,
 		}
 	}
 
@@ -99,7 +106,7 @@ func TestCleanupPipelineRuns(t *testing.T) {
 			maxkeepruns:  3,
 		},
 		{
-			name: "no annotation, using default from config",
+			name: "no max-keep-runs annotation, using default from config",
 			pruns: []*tektonv1.PipelineRun{
 				tektontest.MakePRCompletion(clock, "pipeline-newest", ns, tektonv1.PipelineRunReasonSuccessful.String(), cleanupLabels, 10),
 				tektontest.MakePRCompletion(clock, "pipeline-middest", ns, tektonv1.PipelineRunReasonSuccessful.String(), cleanupLabels, 20),
@@ -107,7 +114,7 @@ func TestCleanupPipelineRuns(t *testing.T) {
 			},
 			repoNs:             ns,
 			repoName:           cleanupRepoName,
-			currentpr:          &tektonv1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Labels: cleanupLabels}},
+			currentpr:          &tektonv1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Labels: cleanupLabels, Annotations: cleanupAnnotation}},
 			afterCleanup:       2,
 			defaultmaxkeepruns: 2,
 		},

--- a/pkg/reconciler/controller.go
+++ b/pkg/reconciler/controller.go
@@ -77,7 +77,7 @@ func checkStateAndEnqueue(impl *controller.Impl) func(obj interface{}) {
 	return func(obj interface{}) {
 		object, err := kmeta.DeletionHandlingAccessor(obj)
 		if err == nil {
-			_, exist := object.GetLabels()[keys.State]
+			_, exist := object.GetAnnotations()[keys.State]
 			if exist {
 				impl.EnqueueKey(types.NamespacedName{Namespace: object.GetNamespace(), Name: object.GetName()})
 			}
@@ -90,7 +90,7 @@ func ctrlOpts() func(impl *controller.Impl) controller.Options {
 		return controller.Options{
 			FinalizerName: pipelinesascode.GroupName,
 			PromoteFilterFunc: func(obj interface{}) bool {
-				_, exist := obj.(*tektonv1.PipelineRun).GetLabels()[keys.State]
+				_, exist := obj.(*tektonv1.PipelineRun).GetAnnotations()[keys.State]
 				return exist
 			},
 		}

--- a/pkg/reconciler/emit_metrics.go
+++ b/pkg/reconciler/emit_metrics.go
@@ -8,8 +8,8 @@ import (
 )
 
 func (r *Reconciler) emitMetrics(pr *tektonv1.PipelineRun) error {
-	gitProvider := pr.GetLabels()[keys.GitProvider]
-	eventType := pr.GetLabels()[keys.EventType]
+	gitProvider := pr.GetAnnotations()[keys.GitProvider]
+	eventType := pr.GetAnnotations()[keys.EventType]
 
 	if strings.HasPrefix(gitProvider, "github") {
 		if _, ok := pr.GetAnnotations()[keys.InstallationID]; ok {

--- a/pkg/reconciler/event.go
+++ b/pkg/reconciler/event.go
@@ -19,7 +19,7 @@ import (
 )
 
 func (r *Reconciler) detectProvider(ctx context.Context, logger *zap.SugaredLogger, pr *tektonv1.PipelineRun) (provider.Interface, *info.Event, error) {
-	gitProvider, ok := pr.GetLabels()[keys.GitProvider]
+	gitProvider, ok := pr.GetAnnotations()[keys.GitProvider]
 	if !ok {
 		return nil, nil, fmt.Errorf("failed to detect git provider for pipleinerun %s : git-provider label not found", pr.GetName())
 	}
@@ -54,7 +54,6 @@ func (r *Reconciler) detectProvider(ctx context.Context, logger *zap.SugaredLogg
 func buildEventFromPipelineRun(pr *tektonv1.PipelineRun) *info.Event {
 	event := info.NewEvent()
 
-	prLabels := pr.GetLabels()
 	prAnno := pr.GetAnnotations()
 
 	event.URL = prAnno[keys.RepoURL]
@@ -63,14 +62,14 @@ func buildEventFromPipelineRun(pr *tektonv1.PipelineRun) *info.Event {
 	repo, org, _ := formatting.GetRepoOwnerSplitted(event.URL)
 	event.Organization = repo
 	event.Repository = org
-	event.EventType = prLabels[keys.EventType]
-	event.BaseBranch = prLabels[keys.Branch]
-	event.SHA = prLabels[keys.SHA]
+	event.EventType = prAnno[keys.EventType]
+	event.BaseBranch = prAnno[keys.Branch]
+	event.SHA = prAnno[keys.SHA]
 
 	event.SHATitle = prAnno[keys.ShaTitle]
 	event.SHAURL = prAnno[keys.ShaURL]
 
-	prNumber := prLabels[keys.PullRequest]
+	prNumber := prAnno[keys.PullRequest]
 	if prNumber != "" {
 		event.PullRequestNumber, _ = strconv.Atoi(prNumber)
 	}

--- a/pkg/reconciler/event_test.go
+++ b/pkg/reconciler/event_test.go
@@ -59,6 +59,13 @@ func TestBuildEventFromPipelineRun(t *testing.T) {
 						// gitlab
 						keys.SourceProjectID: "1234",
 						keys.TargetProjectID: "2345",
+						keys.URLOrg:          "url-org",
+						keys.URLRepository:   "repo",
+						keys.SHA:             "sha",
+						keys.EventType:       "push",
+						keys.Branch:          "branch",
+						keys.State:           kubeinteraction.StateStarted,
+						keys.PullRequest:     "1234",
 					},
 				},
 			},
@@ -84,18 +91,18 @@ func TestDetectProvider(t *testing.T) {
 	tests := []struct {
 		name         string
 		missTheLabel bool
-		label        string
+		annotation   string
 		errStr       string
 	}{
 		{
-			name:   "known provider",
-			label:  "gitlab",
-			errStr: "",
+			name:       "known provider",
+			annotation: "gitlab",
+			errStr:     "",
 		},
 		{
-			name:   "unknown provider",
-			label:  "batman",
-			errStr: "failed to detect provider for pipelinerun: test : unknown provider",
+			name:       "unknown provider",
+			annotation: "batman",
+			errStr:     "failed to detect provider for pipelinerun: test : unknown provider",
 		},
 		{
 			name:         "no label",
@@ -113,8 +120,8 @@ func TestDetectProvider(t *testing.T) {
 				pr = &tektonv1.PipelineRun{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "test",
-						Labels: map[string]string{
-							keys.GitProvider: tt.label,
+						Annotations: map[string]string{
+							keys.GitProvider: tt.annotation,
 						},
 					},
 				}

--- a/pkg/reconciler/finalizer.go
+++ b/pkg/reconciler/finalizer.go
@@ -16,13 +16,13 @@ import (
 
 func (r *Reconciler) FinalizeKind(ctx context.Context, pr *tektonv1.PipelineRun) pkgreconciler.Event {
 	logger := logging.FromContext(ctx)
-	state, exist := pr.GetLabels()[keys.State]
+	state, exist := pr.GetAnnotations()[keys.State]
 	if !exist || state == kubeinteraction.StateCompleted {
 		return nil
 	}
 
 	if state == kubeinteraction.StateQueued || state == kubeinteraction.StateStarted {
-		repoName, ok := pr.GetLabels()[keys.Repository]
+		repoName, ok := pr.GetAnnotations()[keys.Repository]
 		if !ok {
 			return nil
 		}

--- a/pkg/reconciler/finalizer_test.go
+++ b/pkg/reconciler/finalizer_test.go
@@ -41,7 +41,7 @@ func getTestPR(name, state string) *tektonv1.PipelineRun {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: finalizeTestRepo.Namespace,
-			Labels: map[string]string{
+			Annotations: map[string]string{
 				keys.State:      state,
 				keys.Repository: finalizeTestRepo.Name,
 			},
@@ -66,7 +66,7 @@ func TestReconciler_FinalizeKind(t *testing.T) {
 			name: "completed pipelinerun",
 			pipelinerun: &tektonv1.PipelineRun{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
+					Annotations: map[string]string{
 						keys.State: kubeinteraction.StateCompleted,
 					},
 				},

--- a/pkg/reconciler/queue_pipelineruns.go
+++ b/pkg/reconciler/queue_pipelineruns.go
@@ -20,7 +20,7 @@ func (r *Reconciler) queuePipelineRun(ctx context.Context, logger *zap.SugaredLo
 		return nil
 	}
 
-	repoName := pr.GetLabels()[keys.Repository]
+	repoName := pr.GetAnnotations()[keys.Repository]
 	repo, err := r.repoLister.Repositories(pr.Namespace).Get(repoName)
 	if err != nil {
 		// if repository is not found, then skip processing the pipelineRun and return nil

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -154,11 +154,12 @@ func TestReconciler_ReconcileKind(t *testing.T) {
 				keys.State:          kubeinteraction.StateCompleted,
 				keys.InstallationID: "1234",
 				keys.RepoURL:        randomURL,
+				keys.Repository:     pr.GetName(),
+				keys.OriginalPRName: pr.GetName(),
+				keys.CheckRunID:     tt.checkRunID,
 			}
 			pr.Labels = map[string]string{
-				keys.Repository:     pr.GetName(),
-				keys.CheckRunID:     tt.checkRunID,
-				keys.OriginalPRName: pr.GetName(),
+				keys.Repository: pr.GetName(),
 			}
 
 			testRepo := &v1alpha1.Repository{
@@ -245,7 +246,7 @@ func TestReconciler_ReconcileKind(t *testing.T) {
 			assert.NilError(t, err)
 
 			// state must be updated to completed
-			assert.Equal(t, got.Labels[keys.State], kubeinteraction.StateCompleted)
+			assert.Equal(t, got.Annotations[keys.State], kubeinteraction.StateCompleted)
 		})
 	}
 }
@@ -265,7 +266,7 @@ func TestUpdatePipelineRunState(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test",
 					Name:      "test",
-					Labels: map[string]string{
+					Annotations: map[string]string{
 						keys.State: kubeinteraction.StateQueued,
 					},
 				},
@@ -282,7 +283,7 @@ func TestUpdatePipelineRunState(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test",
 					Name:      "test",
-					Labels: map[string]string{
+					Annotations: map[string]string{
 						keys.State: kubeinteraction.StateStarted,
 					},
 				},
@@ -310,7 +311,7 @@ func TestUpdatePipelineRunState(t *testing.T) {
 			updatedPR, err := r.updatePipelineRunState(ctx, fakelogger, tt.pipelineRun, tt.state)
 			assert.NilError(t, err)
 
-			assert.Equal(t, updatedPR.Labels[keys.State], tt.state)
+			assert.Equal(t, updatedPR.Annotations[keys.State], tt.state)
 			assert.Equal(t, updatedPR.Spec.Status, tektonv1.PipelineRunSpecStatus(""))
 		})
 	}

--- a/pkg/reconciler/status.go
+++ b/pkg/reconciler/status.go
@@ -134,7 +134,7 @@ func (r *Reconciler) postFinalStatus(ctx context.Context, logger *zap.SugaredLog
 		Text:                    taskStatusText,
 		PipelineRunName:         pr.Name,
 		DetailsURL:              r.run.Clients.ConsoleUI.DetailURL(pr),
-		OriginalPipelineRunName: pr.GetLabels()[apipac.OriginalPRName],
+		OriginalPipelineRunName: pr.GetAnnotations()[apipac.OriginalPRName],
 	}
 
 	err = createStatusWithRetry(ctx, logger, r.run.Clients.Tekton, vcx, event, r.run.Info.Pac, status)

--- a/pkg/resolve/resolve.go
+++ b/pkg/resolve/resolve.go
@@ -263,7 +263,12 @@ func Resolve(ctx context.Context, cs *params.Run, logger *zap.SugaredLogger, pro
 		if pipelinerun.Labels == nil {
 			pipelinerun.Labels = map[string]string{}
 		}
+		// Don't overwrite the annotation if there is some who already exist set by the user in repo
+		if pipelinerun.Annotations == nil {
+			pipelinerun.Annotations = map[string]string{}
+		}
 		pipelinerun.Labels[apipac.OriginalPRName] = formatting.CleanValueKubernetes(originPipelinerunName)
+		pipelinerun.Annotations[apipac.OriginalPRName] = originPipelinerunName
 	}
 	return types.PipelineRuns, nil
 }

--- a/pkg/secrets/basic_auth.go
+++ b/pkg/secrets/basic_auth.go
@@ -66,6 +66,8 @@ func MakeBasicAuthSecret(runevent *info.Event, secretName string) (*corev1.Secre
 	annotations := map[string]string{
 		"pipelinesascode.tekton.dev/url": cloneURL,
 		"pipelinesascode.tekton.dev/sha": runevent.SHA,
+		keys.URLOrg:                      runevent.Organization,
+		keys.URLRepository:               runevent.Repository,
 	}
 
 	labels := map[string]string{

--- a/pkg/sync/queue_manager_test.go
+++ b/pkg/sync/queue_manager_test.go
@@ -164,12 +164,17 @@ func TestQueueManager_InitQueues(t *testing.T) {
 
 	repo := newTestRepo("test", 1)
 
-	annotations := map[string]string{
+	queuedAnnotations := map[string]string{
 		keys.ExecutionOrder: "test-ns/first,test-ns/second,test-ns/third",
+		keys.State:          kubeinteraction.StateQueued,
 	}
-	firstPR := newTestPR("first", cw.Now(), startedLabel, annotations)
-	secondPR := newTestPR("second", cw.Now().Add(5*time.Second), queuedLabel, annotations)
-	thirdPR := newTestPR("third", cw.Now().Add(3*time.Second), queuedLabel, annotations)
+	startedAnnotations := map[string]string{
+		keys.ExecutionOrder: "test-ns/first,test-ns/second,test-ns/third",
+		keys.State:          kubeinteraction.StateStarted,
+	}
+	firstPR := newTestPR("first", cw.Now(), startedLabel, startedAnnotations)
+	secondPR := newTestPR("second", cw.Now().Add(5*time.Second), queuedLabel, queuedAnnotations)
+	thirdPR := newTestPR("third", cw.Now().Add(3*time.Second), queuedLabel, queuedAnnotations)
 
 	tdata := testclient.Data{
 		Repositories: []*v1alpha1.Repository{repo},

--- a/pkg/test/tekton/genz.go
+++ b/pkg/test/tekton/genz.go
@@ -81,9 +81,10 @@ func MakePRCompletion(clock clockwork.FakeClock, name, namespace, runstatus stri
 
 	return &tektonv1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-			Labels:    labels,
+			Name:        name,
+			Namespace:   namespace,
+			Labels:      labels,
+			Annotations: labels,
 		},
 		Status: tektonv1.PipelineRunStatus{
 			Status: knativeduckv1.Status{
@@ -103,7 +104,7 @@ func MakePRCompletion(clock clockwork.FakeClock, name, namespace, runstatus stri
 	}
 }
 
-func MakeTaskRunCompletion(clock clockwork.FakeClock, name, namespace, runstatus string, labels map[string]string, taskStatus tektonv1.TaskRunStatusFields, conditions knativeduckv1.Conditions, timeshift int) *tektonv1.TaskRun {
+func MakeTaskRunCompletion(clock clockwork.FakeClock, name, namespace, runstatus string, annotation map[string]string, taskStatus tektonv1.TaskRunStatusFields, conditions knativeduckv1.Conditions, timeshift int) *tektonv1.TaskRun {
 	starttime := time.Duration((timeshift - 5*-1) * int(time.Minute))
 	endtime := time.Duration((timeshift * -1) * int(time.Minute))
 
@@ -121,9 +122,9 @@ func MakeTaskRunCompletion(clock clockwork.FakeClock, name, namespace, runstatus
 
 	return &tektonv1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-			Labels:    labels,
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: annotation,
 		},
 		Status: tektonv1.TaskRunStatus{
 			Status: knativeduckv1.Status{

--- a/test/pkg/gitea/test.go
+++ b/test/pkg/gitea/test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	pgitea "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/gitea"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
@@ -133,7 +134,7 @@ func TestPR(t *testing.T, topts *TestOpts) func() {
 	}
 
 	events, err := topts.ParamsRun.Clients.Kube.CoreV1().Events(topts.TargetNS).List(ctx, metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("%s=%s", keys.Repository, topts.TargetNS),
+		LabelSelector: fmt.Sprintf("%s=%s", keys.Repository, formatting.CleanValueKubernetes(topts.TargetNS)),
 	})
 	assert.NilError(t, err)
 	if topts.ExpectEvents {
@@ -144,7 +145,7 @@ func TestPR(t *testing.T, topts *TestOpts) func() {
 			// loop 30 times over a 5 second period and try to get any events
 			for i := 0; i < 30; i++ {
 				events, err = topts.ParamsRun.Clients.Kube.CoreV1().Events(topts.TargetNS).List(ctx, metav1.ListOptions{
-					LabelSelector: fmt.Sprintf("%s=%s", keys.Repository, topts.TargetNS),
+					LabelSelector: fmt.Sprintf("%s=%s", keys.Repository, formatting.CleanValueKubernetes(topts.TargetNS)),
 				})
 				assert.NilError(t, err)
 				if len(events.Items) > 0 {
@@ -255,7 +256,7 @@ func CheckIfPipelineRunsCancelled(t *testing.T, topts *TestOpts) {
 	for {
 		list, err := topts.ParamsRun.Clients.Tekton.TektonV1().PipelineRuns(topts.TargetNS).
 			List(context.Background(), metav1.ListOptions{
-				LabelSelector: fmt.Sprintf("%v=%v", keys.Repository, topts.TargetNS),
+				LabelSelector: fmt.Sprintf("%v=%v", keys.Repository, formatting.CleanValueKubernetes((topts.TargetNS))),
 			})
 		assert.NilError(t, err)
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

**Fixes:** https://issues.redhat.com/browse/SRVKP-2994

**Reason:**
Kubernetes labels have some limitations like it doesn't support `/` and length can not be more than 63 etc...
and in order to address this PAC uses [CleanValueKubernetes](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/pkg/formatting/k8labels.go#L13) function to replace `/` with `-` and all
ex: strings.NewReplacer("/", "-", " ", "_", "[", "__", "]", "__")

Doing this way the data may change and that will be stored in the labels but for users like ServiceFirst/CLI/DevConsole relay on labels and may get some different data

So to avoid this Moving all Labels to Annotations so that **ServiceFirst/CLI/DevConsole/Customers can now start relying on Annotations**

**Note:**
We are not completely removing labels because some of the labels used in `LabelSelector` to query PipelineRun so those labels will exist s it is

But we will be removing support for these labels may be In PAC v0.20.x
```
pipelinesascode.tekton.dev/sender
pipelinesascode.tekton.dev/branch
pipelinesascode.tekton.dev/git-provider
```

PipelineRun looks like below
```
$ kubectl get pipelinerun -n article-pipelines article-no-operation-run-p2t6d -o yaml

apiVersion: tekton.dev/v1
kind: PipelineRun
metadata:
  annotations:
    pipelinesascode.tekton.dev/branch: main
    pipelinesascode.tekton.dev/check-run-id: "12716404496"
    pipelinesascode.tekton.dev/event-type: pull_request
    pipelinesascode.tekton.dev/git-auth-secret: pac-gitauth-iolf
    pipelinesascode.tekton.dev/git-provider: github
    pipelinesascode.tekton.dev/installation-id: "36391784"
    pipelinesascode.tekton.dev/log-url: https://console-openshift-console.apps.up12.psi.ospqa.com/k8s/ns/article-pipelines/tekton.dev~v1beta1~PipelineRun/article-no-operation-run-p2t6d
    pipelinesascode.tekton.dev/max-keep-runs: "5"
    pipelinesascode.tekton.dev/on-event: '[pull_request, push]'
    pipelinesascode.tekton.dev/on-target-branch: '[main]'
    pipelinesascode.tekton.dev/original-prname: article-no-operation-run
    pipelinesascode.tekton.dev/pull-request: "238"
    pipelinesascode.tekton.dev/repo-url: https://github.com/savitaashture/article
    pipelinesascode.tekton.dev/repository: savitaashture-article
    pipelinesascode.tekton.dev/sender: savitaashture
    pipelinesascode.tekton.dev/sha: 509769f5f659f11cca89466346554d79e245c0a2
    pipelinesascode.tekton.dev/sha-title: Update README.md
    pipelinesascode.tekton.dev/sha-url: https://github.com/savitaashture/article/commit/509769f5f659f11cca89466346554d79e245c0a2
    pipelinesascode.tekton.dev/state: completed
    pipelinesascode.tekton.dev/url-org: savitaashture
    pipelinesascode.tekton.dev/url-repository: article
  creationTimestamp: "2023-04-13T09:14:26Z"
  finalizers:
  - pipelinesascode.tekton.dev
  generateName: article-no-operation-run-
  generation: 1
  labels:
    app.kubernetes.io/managed-by: pipelinesascode.tekton.dev
    app.kubernetes.io/version: nightly
    pipelinesascode.tekton.dev/branch: main
    pipelinesascode.tekton.dev/check-run-id: "12716404496"
    pipelinesascode.tekton.dev/event-type: pull_request
    pipelinesascode.tekton.dev/git-provider: github
    pipelinesascode.tekton.dev/original-prname: article-no-operation-run
    pipelinesascode.tekton.dev/pull-request: "238"
    pipelinesascode.tekton.dev/repository: savitaashture-article
    pipelinesascode.tekton.dev/sender: savitaashture
    pipelinesascode.tekton.dev/sha: 509769f5f659f11cca89466346554d79e245c0a2
    pipelinesascode.tekton.dev/state: completed
    pipelinesascode.tekton.dev/url-org: savitaashture
    pipelinesascode.tekton.dev/url-repository: article
    tekton.dev/pipeline: article-no-operation-run-p2t6d
  name: article-no-operation-run-p2t6d
  namespace: article-pipelines
  resourceVersion: "55185"
  uid: cab7a712-b356-4da6-8b28-3a6ac51e547f
spec:
  ...
status:
  ...

```
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
