### PR TITLE
Revert "set, then unset, pending pipelinerun regardless of concurrency limit in startPR"

### DIFF
--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -146,16 +146,11 @@ func (p *PacRun) startPR(ctx context.Context, match matcher.Match) (*tektonv1.Pi
 	// Add labels and annotations to pipelinerun
 	kubeinteraction.AddLabelsAndAnnotations(p.event, match.PipelineRun, match.Repo, p.vcx.GetConfig())
 
-	userAsksForPending := match.Repo.Spec.ConcurrencyLimit != nil && *match.Repo.Spec.ConcurrencyLimit != 0
-	// regardless of whether the user has set concurrency, we use the pending bit for a very short time to
-	// attempt to reduce updates conflicts between ourselves and other controllers that start updating the PipelineRun
-	// as soon as the underlying Pod(s) have started, so we have a better chance updating the PipelineRun after its
-	// initial creation
-	match.PipelineRun.Spec.Status = tektonv1.PipelineRunSpecStatusPending
-
 	// if concurrency is defined then start the pipelineRun in pending state and
 	// state as queued
-	if userAsksForPending {
+	if match.Repo.Spec.ConcurrencyLimit != nil && *match.Repo.Spec.ConcurrencyLimit != 0 {
+		// pending status
+		match.PipelineRun.Spec.Status = tektonv1.PipelineRunSpecStatusPending
 		// pac state as queued
 		match.PipelineRun.Labels[keys.State] = kubeinteraction.StateQueued
 		match.PipelineRun.Annotations[keys.State] = kubeinteraction.StateQueued
@@ -192,7 +187,7 @@ func (p *PacRun) startPR(ctx context.Context, match matcher.Match) (*tektonv1.Pi
 	}
 
 	// if pipelineRun is in pending state then report status as queued
-	if pr.Spec.Status == tektonv1.PipelineRunSpecStatusPending && userAsksForPending {
+	if pr.Spec.Status == tektonv1.PipelineRunSpecStatusPending {
 		status.Status = "queued"
 		status.Text = fmt.Sprintf(params.QueuingPipelineRunText, pr.GetName(), match.Repo.GetNamespace())
 	}
@@ -222,15 +217,6 @@ func (p *PacRun) startPR(ctx context.Context, match matcher.Match) (*tektonv1.Pi
 			return pr, fmt.Errorf("cannot update pipelinerun %s with ownerRef: %w", pr.GetGenerateName(), err)
 		}
 	}
-
-	// now unset pending bit to get the other controllers, including the tekton pipeline controller, started with the PipelineRun,
-	// where they start making updates, unless user has specified concurrency control
-	if !userAsksForPending {
-		pr, err = action.PatchPipelineRun(ctx, p.logger, "specStatus", p.run.Clients.Tekton, pr, getPendingPatch(""))
-		if err != nil {
-			return pr, fmt.Errorf("cannot patch pipelinerun pending bit %s: %w", pr.GetGenerateName(), err)
-		}
-	}
 	return pr, nil
 }
 
@@ -250,14 +236,6 @@ func getExecutionOrderPatch(order string) map[string]interface{} {
 			"annotations": map[string]string{
 				keys.ExecutionOrder: order,
 			},
-		},
-	}
-}
-
-func getPendingPatch(specStatus string) map[string]interface{} {
-	return map[string]interface{}{
-		"spec": map[string]interface{}{
-			"status": specStatus,
 		},
 	}
 }


### PR DESCRIPTION
This reverts commit 13aa6e597aa66011d5b496e9850e91e400610601.

We have seen a lot of nightly issues lately and would like to figure out if the
issues is this commit.

Let's keep this for a little while to see if our failures flakyness gets away.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [X] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [X] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [X] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [X] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [X] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [X] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
