### PR TITLE
Cancel old jobs attached to PR when there is update

### DIFF
--- a/.github/workflows/kind-e2e-tests.yaml
+++ b/.github/workflows/kind-e2e-tests.yaml
@@ -8,6 +8,9 @@ on:
       - '**.go'
 jobs:
   e2e-tests:
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     name: e2e tests
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
This wil to cancel previous runs in the PR when pushishing new commits
on kind github actions

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
