### PR TITLE
Fix /ok-to-test behaviour and add remember-ok-to-test flag

### DIFF
--- a/config/302-pac-configmap.yaml
+++ b/config/302-pac-configmap.yaml
@@ -122,6 +122,15 @@ data:
   # https://github.com/owner/repo will be `owner-repo-ci`
   auto-configure-repo-namespace-template: ""
 
+  # Enable or disable the feature to rerun the CI if push event happens on
+  # a pull request
+  #
+  # By default it is true and CI will be re-run in case of push/amend on the
+  # pull request if ok-to-test is done once
+  #
+  # you may want to disable this if ok-to-test should be done on each iteration
+  remember-ok-to-test: "true"
+
   # Configure a custom console here, the driver support custom parameters from
   # Repo CR along a few other template variable, see documentation for more
   # details

--- a/docs/content/docs/install/operator_installation.md
+++ b/docs/content/docs/install/operator_installation.md
@@ -41,6 +41,7 @@ spec:
             ]*)?(?P<error>.*)
           secret-auto-create: 'true'
           secret-github-app-token-scoped: 'true'
+          remember-ok-to-test: 'true'
 ```
 
 You can add or update all supported configuration keys for Pipelines-as-Code under `settings`. After you change the `TektonConfig` custom resource, the operator updates the configuration of your `pipelines-as-code` configmap automatically.

--- a/docs/content/docs/install/settings.md
+++ b/docs/content/docs/install/settings.md
@@ -124,6 +124,15 @@ There is a few things you can configure through the config map
 
   `https://github.com/owner/repo` will be `owner-repo-ci`
 
+* `remember-ok-to-test`
+
+  If `remember-ok-to-test` is true then if `ok-to-test` is done on pull request then in
+  case of push event on pull request either through new commit or amend, then CI will
+  re-run automatically
+
+  You can disable by setting false if you want to provide `ok-to-test` on every iteration
+  (only GitHub and Gitea is supported at the moment).
+
 ### Tekton Hub support
 
 Pipelines-as-Code supports fetching task with its remote annotations feature, by default it will fetch it from the [public tekton hub](https://hub.tekton.dev/) but you can configure it to point to your own with these settings:

--- a/pkg/params/settings/config.go
+++ b/pkg/params/settings/config.go
@@ -54,6 +54,9 @@ const (
 
 	ErrorDetectionSimpleRegexpKey   = "error-detection-simple-regexp"
 	errorDetectionSimpleRegexpValue = `^(?P<filename>[^:]*):(?P<line>[0-9]+):(?P<column>[0-9]+):([ ]*)?(?P<error>.*)`
+
+	RememberOKToTestKey   = "remember-ok-to-test"
+	rememberOKToTestValue = "true"
 )
 
 var (
@@ -94,6 +97,8 @@ type Settings struct {
 	CustomConsoleURL       string
 	CustomConsolePRdetail  string
 	CustomConsolePRTaskLog string
+
+	RememberOKToTest bool
 }
 
 func ConfigToSettings(logger *zap.SugaredLogger, setting *Settings, config map[string]string) error {
@@ -224,6 +229,12 @@ func ConfigToSettings(logger *zap.SugaredLogger, setting *Settings, config map[s
 	if setting.CustomConsolePRTaskLog != config[CustomConsolePRTaskLogKey] {
 		logger.Infof("CONFIG: setting custom console pr task log URL to %v", config[CustomConsolePRTaskLogKey])
 		setting.CustomConsolePRTaskLog = config[CustomConsolePRTaskLogKey]
+	}
+
+	rememberOKToTest := StringToBool(config[RememberOKToTestKey])
+	if setting.RememberOKToTest != rememberOKToTest {
+		logger.Infof("CONFIG: setting remember ok-to-test to %v", rememberOKToTest)
+		setting.RememberOKToTest = rememberOKToTest
 	}
 
 	return nil

--- a/pkg/params/settings/config_test.go
+++ b/pkg/params/settings/config_test.go
@@ -82,6 +82,16 @@ func TestConfigToSettings(t *testing.T) {
 			wantLogContains: "secret auto create",
 		},
 		{
+			name: "set remember-ok-to-test key",
+			args: args{
+				setting: &Settings{RememberOKToTest: true},
+				config: map[string]string{
+					RememberOKToTestKey: "false",
+				},
+			},
+			wantLogContains: "remember ok-to-test",
+		},
+		{
 			name: "set hub url",
 			args: args{
 				setting: &Settings{},

--- a/pkg/params/settings/default.go
+++ b/pkg/params/settings/default.go
@@ -121,4 +121,8 @@ func SetDefaults(config map[string]string) {
 	if v, ok := config[CustomConsolePRTaskLogKey]; !ok || v == "" {
 		config[CustomConsolePRTaskLogKey] = v
 	}
+
+	if rememberOKToTest, ok := config[RememberOKToTestKey]; !ok || rememberOKToTest == "" {
+		config[RememberOKToTestKey] = rememberOKToTestValue
+	}
 }

--- a/pkg/params/settings/default_test.go
+++ b/pkg/params/settings/default_test.go
@@ -15,6 +15,7 @@ func TestSetDefaults(t *testing.T) {
 	assert.Equal(t, config[SecretAutoCreateKey], secretAutoCreateDefaultValue)
 	assert.Equal(t, config[BitbucketCloudCheckSourceIPKey], bitbucketCloudCheckSourceIPDefaultValue)
 	assert.Equal(t, config[ApplicationNameKey], PACApplicationNameDefaultValue)
+	assert.Equal(t, config[RememberOKToTestKey], rememberOKToTestValue)
 }
 
 func TestGetCatalogHub(t *testing.T) {

--- a/pkg/params/settings/validation.go
+++ b/pkg/params/settings/validation.go
@@ -83,6 +83,13 @@ func Validate(config map[string]string) error {
 			return fmt.Errorf("invalid value for key %v, must start with http:// or https://", CustomConsolePRTaskLogKey)
 		}
 	}
+
+	if check, ok := config[RememberOKToTestKey]; ok && check != "" {
+		if !isValidBool(check) {
+			return fmt.Errorf("invalid value for key %v, acceptable values: true or false", RememberOKToTestKey)
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/params/settings/validation_test.go
+++ b/pkg/params/settings/validation_test.go
@@ -20,6 +20,7 @@ func TestValidate(t *testing.T) {
 				BitbucketCloudCheckSourceIPKey: "false",
 				MaxKeepRunUpperLimitKey:        "7",
 				DefaultMaxKeepRunsKey:          "8",
+				RememberOKToTestKey:            "true",
 			},
 			wantErr: "",
 		},
@@ -29,6 +30,13 @@ func TestValidate(t *testing.T) {
 				SecretAutoCreateKey: "random",
 			},
 			wantErr: "invalid value for key secret-auto-create, acceptable values: true or false",
+		},
+		{
+			name: "invalid bool",
+			config: map[string]string{
+				RememberOKToTestKey: "random",
+			},
+			wantErr: "invalid value for key remember-ok-to-test, acceptable values: true or false",
 		},
 		{
 			name: "invalid max keep run upper limit",

--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -116,7 +116,7 @@ is that what you want? make sure you use -n when generating the secret, eg: echo
 
 	// Check if the submitter is allowed to run this.
 	if p.event.TriggerTarget != "push" {
-		allowed, err := p.vcx.IsAllowed(ctx, p.event)
+		allowed, err := p.vcx.IsAllowed(ctx, p.event, p.run.Info.Pac)
 		if err != nil {
 			return repo, err
 		}

--- a/pkg/provider/bitbucketcloud/acl.go
+++ b/pkg/provider/bitbucketcloud/acl.go
@@ -11,7 +11,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketcloud/types"
 )
 
-func (v *Provider) IsAllowed(_ context.Context, event *info.Event) (bool, error) {
+func (v *Provider) IsAllowed(_ context.Context, event *info.Event, _ *info.PacOpts) (bool, error) {
 	// Check first if the user is in the owner file or part of the workspace
 	allowed, err := v.checkMember(event)
 	if err != nil {

--- a/pkg/provider/bitbucketcloud/acl_test.go
+++ b/pkg/provider/bitbucketcloud/acl_test.go
@@ -181,7 +181,9 @@ func TestIsAllowed(t *testing.T) {
 
 			v := &Provider{Client: bbclient}
 
-			got, err := v.IsAllowed(ctx, tt.event)
+			pacopts := info.PacOpts{}
+
+			got, err := v.IsAllowed(ctx, tt.event, &pacopts)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Provider.IsAllowed() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/provider/bitbucketserver/acl.go
+++ b/pkg/provider/bitbucketserver/acl.go
@@ -14,7 +14,7 @@ import (
 
 type activitiesTypes struct{ Values []*bbv1.Activity }
 
-func (v *Provider) IsAllowed(_ context.Context, event *info.Event) (bool, error) {
+func (v *Provider) IsAllowed(_ context.Context, event *info.Event, _ *info.PacOpts) (bool, error) {
 	allowed, err := v.checkMemberShip(event)
 	if err != nil {
 		return false, err

--- a/pkg/provider/bitbucketserver/acl_test.go
+++ b/pkg/provider/bitbucketserver/acl_test.go
@@ -217,7 +217,9 @@ func TestIsAllowed(t *testing.T) {
 				projectKey:                tt.event.Organization,
 			}
 
-			got, err := v.IsAllowed(ctx, tt.event)
+			pacopts := info.PacOpts{}
+
+			got, err := v.IsAllowed(ctx, tt.event, &pacopts)
 			if tt.wantErrSubstr != "" {
 				assert.ErrorContains(t, err, tt.wantErrSubstr)
 				return

--- a/pkg/provider/github/acl.go
+++ b/pkg/provider/github/acl.go
@@ -46,7 +46,7 @@ func (v *Provider) CheckPolicyAllowing(ctx context.Context, event *info.Event, a
 	return false, fmt.Sprintf("user: %s is not a member of any of the allowed teams: %v", event.Sender, allowedTeams)
 }
 
-func (v *Provider) IsAllowed(ctx context.Context, event *info.Event) (bool, error) {
+func (v *Provider) IsAllowed(ctx context.Context, event *info.Event, pac *info.PacOpts) (bool, error) {
 	aclPolicy := policy.Policy{
 		Settings: v.repoSettings,
 		Event:    event,
@@ -76,15 +76,15 @@ func (v *Provider) IsAllowed(ctx context.Context, event *info.Event) (bool, erro
 		return true, nil
 	}
 
-	// Finally try to parse all comments
-	return v.aclAllowedOkToTestFromAnOwner(ctx, event)
+	// Finally try to parse comments
+	return v.aclAllowedOkToTestFromAnOwner(ctx, event, pac)
 }
 
-// allowedOkToTestFromAnOwner Go over every comments in a pull request and check
+// allowedOkToTestFromAnOwner Go over comments in a pull request and check
 // if there is a /ok-to-test in there running an aclCheck again on the comment
 // Sender if she is an OWNER and then allow it to run CI.
 // TODO: pull out the github logic from there in an agnostic way.
-func (v *Provider) aclAllowedOkToTestFromAnOwner(ctx context.Context, event *info.Event) (bool, error) {
+func (v *Provider) aclAllowedOkToTestFromAnOwner(ctx context.Context, event *info.Event, pac *info.PacOpts) (bool, error) {
 	revent := info.NewEvent()
 	event.DeepCopyInto(revent)
 	revent.EventType = ""
@@ -95,8 +95,18 @@ func (v *Provider) aclAllowedOkToTestFromAnOwner(ctx context.Context, event *inf
 
 	switch event := revent.Event.(type) {
 	case *github.IssueCommentEvent:
+		// if we don't need to check old comments, then on issue comment we
+		// need to check if comment have /ok-to-test and is from allowed user
+		if !pac.RememberOKToTest {
+			return v.aclAllowedOkToTestCurrentComment(ctx, revent, event.Comment.GetID())
+		}
 		revent.URL = event.Issue.GetPullRequestLinks().GetHTMLURL()
 	case *github.PullRequestEvent:
+		// if we don't need to check old comments, then on push event we don't need
+		// to check anything for the non-allowed user
+		if !pac.RememberOKToTest {
+			return false, nil
+		}
 		revent.URL = event.GetPullRequest().GetHTMLURL()
 	default:
 		return false, nil
@@ -108,6 +118,26 @@ func (v *Provider) aclAllowedOkToTestFromAnOwner(ctx context.Context, event *inf
 	}
 
 	for _, comment := range comments {
+		revent.Sender = comment.User.GetLogin()
+		allowed, err := v.aclCheckAll(ctx, revent)
+		if err != nil {
+			return false, err
+		}
+		if allowed {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// aclAllowedOkToTestCurrentEvent only check if this is issue comment event
+// have /ok-to-test regex and sender is allowed.
+func (v *Provider) aclAllowedOkToTestCurrentComment(ctx context.Context, revent *info.Event, id int64) (bool, error) {
+	comment, _, err := v.Client.Issues.GetComment(ctx, revent.Organization, revent.Repository, id)
+	if err != nil {
+		return false, err
+	}
+	if acl.MatchRegexp(acl.OKToTestCommentRegexp, comment.GetBody()) {
 		revent.Sender = comment.User.GetLogin()
 		allowed, err := v.aclCheckAll(ctx, revent)
 		if err != nil {

--- a/pkg/provider/github/parse_payload.go
+++ b/pkg/provider/github/parse_payload.go
@@ -246,7 +246,6 @@ func (v *Provider) processEvent(ctx context.Context, event *info.Event, eventInt
 		processedEvent.BaseURL = gitEvent.GetRepo().GetHTMLURL()
 		processedEvent.HeadURL = processedEvent.BaseURL // in push events Head URL is the same as BaseURL
 	case *github.PullRequestEvent:
-		processedEvent = info.NewEvent()
 		processedEvent.Repository = gitEvent.GetRepo().GetName()
 		processedEvent.Organization = gitEvent.GetRepo().Owner.GetLogin()
 		processedEvent.DefaultBranch = gitEvent.GetRepo().GetDefaultBranch()

--- a/pkg/provider/gitlab/acl.go
+++ b/pkg/provider/gitlab/acl.go
@@ -63,7 +63,7 @@ func (v *Provider) checkOkToTestCommentFromApprovedMember(event *info.Event, pag
 	return false, nil
 }
 
-func (v *Provider) IsAllowed(_ context.Context, event *info.Event) (bool, error) {
+func (v *Provider) IsAllowed(_ context.Context, event *info.Event, _ *info.PacOpts) (bool, error) {
 	if v.Client == nil {
 		return false, fmt.Errorf("no github client has been initiliazed, " +
 			"exiting... (hint: did you forget setting a secret on your repo?)")

--- a/pkg/provider/gitlab/acl_test.go
+++ b/pkg/provider/gitlab/acl_test.go
@@ -115,7 +115,8 @@ func TestIsAllowed(t *testing.T) {
 
 				defer tearDown()
 			}
-			got, err := v.IsAllowed(ctx, tt.args.event)
+			pacopts := info.PacOpts{}
+			got, err := v.IsAllowed(ctx, tt.args.event, &pacopts)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("IsAllowed() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/provider/interface.go
+++ b/pkg/provider/interface.go
@@ -29,7 +29,7 @@ type Interface interface {
 	Validate(ctx context.Context, params *params.Run, event *info.Event) error
 	Detect(*http.Request, string, *zap.SugaredLogger) (bool, bool, *zap.SugaredLogger, string, error)
 	ParsePayload(context.Context, *params.Run, *http.Request, string) (*info.Event, error)
-	IsAllowed(context.Context, *info.Event) (bool, error)
+	IsAllowed(context.Context, *info.Event, *info.PacOpts) (bool, error)
 	CreateStatus(context.Context, versioned.Interface, *info.Event, *info.PacOpts, StatusOpts) error
 	GetTektonDir(context.Context, *info.Event, string, string) (string, error)      // ctx, event, path, provenance
 	GetFileInsideRepo(context.Context, *info.Event, string, string) (string, error) // ctx, event, path, branch

--- a/pkg/test/provider/testwebvcs.go
+++ b/pkg/test/provider/testwebvcs.go
@@ -59,7 +59,7 @@ func (v *TestProviderImp) SetClient(_ context.Context, _ *params.Run, _ *info.Ev
 	return nil
 }
 
-func (v *TestProviderImp) IsAllowed(_ context.Context, _ *info.Event) (bool, error) {
+func (v *TestProviderImp) IsAllowed(_ context.Context, _ *info.Event, _ *info.PacOpts) (bool, error) {
 	if v.AllowIT {
 		return true, nil
 	}


### PR DESCRIPTION


# Changes

This will fix /ok-to-test comment which was not triggering jobs
on a push to the PR.

Also remember-ok-to-test flag has been added which is by default true
and will trigger the jobs on push to PR.
if /ok-to-test is needed to be done on push event in PR, this flag
needs to be set to false and it will not trigger runs

# Submitter Checklist

- [x] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [x] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [x] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [x] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
