### PR TITLE
Delete git-clone basic-auth secret when deleting a pipelinerun

### DIFF
--- a/pkg/cmd/tknpac/describe/describe_test.go
+++ b/pkg/cmd/tknpac/describe/describe_test.go
@@ -52,7 +52,7 @@ func TestDescribe(t *testing.T) {
 				currentNamespace: ns,
 				opts:             &describeOpts{},
 				pruns: []*tektonv1.PipelineRun{
-					tektontest.MakePRCompletion(cw, "running", ns, running, map[string]string{
+					tektontest.MakePRCompletion(cw, "running", ns, running, nil, map[string]string{
 						keys.Repository: "test-run",
 						keys.Branch:     "tartanpion",
 						keys.EventType:  "papayolo",
@@ -89,7 +89,7 @@ func TestDescribe(t *testing.T) {
 				currentNamespace: ns,
 				opts:             &describeOpts{},
 				pruns: []*tektonv1.PipelineRun{
-					tektontest.MakePRCompletion(cw, "running", ns, running, map[string]string{
+					tektontest.MakePRCompletion(cw, "running", ns, running, nil, map[string]string{
 						keys.Repository: "test-run",
 						keys.Branch:     "tartanpion",
 					}, 30),
@@ -105,11 +105,11 @@ func TestDescribe(t *testing.T) {
 				currentNamespace: ns,
 				opts:             &describeOpts{TargetPipelineRun: "running2"},
 				pruns: []*tektonv1.PipelineRun{
-					tektontest.MakePRCompletion(cw, "running", ns, running, map[string]string{
+					tektontest.MakePRCompletion(cw, "running", ns, running, nil, map[string]string{
 						keys.Repository: "test-run",
 						keys.Branch:     "tartanpion",
 					}, 30),
-					tektontest.MakePRCompletion(cw, "running2", ns, running, map[string]string{
+					tektontest.MakePRCompletion(cw, "running2", ns, running, nil, map[string]string{
 						keys.Repository: "test-run",
 						keys.Branch:     "vavaroom",
 					}, 30),
@@ -125,11 +125,11 @@ func TestDescribe(t *testing.T) {
 				currentNamespace: ns,
 				opts:             &describeOpts{},
 				pruns: []*tektonv1.PipelineRun{
-					tektontest.MakePRCompletion(cw, "running", ns, running, map[string]string{
+					tektontest.MakePRCompletion(cw, "running", ns, running, nil, map[string]string{
 						keys.Repository: "test-run",
 						keys.Branch:     "tartanpion",
 					}, 30),
-					tektontest.MakePRCompletion(cw, "running2", ns, running, map[string]string{
+					tektontest.MakePRCompletion(cw, "running2", ns, running, nil, map[string]string{
 						keys.Repository: "test-run",
 						keys.Branch:     "vavaroom",
 					}, 30),

--- a/pkg/cmd/tknpac/list/list_test.go
+++ b/pkg/cmd/tknpac/list/list_test.go
@@ -170,7 +170,7 @@ func TestList(t *testing.T) {
 				},
 				repositories: []*pacv1alpha1.Repository{repoNamespace1},
 				pipelineruns: []*tektonv1.PipelineRun{
-					tektontest.MakePRCompletion(cw, "running", namespace1.GetName(), running, map[string]string{
+					tektontest.MakePRCompletion(cw, "running", namespace1.GetName(), running, nil, map[string]string{
 						keys.Repository: repoNamespace1.GetName(),
 						keys.SHA:        repoNamespace1SHA,
 					}, 30),

--- a/pkg/cmd/tknpac/logs/logs_test.go
+++ b/pkg/cmd/tknpac/logs/logs_test.go
@@ -44,7 +44,7 @@ func TestLogs(t *testing.T) {
 			currentNamespace: ns,
 			shift:            0,
 			pruns: []*tektonv1.PipelineRun{
-				tektontest.MakePRCompletion(cw, "test-pipeline", ns, completed, map[string]string{
+				tektontest.MakePRCompletion(cw, "test-pipeline", ns, completed, nil, map[string]string{
 					keys.Repository: "test",
 				}, 30),
 			},
@@ -56,10 +56,10 @@ func TestLogs(t *testing.T) {
 			currentNamespace: ns,
 			useLastPR:        true,
 			pruns: []*tektonv1.PipelineRun{
-				tektontest.MakePRCompletion(cw, "test-pipeline", ns, completed, map[string]string{
+				tektontest.MakePRCompletion(cw, "test-pipeline", ns, completed, nil, map[string]string{
 					keys.Repository: "test",
 				}, 30),
-				tektontest.MakePRCompletion(cw, "test-pipeline2", ns, completed, map[string]string{
+				tektontest.MakePRCompletion(cw, "test-pipeline2", ns, completed, nil, map[string]string{
 					keys.Repository: "test",
 				}, 30),
 			},
@@ -71,7 +71,7 @@ func TestLogs(t *testing.T) {
 			currentNamespace: ns,
 			shift:            2,
 			pruns: []*tektonv1.PipelineRun{
-				tektontest.MakePRCompletion(cw, "test-pipeline", ns, completed, map[string]string{
+				tektontest.MakePRCompletion(cw, "test-pipeline", ns, completed, nil, map[string]string{
 					keys.Repository: "test",
 				}, 30),
 			},

--- a/pkg/kubeinteraction/cleanups.go
+++ b/pkg/kubeinteraction/cleanups.go
@@ -16,9 +16,7 @@ import (
 
 func (k Interaction) CleanupPipelines(ctx context.Context, logger *zap.SugaredLogger, repo *v1alpha1.Repository, pr *tektonv1.PipelineRun, maxKeep int) error {
 	if _, ok := pr.GetAnnotations()[keys.OriginalPRName]; !ok {
-		return fmt.Errorf("generate pipelienrun should have had the %s label for selection set but we could not find"+
-			" it",
-			keys.OriginalPRName)
+		return fmt.Errorf("generated pipelinerun should have had the %s label for selection set but we could not find it", keys.OriginalPRName)
 	}
 
 	// Select PR by repository and by its true pipelineRun name (not auto generated one)
@@ -44,6 +42,12 @@ func (k Interaction) CleanupPipelines(ctx context.Context, logger *zap.SugaredLo
 				ctx, prun.GetName(), metav1.DeleteOptions{})
 			if err != nil {
 				return err
+			}
+
+			// Try to Delete the secret created for git-clone basic-auth, it should have been created with a owneref on the pipelinerun and due being deleted when the pipelinerun is deleted
+			// but in some cases of conflicts and the ownerRef not being set, the secret is not deleted and we need to delete it manually.
+			if secretName, ok := pr.GetAnnotations()[keys.GitAuthSecret]; ok {
+				_ = k.Run.Clients.Kube.CoreV1().Secrets(repo.GetNamespace()).Delete(ctx, secretName, metav1.DeleteOptions{})
 			}
 		}
 	}

--- a/pkg/kubeinteraction/cleanups.go
+++ b/pkg/kubeinteraction/cleanups.go
@@ -47,7 +47,10 @@ func (k Interaction) CleanupPipelines(ctx context.Context, logger *zap.SugaredLo
 			// Try to Delete the secret created for git-clone basic-auth, it should have been created with a owneref on the pipelinerun and due being deleted when the pipelinerun is deleted
 			// but in some cases of conflicts and the ownerRef not being set, the secret is not deleted and we need to delete it manually.
 			if secretName, ok := pr.GetAnnotations()[keys.GitAuthSecret]; ok {
-				_ = k.Run.Clients.Kube.CoreV1().Secrets(repo.GetNamespace()).Delete(ctx, secretName, metav1.DeleteOptions{})
+				err = k.Run.Clients.Kube.CoreV1().Secrets(repo.GetNamespace()).Delete(ctx, secretName, metav1.DeleteOptions{})
+				if err == nil {
+					logger.Infof("secret %s attached to pipelinerun %s has been deleted", secretName, prun.GetName())
+				}
 			}
 		}
 	}

--- a/pkg/kubeinteraction/status/task_status_test.go
+++ b/pkg/kubeinteraction/status/task_status_test.go
@@ -51,7 +51,7 @@ func TestCollectFailedTasksLogSnippet(t *testing.T) {
 				exitcode = 1
 			}
 
-			pr := tektontest.MakePRCompletion(clock, "pipeline-newest", "ns", tektonv1.PipelineRunReasonSuccessful.String(), make(map[string]string), 10)
+			pr := tektontest.MakePRCompletion(clock, "pipeline-newest", "ns", tektonv1.PipelineRunReasonSuccessful.String(), nil, make(map[string]string), 10)
 			pr.Status.ChildReferences = []tektonv1.ChildStatusReference{
 				{
 					TypeMeta: runtime.TypeMeta{

--- a/pkg/reconciler/cleanup_test.go
+++ b/pkg/reconciler/cleanup_test.go
@@ -59,9 +59,9 @@ func TestCleanupPipelineRuns(t *testing.T) {
 		{
 			name: "using from annotation",
 			pruns: []*tektonv1.PipelineRun{
-				tektontest.MakePRCompletion(clock, "pipeline-newest", ns, tektonv1.PipelineRunReasonSuccessful.String(), cleanupLabels, 10),
-				tektontest.MakePRCompletion(clock, "pipeline-middest", ns, tektonv1.PipelineRunReasonSuccessful.String(), cleanupLabels, 20),
-				tektontest.MakePRCompletion(clock, "pipeline-oldest", ns, tektonv1.PipelineRunReasonSuccessful.String(), cleanupLabels, 30),
+				tektontest.MakePRCompletion(clock, "pipeline-newest", ns, tektonv1.PipelineRunReasonSuccessful.String(), nil, cleanupLabels, 10),
+				tektontest.MakePRCompletion(clock, "pipeline-middest", ns, tektonv1.PipelineRunReasonSuccessful.String(), nil, cleanupLabels, 20),
+				tektontest.MakePRCompletion(clock, "pipeline-oldest", ns, tektonv1.PipelineRunReasonSuccessful.String(), nil, cleanupLabels, 30),
 			},
 			repoNs:   ns,
 			repoName: cleanupRepoName,
@@ -75,9 +75,9 @@ func TestCleanupPipelineRuns(t *testing.T) {
 		{
 			name: "using from config, as annotation value is more than config",
 			pruns: []*tektonv1.PipelineRun{
-				tektontest.MakePRCompletion(clock, "pipeline-newest", ns, tektonv1.PipelineRunReasonSuccessful.String(), cleanupLabels, 10),
-				tektontest.MakePRCompletion(clock, "pipeline-middest", ns, tektonv1.PipelineRunReasonSuccessful.String(), cleanupLabels, 20),
-				tektontest.MakePRCompletion(clock, "pipeline-oldest", ns, tektonv1.PipelineRunReasonSuccessful.String(), cleanupLabels, 30),
+				tektontest.MakePRCompletion(clock, "pipeline-newest", ns, tektonv1.PipelineRunReasonSuccessful.String(), nil, cleanupLabels, 10),
+				tektontest.MakePRCompletion(clock, "pipeline-middest", ns, tektonv1.PipelineRunReasonSuccessful.String(), nil, cleanupLabels, 20),
+				tektontest.MakePRCompletion(clock, "pipeline-oldest", ns, tektonv1.PipelineRunReasonSuccessful.String(), nil, cleanupLabels, 30),
 			},
 			repoNs:   ns,
 			repoName: cleanupRepoName,
@@ -92,9 +92,9 @@ func TestCleanupPipelineRuns(t *testing.T) {
 		{
 			name: "using from annotation, as annotation value is less than config",
 			pruns: []*tektonv1.PipelineRun{
-				tektontest.MakePRCompletion(clock, "pipeline-newest", ns, tektonv1.PipelineRunReasonSuccessful.String(), cleanupLabels, 10),
-				tektontest.MakePRCompletion(clock, "pipeline-middest", ns, tektonv1.PipelineRunReasonSuccessful.String(), cleanupLabels, 20),
-				tektontest.MakePRCompletion(clock, "pipeline-oldest", ns, tektonv1.PipelineRunReasonSuccessful.String(), cleanupLabels, 30),
+				tektontest.MakePRCompletion(clock, "pipeline-newest", ns, tektonv1.PipelineRunReasonSuccessful.String(), nil, cleanupLabels, 10),
+				tektontest.MakePRCompletion(clock, "pipeline-middest", ns, tektonv1.PipelineRunReasonSuccessful.String(), nil, cleanupLabels, 20),
+				tektontest.MakePRCompletion(clock, "pipeline-oldest", ns, tektonv1.PipelineRunReasonSuccessful.String(), nil, cleanupLabels, 30),
 			},
 			repoNs:   ns,
 			repoName: cleanupRepoName,
@@ -109,9 +109,9 @@ func TestCleanupPipelineRuns(t *testing.T) {
 		{
 			name: "no max-keep-runs annotation, using default from config",
 			pruns: []*tektonv1.PipelineRun{
-				tektontest.MakePRCompletion(clock, "pipeline-newest", ns, tektonv1.PipelineRunReasonSuccessful.String(), cleanupLabels, 10),
-				tektontest.MakePRCompletion(clock, "pipeline-middest", ns, tektonv1.PipelineRunReasonSuccessful.String(), cleanupLabels, 20),
-				tektontest.MakePRCompletion(clock, "pipeline-oldest", ns, tektonv1.PipelineRunReasonSuccessful.String(), cleanupLabels, 30),
+				tektontest.MakePRCompletion(clock, "pipeline-newest", ns, tektonv1.PipelineRunReasonSuccessful.String(), nil, cleanupLabels, 10),
+				tektontest.MakePRCompletion(clock, "pipeline-middest", ns, tektonv1.PipelineRunReasonSuccessful.String(), nil, cleanupLabels, 20),
+				tektontest.MakePRCompletion(clock, "pipeline-oldest", ns, tektonv1.PipelineRunReasonSuccessful.String(), nil, cleanupLabels, 30),
 			},
 			repoNs:             ns,
 			repoName:           cleanupRepoName,

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -137,7 +137,7 @@ func TestReconciler_ReconcileKind(t *testing.T) {
 			if tt.finalStatus == finalFailureStatus {
 				statusPR = tektonv1.PipelineRunReasonFailed
 			}
-			pr := tektontest.MakePRCompletion(clock, "pipeline-newest", "ns", string(statusPR), make(map[string]string), 10)
+			pr := tektontest.MakePRCompletion(clock, "pipeline-newest", "ns", string(statusPR), nil, make(map[string]string), 10)
 			pr.Status.ChildReferences = []tektonv1.ChildStatusReference{
 				{
 					TypeMeta: runtime.TypeMeta{

--- a/pkg/reconciler/status_test.go
+++ b/pkg/reconciler/status_test.go
@@ -48,7 +48,7 @@ func TestPostFinalStatus(t *testing.T) {
 	labels := map[string]string{}
 	ns := "namespace"
 	clock := clockwork.NewFakeClock()
-	pr1 := tektontest.MakePRCompletion(clock, "pipeline-newest", ns, tektonv1.PipelineRunReasonSuccessful.String(), labels, 10)
+	pr1 := tektontest.MakePRCompletion(clock, "pipeline-newest", ns, tektonv1.PipelineRunReasonSuccessful.String(), nil, labels, 10)
 	pr1.Status.Conditions = append(pr1.Status.Conditions, apis.Condition{Status: "False", Message: "Hello not good", Type: "Succeeded", Reason: "CouldntGetTask"})
 	ctx, _ := rtesting.SetupFakeContext(t)
 	tdata := testclient.Data{PipelineRuns: []*tektonv1.PipelineRun{pr1}}

--- a/pkg/sort/pipelinerun_test.go
+++ b/pkg/sort/pipelinerun_test.go
@@ -23,9 +23,9 @@ func TestPipelineRunSortByCompletionTime(t *testing.T) {
 	}{
 		{
 			pruns: []tektonv1.PipelineRun{
-				*(tektontest.MakePRCompletion(clock, "troisieme", ns, success, labels, 30)),
-				*(tektontest.MakePRCompletion(clock, "premier", ns, success, labels, 10)),
-				*(tektontest.MakePRCompletion(clock, "second", ns, success, labels, 20)),
+				*(tektontest.MakePRCompletion(clock, "troisieme", ns, success, nil, labels, 30)),
+				*(tektontest.MakePRCompletion(clock, "premier", ns, success, nil, labels, 10)),
+				*(tektontest.MakePRCompletion(clock, "second", ns, success, nil, labels, 20)),
 			},
 			wantName: []string{"premier", "second", "troisieme"},
 		},
@@ -45,14 +45,14 @@ func TestPipelineRunSortByStartTime(t *testing.T) {
 	ns := "namespace"
 	labels := map[string]string{}
 	success := tektonv1.PipelineRunReasonSuccessful.String()
-	startedEarlierPR := tektontest.MakePRCompletion(clock, "earlier", ns, success, labels, 5)
+	startedEarlierPR := tektontest.MakePRCompletion(clock, "earlier", ns, success, nil, labels, 5)
 	startedEarlierPR.Status.StartTime = &metav1.Time{Time: clock.Now().Add(100 * time.Minute)}
 
-	noCompletionPR := tektontest.MakePRCompletion(clock, "noCompletion", ns, success, labels, 5)
+	noCompletionPR := tektontest.MakePRCompletion(clock, "noCompletion", ns, success, nil, labels, 5)
 	noCompletionPR.Status.StartTime = &metav1.Time{Time: clock.Now().Add(500 * time.Minute)}
 	noCompletionPR.Status.CompletionTime = nil
 
-	notStartedYet := tektontest.MakePRCompletion(clock, "notStarted", ns, success, labels, 5)
+	notStartedYet := tektontest.MakePRCompletion(clock, "notStarted", ns, success, nil, labels, 5)
 	noCompletionPR.Status.StartTime = nil
 	noCompletionPR.Status.CompletionTime = nil
 
@@ -64,8 +64,8 @@ func TestPipelineRunSortByStartTime(t *testing.T) {
 		{
 			name: "finished last started first",
 			pruns: []tektonv1.PipelineRun{
-				*(tektontest.MakePRCompletion(clock, "otherFirst", ns, success, labels, 30)),
-				*(tektontest.MakePRCompletion(clock, "otherSecond", ns, success, labels, 10)),
+				*(tektontest.MakePRCompletion(clock, "otherFirst", ns, success, nil, labels, 30)),
+				*(tektontest.MakePRCompletion(clock, "otherSecond", ns, success, nil, labels, 10)),
 				*startedEarlierPR,
 			},
 			wantName: []string{"earlier", "otherFirst", "otherSecond"},
@@ -74,8 +74,8 @@ func TestPipelineRunSortByStartTime(t *testing.T) {
 			name: "no completion but started first",
 			pruns: []tektonv1.PipelineRun{
 				*noCompletionPR,
-				*(tektontest.MakePRCompletion(clock, "otherFirst", ns, success, labels, 30)),
-				*(tektontest.MakePRCompletion(clock, "otherSecond", ns, success, labels, 10)),
+				*(tektontest.MakePRCompletion(clock, "otherFirst", ns, success, nil, labels, 30)),
+				*(tektontest.MakePRCompletion(clock, "otherSecond", ns, success, nil, labels, 10)),
 			},
 			wantName: []string{"noCompletion", "otherFirst", "otherSecond"},
 		},
@@ -84,8 +84,8 @@ func TestPipelineRunSortByStartTime(t *testing.T) {
 			name: "not started yet",
 			pruns: []tektonv1.PipelineRun{
 				*notStartedYet,
-				*(tektontest.MakePRCompletion(clock, "otherFirst", ns, success, labels, 30)),
-				*(tektontest.MakePRCompletion(clock, "otherSecond", ns, success, labels, 10)),
+				*(tektontest.MakePRCompletion(clock, "otherFirst", ns, success, nil, labels, 30)),
+				*(tektontest.MakePRCompletion(clock, "otherSecond", ns, success, nil, labels, 10)),
 			},
 			wantName: []string{"otherFirst", "otherSecond", "notStarted"},
 		},

--- a/pkg/test/tekton/genz.go
+++ b/pkg/test/tekton/genz.go
@@ -65,7 +65,7 @@ func MakePR(namespace, name string, childStatus []tektonv1.ChildStatusReference,
 	}
 }
 
-func MakePRCompletion(clock clockwork.FakeClock, name, namespace, runstatus string, labels map[string]string, timeshift int) *tektonv1.PipelineRun {
+func MakePRCompletion(clock clockwork.FakeClock, name, namespace, runstatus string, annotations, labels map[string]string, timeshift int) *tektonv1.PipelineRun {
 	// fakeing time logic give me headache
 	// this will make the pr finish 5mn ago, starting 5-5mn ago
 	starttime := time.Duration((timeshift - 5*-1) * int(time.Minute))
@@ -78,13 +78,16 @@ func MakePRCompletion(clock clockwork.FakeClock, name, namespace, runstatus stri
 		runstatus = "Failed"
 		statuscondition = corev1.ConditionFalse
 	}
+	if len(annotations) == 0 {
+		annotations = labels
+	}
 
 	return &tektonv1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Namespace:   namespace,
 			Labels:      labels,
-			Annotations: labels,
+			Annotations: annotations,
 		},
 		Status: tektonv1.PipelineRunStatus{
 			Status: knativeduckv1.Status{


### PR DESCRIPTION
When deleting a pipelinerun, the git-clone basic-auth secret should be deleted
as well, but in some cases of conflicts and the ownerRef not being set, the
secret is not deleted and we need to delete it manually.

Fixes #1297
