### PR TITLE
Add support for multiple catalog hubs

### DIFF
--- a/config/302-pac-configmap.yaml
+++ b/config/302-pac-configmap.yaml
@@ -49,6 +49,18 @@ data:
   # Tekton HUB catalog name
   hub-catalog-name: "tekton"
 
+  # Additional Hub Catalogs is supported, for example:
+  #
+  # catalog-1-id: anotherhub
+  # catalog-1-name: tekton
+  # catalog-1-url: https://api.other.com/v1
+  #
+  # this configuration will have a new catalog named anotherhub on  https://api.other.com/v1 endpoint and catalog name tekton
+  # to be used by a user in their templates like this:
+  # pipelinesascode.tekton.dev/task: "anotherhub://task"
+  #
+  # Increase the number of the catalog to add more of them
+
   # Allow fetching remote tasks
   remote-tasks: "true"
 

--- a/docs/content/docs/guide/resolver.md
+++ b/docs/content/docs/guide/resolver.md
@@ -48,6 +48,9 @@ location with annotations on PipelineRun.
 If the resolver sees a PipelineRun referencing a remote task or a Pipeline in
 a PipelineRun or a PipelineSpec it will automatically inlines them.
 
+If multiple annotations reference the same task name the resolver will pick the
+first one fetched from the annotations.
+
 An annotation to a remote task looks like this :
 
 ```yaml
@@ -98,6 +101,20 @@ this example :
 ```yaml
 pipelinesascode.tekton.dev/task: "[git-clone:0.1]" # this will install git-clone 0.1 from tekton.hub
 ```
+
+#### Custom [Tekton Hub](https://github.com/tektoncd/hub/)
+
+Additionally if the cluster administrator has [set-up](/docs/install/settings#tekton-hub-support) a custom Tekton Hub you
+are able to reference it from your template like this example:
+
+```yaml
+pipelinesascode.tekton.dev/task: "[anothercatalog://curl]" # this will install curl from the custom catalog configured by the cluster administrator as anothercatalog
+```
+
+There is no fallback to the default Tekton Hub if the custom Tekton Hub does not
+have the task referenced it will fail.
+
+There is no support for custom hub from the CLI on the `tkn pac resolver` command.
 
 ### Remote HTTP URL
 

--- a/docs/content/docs/install/settings.md
+++ b/docs/content/docs/install/settings.md
@@ -3,7 +3,7 @@ title: Settings
 weight: 3
 ---
 
-## Pipelines-As-Code configuration settings
+## Pipelines-as-Code configuration settings
 
 There is a few things you can configure through the config map
 `pipelines-as-code` in the `pipelines-as-code` namespace.
@@ -62,15 +62,6 @@ There is a few things you can configure through the config map
 
   This allows fetching remote tasks on pipelinerun annotations. This feature is
   enabled by default.
-
-* `hub-url`
-
-  The base URL for the [tekton hub](https://github.com/tektoncd/hub/)
-  API. This default to the [public hub](https://hub.tekton.dev/): <https://api.hub.tekton.dev/v1>
-
-* `hub-catalog-name`
-
-  The [tekton hub](https://github.com/tektoncd/hub/) catalog name. default to `tekton`
 
 * `bitbucket-cloud-check-source-ip`
 
@@ -133,13 +124,44 @@ There is a few things you can configure through the config map
 
   `https://github.com/owner/repo` will be `owner-repo-ci`
 
+### Tekton Hub support
+
+Pipelines-as-Code supports fetching task with its remote annotations feature, by default it will fetch it from the [public tekton hub](https://hub.tekton.dev/) but you can configure it to point to your own with these settings:
+
+* `hub-url`
+
+  The base URL for the [tekton hub](https://github.com/tektoncd/hub/)
+  API. This default to the [public hub](https://hub.tekton.dev/): <https://api.hub.tekton.dev/v1>
+
+* `hub-catalog-name`
+
+  The [tekton hub](https://github.com/tektoncd/hub/) catalog name. default to `tekton`
+
+* Additionally you can have multiple hub configured by using the following format:
+
+  ```yaml
+  catalog-1-id: "custom"
+  catalog-1-name: "tekton"
+  catalog-1-url: "https://api.custom.hub/v1"
+  ```
+
+  Users are able to reference the custom hub by adding a `custom://` prefix to
+  their task they want to fetch from the `custom` catalog.
+
+  You can add as many custom hub as you want by incrementing the `catalog-NUMBER` number.
+
+  Pipelines-as-Code will not try to fallback to the default or another custom hub
+  if the task referenced is not found (the Pull Request will be set as failed)
+
 ### Error Detection
 
 Pipelines-as-Code detect if the PipelineRun has failed and show a snippet of
 the last few lines of the error.
 
-On GitHub Aopps, It also try to detect and match the error messages in the container logs and expose them as annotations on Pull
-Request.
+When using the GitHub App, It will try to detect and match the error messages
+in the container logs and expose them as [GitHub
+annotations](https://github.blog/2018-12-14-introducing-check-runs-and-annotations/)
+on Pull Request.
 
 A few settings are available to configure this feature:
 
@@ -231,7 +253,7 @@ A few settings are available to configure this feature:
 
   * `{{ namespace }}`: The target namespace where the pipelinerun is executed
   * `{{ pr }}`: The PipelineRun name.
-  
+
   example: `https://mycorp.com/ns/{{ namespace }}/pipelinerun/{{ pr }}`
 
   Moreover it can access the [custom parameters](../guide/repositorycrd/#custom-parameter-expansion) from a
@@ -246,16 +268,16 @@ A few settings are available to configure this feature:
    ```
 
   and the global configuration setting for `custom-console-url-pr-details` is:
-  
+
   `https://mycorp.com/ns/{{ namespace }}/{{ custom }}`
-  
+
   the `{{ custom }}` tag in the URL is expanded as `value`.
-  
+
   This let operator to add specific informations like a `UUID` about a user as
   parameter in their repo CR and let it link to the console.
-  
+
 * `custom-console-url-pr-tasklog`
-  
+
   Set this to the URL where to view the log of the taskrun of the `PipelineRun`. This is
   shown when we post a result of the task breakdown to link to the logs of the taskrun.
 
@@ -271,7 +293,7 @@ A few settings are available to configure this feature:
 
   example: `https://mycorp.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}#{{ pod }}-{{ firstFailedStep }}`
 
-## Pipelines-As-Code Info
+## Pipelines-as-Code Info
 
   There are a settings exposed through a config map for which any authenticated
   user can access to know about the Pipelines-as-Code status. This Configmap

--- a/hack/dev/kind/install.sh
+++ b/hack/dev/kind/install.sh
@@ -164,7 +164,8 @@ function configure_pac() {
 
     kubectl patch configmap -n pipelines-as-code -p "{\"data\":{\"bitbucket-cloud-check-source-ip\": \"false\"}}"  pipelines-as-code && \
     kubectl patch configmap -n pipelines-as-code -p "{\"data\":{\"tekton-dashboard-url\": \"http://dashboard.${DOMAIN_NAME}\"}}" --type merge pipelines-as-code
-
+    # add custom catalog so we can use it in e2e, this will points to the normal upstream hub so we can easily use it
+    kubectl patch configmap -n pipelines-as-code -p '{"data":{"catalog-1-id": "custom", "catalog-1-name": "tekton", "catalog-1-url": "https://api.hub.tekton.dev/v1"}}' --type merge pipelines-as-code
     set +x
     if [[ -n ${PAC_PASS_SECRET_FOLDER} ]];then
         echo "Installing PAC secrets"

--- a/pkg/hub/get.go
+++ b/pkg/hub/get.go
@@ -9,11 +9,11 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 )
 
-func getSpecificVersion(ctx context.Context, cs *params.Run, task string) (string, error) {
+func getSpecificVersion(ctx context.Context, cs *params.Run, catalogName, task string) (string, error) {
 	split := strings.Split(task, ":")
 	version := split[len(split)-1]
 	taskName := split[0]
-	url := fmt.Sprintf("%s/resource/%s/task/%s/%s", cs.Info.Pac.HubURL, cs.Info.Pac.HubCatalogName, taskName, version)
+	url := fmt.Sprintf("%s/resource/%s/task/%s/%s", cs.Info.Pac.HubCatalogs[catalogName].URL, cs.Info.Pac.HubCatalogs[catalogName].Name, taskName, version)
 	hr := hubResourceVersion{}
 	data, err := cs.Clients.GetURL(ctx, url)
 	if err != nil {
@@ -26,8 +26,8 @@ func getSpecificVersion(ctx context.Context, cs *params.Run, task string) (strin
 	return fmt.Sprintf("%s/raw", url), nil
 }
 
-func getLatestVersion(ctx context.Context, cs *params.Run, task string) (string, error) {
-	url := fmt.Sprintf("%s/resource/%s/task/%s", cs.Info.Pac.HubURL, cs.Info.Pac.HubCatalogName, task)
+func getLatestVersion(ctx context.Context, cs *params.Run, catalogName, task string) (string, error) {
+	url := fmt.Sprintf("%s/resource/%s/task/%s", cs.Info.Pac.HubCatalogs[catalogName].URL, cs.Info.Pac.HubCatalogs[catalogName].Name, task)
 	hr := new(hubResource)
 	data, err := cs.Clients.GetURL(ctx, url)
 	if err != nil {
@@ -41,14 +41,14 @@ func getLatestVersion(ctx context.Context, cs *params.Run, task string) (string,
 	return fmt.Sprintf("%s/%s/raw", url, *hr.Data.LatestVersion.Version), nil
 }
 
-func GetTask(ctx context.Context, cli *params.Run, task string) (string, error) {
+func GetTask(ctx context.Context, cli *params.Run, catalogName, task string) (string, error) {
 	var rawURL string
 	var err error
 
 	if strings.Contains(task, ":") {
-		rawURL, err = getSpecificVersion(ctx, cli, task)
+		rawURL, err = getSpecificVersion(ctx, cli, catalogName, task)
 	} else {
-		rawURL, err = getLatestVersion(ctx, cli, task)
+		rawURL, err = getLatestVersion(ctx, cli, catalogName, task)
 	}
 	if err != nil {
 		return "", fmt.Errorf("could not fetch remote task %s, hub API returned: %w", task, err)

--- a/pkg/params/run.go
+++ b/pkg/params/run.go
@@ -125,7 +125,13 @@ func New() *Run {
 			Pac: &info.PacOpts{
 				Settings: &settings.Settings{
 					ApplicationName: settings.PACApplicationNameDefaultValue,
-					HubURL:          settings.HubURLDefaultValue,
+					HubCatalogs: map[string]settings.HubCatalog{
+						"default": {
+							ID:   "default",
+							Name: settings.HubCatalogNameDefaultValue,
+							URL:  settings.HubURLDefaultValue,
+						},
+					},
 				},
 			},
 		},

--- a/pkg/params/settings/config_test.go
+++ b/pkg/params/settings/config_test.go
@@ -89,7 +89,15 @@ func TestConfigToSettings(t *testing.T) {
 					HubURLKey: "https://test",
 				},
 			},
-			wantLogContains: "hub URL set to https://test",
+		},
+		{
+			name: "set hub name",
+			args: args{
+				setting: &Settings{},
+				config: map[string]string{
+					HubCatalogNameKey: "foo",
+				},
+			},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/params/settings/default.go
+++ b/pkg/params/settings/default.go
@@ -1,6 +1,73 @@
 package settings
 
-import "strconv"
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+
+	"go.uber.org/zap"
+)
+
+func gethHubCatalogs(logger *zap.SugaredLogger, settings *Settings, config map[string]string) map[string]HubCatalog {
+	catalogs := make(map[string]HubCatalog)
+	if hubURL, ok := config[HubURLKey]; !ok || hubURL == "" {
+		config[HubURLKey] = HubURLDefaultValue
+		logger.Infof("CONFIG: using default hub url %s", HubURLDefaultValue)
+	}
+
+	if hubCatalogName, ok := config[HubCatalogNameKey]; !ok || hubCatalogName == "" {
+		config[HubCatalogNameKey] = HubCatalogNameDefaultValue
+	}
+	catalogs["default"] = HubCatalog{
+		ID:   "default",
+		Name: config[HubCatalogNameKey],
+		URL:  config[HubURLKey],
+	}
+
+	for k := range config {
+		m := hubCatalogNameRegex.FindStringSubmatch(k)
+		if len(m) > 0 {
+			id := m[1]
+			cPrefix := fmt.Sprintf("catalog-%s", id)
+			skip := false
+			for _, kk := range []string{"id", "name", "url"} {
+				cKey := fmt.Sprintf("%s-%s", cPrefix, kk)
+				// check if key exist in config
+				if _, ok := config[cKey]; !ok {
+					logger.Warnf("CONFIG: hub %v should have the key %s, skipping catalog configuration", id, cKey)
+					skip = true
+					break
+				} else if config[cKey] == "" {
+					logger.Warnf("CONFIG: hub %v catalog configuration is empty, skipping catalog configuration", id)
+					skip = true
+					break
+				}
+			}
+			if !skip {
+				catalogID := config[fmt.Sprintf("%s-id", cPrefix)]
+				if catalogID == "http" || catalogID == "https" {
+					logger.Warnf("CONFIG: custom hub catalog name cannot be %s, skipping catalog configuration", catalogID)
+					break
+				}
+				catalogURL := config[fmt.Sprintf("%s-url", cPrefix)]
+				u, err := url.Parse(catalogURL)
+				if err != nil || u.Scheme == "" || u.Host == "" {
+					logger.Warnf("CONFIG: custom hub %s, catalog url %s is not valid, skipping catalog configuration", catalogID, catalogURL)
+					break
+				}
+				if _, ok := settings.HubCatalogs[catalogID]; !ok {
+					logger.Infof("CONFIG: setting custom hub %s, catalog %s", catalogID, catalogURL)
+				}
+				catalogs[catalogID] = HubCatalog{
+					ID:   catalogID,
+					Name: config[fmt.Sprintf("%s-name", cPrefix)],
+					URL:  catalogURL,
+				}
+			}
+		}
+	}
+	return catalogs
+}
 
 func SetDefaults(config map[string]string) {
 	if appName, ok := config[ApplicationNameKey]; !ok || appName == "" {
@@ -13,14 +80,6 @@ func SetDefaults(config map[string]string) {
 
 	if ghScopedToken, ok := config[SecretGhAppTokenRepoScopedKey]; !ok || ghScopedToken == "" {
 		config[SecretGhAppTokenRepoScopedKey] = secretGhAppTokenRepoScopedDefaultValue
-	}
-
-	if hubURL, ok := config[HubURLKey]; !ok || hubURL == "" {
-		config[HubURLKey] = HubURLDefaultValue
-	}
-
-	if hubCatalogName, ok := config[HubCatalogNameKey]; !ok || hubCatalogName == "" {
-		config[HubCatalogNameKey] = hubCatalogNameDefaultValue
 	}
 
 	if remoteTasks, ok := config[RemoteTasksKey]; !ok || remoteTasks == "" {

--- a/pkg/params/settings/default_test.go
+++ b/pkg/params/settings/default_test.go
@@ -3,6 +3,8 @@ package settings
 import (
 	"testing"
 
+	"go.uber.org/zap"
+	zapobserver "go.uber.org/zap/zaptest/observer"
 	"gotest.tools/v3/assert"
 )
 
@@ -13,6 +15,79 @@ func TestSetDefaults(t *testing.T) {
 	assert.Equal(t, config[SecretAutoCreateKey], secretAutoCreateDefaultValue)
 	assert.Equal(t, config[BitbucketCloudCheckSourceIPKey], bitbucketCloudCheckSourceIPDefaultValue)
 	assert.Equal(t, config[ApplicationNameKey], PACApplicationNameDefaultValue)
-	assert.Equal(t, config[HubURLKey], HubURLDefaultValue)
-	assert.Equal(t, config[HubCatalogNameKey], hubCatalogNameDefaultValue)
+}
+
+func TestGetCatalogHub(t *testing.T) {
+	config := make(map[string]string)
+	config["catalog-1-id"] = "custom"
+	config["catalog-1-url"] = "https://foo.com"
+	config["catalog-1-name"] = "https://foo.com"
+	tests := []struct {
+		name             string
+		config           map[string]string
+		numCatalogs      int
+		wantLog          string
+		existingSettings *Settings
+	}{
+		{
+			name:        "good/default catalog",
+			numCatalogs: 1,
+		},
+		{
+			name: "good/custom catalog",
+			config: map[string]string{
+				"catalog-1-id":   "custom",
+				"catalog-1-url":  "https://foo.com",
+				"catalog-1-name": "tekton",
+			},
+			numCatalogs: 2,
+			wantLog:     "CONFIG: setting custom hub custom, catalog https://foo.com",
+		},
+		{
+			name: "bad/missing keys custom catalog",
+			config: map[string]string{
+				"catalog-1-id":   "custom",
+				"catalog-1-name": "tekton",
+			},
+			numCatalogs: 1,
+			wantLog:     "CONFIG: hub 1 should have the key catalog-1-url, skipping catalog configuration",
+		},
+		{
+			name: "bad/custom catalog called https",
+			config: map[string]string{
+				"catalog-1-id":   "https",
+				"catalog-1-url":  "https://foo.com",
+				"catalog-1-name": "tekton",
+			},
+			numCatalogs: 1,
+			wantLog:     "CONFIG: custom hub catalog name cannot be https, skipping catalog configuration",
+		},
+		{
+			name: "bad/invalid url",
+			config: map[string]string{
+				"catalog-1-id":   "custom",
+				"catalog-1-url":  "/u1!@1!@#$afoo.com",
+				"catalog-1-name": "tekton",
+			},
+			numCatalogs: 1,
+			wantLog:     "catalog url /u1!@1!@#$afoo.com is not valid, skipping catalog configuration",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			observer, catcher := zapobserver.New(zap.InfoLevel)
+			fakelogger := zap.New(observer).Sugar()
+			if tt.config == nil {
+				tt.config = map[string]string{}
+			}
+			if tt.existingSettings == nil {
+				tt.existingSettings = &Settings{}
+			}
+			catalogs := gethHubCatalogs(fakelogger, tt.existingSettings, tt.config)
+			assert.Equal(t, len(catalogs), tt.numCatalogs)
+			if tt.wantLog != "" {
+				assert.Assert(t, len(catcher.FilterMessageSnippet(tt.wantLog).TakeAll()) > 0, "could not find log message: got ", catcher)
+			}
+		})
+	}
 }

--- a/pkg/resolve/resolve.go
+++ b/pkg/resolve/resolve.go
@@ -74,6 +74,10 @@ func readTypes(ctx context.Context, log *zap.SugaredLogger, data string) (Types,
 	return types, nil
 }
 
+// getTaskRunByName returns the taskrun with the given name the first one found
+// will be matched. It does not handle conflicts so user has fetched multiple
+// taskruns with the same name it will just pick up the first one.
+// if the taskrun is not found it returns an error
 func getTaskByName(name string, tasks []*tektonv1.Task) (*tektonv1.Task, error) {
 	for _, value := range tasks {
 		if value.Name == name {

--- a/test/testdata/pipeline_in_tektondir.yaml
+++ b/test/testdata/pipeline_in_tektondir.yaml
@@ -21,3 +21,14 @@ spec:
     - name: task-referenced-internally
       taskRef:
         name: task-referenced-internally
+
+    - name: task-from-custom-hub
+      taskRef:
+        name: curl
+      params:
+        - name: url
+          value: https://icanhazip.com
+        - name: options
+          value:
+          - "-f"
+          - "--fail-early"

--- a/test/testdata/pipelinerun_remote_task_annotations.yaml
+++ b/test/testdata/pipelinerun_remote_task_annotations.yaml
@@ -10,6 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/task: "[.other-tasks/task-referenced-internally.yaml]"
     pipelinesascode.tekton.dev/task-1: "[\\ .RemoteTaskURL //]"
     pipelinesascode.tekton.dev/task-2: "pylint"
+    pipelinesascode.tekton.dev/task-3: "custom://curl"
 spec:
   pipelineRef:
     name: pipeline-in-tekton-dir


### PR DESCRIPTION
Epic: https://issues.redhat.com/browse/SRVKP-3219

## Description:

- Let platform administrators setup multiple hub endpoint

  Pipelines as Code allows customization of the catalog hub from where the tasks are fetched, using upstream hub as default.

  Platforms Administrators may want to configure multiple catalog hubs to utilize tasks from different locations. For example, they might have their own set of tasks from their own hub and also want to use tasks from the official upstream Hub.

- Let the user specify the catalog hub from which they want to fetch tasks in the PipelineRun.

  Users should be able to specify in the PipelineRun from which catalog hub they want to fetch tasks. This allows them to use tasks from different catalog hubs within the same PipelineRun.

## Non-Goals:

This applies only to Pipelines as Code's remote resolution from hub feature using annotations and does not apply to the Tekton custom resolver feature.

Implementation:

An admin can configure multiple hubs within the Pipelines-as-Code Configmap.

The default configuration for fetching task from the hub isas follows:

```yaml
hub-catalog-name: tekton
hub-catalog-url: https://api.hub.tekton.dev/v1
Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
```

When a user writes a PipelineRun with the annotation:

```
pipelinesascode.tekton.dev/task: "task"
```

the task will be fetched from the default hub.

If the cluster administrator wants to configure multiple hubs, they can add a setting in the configmap as follows:

```yaml=
catalog-1-id: anotherhub
catalog-1-name: tekton
catalog-1-url: https://api.other.com/v1
```

To use this hub, the user can write the following annotation in their PipelineRun:

```
pipelinesascode.tekton.dev/task: "anotherhub://task"
```

Additional hubs can be added by increasing the number in the configmap:

```yaml=
catalog-2-catalog-id: myhub
catalog-2-name: tekton
catalog-2-url: https://api.myhub.com/v1
catalog-3-id: anotherone
catalog-3-name: tekton
catalog-3-url: https://api.myhub.com/v1
```

*(**Note**: `catalog-name` is an implementation detail of the hub API to specify multiple catalogs from the same hub endpoint.)*

## Fallback:

No fallback mechanism is implemented. If the task is not found on the specified hub, the PipelineRun will fail.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [X] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [X] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [X] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [X] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [X] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [X] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
