### PR TITLE
fetch binary ourselves for hugo instead of using the container

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,8 @@ your descriptive commit message(s)! -->
 
 # Submitter Checklist
 
-- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
+- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
+- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
 - [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
 - [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
 - [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.

--- a/.tekton/doc.yaml
+++ b/.tekton/doc.yaml
@@ -40,7 +40,7 @@ spec:
             - name: source
           steps:
             - name: hugo-gen
-              image: quay.io/thegeeklab/hugo
+              image: registry.access.redhat.com/ubi9/python-311 # using this image since it has git and curl and python
               workingDir: $(workspaces.source.path)
               env:
                 - name: UPLOADER_PUBLIC_URL
@@ -49,11 +49,13 @@ spec:
                       name: "uploader-upload-credentials"
                       key: "public_url"
               script: |
+                version=$(curl -s https://api.github.com/repos/gohugoio/hugo/releases/latest|python -c 'import sys, json;dico=json.load(sys.stdin);print(dico["tag_name"])')
+                curl --fail-early -sL https://github.com/gohugoio/hugo/releases/download/${version}/hugo_extended_${version/v/}_Linux-64bit.tar.gz -o-|tar -x -z -v -f- hugo
                 git config --global --add safe.directory $(workspaces.source.path)
                 cd docs
                 sed -i '1acanonifyURLs = true' config.toml
                 url="${UPLOADER_PUBLIC_URL}/docs/{{ pull_request_number }}"
-                hugo --gc --minify -d {{ pull_request_number }} -b ${url}
+                ../hugo --gc --minify -d {{ pull_request_number }} -b ${url}
                 echo "Preview URL: ${url}"
             - name: upload-to-static-server
               # it has curl and we already pulled it

--- a/docs/content/dev/_index.md
+++ b/docs/content/dev/_index.md
@@ -22,6 +22,7 @@ When it finished you will have the following installed in your kind cluster:
 - A ingress controller with nginx for routing.
 - Tekton and Dashboard installed with a ingress route.
 - Pipelines as code deployed from your repo with ko.
+- Gitea service running locally so you can run your E2E tests that targets gitea (the most comprehensive ones)
 
 By default it will try to install from
 $GOPATH/src/github.com/openshift-pipelines/pipelines-as-code, if you want to
@@ -46,10 +47,10 @@ override it you can set the `PAC_DIRS` environment variable.
 - If you need to redeploy your pac install (and only pac) you can do :
 
   ```shell
-  ./install.sh -p
+  ./hack/dev/kind/install.sh/install.sh -p
   ```
 
-  or directly with ko :
+  or you can do this directly with ko :
 
   ```shell
   env KO_DOCKER_REPO=localhost:5000 ko apply -f ${1:-"config"} -B
@@ -59,6 +60,8 @@ override it you can set the `PAC_DIRS` environment variable.
   install from latest stable release (override with env variable `PAC_RELEASE`)
   instead of ko. `-c` will only do the pac configuration (ie: creation of
   secrets/ingress etc..)
+
+- see the [install.sh](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/hack/dev/kind/install.sh) -h for all flags
 
 ## Gitea
 

--- a/hack/dev/kind/install.sh
+++ b/hack/dev/kind/install.sh
@@ -210,8 +210,28 @@ main() {
     echo "And we are done :): "
 }
 
-while getopts "RGgpcrb" o; do
+function usage() {
+    cat <<EOF
+Usage: $0 [OPTIONS]
+
+Options:
+  -h          Show this message
+  -b          Only install the registry/kind/nginx and tekton and don't install PAC
+  -c          Configure PAC
+  -p          Install only PAC
+  -g          Install only Gitea
+  -G          Disable Gitea when installing
+  -r          Install from release instead of local checkout with ko
+  -R          Restart the PAC pods
+EOF
+}
+
+while getopts "RGhgpcrb" o; do
     case "${o}" in
+        h)
+            usage
+            exit
+            ;;
         b)
             start_registry
             reinstall_kind


### PR DESCRIPTION
Fetch the hugo binary ourselves since the containers are broken and not working.

Fixes #1312 

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽  Run `make test lint` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
