### PR TITLE
Use internal url from hub instead of public rawurl

### DIFF
--- a/pkg/hub/get.go
+++ b/pkg/hub/get.go
@@ -13,9 +13,9 @@ func getSpecificVersion(ctx context.Context, cs *params.Run, task string) (strin
 	split := strings.Split(task, ":")
 	version := split[len(split)-1]
 	taskName := split[0]
+	url := fmt.Sprintf("%s/resource/%s/task/%s/%s", cs.Info.Pac.HubURL, cs.Info.Pac.HubCatalogName, taskName, version)
 	hr := hubResourceVersion{}
-	data, err := cs.Clients.GetURL(ctx,
-		fmt.Sprintf("%s/resource/%s/task/%s/%s", cs.Info.Pac.HubURL, cs.Info.Pac.HubCatalogName, taskName, version))
+	data, err := cs.Clients.GetURL(ctx, url)
 	if err != nil {
 		return "", fmt.Errorf("could not fetch specific task version from the hub %s:%s: %w", task, version, err)
 	}
@@ -23,12 +23,13 @@ func getSpecificVersion(ctx context.Context, cs *params.Run, task string) (strin
 	if err != nil {
 		return "", err
 	}
-	return *hr.Data.RawURL, nil
+	return fmt.Sprintf("%s/raw", url), nil
 }
 
 func getLatestVersion(ctx context.Context, cs *params.Run, task string) (string, error) {
+	url := fmt.Sprintf("%s/resource/%s/task/%s", cs.Info.Pac.HubURL, cs.Info.Pac.HubCatalogName, task)
 	hr := new(hubResource)
-	data, err := cs.Clients.GetURL(ctx, fmt.Sprintf("%s/resource/%s/task/%s", cs.Info.Pac.HubURL, cs.Info.Pac.HubCatalogName, task))
+	data, err := cs.Clients.GetURL(ctx, url)
 	if err != nil {
 		return "", err
 	}
@@ -37,7 +38,7 @@ func getLatestVersion(ctx context.Context, cs *params.Run, task string) (string,
 		return "", err
 	}
 
-	return *hr.Data.LatestVersion.RawURL, nil
+	return fmt.Sprintf("%s/%s/raw", url, *hr.Data.LatestVersion.Version), nil
 }
 
 func GetTask(ctx context.Context, cli *params.Run, task string) (string, error) {

--- a/pkg/hub/get_test.go
+++ b/pkg/hub/get_test.go
@@ -30,10 +30,10 @@ func TestGetTask(t *testing.T) {
 			wantErr: false,
 			config: map[string]map[string]string{
 				fmt.Sprintf("%s/resource/%s/task/task1", testHubURL, testCatalogHubName): {
-					"body": `{"data":{"latestVersion": {"rawURL": "https://get.me/task1"}}}`,
+					"body": `{"data":{"latestVersion": {"version": "0.2"}}}`,
 					"code": "200",
 				},
-				"https://get.me/task1": {
+				fmt.Sprintf("%s/resource/%s/task/task1/0.2/raw", testHubURL, testCatalogHubName): {
 					"body": "This is Task1",
 					"code": "200",
 				},
@@ -66,10 +66,10 @@ func TestGetTask(t *testing.T) {
 			wantErr: false,
 			config: map[string]map[string]string{
 				fmt.Sprintf("%s/resource/%s/task/task2/1.1", testHubURL, testCatalogHubName): {
-					"body": `{"data":{"rawURL": "https://get.me/task2"}}`,
+					"body": `{}`,
 					"code": "200",
 				},
-				"https://get.me/task2": {
+				fmt.Sprintf("%s/resource/%s/task/task2/1.1/raw", testHubURL, testCatalogHubName): {
 					"body": "This is Task2",
 					"code": "200",
 				},

--- a/pkg/matcher/annotation_tasks_install_test.go
+++ b/pkg/matcher/annotation_tasks_install_test.go
@@ -1,6 +1,7 @@
 package matcher
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"testing"
@@ -185,10 +186,10 @@ func TestRemoteTasksGetTaskFromAnnotations(t *testing.T) {
 			},
 			remoteURLS: map[string]map[string]string{
 				testHubURL + "/resource/" + testCatalogHubName + "/task/chmouzie": {
-					"body": `{"data": {"LatestVersion": {"RawURL": "http://simple.task"}}}`,
+					"body": `{"data": {"LatestVersion": {"version": "0.1"}}}`,
 					"code": "200",
 				},
-				"http://simple.task": {
+				fmt.Sprintf("%s/resource/%s/task/chmouzie/0.1/raw", testHubURL, testCatalogHubName): {
 					"body": readTDfile(t, "task-good"),
 					"code": "200",
 				},
@@ -202,10 +203,10 @@ func TestRemoteTasksGetTaskFromAnnotations(t *testing.T) {
 			},
 			remoteURLS: map[string]map[string]string{
 				testHubURL + "/resource/" + testCatalogHubName + "/task/chmouzie/0.2": {
-					"body": `{"data": {"RawURL": "http://simple.task"}}`,
+					"body": `{}`,
 					"code": "200",
 				},
-				"http://simple.task": {
+				fmt.Sprintf("%s/resource/%s/task/chmouzie/0.2/raw", testHubURL, testCatalogHubName): {
 					"body": readTDfile(t, "task-good"),
 					"code": "200",
 				},


### PR DESCRIPTION
We used raw url which usually go to github, but that fail for private
hubs with rawurl going to a private repos.

let use the internal url instead so this would be succefull.

https://issues.redhat.com/browse/SRVKP-3048

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
