### PR TITLE
Fix hack/upload-file-to-github.py upload

### DIFF
--- a/hack/upload-file-to-github.py
+++ b/hack/upload-file-to-github.py
@@ -148,7 +148,7 @@ def upload_to_github(args):
                 f"Setting value {left} into the destionation {dest} based on {last_commit_sha}"
             )
 
-        base64content = base64.b64encode(content)
+        base64content = base64.b64encode(content.encode())
         _, jeez = github_request(
             args.token,
             "POST",


### PR DESCRIPTION
python base64 lib expect bytes instead of string

see https://redhat-internal.slack.com/archives/C0382KN768J/p1683101806725329 for investigation process 
