### PR TITLE
Add the change_files new standard params

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,7 +16,7 @@ linters:
   enable:
     - asciicheck
     - bodyclose
-    - depguard
+    # - depguard
     - dogsled
     - durationcheck
     - exhaustive

--- a/docs/content/docs/guide/authoringprs.md
+++ b/docs/content/docs/guide/authoringprs.md
@@ -39,6 +39,7 @@ weight: 3
   * `{{target_branch}}`: The branch name on which the event targets (same as `source_branch` for push events).
   * `{{pull_request_number}}`: The pull or merge request number, only defined when we are in a `pull_request` event type.
   * `{{git_auth_secret}}`: The secret name auto generated with provider token to check out private repos.
+  * `{{change_files}}`: The list of files changed in the event separated by a comma. On pull request every files belonging to the pull request will be listed.
 
 * For Pipelines as Code to process your `PipelineRun`, you must have either an
   embedded `PipelineSpec` or a separate `Pipeline` object that references a YAML

--- a/pkg/customparams/customparams.go
+++ b/pkg/customparams/customparams.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	sectypes "github.com/openshift-pipelines/pipelines-as-code/pkg/secrets/types"
 	"go.uber.org/zap"
 )
@@ -19,15 +20,17 @@ type CustomParams struct {
 	k8int        kubeinteraction.Interface
 	eventEmitter *events.EventEmitter
 	repo         *v1alpha1.Repository
+	vcx          provider.Interface
 }
 
-func NewCustomParams(event *info.Event, repo *v1alpha1.Repository, run *params.Run, k8int kubeinteraction.Interface, eventEmitter *events.EventEmitter) CustomParams {
+func NewCustomParams(event *info.Event, repo *v1alpha1.Repository, run *params.Run, k8int kubeinteraction.Interface, eventEmitter *events.EventEmitter, vcx provider.Interface) CustomParams {
 	return CustomParams{
 		event:        event,
 		repo:         repo,
 		run:          run,
 		k8int:        k8int,
 		eventEmitter: eventEmitter,
+		vcx:          vcx,
 	}
 }
 
@@ -38,7 +41,7 @@ func NewCustomParams(event *info.Event, repo *v1alpha1.Repository, run *params.R
 // if multiple params name has a filter we pick up the first one that has
 // matched true.
 func (p *CustomParams) GetParams(ctx context.Context) (map[string]string, error) {
-	stdParams := p.makeStandardParamsFromEvent()
+	stdParams := p.makeStandardParamsFromEvent(ctx)
 	if p.repo.Spec.Params == nil {
 		return stdParams, nil
 	}

--- a/pkg/customparams/customparams_test.go
+++ b/pkg/customparams/customparams_test.go
@@ -261,7 +261,7 @@ func TestProcessTemplates(t *testing.T) {
 			if tt.event == nil {
 				tt.event = &info.Event{}
 			}
-			p := NewCustomParams(tt.event, repo, run, &kitesthelper.KinterfaceTest{GetSecretResult: tt.secretData}, nil)
+			p := NewCustomParams(tt.event, repo, run, &kitesthelper.KinterfaceTest{GetSecretResult: tt.secretData}, nil, nil)
 			stdata, _ := testclient.SeedTestData(t, ctx, testclient.Data{})
 			p.eventEmitter = events.NewEventEmitter(stdata.Kube, logger)
 			ret, err := p.GetParams(ctx)

--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -66,7 +66,7 @@ func (p *PacRun) Run(ctx context.Context) error {
 	}
 
 	// set params for the console driver, only used for the custom console ones
-	cp := customparams.NewCustomParams(p.event, repo, p.run, p.k8int, p.eventEmitter)
+	cp := customparams.NewCustomParams(p.event, repo, p.run, p.k8int, p.eventEmitter, p.vcx)
 	maptemplate, err := cp.GetParams(ctx)
 	if err != nil {
 		p.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "ParamsError",

--- a/pkg/pipelineascode/template.go
+++ b/pkg/pipelineascode/template.go
@@ -13,7 +13,7 @@ import (
 // makeTemplate will process all templates replacing the value from the event and from the
 // params as set on Repo CR
 func (p *PacRun) makeTemplate(ctx context.Context, repo *v1alpha1.Repository, template string) string {
-	cp := customparams.NewCustomParams(p.event, repo, p.run, p.k8int, p.eventEmitter)
+	cp := customparams.NewCustomParams(p.event, repo, p.run, p.k8int, p.eventEmitter, p.vcx)
 	maptemplate, err := cp.GetParams(ctx)
 	if err != nil {
 		p.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "ParamsError",

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -100,7 +100,7 @@ func (r *Reconciler) reportFinalStatus(ctx context.Context, logger *zap.SugaredL
 		return nil, fmt.Errorf("reportFinalStatus: %w", err)
 	}
 
-	cp := customparams.NewCustomParams(event, repo, r.run, r.kinteract, r.eventEmitter)
+	cp := customparams.NewCustomParams(event, repo, r.run, r.kinteract, r.eventEmitter, nil)
 	maptemplate, err := cp.GetParams(ctx)
 	if err != nil {
 		r.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "ParamsError",

--- a/pkg/test/provider/testwebvcs.go
+++ b/pkg/test/provider/testwebvcs.go
@@ -21,6 +21,7 @@ type TestProviderImp struct {
 	CreateStatusErorring   bool
 	FilesInsideRepo        map[string]string
 	WantProviderRemoteTask bool
+	WantGetFiles           []string
 }
 
 func (v *TestProviderImp) SetLogger(_ *zap.SugaredLogger) {
@@ -80,7 +81,7 @@ func (v *TestProviderImp) GetFileInsideRepo(_ context.Context, _ *info.Event, fi
 }
 
 func (v *TestProviderImp) GetFiles(_ context.Context, _ *info.Event) ([]string, error) {
-	return []string{}, nil
+	return v.WantGetFiles, nil
 }
 
 func (v *TestProviderImp) CreateToken(_ context.Context, _ []string, _ *params.Run, _ *info.Event) (string, error) {


### PR DESCRIPTION
This introduce a new param letting you list the files inside the event like pull request files for example.

{{ change_files }}

will list all the files comma separated values.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
