### PR TITLE
Fix GitHub token scope issue when secret-github-app-token-scoped key is enabled and repo level as well as global configuration provided 

### DIFF
--- a/pkg/provider/github/scope.go
+++ b/pkg/provider/github/scope.go
@@ -60,7 +60,8 @@ func ScopeTokenToListOfRepos(ctx context.Context, vcx provider.Interface, repo *
 			}
 			repoListToScopeToken = append(repoListToScopeToken, repo.Spec.Settings.GithubAppTokenScopeRepos[i])
 		}
-		if run.Info.Pac.SecretGHAppRepoScoped {
+		// When the global configuration is not set then check for secret-github-app-token-scoped key for the repo level configuration
+		if run.Info.Pac.SecretGHAppRepoScoped && run.Info.Pac.SecretGhAppTokenScopedExtraRepos == "" {
 			msg := fmt.Sprintf(`failed to scope GitHub token as repo scoped key %s is enabled. Hint: update key %s from pipelines-as-code configmap to false`,
 				settings.SecretGhAppTokenRepoScopedKey, settings.SecretGhAppTokenRepoScopedKey)
 			eventEmitter.EmitMessage(nil, zap.ErrorLevel, "SecretGHAppTokenRepoScopeIsEnabled", msg)

--- a/pkg/provider/github/scope_test.go
+++ b/pkg/provider/github/scope_test.go
@@ -160,7 +160,7 @@ func TestScopeTokenToListOfRipos(t *testing.T) {
 			repositoryID:          []int64{789, 10112, 112233},
 		},
 		{
-			name: "failed to scope GitHub token as repo scoped key secret-github-app-token-scoped is enabled",
+			name: "failed to scope GitHub token to a list of repositories provided by repo level as repo scoped key secret-github-app-token-scoped is enabled",
 			tData: testclient.Data{
 				Namespaces: []*corev1.Namespace{testNamespace},
 				Secret:     []*corev1.Secret{validSecret},
@@ -176,6 +176,25 @@ func TestScopeTokenToListOfRipos(t *testing.T) {
 			wantError: "failed to scope GitHub token as repo scoped key secret-github-app-token-scoped is enabled. " +
 				"Hint: update key secret-github-app-token-scoped from pipelines-as-code configmap to false",
 			wantToken: "",
+		},
+		{
+			name: "successfully scoped GitHub token to a list of repositories provided by global and repo level even though secret-github-app-token-scoped key is enabled because global configuration takes precedence",
+			tData: testclient.Data{
+				Namespaces: []*corev1.Namespace{testNamespace},
+				Secret:     []*corev1.Secret{validSecret},
+				Repositories: []*v1alpha1.Repository{
+					repoData, repoData1,
+				},
+			},
+			envs: map[string]string{
+				"SYSTEM_NAMESPACE": testNamespace.Name,
+			},
+			repository:               repoData,
+			secretGHAppRepoScopedKey: true,
+			repoListsByGlobalConf:    "owner1/repo1",
+			wantError:                "",
+			wantToken:                "123abcdfrf",
+			repositoryID:             []int64{789, 10112, 112233},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

**Issue:** 

`TestGithubPullRequestScopeTokenToListOfReposByGlobalConfiguration` failed on [nightly](https://github.com/openshift-pipelines/pipelines-as-code/actions/runs/5087442660/jobs/9142820089) 

**Error logs from PAC controller:**

```
2023-05-26T05:36:17.952981493Z stdout F {"level":"info","ts":"2023-05-26T05:36:17.952Z","logger":"pipelinesascode","caller":"github/scope.go:40","msg":"configured Global configuration to [openshift-pipelines/pipelines-as-code-e2e-tests-private] to scope Github token ","commit":"7aff449","provider":"github","event-id":"366cb562-fb87-11ed-83ba-e9a44d6b4f83","event-sha":"f5f1c1242a31909e6e261f96f6b644acf06f9aaa","event-type":"push","namespace":"pac-e2e-ns-4jbwm"}
2023-05-26T05:36:17.955250163Z stdout F {"level":"error","ts":"2023-05-26T05:36:17.955Z","logger":"pipelinesascode","caller":"events/emit.go:46","msg":"failed to scope GitHub token as repo scoped key secret-github-app-token-scoped is enabled. Hint: update key secret-github-app-token-scoped from pipelines-as-code configmap to false","commit":"7aff449","provider":"github","event-id":"366cb562-fb87-11ed-83ba-e9a44d6b4f83","event-sha":"f5f1c1242a31909e6e261f96f6b644acf06f9aaa","event-type":"push","namespace":"pac-e2e-ns-4jbwm","stacktrace":"github.com/openshift-pipelines/pipelines-as-code/pkg/events.(*EventEmitter).EmitMessage\n\tgithub.com/openshift-pipelines/pipelines-as-code/pkg/events/emit.go:46\ngithub.com/openshift-pipelines/pipelines-as-code/pkg/provider/github.ScopeTokenToListOfRepos\n\tgithub.com/openshift-pipelines/pipelines-as-code/pkg/provider/github/scope.go:66\ngithub.com/openshift-pipelines/pipelines-as-code/pkg/pipelineascode.(*PacRun).verifyRepoAndUser\n\tgithub.com/openshift-pipelines/pipelines-as-code/pkg/pipelineascode/match.go:107\ngithub.com/openshift-pipelines/pipelines-as-code/pkg/pipelineascode.(*PacRun).matchRepoPR\n\tgithub.com/openshift-pipelines/pipelines-as-code/pkg/pipelineascode/match.go:23\ngithub.com/openshift-pipelines/pipelines-as-code/pkg/pipelineascode.(*PacRun).Run\n\tgithub.com/openshift-pipelines/pipelines-as-code/pkg/pipelineascode/pipelineascode.go:48\ngithub.com/openshift-pipelines/pipelines-as-code/pkg/adapter.(*sinker).processEvent\n\tgithub.com/openshift-pipelines/pipelines-as-code/pkg/adapter/sinker.go:52\ngithub.com/openshift-pipelines/pipelines-as-code/pkg/adapter.listener.handleEvent.func1.2\n\tgithub.com/openshift-pipelines/pipelines-as-code/pkg/adapter/adapter.go:190"}
```

**Root Cause:**

As part of this PR https://github.com/openshift-pipelines/pipelines-as-code/pull/1274 added condition check to validate enable/disable of `secret-github-app-token-scoped` key  but failed to handle the scenario when Global configuration provided using `secret-github-app-scope-extra-repos` key

**Fix:** 

1. when Global configuration is provided using `secret-github-app-scope-extra-repos` then don't check for `secret-github-app-token-scoped` key
2. when both Repo level and Global configuration is provided don't check for `secret-github-app-token-scoped` key
3. when only repo level configuration is provided (**no global configuration**) then validate for `secret-github-app-token-scoped` key 

     1. If `secret-github-app-token-scoped` true report error  
         ```
         failed to scope GitHub token as repo scoped key secret-github-app-token-scoped is enabled. Hint: update key secret- 
         github-app-token-scoped from pipelines-as-code configmap to false
         ```
     3. if `secret-github-app-token-scoped` false then continue

Ran e2e locally

![Screenshot from 2023-05-26 14-26-33](https://github.com/openshift-pipelines/pipelines-as-code/assets/9441662/5d617d6f-6e78-49b7-981a-a59d0a4c075d)



<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
