### PR TITLE
Update custom param doc with proper syntax for filter

### DIFF
--- a/docs/content/docs/guide/repositorycrd.md
+++ b/docs/content/docs/guide/repositorycrd.md
@@ -194,10 +194,7 @@ spec:
   params:
     - name: company
       value: "My Beautiful Company"
-      filter:
-        - name: event
-          value: |
-      pac.event_type == "pull_request"
+      filter: pac.event_type == "pull_request"
 ```
 
 The `pac` prefix contains all the values as set by default in the templates
@@ -224,10 +221,7 @@ spec:
   params:
     - name: company
       value: "My Beautiful Company"
-      filter:
-        - name: event
-          value: |
-      body.action == "opened" && pac.event_type == "pull_request"
+      filter: body.action == "opened" && pac.event_type == "pull_request"
 ```
 
 The payload of the event contains much more information that can be used with


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
when syntax followed for custom params using doc getting below error
```
Error "Invalid value: "array": spec.params[0].filter in body must be of type string: "array"" for field "spec.params[0].filter".
```
because filter is of type string https://github.com/openshift-pipelines/pipelines-as-code/blob/main/pkg/apis/pipelinesascode/v1alpha1/types.go#L96 so updated doc accordingly 

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
