### PR TITLE
Fix goreleaser.yaml indentation and deprecations

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,15 +23,15 @@ builds:
       - -X github.com/openshift-pipelines/pipelines-as-code/pkg/params/version.Version={{.Version}}
 archives:
   - name_template: >-
-     {{ .Binary }}_
-     {{ .Version }}_
-     {{ .Os }}_
-     {{- if eq .Arch "amd64" }}x86_64
-     {{- else if eq .Arch "386" }}i386
-     {{- else if eq .Arch "darwin" }}MacOS
-     {{- else if eq .Arch "linux" }}Linux
-     {{- else if eq .Arch "windows" }}Windows
-     {{- else }}{{ .Arch }}{{ end }}
+      {{ .Binary }}_
+      {{ .Version }}_
+      {{ .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else if eq .Arch "darwin" }}MacOS
+      {{- else if eq .Arch "linux" }}Linux
+      {{- else if eq .Arch "windows" }}Windows
+      {{- else }}{{ .Arch }}{{ end }}
     format_overrides:
       - goos: windows
         format: zip
@@ -72,7 +72,7 @@ release:
 
 brews:
   - name: tektoncd-pac
-    tap:
+    repository:
       owner: openshift-pipelines
       name: homebrew-pipelines-as-code
     folder: Formula


### PR DESCRIPTION
This will fix the goreleaser.yaml indentation possibly fixing the extra space issue in formula and remove one more deprecation warning

# Submitter Checklist

- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
