### PR TITLE
Simplify auto-generated pac-gitauth secret URL

### DIFF
--- a/docs/content/docs/guide/privaterepo.md
+++ b/docs/content/docs/guide/privaterepo.md
@@ -18,6 +18,12 @@ This secret contains a [Git Config](https://git-scm.com/docs/git-config) file:
 file: .git-credentials, which includes the https URL using the token obtained
 from the GitHub application or secret attached to the repo CR.
 
+{{< hint info >}} For compatibility, the [Git
+Config](https://git-scm.com/docs/git-config) file uses the detected repository's
+base URL instead of the full URL. For more information, see [this
+issue](https://github.com/openshift-pipelines/pipelines-as-code/issues/1307) {{<
+/hint >}}
+
 The secret includes a key referencing the token as a key to let you easily use it in your task for
 other provider operations. See the documentation with example on how to use it
 [here](../authoringprs/#using-the-temporary-github-app-token-for-github-api-operations)

--- a/pkg/secrets/basic_auth.go
+++ b/pkg/secrets/basic_auth.go
@@ -54,9 +54,10 @@ func MakeBasicAuthSecret(runevent *info.Event, secretName string) (*corev1.Secre
 	// in the *** to do it in shell.
 	token := url.QueryEscape(runevent.Provider.Token)
 
+	baseCloneURL := fmt.Sprintf("%s://%s", repoURL.Scheme, repoURL.Host)
 	urlWithToken := fmt.Sprintf("%s://%s:%s@%s%s", repoURL.Scheme, gitUser, token, repoURL.Host, repoURL.Path)
 	secretData := map[string]string{
-		".gitconfig":       fmt.Sprintf(basicAuthGitConfigData, cloneURL),
+		".gitconfig":       fmt.Sprintf(basicAuthGitConfigData, baseCloneURL),
 		".git-credentials": urlWithToken,
 		// With the GitHub APP method the token is available for 8h if you have
 		// the user to server token expiration.  the token is scoped to the


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Changed GitLab's payload parser to get repository URL from `project.get_http_url` instead of `project.web_url`.

Fixes #1307 

# Submitter Checklist

- [x] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [x] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [x] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [x] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [x] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
