### PR TITLE
Only rebuild the Docker image when Go files changes

### DIFF
--- a/.github/workflows/ghcr.yaml
+++ b/.github/workflows/ghcr.yaml
@@ -1,6 +1,9 @@
 name: Create and publish a Docker image to ghcr
 
-on: ["push"]
+on:
+  push:
+    paths:
+      - "**.go"
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
no need to waste resources rebuilding the Docker image when not needed

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
