### PR TITLE
Fix branch matching based on base name

### DIFF
--- a/pkg/matcher/annotation_matcher.go
+++ b/pkg/matcher/annotation_matcher.go
@@ -3,7 +3,6 @@ package matcher
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -26,12 +25,6 @@ const (
 )
 
 func branchMatch(prunBranch, baseBranch string) bool {
-	// If we have targetBranch in annotation and refs/heads/targetBranch from
-	// webhook, then allow it.
-	if filepath.Base(baseBranch) == filepath.Base(prunBranch) {
-		return true
-	}
-
 	// if target is refs/heads/.. and base is without ref (for pullRequest)
 	if strings.HasPrefix(prunBranch, "refs/heads") && !strings.Contains(baseBranch, "/") {
 		ref := "refs/heads/" + baseBranch

--- a/pkg/matcher/annotation_matcher_test.go
+++ b/pkg/matcher/annotation_matcher_test.go
@@ -813,6 +813,16 @@ func TestMatchPipelinerunByAnnotation(t *testing.T) {
 		},
 	}
 
+	pipelinePush := &tektonv1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pipeline-push",
+			Annotations: map[string]string{
+				keys.OnEvent:        "[push]",
+				keys.OnTargetBranch: "[main]",
+			},
+		},
+	}
+
 	pipelineOther := &tektonv1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "pipeline-other",
@@ -1049,6 +1059,22 @@ func TestMatchPipelinerunByAnnotation(t *testing.T) {
 				runevent: info.Event{TriggerTarget: "pull_request", EventType: "pull_request", BaseBranch: "refs/heads/main"},
 			},
 			wantErr: false,
+		},
+		{
+			name: "not-match-push-branch-matching",
+			args: args{
+				runevent: info.Event{TriggerTarget: "push", EventType: "push", BaseBranch: "refs/heads/someothername/then/main"},
+				pruns:    []*tektonv1.PipelineRun{pipelineGood, pipelinePush},
+			},
+			wantErr: true,
+		},
+		{
+			name: "not-match-pull-request-branch-matching",
+			args: args{
+				runevent: info.Event{TriggerTarget: "pull_request", EventType: "pull_request", BaseBranch: "someothername/then/main"},
+				pruns:    []*tektonv1.PipelineRun{pipelineGood, pipelinePush},
+			},
+			wantErr: true,
 		},
 	}
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Fixes : https://issues.redhat.com/browse/SRVKP-3296

After this fix PAC will not run all those PipelineRuns based on branch base name instead will check base name and exact branch name

**Before :**
Ex: https://github.com/savitaashture/article/pull/362

The `test-jira-issue` branch have 2 pipelineruns and when we push to `me/test/test-jira-issue` branch then the push pipeline use to trigger for branch `test-jira-issue`

**After :**
Ex: https://github.com/savitaashture/article/pull/369

The `test-jira-issue` branch have 2 pipelineruns and when we push to `m/l/test-jira-issue` branch then the push pipeline will not trigger now


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
