### PR TITLE
fix some gosec errors on golangci 1.54.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,9 @@
+issues:
+  exclude-rules:
+    # Exclude some linters from running on tests files.
+    - path: _test\.go
+      linters:
+        - gosec
 run:
   build-tags:
     - e2e

--- a/pkg/params/settings/config.go
+++ b/pkg/params/settings/config.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	ApplicationNameKey                    = "application-name"
-	HubURLKey                             = "hub-url"
-	HubCatalogNameKey                     = "hub-catalog-name"
+	ApplicationNameKey = "application-name"
+	HubURLKey          = "hub-url"
+	HubCatalogNameKey  = "hub-catalog-name"
+	//nolint: gosec
 	MaxKeepRunUpperLimitKey               = "max-keep-run-upper-limit"
 	DefaultMaxKeepRunsKey                 = "default-max-keep-runs"
 	RemoteTasksKey                        = "remote-tasks"

--- a/pkg/provider/github/github_test.go
+++ b/pkg/provider/github/github_test.go
@@ -3,8 +3,6 @@ package github
 import (
 	"context"
 	"crypto/hmac"
-
-	//nolint: gosec
 	"crypto/sha1"
 	"crypto/sha256"
 	"encoding/hex"


### PR DESCRIPTION
avoid running gosec on test files since we have false positives there

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
