### PR TITLE
Make target_url and source_url field available in cel 

### DIFF
--- a/docs/content/docs/guide/authoringprs.md
+++ b/docs/content/docs/guide/authoringprs.md
@@ -149,6 +149,9 @@ The fields available are :
 * `target_branch`: The branch we are targeting.
 * `source_branch`: The branch where this pull_request come from. (on `push` this
   is the same as `target_branch`).
+* `target_url`: The url of the repository we are targeting.
+* `source_url`: The url of the repository where this pull_request come from. (on `push` this
+  is the same as `target_url`).
 * `event_title`: Match the title of the event. When doing a push this will match
   the commit title and when matching on PR it will match the Pull or Merge
   Request title. (only `GitHub`, `Gitlab` and `BitbucketCloud` providers are supported)

--- a/pkg/matcher/cel.go
+++ b/pkg/matcher/cel.go
@@ -43,6 +43,8 @@ func celEvaluate(ctx context.Context, expr string, event *info.Event, vcx provid
 		"event_title":   eventTitle,
 		"target_branch": event.BaseBranch,
 		"source_branch": event.HeadBranch,
+		"target_url":    event.BaseURL,
+		"source_url":    event.HeadURL,
 	}
 
 	env, err := cel.NewEnv(
@@ -51,7 +53,9 @@ func celEvaluate(ctx context.Context, expr string, event *info.Event, vcx provid
 			decls.NewVar("event", decls.String),
 			decls.NewVar("event_title", decls.String),
 			decls.NewVar("target_branch", decls.String),
-			decls.NewVar("source_branch", decls.String)))
+			decls.NewVar("source_branch", decls.String),
+			decls.NewVar("target_url", decls.String),
+			decls.NewVar("source_url", decls.String)))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/params/info/events.go
+++ b/pkg/params/info/events.go
@@ -27,6 +27,8 @@ type Event struct {
 	BaseBranch        string // branch against where we are making the PR
 	DefaultBranch     string // master/main branches to know where things like the OWNERS file is located.
 	HeadBranch        string // branch from where our SHA get tested
+	BaseURL           string // url against where we are making the PR
+	HeadURL           string // url from where our SHA get tested
 	SHA               string
 	Sender            string
 	URL               string // WEB url not the git URL, which would match to the repo.spec

--- a/pkg/provider/bitbucketcloud/parse_payload.go
+++ b/pkg/provider/bitbucketcloud/parse_payload.go
@@ -155,6 +155,8 @@ func (v *Provider) ParsePayload(ctx context.Context, run *params.Run, request *h
 		processedEvent.URL = e.Repository.Links.HTML.HRef
 		processedEvent.BaseBranch = e.PullRequest.Destination.Branch.Name
 		processedEvent.HeadBranch = e.PullRequest.Source.Branch.Name
+		processedEvent.BaseURL = e.PullRequest.Destination.Repository.Links.HTML.HRef
+		processedEvent.HeadURL = e.PullRequest.Source.Repository.Links.HTML.HRef
 		processedEvent.AccountID = e.PullRequest.Author.AccountID
 		processedEvent.Sender = e.PullRequest.Author.Nickname
 		processedEvent.PullRequestNumber = e.PullRequest.ID
@@ -168,6 +170,8 @@ func (v *Provider) ParsePayload(ctx context.Context, run *params.Run, request *h
 		processedEvent.URL = e.Repository.Links.HTML.HRef
 		processedEvent.BaseBranch = e.Push.Changes[0].New.Name
 		processedEvent.HeadBranch = e.Push.Changes[0].Old.Name
+		processedEvent.BaseURL = e.Push.Changes[0].New.Target.Links.HTML.HRef
+		processedEvent.HeadURL = e.Push.Changes[0].Old.Target.Links.HTML.HRef
 		processedEvent.AccountID = e.Actor.AccountID
 		processedEvent.Sender = e.Actor.Nickname
 	default:

--- a/pkg/provider/bitbucketcloud/types/types.go
+++ b/pkg/provider/bitbucketcloud/types/types.go
@@ -29,7 +29,9 @@ type Branch struct {
 }
 
 type Destination struct {
-	Branch Branch `json:"branch"`
+	Branch     Branch     `json:"branch"`
+	Commit     Commit     `json:"commit"`
+	Repository Repository `json:"repository"`
 }
 
 type Commit struct {
@@ -40,8 +42,9 @@ type Commit struct {
 }
 
 type Source struct {
-	Branch Branch `json:"branch"`
-	Commit Commit `json:"commit"`
+	Branch     Branch     `json:"branch"`
+	Commit     Commit     `json:"commit"`
+	Repository Repository `json:"repository"`
 }
 
 type PullRequest struct {

--- a/pkg/provider/bitbucketserver/parse_payload.go
+++ b/pkg/provider/bitbucketserver/parse_payload.go
@@ -78,6 +78,8 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 		processedEvent.URL = e.PulRequest.ToRef.Repository.Links.Self[0].Href
 		processedEvent.BaseBranch = e.PulRequest.ToRef.DisplayID
 		processedEvent.HeadBranch = e.PulRequest.FromRef.DisplayID
+		processedEvent.BaseURL = e.PulRequest.ToRef.Repository.Links.Self[0].Href
+		processedEvent.HeadURL = e.PulRequest.FromRef.Repository.Links.Self[0].Href
 		processedEvent.AccountID = fmt.Sprintf("%d", e.Actor.ID)
 		processedEvent.Sender = e.Actor.Name
 		for _, value := range e.PulRequest.FromRef.Repository.Links.Clone {
@@ -95,6 +97,8 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 		processedEvent.URL = e.Repository.Links.Self[0].Href
 		processedEvent.BaseBranch = e.Changes[0].RefID
 		processedEvent.HeadBranch = e.Changes[0].RefID
+		processedEvent.BaseURL = e.Repository.Links.Self[0].Href
+		processedEvent.HeadURL = e.Repository.Links.Self[0].Href
 		processedEvent.AccountID = fmt.Sprintf("%d", e.Actor.ID)
 		processedEvent.Sender = e.Actor.Name
 		// Should we care about clone via SSH or just only do HTTP clones?

--- a/pkg/provider/bitbucketserver/test/test.go
+++ b/pkg/provider/bitbucketserver/test/test.go
@@ -296,6 +296,11 @@ func MakePREvent(event *info.Event, comment string) *types.PullRequestEvent {
 						Clone []bbv1.CloneLink "json:\"clone,omitempty\""
 						Self  []bbv1.SelfLink  "json:\"self,omitempty\""
 					}{
+						Self: []bbv1.SelfLink{
+							{
+								Href: event.HeadURL,
+							},
+						},
 						Clone: []bbv1.CloneLink{
 							{
 								Name: "http",

--- a/pkg/provider/gitea/parse_payload.go
+++ b/pkg/provider/gitea/parse_payload.go
@@ -41,6 +41,8 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 		processedEvent.SHAURL = fmt.Sprintf("%s/commit/%s", gitEvent.PullRequest.HTMLURL, processedEvent.SHA)
 		processedEvent.HeadBranch = gitEvent.PullRequest.Head.Ref
 		processedEvent.BaseBranch = gitEvent.PullRequest.Base.Ref
+		processedEvent.HeadURL = gitEvent.PullRequest.Head.Repository.HTMLURL
+		processedEvent.BaseURL = gitEvent.PullRequest.Base.Repository.HTMLURL
 		processedEvent.PullRequestNumber = int(gitEvent.Index)
 		processedEvent.PullRequestTitle = gitEvent.PullRequest.Title
 		processedEvent.Organization = gitEvent.Repository.Owner.UserName
@@ -66,6 +68,8 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 		processedEvent.BaseBranch = gitEvent.Ref
 		processedEvent.EventType = eventType
 		processedEvent.HeadBranch = processedEvent.BaseBranch // in push events Head Branch is the same as Basebranch
+		processedEvent.BaseURL = gitEvent.Repo.HTMLURL
+		processedEvent.HeadURL = processedEvent.BaseURL // in push events Head URL is the same as BaseURL
 		processedEvent.TriggerTarget = "push"
 	case *giteastruct.IssueCommentPayload:
 		if gitEvent.Issue.PullRequest == nil {

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -396,6 +396,8 @@ func (v *Provider) getPullRequest(ctx context.Context, runevent *info.Event) (*i
 	}
 	runevent.HeadBranch = pr.GetHead().GetRef()
 	runevent.BaseBranch = pr.GetBase().GetRef()
+	runevent.HeadURL = pr.GetHead().GetRepo().GetHTMLURL()
+	runevent.BaseURL = pr.GetBase().GetRepo().GetHTMLURL()
 	runevent.EventType = "pull_request"
 
 	v.RepositoryIDs = []int64{

--- a/pkg/provider/github/parse_payload.go
+++ b/pkg/provider/github/parse_payload.go
@@ -243,6 +243,8 @@ func (v *Provider) processEvent(ctx context.Context, event *info.Event, eventInt
 		processedEvent.BaseBranch = gitEvent.GetRef()
 		processedEvent.EventType = event.TriggerTarget
 		processedEvent.HeadBranch = processedEvent.BaseBranch // in push events Head Branch is the same as Basebranch
+		processedEvent.BaseURL = gitEvent.GetRepo().GetHTMLURL()
+		processedEvent.HeadURL = processedEvent.BaseURL // in push events Head URL is the same as BaseURL
 	case *github.PullRequestEvent:
 		processedEvent = info.NewEvent()
 		processedEvent.Repository = gitEvent.GetRepo().GetName()
@@ -252,6 +254,8 @@ func (v *Provider) processEvent(ctx context.Context, event *info.Event, eventInt
 		processedEvent.URL = gitEvent.GetRepo().GetHTMLURL()
 		processedEvent.BaseBranch = gitEvent.GetPullRequest().Base.GetRef()
 		processedEvent.HeadBranch = gitEvent.GetPullRequest().Head.GetRef()
+		processedEvent.BaseURL = gitEvent.GetPullRequest().Base.GetRepo().GetHTMLURL()
+		processedEvent.HeadURL = gitEvent.GetPullRequest().Head.GetRepo().GetHTMLURL()
 		processedEvent.Sender = gitEvent.GetPullRequest().GetUser().GetLogin()
 		processedEvent.EventType = event.EventType
 		processedEvent.PullRequestNumber = gitEvent.GetPullRequest().GetNumber()
@@ -278,9 +282,11 @@ func (v *Provider) handleReRequestEvent(ctx context.Context, event *github.Check
 	runevent.DefaultBranch = event.GetRepo().GetDefaultBranch()
 	runevent.SHA = event.GetCheckRun().GetCheckSuite().GetHeadSHA()
 	runevent.HeadBranch = event.GetCheckRun().GetCheckSuite().GetHeadBranch()
+	runevent.HeadURL = event.GetCheckRun().GetCheckSuite().GetRepository().GetHTMLURL()
 	// If we don't have a pull_request in this it probably mean a push
 	if len(event.GetCheckRun().GetCheckSuite().PullRequests) == 0 {
 		runevent.BaseBranch = runevent.HeadBranch
+		runevent.BaseURL = runevent.HeadURL
 		runevent.EventType = "push"
 		// we allow the rerequest user here, not the push user, i guess it's
 		// fine because you can't do a rereq without being a github owner?
@@ -301,10 +307,12 @@ func (v *Provider) handleCheckSuites(ctx context.Context, event *github.CheckSui
 	runevent.DefaultBranch = event.GetRepo().GetDefaultBranch()
 	runevent.SHA = event.GetCheckSuite().GetHeadSHA()
 	runevent.HeadBranch = event.GetCheckSuite().GetHeadBranch()
+	runevent.HeadURL = event.GetCheckSuite().GetRepository().GetHTMLURL()
 	// If we don't have a pull_request in this it probably mean a push
 	// we are not able to know which
 	if len(event.GetCheckSuite().PullRequests) == 0 {
 		runevent.BaseBranch = runevent.HeadBranch
+		runevent.BaseURL = runevent.HeadURL
 		runevent.EventType = "push"
 		runevent.TriggerTarget = "push"
 		// we allow the rerequest user here, not the push user, i guess it's

--- a/pkg/provider/gitlab/parse_payload.go
+++ b/pkg/provider/gitlab/parse_payload.go
@@ -43,6 +43,8 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 		processedEvent.SHATitle = gitEvent.ObjectAttributes.Title
 		processedEvent.HeadBranch = gitEvent.ObjectAttributes.SourceBranch
 		processedEvent.BaseBranch = gitEvent.ObjectAttributes.TargetBranch
+		processedEvent.HeadURL = gitEvent.ObjectAttributes.Source.WebURL
+		processedEvent.BaseURL = gitEvent.ObjectAttributes.Target.WebURL
 		processedEvent.PullRequestNumber = gitEvent.ObjectAttributes.IID
 		processedEvent.PullRequestTitle = gitEvent.ObjectAttributes.Title
 		v.targetProjectID = gitEvent.Project.ID
@@ -67,6 +69,8 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 		processedEvent.SHATitle = gitEvent.Commits[0].Title
 		processedEvent.HeadBranch = gitEvent.Ref
 		processedEvent.BaseBranch = gitEvent.Ref
+		processedEvent.HeadURL = gitEvent.Project.WebURL
+		processedEvent.BaseURL = processedEvent.HeadURL
 		processedEvent.TriggerTarget = "push"
 		v.pathWithNamespace = gitEvent.Project.PathWithNamespace
 		processedEvent.Organization, processedEvent.Repository = getOrgRepo(v.pathWithNamespace)
@@ -86,6 +90,8 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 		processedEvent.SHATitle = gitEvent.MergeRequest.LastCommit.Message
 		processedEvent.BaseBranch = gitEvent.MergeRequest.TargetBranch
 		processedEvent.HeadBranch = gitEvent.MergeRequest.SourceBranch
+		processedEvent.BaseURL = gitEvent.MergeRequest.Target.WebURL
+		processedEvent.HeadURL = gitEvent.MergeRequest.Source.WebURL
 		// if it is a /test or /retest comment with pipelinerun name figure out the pipelineRun name
 		if provider.IsTestRetestComment(gitEvent.ObjectAttributes.Note) {
 			processedEvent.TargetTestPipelineRun = provider.GetPipelineRunFromTestComment(gitEvent.ObjectAttributes.Note)

--- a/pkg/provider/gitlab/test/test.go
+++ b/pkg/provider/gitlab/test/test.go
@@ -102,9 +102,9 @@ func MuxGetFile(mux *http.ServeMux, pid int, fname, content string) {
 }
 
 type TEvent struct {
-	Username, DefaultBranch, URL, SHA, SHAurl, SHAtitle, Headbranch, Basebranch string
-	UserID, MRID, TargetProjectID, SourceProjectID                              int
-	PathWithNameSpace, Comment                                                  string
+	Username, DefaultBranch, URL, SHA, SHAurl, SHAtitle, Headbranch, Basebranch, HeadURL, BaseURL string
+	UserID, MRID, TargetProjectID, SourceProjectID                                                int
+	PathWithNameSpace, Comment                                                                    string
 }
 
 func (t TEvent) PushEventAsJSON(withcommits bool) string {
@@ -163,9 +163,15 @@ func (t TEvent) NoteEventAsJSON(comment string) string {
             "url": "%s://gitlab.com/pac-chmou/pac-group/-/commit/e29c24f4b6000cf0c2eae3b8bc588cb855b67756",
             "title": "%s",
             "message": "%s"
-        }
+        },
+		"target": {
+			"web_url": "%s"
+		},
+		"source": {
+			"web_url": "%s"
+		}
     }
-}`, comment, t.Username, t.DefaultBranch, t.URL, t.PathWithNameSpace, t.MRID, t.TargetProjectID, t.SourceProjectID, t.Basebranch, t.Headbranch, t.SHA, t.SHAurl, t.SHAtitle, t.SHAtitle)
+}`, comment, t.Username, t.DefaultBranch, t.URL, t.PathWithNameSpace, t.MRID, t.TargetProjectID, t.SourceProjectID, t.Basebranch, t.Headbranch, t.SHA, t.SHAurl, t.SHAtitle, t.SHAtitle, t.BaseURL, t.HeadURL)
 }
 
 func (t TEvent) MREventAsJSON() string {
@@ -191,9 +197,13 @@ func (t TEvent) MREventAsJSON() string {
             "url": "%s"
         },
 		"target": {
-			"path_with_namespace": "%s"
+			"path_with_namespace": "%s",
+			"web_url": "%s"
+		},
+		"source": {
+			"web_url": "%s"
 		}
     }
 }`, t.UserID, t.Username, t.TargetProjectID, t.URL, t.DefaultBranch, t.MRID,
-		t.SourceProjectID, t.SHAtitle, t.Headbranch, t.Basebranch, t.SHA, t.SHAurl, t.PathWithNameSpace)
+		t.SourceProjectID, t.SHAtitle, t.Headbranch, t.Basebranch, t.SHA, t.SHAurl, t.PathWithNameSpace, t.BaseURL, t.HeadURL)
 }

--- a/test/pkg/github/pr.go
+++ b/test/pkg/github/pr.go
@@ -121,7 +121,8 @@ func RunPullRequest(ctx context.Context, t *testing.T, label string, yamlFiles [
 		yamlEntries[filepath.Join(".tekton", filepath.Base(v))] = v
 	}
 
-	entries, err := payload.GetEntries(yamlEntries, targetNS, options.MainBranch, options.PullRequestEvent, map[string]string{})
+	entries, err := payload.GetEntries(yamlEntries, targetNS, options.MainBranch, options.PullRequestEvent,
+		map[string]string{"TargetURL": repoinfo.GetHTMLURL(), "SourceURL": repoinfo.GetHTMLURL()})
 	assert.NilError(t, err)
 
 	targetRefName := fmt.Sprintf("refs/heads/%s",

--- a/test/testdata/pipelinerun-cel-annotation.yaml
+++ b/test/testdata/pipelinerun-cel-annotation.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
     pipelinesascode.tekton.dev/on-cel-expression: |
-      target_branch == "\\ .TargetBranch //" && event == "\\ .TargetEvent //"
+      target_branch == "\\ .TargetBranch //" && event == "\\ .TargetEvent //" && target_url == "\\ .TargetURL //" && source_url == "\\ .SourceURL //"
 spec:
   pipelineSpec:
     tasks:


### PR DESCRIPTION
This will make target_url and self_url field available to be used in cel expression
which have the url of the respective repository and can be used to filter the
events for specific run to be trigger or not

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
