### PR TITLE
Create service monitor for pac controller

### DIFF
--- a/config/openshift/20-monitoring.yaml
+++ b/config/openshift/20-monitoring.yaml
@@ -64,3 +64,25 @@ spec:
   selector:
     matchLabels:
       app: pipelines-as-code-watcher
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: pipelines-as-code-controller-monitor
+  namespace: pipelines-as-code
+  labels:
+    app.kubernetes.io/version: "devel"
+    app.kubernetes.io/part-of: pipelines-as-code
+  annotations:
+    networkoperator.openshift.io/ignore-errors: ""
+spec:
+  endpoints:
+    - interval: 10s
+      port: http-metrics
+  jobLabel: app
+  namespaceSelector:
+    matchNames:
+    - pipelines-as-code
+  selector:
+    matchLabels:
+      app: pipelines-as-code-controller


### PR DESCRIPTION
service monitor for pac controller is required to see the controller metrics after we install the pac operator. Currently we are missing service monitor for `pipelines-as-code-controller` service, hence it is not showing up the metrics.

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

- Adds servicemonitor for pac controller metrics observability which was missed in https://github.com/openshift-pipelines/pipelines-as-code/pull/1328 

# Submitter Checklist

- [X] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [X] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [X] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [x] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [X] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [X] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
