### PR TITLE
[cli] Don't error when user cannot acces pac ns

### DIFF
--- a/pkg/cmd/tknpac/create/repository.go
+++ b/pkg/cmd/tknpac/create/repository.go
@@ -76,7 +76,10 @@ func repositoryCommand(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command
 			}
 
 			var providerName string
-			_, installationNS, err := bootstrap.DetectPacInstallation(ctx, createOpts.pacNamespace, run)
+			installed, installationNS, err := bootstrap.DetectPacInstallation(ctx, createOpts.pacNamespace, run)
+			if !installed {
+				return fmt.Errorf("pipelines-as-code is not installed in the cluster")
+			}
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
when we have issue accessing the pac-configmap or listing the repo CR we
would error out. While it's perfectly valid to not be able to have those
right as user.

cf #780

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
