### PR TITLE
Improve testing for unknown secret in custom param

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,7 +16,7 @@ linters:
   enable:
     - asciicheck
     - bodyclose
-    - depguard
+    # - depguard
     - dogsled
     - durationcheck
     - exhaustive

--- a/pkg/customparams/customparams_test.go
+++ b/pkg/customparams/customparams_test.go
@@ -67,6 +67,25 @@ func TestProcessTemplates(t *testing.T) {
 			},
 		},
 		{
+			name:          "params/from unknown secret",
+			expectedError: true,
+			repository: &v1alpha1.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns,
+				},
+				Spec: v1alpha1.RepositorySpec{
+					Params: &[]v1alpha1.Params{
+						{
+							Name: "params",
+							SecretRef: &v1alpha1.Secret{
+								Name: "unknown",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name:     "params/use last params when two values of the same name",
 			expected: map[string]string{"params": "robin"},
 			repository: &v1alpha1.Repository{

--- a/pkg/pipelineascode/template_test.go
+++ b/pkg/pipelineascode/template_test.go
@@ -263,6 +263,24 @@ func TestProcessTemplates(t *testing.T) {
 			},
 		},
 		{
+			name:     "params/unnown secret skipped",
+			template: `No {{ customparams }}`,
+			expected: "No {{ customparams }}",
+			event:    &info.Event{EventType: "push"},
+			repository: &v1alpha1.Repository{
+				Spec: v1alpha1.RepositorySpec{
+					Params: &[]v1alpha1.Params{
+						{
+							Name: "customparams",
+							SecretRef: &v1alpha1.Secret{
+								Name: "unkownsecret",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name:     "params/bad filter skipped",
 			template: `I am {{ params }}`,
 			expected: "I am {{ params }}",

--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -750,6 +750,13 @@ func TestGiteaParamsOnRepoCR(t *testing.T) {
 					Key:  "secret",
 				},
 			},
+			{
+				Name: "secret_nothere",
+				SecretRef: &v1alpha1.Secret{
+					Name: "param-secret-not-present",
+					Key:  "unknowsecret",
+				},
+			},
 		},
 	}
 	topts.TargetRefName = names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test")
@@ -774,9 +781,7 @@ func TestGiteaParamsOnRepoCR(t *testing.T) {
 			fmt.Sprintf("tekton.dev/pipelineRun=%s,tekton.dev/pipelineTask=params",
 				repo.Status[0].PipelineRunName),
 			"step-test-params-value", *regexp.MustCompile(
-				"I am the most Kawaī params\nSHHHHHHH\nFollow me on my ig #nofilter\n{{ no_match }}\nHey I show up from" +
-					" a" +
-					" payload match"), 2))
+				"I am the most Kawaī params\nSHHHHHHH\nFollow me on my ig #nofilter\n{{ no_match }}\nHey I show up from a payload match\n{{ secret_nothere }}"), 2))
 }
 
 func TestGiteaParamsOnRepoCRWithCustomConsole(t *testing.T) {

--- a/test/testdata/params.yaml
+++ b/test/testdata/params.yaml
@@ -21,3 +21,4 @@ spec:
                 echo "{{ no_filter }}"
                 echo "{{ no_match }}"
                 echo "{{ filter_on_body }}"
+                echo "{{ secret_nothere }}"


### PR DESCRIPTION
they are reports that the substitions come back with empty strings,
added a bunch of tests to try to replicate with no luck. But at least we
have better coverage.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com><!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #1304 

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
