### PR TITLE
Make pod logs configurable with config map.

### DIFF
--- a/cmd/pipelines-as-code-controller/main.go
+++ b/cmd/pipelines-as-code-controller/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"log"
-	"os"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/adapter"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
@@ -12,6 +11,7 @@ import (
 	"knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/signals"
+	"knative.dev/pkg/system"
 )
 
 const (
@@ -40,8 +40,7 @@ func main() {
 	// set up kubernetes interface to retrieve configmap with log configuration
 	ctx = context.WithValue(ctx, client.Key{}, run.Clients.Kube)
 
-
-	ctx = evadapter.WithNamespace(ctx, os.Getenv("SYSTEM_NAMESPACE"))
+	ctx = evadapter.WithNamespace(ctx, system.Namespace())
 	ctx = evadapter.WithConfigWatcherEnabled(ctx)
 
 	evadapter.MainWithContext(ctx, PACControllerLogKey, adapter.NewEnvConfig, adapter.New(run, kinteract))

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -44,7 +44,7 @@ event. Representation of a project may be further defined and clarified by proje
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at
-pipelines-dev@redhat.com. All complaints will be reviewed and investigated and will result in a response
+<pipelines-dev@redhat.com>. All complaints will be reviewed and investigated and will result in a response
 that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality
 with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 

--- a/config/301-config-logging.yaml
+++ b/config/301-config-logging.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pac-config-logging
+  namespace: pipelines-as-code
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: pipelines-as-code
+data:
+  zap-logger-config: |
+    {
+      "level": "info",
+      "development": false,
+      "sampling": {
+        "initial": 100,
+        "thereafter": 100
+      },
+      "outputPaths": ["stdout"],
+      "errorOutputPaths": ["stderr"],
+      "encoding": "json",
+      "encoderConfig": {
+        "timeKey": "ts",
+        "levelKey": "level",
+        "nameKey": "logger",
+        "callerKey": "caller",
+        "messageKey": "msg",
+        "stacktraceKey": "stacktrace",
+        "lineEnding": "",
+        "levelEncoder": "",
+        "timeEncoder": "iso8601",
+        "durationEncoder": "",
+        "callerEncoder": ""
+      }
+    }
+  # Log level overrides
+  loglevel.pipelinesascode: "info"
+  loglevel.pac-watcher: "info"
+  loglevel.pipelines-as-code-webhook: "info"

--- a/config/400-controller.yaml
+++ b/config/400-controller.yaml
@@ -73,6 +73,8 @@ spec:
             successThreshold: 1
             timeoutSeconds: 1
           env:
+            - name: CONFIG_LOGGING_NAME
+              value: pac-config-logging
             - name: TLS_KEY
               value: "key"
             - name: TLS_CERT

--- a/config/500-watcher.yaml
+++ b/config/500-watcher.yaml
@@ -48,6 +48,8 @@ spec:
           image: "ko://github.com/openshift-pipelines/pipelines-as-code/cmd/pipelines-as-code-watcher"
           imagePullPolicy: Always
           env:
+          - name: CONFIG_LOGGING_NAME
+            value: pac-config-logging
           - name: SYSTEM_NAMESPACE
             valueFrom:
               fieldRef:

--- a/config/600-webhook.yaml
+++ b/config/600-webhook.yaml
@@ -46,6 +46,8 @@ spec:
         - name: pac-webhook
           image: "ko://github.com/openshift-pipelines/pipelines-as-code/cmd/pipelines-as-code-webhook"
           env:
+            - name: CONFIG_LOGGING_NAME
+              value: pac-config-logging
             - name: SYSTEM_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/docs/content/dev/_index.md
+++ b/docs/content/dev/_index.md
@@ -116,6 +116,7 @@ data:
 ```
 
 Controllers log level defined in the `loglevel.*` fields:
+
 - loglevel.pipelinesascode - log level for pipelines-as-code-controller component
 - loglevel.pipelines-as-code-webhook - log level for pipelines-as-code-webhook component
 - loglevel.pac-watcher - log level for pipelines-as-code-watcher component
@@ -123,7 +124,7 @@ Controllers log level defined in the `loglevel.*` fields:
 You can change log level from `info` to `debug` or any other supported values. For example, set up log level `debug` for pipelines-as-code-watcher component:
 
 ```bash
-$ kubectl patch configmap pac-config-logging -n pipelines-as-code --type json -p '[{"op": "replace", "path": "/data/loglevel.pac-watcher", "value":"debug"}]'
+kubectl patch configmap pac-config-logging -n pipelines-as-code --type json -p '[{"op": "replace", "path": "/data/loglevel.pac-watcher", "value":"debug"}]'
 ```
 
 After that coresponding controller should get a new log level value.
@@ -131,24 +132,22 @@ If you want to use the same log level for all pipelines-as-code components, then
 to delete `level.*` values from configmap:
 
 ```bash
-$ kubectl patch configmap pac-config-logging -n pipelines-as-code --type json -p '[  {"op": "remove", "path": "/data/loglevel.pac-watcher"},  {"op": "remove", "path": "/data/loglevel.pipelines-as-code-webhook"},  {"op": "remove", "path": "/data/loglevel.pipelinesascode"}]'
+kubectl patch configmap pac-config-logging -n pipelines-as-code --type json -p '[  {"op": "remove", "path": "/data/loglevel.pac-watcher"},  {"op": "remove", "path": "/data/loglevel.pipelines-as-code-webhook"},  {"op": "remove", "path": "/data/loglevel.pipelinesascode"}]'
 ```
 
 In this case pipelines-as-code components should get common log level from `zap-logger-config` - `level` field from the json.
 
 List zap supported log level values:
 
-```
-debug - fine-grained debugging
-info - normal logging
-warn - unexpected but non-critical errors
-error - critical errors; unexpected during normal operation
-dpanic - in debug mode, trigger a panic (crash)
-panic - trigger a panic (crash)
-fatal - immediately exit with exit status 1 (failure)
-```
+- debug - fine-grained debugging
+- info - normal logging
+- warn - unexpected but non-critical errors
+- error - critical errors; unexpected during normal operation
+- dpanic - in debug mode, trigger a panic (crash)
+- panic - trigger a panic (crash)
+- fatal - immediately exit with exit status 1 (failure)
 
-See more: https://knative.dev/docs/serving/observability/logging/config-logging
+See more: <https://knative.dev/docs/serving/observability/logging/config-logging>
 
 ## Gitea
 

--- a/docs/content/dev/_index.md
+++ b/docs/content/dev/_index.md
@@ -126,12 +126,15 @@ You can change log level from `info` to `debug` or any other supported values. F
 $ kubectl patch configmap pac-config-logging -n pipelines-as-code --type json -p '[{"op": "replace", "path": "/data/loglevel.pac-watcher", "value":"debug"}]'
 ```
 
-After that you need to re-scale corresponding controller:
+After that coresponding controller should get a new log level value.
+If you want to use the same log level for all pipelines-as-code components, then you have
+to delete `level.*` values from configmap:
 
 ```bash
-$ kubectl scale deployment pipelines-as-code-watcher --replicas=0 -n pipelines-as-code
-$ kubectl scale deployment pipelines-as-code-watcher --replicas=1 -n pipelines-as-code
+$ kubectl patch configmap pac-config-logging -n pipelines-as-code --type json -p '[  {"op": "remove", "path": "/data/loglevel.pac-watcher"},  {"op": "remove", "path": "/data/loglevel.pipelines-as-code-webhook"},  {"op": "remove", "path": "/data/loglevel.pipelinesascode"}]'
 ```
+
+In this case pipelines-as-code components should get common log level from `zap-logger-config` - `level` field from the json.
 
 List zap supported log level values:
 

--- a/pkg/reconciler/controller.go
+++ b/pkg/reconciler/controller.go
@@ -2,7 +2,6 @@ package reconciler
 
 import (
 	"context"
-	"log"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
@@ -19,10 +18,12 @@ import (
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/kmeta"
+	"knative.dev/pkg/logging"
 )
 
 func NewController() func(context.Context, configmap.Watcher) *controller.Impl {
 	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+		log := logging.FromContext(ctx)
 		run := params.New()
 		err := run.Clients.NewClients(ctx, &run.Info)
 		if err != nil {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Make pipelines-as-code log level configurable with help of configmap. 

# Demo

https://youtu.be/pHId9-WT-Ds

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
