### PR TITLE
don't just rely on ldflags to generate version

### DIFF
--- a/.tekton/generate-coverage-release.yaml
+++ b/.tekton/generate-coverage-release.yaml
@@ -106,6 +106,7 @@ spec:
           steps:
             - image: registry.access.redhat.com/ubi9/python-39
               name: release
+              workingDir: $(workspaces.source.path)
               env:
                 - name: HUB_TOKEN
                   valueFrom:
@@ -115,11 +116,11 @@ spec:
               script: |
                 #!/usr/bin/env bash
                 set -eux
+                ssa=$(git rev-parse --short HEAD)
                 bash hack/generate-releaseyaml.sh > release.k8s.yaml
                 env TARGET_OPENSHIFT=true bash hack/generate-releaseyaml.sh > release.yaml
                 set +x # Do not show TOKEN in logs
-                python hack/upload-file-to-github.py --message "Release yaml generated from {{repo_url}}/commit/{{revision}}" --from-ref refs/heads/main --to-ref refs/heads/nightly --owner-repository openshift-pipelines/pipelines-as-code --token ${HUB_TOKEN} -f release.k8s.yaml:release.k8s.yaml -f release.yaml:release.yaml -f nightly:docs/content/VERSION
-              workingDir: $(workspaces.source.path)
+                python hack/upload-file-to-github.py --message "Release yaml generated from {{repo_url}}/commit/{{revision}}" --from-ref refs/heads/main --to-ref refs/heads/nightly --owner-repository openshift-pipelines/pipelines-as-code --token ${HUB_TOKEN} -f release.k8s.yaml:release.k8s.yaml -f release.yaml:release.yaml -f nightly:docs/content/VERSION -f "nightly-$ssa-$(date +%Y%m%d):pkg/params/version/version.txt"
           workspaces:
             - name: source
         workspaces:

--- a/.tekton/release-pipeline.yaml
+++ b/.tekton/release-pipeline.yaml
@@ -77,8 +77,8 @@ spec:
                   env TARGET_OPENSHIFT=true bash hack/generate-releaseyaml.sh > /tmp/release.yaml
                   msg="pac release ${version} on branch ${target}"
                   set +x
-                  echo python hack/upload-file-to-github.py --message "Release yaml generated for ${msg}" --owner-repository openshift-pipelines/pipelines-as-code --token "TOKEN" --to-ref=refs/heads/${target} --from-ref=refs/tags/${version} -f release.k8s.yaml:release.k8s.yaml -f release.yaml:release.yaml -f ${TARGET_BRANCH}:docs/content/VERSION
-                  python hack/upload-file-to-github.py --message "Release yaml generated for ${msg}" --owner-repository openshift-pipelines/pipelines-as-code --token ${HUB_TOKEN} --to-ref=refs/heads/${target} --from-ref=refs/tags/${version} -f /tmp/release.k8s.yaml:release.k8s.yaml -f /tmp/release.yaml:release.yaml -f ${TARGET_BRANCH}:docs/content/VERSION
+                  echo python hack/upload-file-to-github.py --message "Release yaml generated for ${msg}" --owner-repository openshift-pipelines/pipelines-as-code --token "TOKEN" --to-ref=refs/heads/${target} --from-ref=refs/tags/${version} -f release.k8s.yaml:release.k8s.yaml -f release.yaml:release.yaml -f ${TARGET_BRANCH}:docs/content/VERSION -f "${version}:pkg/params/version/version.txt"
+                  python hack/upload-file-to-github.py --message "Release yaml generated for ${msg}" --owner-repository openshift-pipelines/pipelines-as-code --token ${HUB_TOKEN} --to-ref=refs/heads/${target} --from-ref=refs/tags/${version} -f /tmp/release.k8s.yaml:release.k8s.yaml -f /tmp/release.yaml:release.yaml -f ${TARGET_BRANCH}:docs/content/VERSION -f "${version}:pkg/params/version/version.txt"
                   set -x
                 done
       - name: gorelease

--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -66,7 +67,7 @@ func (l *listener) Start(ctx context.Context) error {
 	if envAdapterPort != "" {
 		adapterPort = envAdapterPort
 	}
-	l.logger.Infof("Starting Pipelines as Code version: %s", version.Version)
+	l.logger.Infof("Starting Pipelines as Code version: %s", strings.TrimSpace(version.Version))
 
 	mux := http.NewServeMux()
 

--- a/pkg/cmd/tknpac/version/version.go
+++ b/pkg/cmd/tknpac/version/version.go
@@ -2,6 +2,7 @@ package version
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
@@ -14,7 +15,7 @@ func Command(ioStreams *cli.IOStreams) *cobra.Command {
 		Use:   "version",
 		Short: fmt.Sprintf("Print %s pac version", settings.TknBinaryName),
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Fprintln(ioStreams.Out, version.Version)
+			fmt.Fprintln(ioStreams.Out, strings.TrimSpace(version.Version))
 		},
 		Annotations: map[string]string{
 			"commandType": "main",

--- a/pkg/formatting/k8labels.go
+++ b/pkg/formatting/k8labels.go
@@ -12,5 +12,6 @@ import "strings"
 // '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
 func CleanValueKubernetes(s string) string {
 	replasoeur := strings.NewReplacer("/", "-", " ", "_", "[", "__", "]", "__")
-	return replasoeur.Replace(strings.TrimRight(s, " -_[]"))
+	replaced := replasoeur.Replace(strings.TrimRight(s, " -_[]"))
+	return strings.TrimSpace(replaced)
 }

--- a/pkg/formatting/k8labels_test.go
+++ b/pkg/formatting/k8labels_test.go
@@ -28,6 +28,11 @@ func TestK8LabelsCleanup(t *testing.T) {
 			str:  "MBAPPEvsMESSI--",
 			want: "MBAPPEvsMESSI",
 		},
+		{
+			name: "remove new line",
+			str:  "foo\n",
+			want: "foo",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/kubeinteraction/labels.go
+++ b/pkg/kubeinteraction/labels.go
@@ -26,7 +26,7 @@ func AddLabelsAndAnnotations(event *info.Event, pipelineRun *tektonv1.PipelineRu
 		// These keys are used in LabelSelector query so we are keeping in Labels as it is.
 		// But adding same keys to Annotations so UI/CLI can fetch the actual value instead of modified value
 		"app.kubernetes.io/managed-by": pipelinesascode.GroupName,
-		"app.kubernetes.io/version":    version.Version,
+		"app.kubernetes.io/version":    formatting.CleanValueKubernetes(version.Version),
 		keys.URLOrg:                    formatting.CleanValueKubernetes(event.Organization),
 		keys.URLRepository:             formatting.CleanValueKubernetes(event.Repository),
 		keys.SHA:                       formatting.CleanValueKubernetes(event.SHA),

--- a/pkg/params/version/version.go
+++ b/pkg/params/version/version.go
@@ -1,4 +1,6 @@
 package version
 
-// Version is dynamically set by the toolchain or overridden by the Makefile.
-var Version = "nightly"
+import _ "embed"
+
+//go:embed version.txt
+var Version string

--- a/pkg/params/version/version.txt
+++ b/pkg/params/version/version.txt
@@ -1,0 +1,1 @@
+nightly


### PR DESCRIPTION
set it on release or nightly directly, so docker/cpaas and other who
don't use the make target or goreleaser works

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
