### PR TITLE
SRVKP-3134: fix SIGSEGV in startPR error logging

### DIFF
--- a/pkg/action/patch.go
+++ b/pkg/action/patch.go
@@ -18,6 +18,12 @@ func PatchPipelineRun(ctx context.Context, logger *zap.SugaredLogger, whatPatchi
 		return nil, nil
 	}
 	var patchedPR *tektonv1.PipelineRun
+	// double the retry; see https://issues.redhat.com/browse/SRVKP-3134
+	doubleRetry := retry.DefaultRetry
+	doubleRetry.Steps *= 2
+	doubleRetry.Duration *= 2
+	doubleRetry.Factor *= 2
+	doubleRetry.Jitter *= 2
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		patch, err := json.Marshal(mergePatch)
 		if err != nil {

--- a/pkg/action/patch.go
+++ b/pkg/action/patch.go
@@ -38,7 +38,8 @@ func PatchPipelineRun(ctx context.Context, logger *zap.SugaredLogger, whatPatchi
 		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to patch pipelinerun %v/%v with %v: %w", pr.Namespace, whatPatching, pr.Name, err)
+		// return the original PipelineRun, let the caller decide what to do with it after the error is processed
+		return pr, fmt.Errorf("failed to patch pipelinerun %v/%v with %v: %w", pr.Namespace, whatPatching, pr.Name, err)
 	}
 	return patchedPR, nil
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

- Fixes the SIGSEGV in patch error logging in the Jira referenced in the PR title
- per discussion with @chmouel this increases (doubling) the default retry wait.Backoff used in the patch action

# Submitter Checklist

- [/] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [n/a ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [n/a] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [n/a] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [n/a] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
