### PR TITLE
DNM Add setting to only trusts users from repo

### DIFF
--- a/config/300-repositories.yaml
+++ b/config/300-repositories.yaml
@@ -70,6 +70,9 @@ spec:
                   description: Settings relative to the Repository
                   type: object
                   properties:
+                    only_trusts_users_from_repository:
+                      type: boolean
+                      description: Only trusts users from the repository. For example on GitHub do not trust the users from the organisation.
                     github_app_token_scope_repos:
                       type: array
                       items:

--- a/docs/content/docs/guide/repositorycrd.md
+++ b/docs/content/docs/guide/repositorycrd.md
@@ -327,7 +327,7 @@ a `github_app_token_scope_repos` spec configuration in the `Repository` custom r
     kind: ConfigMap
     metadata:
       name: pipelines-as-code
-      namespace: pipelines-as-code    
+      namespace: pipelines-as-code
     data:
       secret-github-app-scope-extra-repos: "owner2/project2, owner3/project3"
     ```
@@ -343,7 +343,7 @@ a `github_app_token_scope_repos` spec configuration in the `Repository` custom r
      spec:
        url: "https://github.com/linda/project"
        settings:
-         github_app_token_scope_repos: 
+         github_app_token_scope_repos:
          - "owner/project"
          - "owner1/project1"
     ```
@@ -375,7 +375,7 @@ and the scoping fails for the repository level configuration because the reposit
   kind: ConfigMap
   metadata:
     name: pipelines-as-code
-    namespace: pipelines-as-code  
+    namespace: pipelines-as-code
   data:
     secret-github-app-scope-extra-repos: "owner5/project5"
   ```
@@ -388,7 +388,7 @@ and the scoping fails for the repository level configuration because the reposit
     namespace: test-repo
   spec:
     url: "https://github.com/linda/project"
-    setting
+    settings:
       github_app_token_scope_repos:
       - "owner5/project5"
   ```
@@ -398,3 +398,28 @@ and the scoping fails for the repository level configuration because the reposit
   ```yaml
   failed to scope github token as repo owner5/project5 does not exist in namespace test-repo
   ```
+
+### Don't automatically allow the users from the organisation to start Pipelines-as-Code on a Repository
+
+By default, when using for example the GitHub provider, if your repository is
+belong to an organization, the users belonging to that organization
+are granted automatic permissions to initiate the pipelines. However,
+considering the potential existence of malicious users within a large organization
+and the need to exercise caution, there may be certain repositories for which we
+do not wish to extend trust to everyone.
+
+To address this, you have the option to deactivate this functionality by
+configuring the repository settings and setting the
+`only_trusts_users_from_repository` parameter to `true`.
+
+```yaml
+apiVersion: "pipelinesascode.tekton.dev/v1alpha1"
+kind: Repository
+metadata:
+  name: test
+  namespace: test-repo
+spec:
+  url: "https://github.com/linda/project"
+  settings:
+    only_trusts_users_from_repository: true
+```

--- a/docs/content/docs/guide/repositorycrd.md
+++ b/docs/content/docs/guide/repositorycrd.md
@@ -423,3 +423,7 @@ spec:
   settings:
     only_trusts_users_from_repository: true
 ```
+
+{{< hint info >}}
+This works with GitHub Application, GitHub Webhook and Gitlab providers.
+{{< /hint >}}

--- a/pkg/apis/pipelinesascode/v1alpha1/types.go
+++ b/pkg/apis/pipelinesascode/v1alpha1/types.go
@@ -79,8 +79,9 @@ type RepositorySpec struct {
 }
 
 type Settings struct {
-	GithubAppTokenScopeRepos []string `json:"github_app_token_scope_repos,omitempty"`
-	PipelineRunProvenance    string   `json:"pipelinerun_provenance,omitempty"`
+	OnlyTrustsUsersFromRepository bool     `json:"only_trusts_users_from_repository,omitempty"`
+	GithubAppTokenScopeRepos      []string `json:"github_app_token_scope_repos,omitempty"`
+	PipelineRunProvenance         string   `json:"pipelinerun_provenance,omitempty"`
 }
 
 type Params struct {

--- a/pkg/params/info/events.go
+++ b/pkg/params/info/events.go
@@ -1,6 +1,10 @@
 package info
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+)
 
 type Event struct {
 	State
@@ -56,6 +60,7 @@ type Event struct {
 	// Gitlab
 	SourceProjectID int
 	TargetProjectID int
+	Settings        *v1alpha1.Settings
 }
 
 type State struct {

--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -60,6 +60,8 @@ func (p *PacRun) verifyRepoAndUser(ctx context.Context) (*v1alpha1.Repository, e
 		return nil, nil
 	}
 
+	// set repo settings in context
+	p.event.Settings = repo.Spec.Settings
 	p.logger = p.logger.With("namespace", repo.Namespace)
 	p.vcx.SetLogger(p.logger)
 	p.eventEmitter.SetLogger(p.logger)

--- a/pkg/provider/gitlab/test/test.go
+++ b/pkg/provider/gitlab/test/test.go
@@ -52,8 +52,12 @@ func MuxNotePost(t *testing.T, mux *http.ServeMux, projectNumber, mrID int, catc
 	})
 }
 
-func MuxAllowUserID(mux *http.ServeMux, projectID, userID int) {
-	path := fmt.Sprintf("/projects/%d/members/all/%d", projectID, userID)
+func MuxAllowUserID(mux *http.ServeMux, projectID, userID int, inherited bool) {
+	d := ""
+	if inherited {
+		d = "/all"
+	}
+	path := fmt.Sprintf("/projects/%d/members%s/%d", projectID, d, userID)
 	mux.HandleFunc(path, func(rw http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(rw, `{"id": %d}`, userID)
 	})

--- a/test/pkg/gitea/scm.go
+++ b/test/pkg/gitea/scm.go
@@ -156,6 +156,15 @@ func GetIssueTimeline(ctx context.Context, topts *TestOpts) (Timelines, error) {
 	return tls, nil
 }
 
+func CreateGiteaOrg(giteaClient *gitea.Client, org, user string) (*gitea.Organization, error) {
+	ret, _, err := giteaClient.AdminCreateOrg(user, gitea.CreateOrgOption{
+		Name:                      org,
+		Visibility:                "public",
+		RepoAdminChangeTeamAccess: false,
+	})
+	return ret, err
+}
+
 func CreateGiteaRepo(giteaClient *gitea.Client, user, name, hookURL string) (*gitea.Repository, error) {
 	// Create a new repo
 	repo, _, err := giteaClient.AdminCreateRepo(user, gitea.CreateRepoOption{


### PR DESCRIPTION
By default, when using for example the GitHub provider, if your repository is belong to an organization, the users belonging to that organization are granted automatic permissions to initiate the pipelines. However, considering the potential existence of malicious users within a large organization and the need to exercise caution, there may be certain repositories for which we do not wish to extend trust to everyone.

To address this, you have the option to deactivate this functionality by configuring the repository settings and setting the `only_trusts_users_from_repository` parameter to `true`.

example:
```yaml
spec:
  settings:
    only_trusts_users_from_repository: true
```

E2E i snot something possible to do without a custom github org/custom users that is not part of it and token etc... so skipping it :\

Need some R&D for other providers as not understanding very well how the ACL works there compared to Github/Gitlab

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
