### PR TITLE
Enable default metrics observability for pac controller

### DIFF
--- a/config/400-controller.yaml
+++ b/config/400-controller.yaml
@@ -31,6 +31,7 @@ spec:
   template:
     metadata:
       labels:
+        app: pipelines-as-code-controller
         app.kubernetes.io/name: controller
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: default
@@ -49,6 +50,8 @@ spec:
           ports:
             - name: api
               containerPort: 8080
+            - name: metrics
+              containerPort: 9090
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -86,9 +89,9 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: K_METRICS_CONFIG
-              value: '{"Domain":"pipelinesascode.tekton.dev/controller","Component":"controller","PrometheusPort":0,"PrometheusHost":"","ConfigMap":{}}'
+              value: '{"Domain":"pipelinesascode.tekton.dev/controller","Component":"pac_controller","PrometheusPort":9090,"ConfigMap":{"name":"pipelines-as-code-config-observability"}}'
             - name: K_TRACING_CONFIG
-              value: '{"backend":"","debug":"false","sample-rate":"0"}'
+              value: '{"backend":"prometheus","debug":"false","sample-rate":"0"}'
             - name: K_SINK_TIMEOUT
               value: "30"
           volumeMounts:

--- a/config/401-controller-service.yaml
+++ b/config/401-controller-service.yaml
@@ -18,6 +18,7 @@ metadata:
   name: pipelines-as-code-controller
   namespace: pipelines-as-code
   labels:
+    app: pipelines-as-code-controller
     app.kubernetes.io/version: "devel"
     app.kubernetes.io/part-of: pipelines-as-code
 spec:
@@ -26,6 +27,10 @@ spec:
     port: 8080
     protocol: TCP
     targetPort: 8080
+  - name: http-metrics
+    port: 9090
+    protocol: TCP
+    targetPort: 9090
   selector:
     app.kubernetes.io/name: controller
     app.kubernetes.io/component: controller


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

- This PR adds ConfigMapName to the controller deployment for configuring metrics and a Service to expose the port.
- Metrics can be accessed by exposing the Service `pipelines-as-code-controller`

# Submitter Checklist

- [x] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [x] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [x] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [x] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [x] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [x] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
