### PR TITLE
don't just list the public members of a org

### DIFF
--- a/docs/content/docs/guide/running.md
+++ b/docs/content/docs/guide/running.md
@@ -17,7 +17,7 @@ with that PipelineRun, and it will run if the following conditions are met:
 
   - The author is the owner of the repository.
   - The author is a collaborator on the repository.
-  - The author is a public member on the organization of the repository.
+  - The author is a member (public or private) on the repository's organization.
   - The author has permissions to push to branches inside the repository.
   - The pull request author is inside an OWNER file located in the
   repository root on the main branch (the main branch as defined in the GitHub

--- a/pkg/pipelineascode/pipelineascode_test.go
+++ b/pkg/pipelineascode/pipelineascode_test.go
@@ -69,7 +69,7 @@ func testSetupCommonGhReplies(t *testing.T, mux *http.ServeMux, runevent info.Ev
 		jj)
 
 	if !noReplyOrgPublicMembers {
-		mux.HandleFunc("/orgs/"+runevent.Organization+"/public_members", func(rw http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("/orgs/"+runevent.Organization+"/members", func(rw http.ResponseWriter, r *http.Request) {
 			_, _ = fmt.Fprintf(rw, `[{"login": "%s"}]`, runevent.Sender)
 		})
 	}

--- a/pkg/provider/github/acl.go
+++ b/pkg/provider/github/acl.go
@@ -141,9 +141,7 @@ func (v *Provider) checkPullRequestForSameURL(ctx context.Context, runevent *inf
 // only get the one that the user sets as public 🤷
 func (v *Provider) checkSenderOrgMembership(ctx context.Context, runevent *info.Event) (bool, error) {
 	users, resp, err := v.Client.Organizations.ListMembers(ctx, runevent.Organization,
-		&github.ListMembersOptions{
-			PublicOnly: true, // We can't list private member in a org
-		})
+		&github.ListMembersOptions{})
 	// If we are 404 it means we are checking a repo owner and not a org so let's bail out with grace
 	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		return false, nil

--- a/pkg/provider/github/acl_test.go
+++ b/pkg/provider/github/acl_test.go
@@ -148,11 +148,11 @@ func TestAclCheckAll(t *testing.T) {
 
 	errit := "err"
 
-	mux.HandleFunc("/orgs/"+orgallowed+"/public_members", func(rw http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/"+orgallowed+"/members", func(rw http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(rw, `[{"login": "login_%s"}]`, orgallowed)
 	})
 
-	mux.HandleFunc("/orgs/"+orgdenied+"/public_members", func(rw http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/"+orgdenied+"/members", func(rw http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(rw, `[]`)
 	})
 
@@ -160,11 +160,11 @@ func TestAclCheckAll(t *testing.T) {
 		fmt.Fprint(rw, `[]`)
 	})
 
-	mux.HandleFunc("/orgs/"+errit+"/public_members", func(rw http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/"+errit+"/members", func(rw http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(rw, `x1x`)
 	})
 
-	mux.HandleFunc("/orgs/"+repoOwnerFileAllowed+"/public_members", func(rw http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/"+repoOwnerFileAllowed+"/members", func(rw http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(rw, `[]`)
 	})
 	mux.HandleFunc("/repos/"+repoOwnerFileAllowed+"/collaborators", func(rw http.ResponseWriter, r *http.Request) {

--- a/pkg/provider/github/github_test.go
+++ b/pkg/provider/github/github_test.go
@@ -335,7 +335,7 @@ func TestCheckSenderOrgMembership(t *testing.T) {
 			gprovider := Provider{
 				Client: fakeclient,
 			}
-			mux.HandleFunc(fmt.Sprintf("/orgs/%s/public_members", tt.runevent.Organization), func(rw http.ResponseWriter, r *http.Request) {
+			mux.HandleFunc(fmt.Sprintf("/orgs/%s/members", tt.runevent.Organization), func(rw http.ResponseWriter, r *http.Request) {
 				fmt.Fprint(rw, tt.apiReturn)
 			})
 


### PR DESCRIPTION
There was previously an issue with the API call where only public
members of a org could get listed, this don't seem to be the case
anymore as per
https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#list-organization-members
and now concealed users from a org will be allowed.

https://issues.redhat.com/browse/SRVKP-3090

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
