### PR TITLE
fix ghapp_token when we don't output jwt tokens

### DIFF
--- a/hack/dev/ghapp_token.py
+++ b/hack/dev/ghapp_token.py
@@ -233,7 +233,7 @@ def parse_args():
         default=os.environ.get("GITHUBAPP_RESULT_PATH"),
     )
     args = parser.parse_args()
-    if not args.installation_id or not args.jwt_token:
+    if not args.installation_id and not args.jwt_token:
         parser.print_help()
         print("Description:", end="")
         print("\n".join([f"  {x}" for x in HELP_TEXT.splitlines()]))


### PR DESCRIPTION
i use that script to generate github token out an app (or jwt token) but it was broken! so adding this quick fix as pr