### PR TITLE
disable depguard for now

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,7 +16,7 @@ linters:
   enable:
     - asciicheck
     - bodyclose
-    - depguard
+    # - depguard
     - dogsled
     - durationcheck
     - exhaustive


### PR DESCRIPTION
since broken, until we update the golangci-lint binary to a fixed release