### PR TITLE
Not list configmaps in all namespaces

### DIFF
--- a/pkg/cmd/tknpac/bootstrap/bootstrap_test.go
+++ b/pkg/cmd/tknpac/bootstrap/bootstrap_test.go
@@ -12,6 +12,8 @@ import (
 	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/test/logger"
 	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	rtesting "knative.dev/pkg/reconciler/testing"
 )
 
@@ -45,4 +47,97 @@ func TestInstall(t *testing.T) {
 	// get an error because i need to figure out how to fake dynamic client
 	assert.Assert(t, err != nil)
 	assert.Equal(t, "=> Checking if Pipelines as Code is installed.\n", out.String())
+}
+
+func TestDetectPacInstallation(t *testing.T) {
+	testParams := []struct {
+		name                  string
+		namespace             string
+		userProvidedNamespace string
+		configMap             *corev1.ConfigMap
+		wantInstalled         bool
+		wantNamespace         string
+		wantError             bool
+		errorMsg              string
+	}{
+		{
+			name:          "get configmap in pipeline-as-code namespace",
+			namespace:     pacNS,
+			configMap:     getConfigMapData(pacNS, "v0.17.2"),
+			wantNamespace: pacNS,
+			wantInstalled: true,
+		}, {
+			name:          "get configmap in openshift-pipelines namespace",
+			namespace:     "openshift-pipelines",
+			configMap:     getConfigMapData("openshift-pipelines", "v0.17.2"),
+			wantNamespace: "openshift-pipelines",
+			wantInstalled: true,
+		}, {
+			name:                  "get configmap present in different namespace other than default namespaces",
+			namespace:             "test",
+			userProvidedNamespace: "test",
+			configMap:             getConfigMapData("test", "dev"),
+			wantNamespace:         "test",
+			wantInstalled:         true,
+		}, {
+			name:                  "configmap not in default namespace",
+			namespace:             "test",
+			userProvidedNamespace: "",
+			configMap:             getConfigMapData("test", "v0.17.2"),
+			wantError:             true,
+			errorMsg:              "could not detect Pipelines as Code configmap on the cluster, please specify the namespace in which pac is installed: ConfigMap not found in default namespaces (\"openshift-pipelines\", \"pipelines-as-code\")",
+			wantInstalled:         false,
+		}, {
+			name:                  "configmap not in default namespace with user provided namespace",
+			namespace:             "test",
+			userProvidedNamespace: "test1",
+			configMap:             getConfigMapData("test", "v0.17.2"),
+			wantError:             true,
+			errorMsg:              "could not detect Pipelines as Code configmap in test1 namespace : configmaps \"pipelines-as-code-info\" not found, please reinstall",
+			wantInstalled:         false,
+		},
+	}
+	for _, tp := range testParams {
+		t.Run(tp.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			cs, _ := testclient.SeedTestData(t, ctx, testclient.Data{})
+			logger, _ := logger.GetLogger()
+
+			run := &params.Run{
+				Clients: clients.Clients{
+					PipelineAsCode: cs.PipelineAsCode,
+					Log:            logger,
+					Kube:           cs.Kube,
+				},
+				Info: info.Info{},
+			}
+			if _, err := run.Clients.Kube.CoreV1().ConfigMaps(tp.namespace).Create(ctx, tp.configMap, metav1.CreateOptions{}); err != nil {
+				t.Errorf("failed to create configmap: %v", err)
+			}
+			installed, ns, err := DetectPacInstallation(ctx, tp.userProvidedNamespace, run)
+			if err != nil {
+				if !tp.wantError {
+					t.Errorf("Not expecting error but got: %v", err)
+				} else {
+					assert.Equal(t, err.Error(), tp.errorMsg)
+				}
+			} else {
+				assert.Equal(t, tp.wantInstalled, installed)
+				assert.Equal(t, tp.wantNamespace, ns)
+			}
+		})
+	}
+}
+
+func getConfigMapData(namespace, version string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      infoConfigMap,
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			"version": version,
+		},
+	}
 }

--- a/pkg/cmd/tknpac/bootstrap/kubestuff.go
+++ b/pkg/cmd/tknpac/bootstrap/kubestuff.go
@@ -10,8 +10,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const configMapPacLabel = "app.kubernetes.io/part-of=pipelines-as-code"
-
 // deleteSecret delete secret first if it exists
 func deleteSecret(ctx context.Context, run *params.Run, opts *bootstrapOpts) error {
 	return run.Clients.Kube.CoreV1().Secrets(opts.targetNamespace).Delete(ctx, secretName, metav1.DeleteOptions{})


### PR DESCRIPTION
This commit makes the changes to detect pac installation only in
default namespace i.e. pipelines-as-cdoe and openshift-pipelines
or other if provided by user through --pac-namespace flag

This makes the tkn pac create repo command usable for
non-admin users too

But on the other side, it will be a breaking change for admin users
who have pac installed in some other namespace and were
using the commands without pac-namespace flag till now

It will affect tkn pac create repo, tkn pac bootstrap and
tkn pac webhook add commands for users who had permissions till now
and were not using --pac-namespace flag

# Submitter Checklist

- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
