### PR TITLE
Fix  pipelinesascode_github_test unit test

### DIFF
--- a/pkg/test/github/github.go
+++ b/pkg/test/github/github.go
@@ -131,7 +131,8 @@ func SetupGitTree(t *testing.T, mux *http.ServeMux, dir string, event *info.Even
 			SHA:  github.String(f.sha),
 		})
 	}
-	mux.HandleFunc(fmt.Sprintf("/repos/%v/%v/git/trees/%v", event.Organization, event.Repository, event.SHA), func(rw http.ResponseWriter, r *http.Request) {
+	u := fmt.Sprintf("/repos/%v/%v/git/trees/%v", event.Organization, event.Repository, event.SHA)
+	mux.HandleFunc(u, func(rw http.ResponseWriter, r *http.Request) {
 		tree := &github.Tree{
 			SHA:     &event.SHA,
 			Entries: entries,

--- a/pkg/test/repository/repository.go
+++ b/pkg/test/repository/repository.go
@@ -18,6 +18,7 @@ type RepoTestcreationOpts struct {
 	ProviderURL       string
 	CreateTime        metav1.Time
 	RepoStatus        []v1alpha1.RepositoryRunStatus
+	ConcurrencyLimit  int
 }
 
 func NewRepo(opts RepoTestcreationOpts) *v1alpha1.Repository {
@@ -69,6 +70,9 @@ func NewRepo(opts RepoTestcreationOpts) *v1alpha1.Repository {
 			URL: opts.URL,
 		},
 		Status: opts.RepoStatus,
+	}
+	if opts.ConcurrencyLimit > 0 {
+		repo.Spec.ConcurrencyLimit = &opts.ConcurrencyLimit
 	}
 
 	if opts.SecretName != "" || opts.ProviderURL != "" || opts.WebhookSecretName != "" {


### PR DESCRIPTION
It wasn't testing anything, and just bailing early.
Fixed it and add a test for concurrency limit to at least check the
label set.

Testing secret auto creation with the fake kubeclient is not working,
but checking for labels being set is good enough at least.

rename the file there isn't going to be any other provider for full flow unit test anytime soon

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
