### PR TITLE
add workspace.source.dir as safe for git

### DIFF
--- a/.tekton/generate-coverage-release.yaml
+++ b/.tekton/generate-coverage-release.yaml
@@ -116,6 +116,7 @@ spec:
               script: |
                 #!/usr/bin/env bash
                 set -eux
+                git config --global --add safe.directory $(workspaces.source.path)
                 ssa=$(git rev-parse --short HEAD)
                 bash hack/generate-releaseyaml.sh > release.k8s.yaml
                 env TARGET_OPENSHIFT=true bash hack/generate-releaseyaml.sh > release.yaml

--- a/config/302-pac-configmap.yaml
+++ b/config/302-pac-configmap.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 # See https://pipelinesascode.com/docs/install/settings/ for the complete
-# documentation of all the settings.
+# documentation of all settings.
 
 apiVersion: v1
 data:


### PR DESCRIPTION
or we will get an error like this:

```
++ git rev-parse --short HEAD
fatal: detected dubious ownership in repository at '/workspace/source'
To add an exception for this directory, call:

	git config --global --add safe.directory /workspace/source
+ ssa=
```

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
