### PR TITLE
Add install information on 'tkn pac info install' command for Pipelines as Code installation

### DIFF
--- a/docs/content/docs/guide/cli.md
+++ b/docs/content/docs/guide/cli.md
@@ -17,6 +17,7 @@ Pipelines as Code provide a powerful CLI designed to work as a plug-in to the [T
 * `describe`: describe a Pipelines as Code Repository and the runs associated with it.
 * `resolve`: Resolve a pipelinerun as if it were executed by pipelines as code on service.
 * `webhook`: Updates webhook secret.
+* `info`: Show informations (currently only about your installation with `info install`).
 
 ## Install
 
@@ -314,6 +315,26 @@ There is no clean-up of the secret after the run.
 ### Update provider token for existing webhook
 
 `tkn pac webhook update-token [-n namespace]`: Allows you to update provider token for an existing `Secret` object to interact with Pipelines as Code.
+
+{{< /details >}}
+
+{{< details "tkn pac info install" >}}
+
+### Installation Info
+
+The command tkn pac info provides information about your Pipelines as Code
+installation, including the location and version. You can also view an overview
+of all Repositories CR created on the cluster and their associated URLs.
+
+If your have your installation set-up with a [GitHub App](../../install/github_apps),
+you will be able to the see details of the installed application along with
+other relevant information. By default, this will display information from the
+public Github API, but you can specify a custom Github API URL using the
+`--github-api-url` argument.
+
+It's important to note that only administrators with permission to read the
+`pipelines-as-code-secret` secret and list all Repository CR on the cluster are
+authorized to access this command.
 
 {{< /details >}}
 

--- a/pkg/adapter/incoming.go
+++ b/pkg/adapter/incoming.go
@@ -5,6 +5,7 @@ import (
 	"crypto/subtle"
 	"fmt"
 	"net/http"
+	"os"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
@@ -71,7 +72,10 @@ func (l *listener) detectIncoming(ctx context.Context, req *http.Request, payloa
 
 	if repo.Spec.GitProvider == nil || repo.Spec.GitProvider.Type == "" {
 		gh := github.New()
-		enterpriseURL, token, installationID, err := app.GetAndUpdateInstallationID(ctx, req, l.run, repo, gh)
+
+		// TODO: move this out of here
+		ns := os.Getenv("SYSTEM_NAMESPACE")
+		enterpriseURL, token, installationID, err := app.GetAndUpdateInstallationID(ctx, req, l.run, repo, gh, ns)
 		if err != nil {
 			return false, nil, err
 		}

--- a/pkg/apis/pipelinesascode/keys/keys.go
+++ b/pkg/apis/pipelinesascode/keys/keys.go
@@ -51,5 +51,7 @@ const (
 	// default is "https://api.github.com" but it can be overridden by X-GitHub-Enterprise-Host header
 	PublicGithubAPIURL = "https://api.github.com"
 	// installationURL give us the Installation ID
-	InstallationURL = "/app/installations"
+	InstallationURL     = "/app/installations"
+	GithubApplicationID = "github-application-id"
+	GithubPrivateKey    = "github-private-key"
 )

--- a/pkg/cmd/tknpac/describe/describe.go
+++ b/pkg/cmd/tknpac/describe/describe.go
@@ -112,8 +112,7 @@ func Root(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
 
 			ctx := context.Background()
 			clock := clockwork.NewRealClock()
-			err = run.Clients.NewClients(ctx, &run.Info)
-			if err != nil {
+			if err := run.Clients.NewClients(ctx, &run.Info); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/tknpac/info/install.go
+++ b/pkg/cmd/tknpac/info/install.go
@@ -1,0 +1,117 @@
+package info
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"text/tabwriter"
+	"text/template"
+
+	_ "embed"
+
+	"github.com/google/go-github/v50/github"
+	"github.com/juju/ansiterm"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/github/app"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var targetNamespaces = []string{"openshift-pipelines", "pipelines-as-code"}
+
+// google/go-github is missing the count from their struct
+type GithubApp struct {
+	*github.App
+	InstallationsCount int `json:"installations_count,omitempty"`
+}
+
+//go:embed templates/info.tmpl
+var infoTemplate string
+
+func getPacLocation(ctx context.Context, run *params.Run) (string, string, error) {
+	for _, ns := range targetNamespaces {
+		version := "unknown"
+		deployment, err := run.Clients.Kube.AppsV1().Deployments(ns).Get(ctx, "pipelines-as-code-controller", metav1.GetOptions{})
+		if err != nil {
+			continue
+		}
+		if val, ok := deployment.GetLabels()["app.kubernetes.io/version"]; ok {
+			version = val
+		}
+		return ns, version, nil
+	}
+	return "", "", fmt.Errorf("cannot find your pipelines-as-code installation, check that it is installed and you have access")
+}
+
+func install(ctx context.Context, run *params.Run, ios *cli.IOStreams, apiURL string) error {
+	targetNs, version, err := getPacLocation(ctx, run)
+	if err != nil {
+		return err
+	}
+	var gapp *GithubApp
+	jwtToken, err := app.GenerateJWT(ctx, targetNs, run)
+	if err == nil {
+		resp, err := app.GetReponse(ctx, "GET", fmt.Sprintf("%s/app", apiURL), jwtToken, run)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		data, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		// parse json response
+		if err := json.Unmarshal(data, &gapp); err != nil {
+			return err
+		}
+	}
+	repos, err := run.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("cannot list alll repo on cluster, check your rights and that paac is installed: %w", err)
+	}
+	reposItems := &repos.Items
+	args := struct {
+		Gapp             *GithubApp
+		InstallNamespace string
+		Version          string
+		Repos            *[]v1alpha1.Repository
+		CS               *cli.ColorScheme
+	}{
+		Gapp:             gapp,
+		InstallNamespace: targetNs,
+		Version:          version,
+		Repos:            reposItems,
+		CS:               ios.ColorScheme(),
+	}
+	w := ansiterm.NewTabWriter(ios.Out, 0, 5, 3, ' ', tabwriter.TabIndent)
+	t := template.Must(template.New("Describe Repository").Parse(infoTemplate))
+	if err := t.Execute(w, args); err != nil {
+		return err
+	}
+
+	return w.Flush()
+}
+
+func installCommand(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
+	var apiURL string
+	cmd := &cobra.Command{
+		Use:   "install",
+		Short: "Provides installation info for pipelines-as-code (admin only).",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			if err := run.Clients.NewClients(ctx, &run.Info); err != nil {
+				return err
+			}
+			return install(ctx, run, ioStreams, apiURL)
+		},
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
+	}
+	// add params for enteprise github
+	cmd.PersistentFlags().StringVarP(&apiURL, "github-api-url", "", "https://api.github.com", "Github API URL")
+	return cmd
+}

--- a/pkg/cmd/tknpac/info/install_test.go
+++ b/pkg/cmd/tknpac/info/install_test.go
@@ -1,0 +1,163 @@
+package info
+
+import (
+	_ "embed"
+	"fmt"
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
+	tcli "github.com/openshift-pipelines/pipelines-as-code/pkg/test/cli"
+	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
+	httptesting "github.com/openshift-pipelines/pipelines-as-code/pkg/test/http"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/golden"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	rtesting "knative.dev/pkg/reconciler/testing"
+)
+
+// script kiddies, don't get too excited, this has been randomly generated with random words
+const fakePrivateKey = `-----BEGIN RSA PRIVATE KEY-----
+MIICXAIBAAKBgQC6GorZBeri0eVERMZQDFh5E1RMPjFk9AevaWr27yJse6eiUlos
+gY2L2vcZKLOrdvVR+TLLapIMFfg1E1qVr1iTHP3IiSCs1uW6NKDmxEQc9Uf/fG9c
+i56tGmTVxLkC94AvlVFmgxtWfHdP3lF2O0EcfRyIi6EIbGkWDqWQVEQG2wIDAQAB
+AoGAaKOd6FK0dB5Si6Uj4ERgxosAvfHGMh4n6BAc7YUd1ONeKR2myBl77eQLRaEm
+DMXRP+sfDVL5lUQRED62ky1JXlDc0TmdLiO+2YVyXI5Tbej0Q6wGVC25/HedguUX
+fw+MdKe8jsOOXVRLrJ2GfpKZ2CmOKGTm/hyrFa10TmeoTxkCQQDa4fvqZYD4vOwZ
+CplONnVk+PyQETj+mAyUiBnHEeLpztMImNLVwZbrmMHnBtCNx5We10oCLW+Qndfw
+Xi4LgliVAkEA2amSV+TZiUVQmm5j9yzon0rt1FK+cmVWfRS/JAUXyvl+Xh/J+7Gu
+QzoEGJNAnzkUIZuwhTfNRWlzURWYA8BVrwJAZFQhfJd6PomaTwAktU0REm9ulTrP
+vSNE4PBhoHX6ZOGAqfgi7AgIfYVPm+3rupE5a82TBtx8vvUa/fqtcGkW4QJAaL9t
+WPUeJyx/XMJxQzuOe1JA4CQt2LmiBLHeRoRY7ephgQSFXKYmed3KqNT8jWOXp5DY
+Q1QWaigUQdpFfNCrqwJBANLgWaJV722PhQXOCmR+INvZ7ksIhJVcq/x1l2BYOLw2
+QsncVExbMiPa9Oclo5qLuTosS8qwHm1MJEytp3/SkB8=
+-----END RSA PRIVATE KEY-----`
+
+func TestInfo(t *testing.T) {
+	ns1 := "ns1"
+	ns2 := "ns2"
+	somerepositories := []*v1alpha1.Repository{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "repo1",
+				Namespace: ns1,
+			},
+			Spec: v1alpha1.RepositorySpec{
+				URL: "https://anurl.com",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "repo2",
+				Namespace: ns2,
+			},
+			Spec: v1alpha1.RepositorySpec{
+				URL: "https://somewhere.com",
+			},
+		},
+	}
+	tests := []struct {
+		name             string
+		wantErr          bool
+		secrets          []*corev1.Secret
+		repositories     []*v1alpha1.Repository
+		controllerLabels map[string]string
+		controllerNs     string
+	}{
+		{
+			name:         "with github app",
+			repositories: somerepositories,
+			controllerNs: "pipelines-as-code",
+			secrets: []*corev1.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pipelines-as-code-secret",
+						Namespace: "pipelines-as-code",
+					},
+					Data: map[string][]byte{
+						"github-application-id": []byte("12345"),
+						"github-private-key":    []byte(fakePrivateKey),
+					},
+				},
+			},
+		},
+		{
+			name:         "without github app",
+			repositories: somerepositories,
+			controllerNs: "pipelines-as-code",
+		},
+		{
+			name:         "no repos",
+			controllerNs: "pipelines-as-code",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			namespaces := []*corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: ns1,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: ns2,
+					},
+				},
+			}
+			if tt.controllerLabels == nil {
+				tt.controllerLabels = map[string]string{
+					"app.kubernetes.io/version": "testing",
+				}
+			}
+
+			tdata := testclient.Data{
+				Namespaces:   namespaces,
+				Repositories: tt.repositories,
+				Deployments: []*appsv1.Deployment{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "pipelines-as-code-controller",
+							Labels:    tt.controllerLabels,
+							Namespace: tt.controllerNs,
+						},
+					},
+				},
+				Secret: tt.secrets,
+			}
+			apiURL := "http://github.url"
+			ghAppJSON := `{
+				"installations_count": 5,
+				"description": "my beautiful app",
+				"html_url": "http://github.url/app/myapp",
+				"external_url": "http://myapp.url",
+				"created_at": "2023-03-22T12:29:10Z",
+				"name": "myapp"
+			}`
+			httpTestClient := httptesting.MakeHTTPTestClient(map[string]map[string]string{
+				apiURL + "/app": {
+					"body": ghAppJSON,
+					"code": "200",
+				},
+			})
+
+			ctx, _ := rtesting.SetupFakeContext(t)
+			stdata, _ := testclient.SeedTestData(t, ctx, tdata)
+			cs := &params.Run{
+				Clients: clients.Clients{
+					PipelineAsCode: stdata.PipelineAsCode,
+					Kube:           stdata.Kube,
+					HTTP:           *httpTestClient,
+				},
+			}
+
+			io, out := tcli.NewIOStream()
+			err := install(ctx, cs, io, apiURL)
+			assert.NilError(t, err)
+			golden.Assert(t, out.String(), fmt.Sprintf("%s.golden", t.Name()))
+		})
+	}
+}

--- a/pkg/cmd/tknpac/info/root.go
+++ b/pkg/cmd/tknpac/info/root.go
@@ -1,0 +1,24 @@
+package info
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+)
+
+func Root(clients *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "info",
+		Aliases:      []string{},
+		Short:        "Add Information",
+		Long:         `Information about your Pipelines as Code installation`,
+		SilenceUsage: true,
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
+	}
+
+	cmd.AddCommand(installCommand(clients, ioStreams))
+	return cmd
+}

--- a/pkg/cmd/tknpac/info/templates/info.tmpl
+++ b/pkg/cmd/tknpac/info/templates/info.tmpl
@@ -1,0 +1,24 @@
+{{.CS.Underline "Pipelines as Code"}}:
+ Version: {{ .Version }}
+ Install Namespace: {{ .InstallNamespace }}
+{{- if .Gapp }}
+
+{{.CS.Underline "Github Application"}}:
+ Name: {{ .Gapp.Name }}
+ URL: {{ .Gapp.HTMLURL }}
+ HomePage: {{ .Gapp.ExternalURL }}
+ Description: {{ .Gapp.Description }}
+ Created: {{ .Gapp.CreatedAt.Format "2006-01-02" }}
+ Installations Count: {{ .Gapp.InstallationsCount }}
+{{- end }}
+{{- if (gt (len .Repos) 1) }}
+
+{{ $.CS.Underline "Repositories CR" }}: {{ len .Repos  }}
+    Namespace	URL
+{{- range $repo := .Repos }}
+  - {{ $repo.GetNamespace }}	{{ $repo.Spec.URL }}
+{{- end  }}
+{{- else  }}
+
+{{.CS.Bold "No repos CR installed on Cluster" }}
+{{- end  }}

--- a/pkg/cmd/tknpac/info/testdata/TestInfo/no_repos.golden
+++ b/pkg/cmd/tknpac/info/testdata/TestInfo/no_repos.golden
@@ -1,0 +1,5 @@
+Pipelines as Code:
+ Version: testing
+ Install Namespace: pipelines-as-code
+
+No repos CR installed on Cluster

--- a/pkg/cmd/tknpac/info/testdata/TestInfo/with_github_app.golden
+++ b/pkg/cmd/tknpac/info/testdata/TestInfo/with_github_app.golden
@@ -1,0 +1,16 @@
+Pipelines as Code:
+ Version: testing
+ Install Namespace: pipelines-as-code
+
+Github Application:
+ Name: myapp
+ URL: http://github.url/app/myapp
+ HomePage: http://myapp.url
+ Description: my beautiful app
+ Created: 2023-03-22
+ Installations Count: 5
+
+Repositories CR: 2
+    Namespace   URL
+  - ns1         https://anurl.com
+  - ns2         https://somewhere.com

--- a/pkg/cmd/tknpac/info/testdata/TestInfo/without_github_app.golden
+++ b/pkg/cmd/tknpac/info/testdata/TestInfo/without_github_app.golden
@@ -1,0 +1,8 @@
+Pipelines as Code:
+ Version: testing
+ Install Namespace: pipelines-as-code
+
+Repositories CR: 2
+    Namespace   URL
+  - ns1         https://anurl.com
+  - ns2         https://somewhere.com

--- a/pkg/cmd/tknpac/root.go
+++ b/pkg/cmd/tknpac/root.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cmd/tknpac/deleterepo"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cmd/tknpac/describe"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cmd/tknpac/generate"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/cmd/tknpac/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cmd/tknpac/list"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cmd/tknpac/logs"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cmd/tknpac/resolve"
@@ -32,6 +33,7 @@ func Root(clients *params.Run) *cobra.Command {
 	ioStreams := cli.NewIOStreams()
 
 	cmd.AddCommand(version.Command(ioStreams))
+	cmd.AddCommand(info.Root(clients, ioStreams))
 	cmd.AddCommand(create.Root(clients, ioStreams))
 	cmd.AddCommand(list.Root(clients, ioStreams))
 	cmd.AddCommand(deleterepo.Root(clients, ioStreams))

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -112,7 +113,9 @@ func (v *Provider) GetTaskURI(ctx context.Context, _ *params.Run, event *info.Ev
 
 func (v *Provider) InitAppClient(ctx context.Context, kube kubernetes.Interface, event *info.Event) error {
 	var err error
-	event.Provider.Token, err = v.GetAppToken(ctx, kube, event.GHEURL, event.InstallationID)
+	// TODO: move this out of here when we move al config inside context
+	ns := os.Getenv("SYSTEM_NAMESPACE")
+	event.Provider.Token, err = v.GetAppToken(ctx, kube, event.GHEURL, event.InstallationID, ns)
 	if err != nil {
 		return err
 	}

--- a/pkg/test/clients/clients.go
+++ b/pkg/test/clients/clients.go
@@ -16,6 +16,7 @@ import (
 	fakepipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client/fake"
 	fakepipelineruninformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1/pipelinerun/fake"
 	pipelinelisterv1 "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
@@ -45,6 +46,7 @@ type Data struct {
 	Secret       []*corev1.Secret
 	Events       []*corev1.Event
 	ConfigMap    []*corev1.ConfigMap
+	Deployments  []*appsv1.Deployment
 }
 
 // SeedTestData returns Clients and Informers populated with the
@@ -108,6 +110,12 @@ func SeedTestData(t *testing.T, ctx context.Context, d Data) (Clients, Informers
 
 	for _, cm := range d.ConfigMap {
 		if _, err := c.Kube.CoreV1().ConfigMaps(cm.Namespace).Create(ctx, cm, metav1.CreateOptions{}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for _, cm := range d.Deployments {
+		if _, err := c.Kube.AppsV1().Deployments(cm.Namespace).Create(ctx, cm, metav1.CreateOptions{}); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/test/pkg/github/setup.go
+++ b/test/pkg/github/setup.go
@@ -82,7 +82,7 @@ func Setup(ctx context.Context, viaDirectWebhook bool) (*params.Run, options.E2E
 		if err != nil {
 			return nil, options.E2E{}, github.New(), fmt.Errorf("TEST_GITHUB_REPO_INSTALLATION_ID need to be set")
 		}
-		githubToken, err = gprovider.GetAppToken(ctx, run.Clients.Kube, githubURL, githubRepoInstallationID)
+		githubToken, err = gprovider.GetAppToken(ctx, run.Clients.Kube, githubURL, githubRepoInstallationID, os.Getenv("SYSTEM_NAMESPACE"))
 		if err != nil {
 			return nil, options.E2E{}, github.New(), err
 		}


### PR DESCRIPTION
This commit adds the 'tkn pac info' command, which provides useful
information about the installation of Pipelines as Code. The command
displays the location and version of the installation, as well as an
overview of all the Repositories CR created on the cluster and their
associated URLs. It also includes details of any installed GitHub Apps.

https://issues.redhat.com/browse/SRVKP-2997
Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

![image](https://user-images.githubusercontent.com/98980/232426756-560d21d8-5e08-4eb9-95f8-9c1d27c794e1.png)

Fixes #874 

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [X] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [X] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [X] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [X] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [X] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
