### PR TITLE
Fix ubuntu failing to install pkgs

### DIFF
--- a/.github/workflows/kind-nightly.yaml
+++ b/.github/workflows/kind-nightly.yaml
@@ -111,6 +111,7 @@ jobs:
 
       - name: Install wine
         run: |
+          sudo apt-get update
           sudo apt-get install -y --install-recommends wine
 
       - name: Compile tkn-pac for windows


### PR DESCRIPTION
This is to fix ubuntu failing to install pkg during nightly run

# Submitter Checklist

- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
