### PR TITLE
Add namespace information to the logger

### DIFF
--- a/pkg/adapter/incoming.go
+++ b/pkg/adapter/incoming.go
@@ -127,9 +127,9 @@ func (l *listener) processIncoming(targetRepo *v1alpha1.Repository) (provider.In
 		case "bitbucket-server":
 			provider = &bitbucketserver.Provider{}
 		default:
-			return l.processRes(false, nil, l.logger, "", fmt.Errorf("no supported Git provider has been detected"))
+			return l.processRes(false, nil, l.logger.With("namespace", targetRepo.Namespace), "", fmt.Errorf("no supported Git provider has been detected"))
 		}
 	}
 
-	return l.processRes(true, provider, l.logger.With("provider", "incoming"), "", nil)
+	return l.processRes(true, provider, l.logger.With("provider", "incoming", "namespace", targetRepo.Namespace), "", nil)
 }

--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -60,6 +60,9 @@ func (p *PacRun) verifyRepoAndUser(ctx context.Context) (*v1alpha1.Repository, e
 		return nil, nil
 	}
 
+	p.logger = p.logger.With("namespace", repo.Namespace)
+	p.vcx.SetLogger(p.logger)
+	p.eventEmitter.SetLogger(p.logger)
 	// If we have a git_provider field in repository spec, then get all the
 	// information from there, including the webhook secret.
 	// otherwise get the secret from the current ns (i.e: pipelines-as-code/openshift-pipelines.)

--- a/pkg/provider/github/repository.go
+++ b/pkg/provider/github/repository.go
@@ -90,6 +90,7 @@ func createRepository(ctx context.Context, nsTemplate string, clients clients.Cl
 	if err != nil {
 		return fmt.Errorf("failed to create repository for repo: %v: %w", gitEvent.Repo.GetHTMLURL(), err)
 	}
+	logger = logger.With("namespace", repo.Namespace)
 	logger.Infof("github: repository created: %s/%s ", repo.Namespace, repo.Name)
 	return nil
 }

--- a/pkg/reconciler/finalizer.go
+++ b/pkg/reconciler/finalizer.go
@@ -38,6 +38,7 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, pr *tektonv1.PipelineRun)
 			return err
 		}
 
+		logger = logger.With("namespace", repo.Namespace)
 		next := r.qm.RemoveFromQueue(repo, pr)
 		if next != "" {
 			key := strings.Split(next, "/")

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -46,7 +46,7 @@ var (
 
 // ReconcileKind is the main entry point for reconciling PipelineRun resources.
 func (r *Reconciler) ReconcileKind(ctx context.Context, pr *tektonv1.PipelineRun) pkgreconciler.Event {
-	logger := logging.FromContext(ctx)
+	logger := logging.FromContext(ctx).With("namespace", pr.GetNamespace())
 
 	// if pipelineRun is in completed or failed state then return
 	state, exist := pr.GetAnnotations()[keys.State]


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fixes: https://issues.redhat.com/browse/SRVKP-3006

Today PAC emits logs without the namespace information which leads to difficulty in debugging logs when there are Repos created in 1000s of namespaces

This changes will add Namespace info to each logs and make easier to grep logs or forward logs based on Namespace information

![Screenshot from 2023-04-25 21-02-09](https://user-images.githubusercontent.com/9441662/234328409-e544ba5b-1463-4de8-8df2-db2fea6f2a00.png)

If .tekton dir doesn't found on project

![Screenshot from 2023-04-25 21-03-16](https://user-images.githubusercontent.com/9441662/234328462-91274551-0f11-4604-972c-8c127c4935e7.png)



<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
