### PR TITLE
Optimize matching pipelineruns with remote annotations

### DIFF
--- a/pkg/cmd/tknpac/resolve/resolve.go
+++ b/pkg/cmd/tknpac/resolve/resolve.go
@@ -206,7 +206,11 @@ func resolveFilenames(ctx context.Context, cs *params.Run, filenames []string, p
 	// We use github here but since we don't do remotetask we would not care
 	providerintf := github.New()
 	event := info.NewEvent()
-	prun, err := resolve.Resolve(ctx, cs, cs.Clients.Log, providerintf, event, allTheYamls, ropt)
+	types, err := resolve.ReadTektonTypes(ctx, cs.Clients.Log, allTheYamls)
+	if err != nil {
+		return "", err
+	}
+	prun, err := resolve.Resolve(ctx, cs, cs.Clients.Log, providerintf, types, event, ropt)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/pipelineascode/pipelineascode_test.go
+++ b/pkg/pipelineascode/pipelineascode_test.go
@@ -150,6 +150,47 @@ func TestRun(t *testing.T) {
 			finalStatusText: "we need at least one pipelinerun to start with",
 		},
 		{
+			name: "pull request/unknown-remotetask-but-fail-on-matching",
+			runevent: info.Event{
+				SHA:           "principale",
+				Organization:  "organizationes",
+				Repository:    "lagaffe",
+				URL:           "https://service/documentation",
+				HeadBranch:    "press",
+				BaseBranch:    "main",
+				Sender:        "fantasio",
+				EventType:     "push",
+				TriggerTarget: "push",
+			},
+			tektondir:       "testdata/pull_request-nomatch-remotetask",
+			finalStatus:     "failure",
+			finalStatusText: "we need at least one pipelinerun to start with",
+		},
+		{
+			name: "pull request/match-but-fail-to-start-on-unknown-remotetask",
+			runevent: info.Event{
+				Event: &github.PullRequestEvent{
+					PullRequest: &github.PullRequest{
+						Number: github.Int(666),
+					},
+				},
+				SHA:               "fromwebhook",
+				Organization:      "owner",
+				Sender:            "owner",
+				Repository:        "repo",
+				URL:               "https://service/documentation",
+				HeadBranch:        "press",
+				BaseBranch:        "main",
+				EventType:         "pull_request",
+				TriggerTarget:     "pull_request",
+				PullRequestNumber: 666,
+				InstallationID:    1234,
+			},
+			tektondir:       "testdata/pull_request-nomatch-remotetask",
+			finalStatus:     "failure",
+			finalStatusText: "error getting remote task",
+		},
+		{
 			name: "pull request/allowed",
 			runevent: info.Event{
 				Event: &github.PullRequestEvent{
@@ -502,6 +543,7 @@ func TestRun(t *testing.T) {
 					Pac: &info.PacOpts{
 						Settings: &settings.Settings{
 							SecretAutoCreation: true,
+							RemoteTasks:        true,
 							HubCatalogs:        &hubCatalogs,
 						},
 					},

--- a/pkg/pipelineascode/testdata/pull_request-nomatch-remotetask/.tekton/pipeline.yaml
+++ b/pkg/pipelineascode/testdata/pull_request-nomatch-remotetask/.tekton/pipeline.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: pipeline1
+tasks:
+  - name: task-from-tektondir
+    taskRef:
+      name: task-from-tektondir

--- a/pkg/pipelineascode/testdata/pull_request-nomatch-remotetask/.tekton/run.yaml
+++ b/pkg/pipelineascode/testdata/pull_request-nomatch-remotetask/.tekton/run.yaml
@@ -1,0 +1,11 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: pull_request
+  annotations:
+    pipelinesascode.tekton.dev/on-target-branch: "[main]"
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+    pipelinesascode.tekton.dev/task: "unknown"
+spec:
+  pipelineRef:
+    name: pipeline1

--- a/pkg/pipelineascode/testdata/pull_request-nomatch-remotetask/.tekton/task.yaml
+++ b/pkg/pipelineascode/testdata/pull_request-nomatch-remotetask/.tekton/task.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: task-from-tektondir
+spec:
+  steps:
+    - name: task-1
+      image: gcr.io/distroless/python3:nonroot
+      script: |
+        #!/usr/bin/python3
+        print("Hello task-from-tektondir")

--- a/pkg/resolve/testdata/pipeline-finally-v1.yaml
+++ b/pkg/resolve/testdata/pipeline-finally-v1.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: pr-test1
+spec:
+  pipelineRef:
+    name: pipeline-with-finally
+  params:
+    - name: key
+      value: "{{value}}"
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: pipeline-with-finally
+spec:
+  params:
+    - name: repo_url
+    - name: revision
+  finally:
+    - name: finally-task
+      taskRef:
+        name: finally-task
+  tasks:
+    - name: normal-task
+      taskRef:
+        name: normal-task
+  steps:
+    - name: first-step
+      image: image
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: normal-task
+spec:
+  steps:
+    - name: normal-task
+      image: image
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: finally-task
+spec:
+  steps:
+    - name: finally-task
+      image: image


### PR DESCRIPTION
We try to optimize the matching of the pipelineruns with the remote tasks when we have a large set of pipelineruns in the .tekton/ directory. We don't want to fetch all the remote tasks every time just for the matching. We first try to match without fetching the remote tasks and if we have a match we try to match with fetching the remote tasks for the matched pipelineruns.

https://issues.redhat.com/browse/SRVKP-3399

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
