### PR TITLE
tkn pac resolver fixes

### DIFF
--- a/.tekton/doc.yaml
+++ b/.tekton/doc.yaml
@@ -57,7 +57,7 @@ spec:
                 echo "Preview URL: ${url}"
             - name: upload-to-static-server
               # it has curl and we already pulled it
-              image: mirror.gcr.io/curlimages/curl:7.85.0
+              image: curlimages/curl
               workingDir: $(workspaces.source.path)
               env:
                 - name: HUB_TOKEN

--- a/docs/content/docs/guide/cli.md
+++ b/docs/content/docs/guide/cli.md
@@ -294,6 +294,12 @@ to push it first before using `tkn pac resolve|kubectl create -`.
 Compared with running directly on CI, you need to explicitly specify the list of
 filenames or directory where you have the templates.
 
+On certain clusters, the conversion from v1beta1 to v1 in Tekton may not
+function correctly, leading to errors when applying the resolved PipelineRun on
+a different cluster that doesn't have the bundle feature enabled. To resolve
+this issue, you can use the `--v1beta1` flag (or `-B` for short) to explicitly
+output the PipelineRun as v1beta1 and work around the error.
+
 When you run the resolver it will try to detect if you have a `{{
 git_auth_secret }}` string inside your template and if there is a match it will
 ask you to provide a Git provider token.

--- a/pkg/cmd/tknpac/resolve/basic_auth_secret_test.go
+++ b/pkg/cmd/tknpac/resolve/basic_auth_secret_test.go
@@ -25,11 +25,15 @@ func TestDetectWebhookSecret(t *testing.T) {
 		want    bool
 	}{
 		{
-			name:    "detects webhook secret",
-			content: basicAuthSecretString,
+			name:    "detects webhook secret single quote",
+			content: "secretName: '{{ git_auth_secret }}'",
 			want:    true,
 		},
-
+		{
+			name:    "detects webhook secret no quote",
+			content: "secretName: {{ git_auth_secret }}",
+			want:    true,
+		},
 		{
 			name:    "not webhook secret detected",
 			content: "foobar",

--- a/pkg/cmd/tknpac/resolve/resolve.go
+++ b/pkg/cmd/tknpac/resolve/resolve.go
@@ -191,7 +191,7 @@ func resolveFilenames(ctx context.Context, cs *params.Run, filenames []string, p
 		SkipInlining:  skipInlining,
 		ProviderToken: providerToken,
 	}
-	allTemplates := enumerateFiles(filenames)
+	allTheYamls := expandYamlsAsSingleTemplate(filenames)
 	if !noSecret {
 		outSecret, secretName, err := makeGitAuthSecret(ctx, cs, filenames, ropt.ProviderToken, params)
 		if err != nil {
@@ -204,17 +204,17 @@ func resolveFilenames(ctx context.Context, cs *params.Run, filenames []string, p
 	}
 
 	// TODO: flags
-	allTemplates = templates.ReplacePlaceHoldersVariables(allTemplates, params)
+	allTheYamls = templates.ReplacePlaceHoldersVariables(allTheYamls, params)
 	// We use github here but since we don't do remotetask we would not care
 	providerintf := github.New()
 	event := info.NewEvent()
-	prun, err := resolve.Resolve(ctx, cs, cs.Clients.Log, providerintf, event, allTemplates, ropt)
+	prun, err := resolve.Resolve(ctx, cs, cs.Clients.Log, providerintf, event, allTheYamls, ropt)
 	if err != nil {
 		return "", err
 	}
 
 	// cleanedup regexp do as much as we can but really it's a lost game to try this
-	cleanRe := regexp.MustCompile(`\n(\t|\s)*(creationTimestamp|spec|taskRunTemplate|metadata|computeResources):\s*(null|{})\n`)
+	cleanRe := regexp.MustCompile(`\n(\t|\s)*(status|taskRunTemplate|creationTimestamp|spec|taskRunTemplate|metadata|computeResources):\s*(null|{})\n`)
 
 	for _, run := range prun {
 		run.APIVersion = tektonv1.SchemeGroupVersion.String()
@@ -241,25 +241,33 @@ func appendYaml(filename string) string {
 	return fmt.Sprintf("---\n%s", s)
 }
 
-func enumerateFiles(filenames []string) string {
-	var yamlDoc string
-	for _, paths := range filenames {
-		if stat, err := os.Stat(paths); err == nil && !stat.IsDir() {
-			yamlDoc += appendYaml(paths)
+// listAllYamls takes a list of paths and returns a list of all the yaml files in those paths even if they are in subdirectories
+func listAllYamls(paths []string) []string {
+	ret := []string{}
+
+	for _, path := range paths {
+		if stat, err := os.Stat(path); err == nil && !stat.IsDir() {
+			ret = append(ret, path)
 			continue
 		}
-
-		// walk dir getting all yamls
-		err := filepath.Walk(paths, func(path string, fi os.FileInfo, err error) error {
-			if filepath.Ext(path) == ".yaml" {
-				yamlDoc += appendYaml(path)
+		err := filepath.Walk(path, func(fname string, fi os.FileInfo, err error) error {
+			if filepath.Ext(fname) == ".yaml" {
+				ret = append(ret, fname)
 			}
 			return nil
 		})
 		if err != nil {
-			log.Fatalf("Error enumerating files: %v", err)
+			log.Fatalf("Error enumerating files in %s: %v", path, err)
 		}
 	}
+	return ret
+}
 
+// expandYamlsAsSingleTemplate takes a list of filenames and returns a single yaml
+func expandYamlsAsSingleTemplate(filenames []string) string {
+	var yamlDoc string
+	for _, paths := range listAllYamls(filenames) {
+		yamlDoc += appendYaml(paths)
+	}
 	return yamlDoc
 }

--- a/pkg/cmd/tknpac/resolve/resolve.go
+++ b/pkg/cmd/tknpac/resolve/resolve.go
@@ -149,7 +149,7 @@ func Command(run *params.Run, streams *cli.IOStreams) *cobra.Command {
 		"Params to resolve (ie: revision, repo_url)")
 
 	cmd.Flags().StringVarP(&output, "output", "o", "",
-		"Params to resolve (ie: revision, repo_url)")
+		"output to this file instead of stdout")
 
 	cmd.Flags().StringSliceVarP(&filenames, "filename", "f", filenames,
 		"Filename, directory, or URL to files to use to create the resource")

--- a/pkg/cmd/tknpac/resolve/resolve_test.go
+++ b/pkg/cmd/tknpac/resolve/resolve_test.go
@@ -106,7 +106,7 @@ func TestResolveFilenames(t *testing.T) {
 				t.Errorf("resolveFilenames() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			} else if !tt.wantErr {
-				golden.Assert(t, string(got), strings.ReplaceAll(fmt.Sprintf("%s.golden", t.Name()), "/", "-"))
+				golden.Assert(t, got, strings.ReplaceAll(fmt.Sprintf("%s.golden", t.Name()), "/", "-"))
 				assert.Assert(t, got != "")
 			}
 		})

--- a/pkg/cmd/tknpac/resolve/resolve_test.go
+++ b/pkg/cmd/tknpac/resolve/resolve_test.go
@@ -75,14 +75,21 @@ func TestResolveFilenames(t *testing.T) {
 	tmplSimpleWithPrefix := fmt.Sprintf("---\n%s", tmplSimpleNoPrefix)
 
 	tests := []struct {
-		name    string
-		tmpl    string
-		wantErr bool
+		name      string
+		tmpl      string
+		wantErr   bool
+		asv1beta1 bool
 	}{
 		{
 			name:    "Resolve templates no prefix",
 			tmpl:    tmplSimpleNoPrefix,
 			wantErr: false,
+		},
+		{
+			name:      "Resolve templates no prefix as v1beta1",
+			tmpl:      tmplSimpleNoPrefix,
+			wantErr:   false,
+			asv1beta1: true,
 		},
 		{
 			name:    "Resolve templates with prefix",
@@ -101,7 +108,7 @@ func TestResolveFilenames(t *testing.T) {
 				assertfs.WithFile("file.yaml", strings.ReplaceAll(tt.tmpl, "\t", "    ")))
 			defer dir.Remove()
 			ctx, _ := rtesting.SetupFakeContext(t)
-			got, err := resolveFilenames(ctx, cs, []string{dir.Path()}, map[string]string{"foo": "bar"})
+			got, err := resolveFilenames(ctx, cs, []string{dir.Path()}, map[string]string{"foo": "bar"}, tt.asv1beta1)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("resolveFilenames() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/cmd/tknpac/resolve/testdata/TestResolveFilenames-Resolve_templates_no_prefix_as_v1beta1.golden
+++ b/pkg/cmd/tknpac/resolve/testdata/TestResolveFilenames-Resolve_templates_no_prefix_as_v1beta1.golden
@@ -1,0 +1,21 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  annotations:
+    pipelinesascode.tekton.dev/original-prname: test
+  generateName: test-
+  labels:
+    pipelinesascode.tekton.dev/original-prname: test
+spec:
+  pipelineSpec:
+    tasks:
+    - name: bar
+      taskSpec:
+        spec: null
+        steps:
+        - image: alpine:3.7
+          name: hello-moto
+          resources: {}
+          script: echo hello moto
+

--- a/pkg/resolve/resolve.go
+++ b/pkg/resolve/resolve.go
@@ -44,44 +44,18 @@ func readTypes(ctx context.Context, log *zap.SugaredLogger, data string) (Types,
 		switch o := obj.(type) {
 		case *tektonv1beta1.Pipeline:
 			c := &tektonv1.Pipeline{}
-			// o.SetDefaults(ctx)
-			// this would fail on Validate otherwise
-			// if o.GetName() == "" {
-			// 	o.SetName(o.GetGenerateName())
-			// }
-			// ctx2 := features.SetFeatureFlag(context.Background())
-			// if err := o.Validate(ctx2); err != nil {
-			// 	return types, fmt.Errorf("pipeline %s cannot be validated properly: err: %w", o.GetName(), err)
-			// }
 			if err := o.ConvertTo(ctx, c); err != nil {
 				return types, fmt.Errorf("pipeline v1beta1 %s cannot be converted as v1: err: %w", o.GetName(), err)
 			}
 			types.Pipelines = append(types.Pipelines, c)
 		case *tektonv1beta1.PipelineRun:
 			c := &tektonv1.PipelineRun{}
-			// o.SetDefaults(ctx)
-			// this would fail on Validate otherwise
-			// if o.GetName() == "" {
-			// 	o.SetName(o.GetGenerateName())
-			// }
-			// ctx2 := features.SetFeatureFlag(context.Background())
-			// if err := o.Validate(ctx2); err != nil {
-			// 	return types, fmt.Errorf("pipelinerun %s cannot be validated properly: err: %w", o.GetName(), err)
-			// }
 			if err := o.ConvertTo(ctx, c); err != nil {
 				return types, fmt.Errorf("pipelinerun v1beta1 %s cannot be converted as v1: err: %w", o.GetName(), err)
 			}
 			types.PipelineRuns = append(types.PipelineRuns, c)
 		case *tektonv1beta1.Task:
 			c := &tektonv1.Task{}
-			// o.SetDefaults(ctx)
-			// // this would fail on Validate otherwise
-			// if o.GetName() == "" {
-			// 	o.SetName(o.GetGenerateName())
-			// }
-			// if err := o.Validate(ctx); err != nil {
-			// 	return types, fmt.Errorf("task %s cannot be validated properly: err: %w", o.GetName(), err)
-			// }
 			if err := o.ConvertTo(ctx, c); err != nil {
 				return types, fmt.Errorf("task v1beta1 %s cannot be converted as v1: err: %w", o.GetName(), err)
 			}


### PR DESCRIPTION
Properly detected git_auth_secret in subdir and subsequent yaml files
Use a regexp for git_auth_secret detection to handle single/double
quotes/no quotes type of directives

add a flag to output pipelinerun as v1beta1 to easy migrate to cluster that doesn't support v1

fix help message for -o

use curl from docker hub since gcr mirror seems down/abandonware 

https://issues.redhat.com/browse/SRVKP-3116
https://issues.redhat.com/browse/SRVKP-3117
