### PR TITLE
Fix resolve arguments help and extra arguments

### DIFF
--- a/pkg/cmd/tknpac/resolve/resolve.go
+++ b/pkg/cmd/tknpac/resolve/resolve.go
@@ -155,10 +155,9 @@ func Command(run *params.Run, streams *cli.IOStreams) *cobra.Command {
 		"Filename, directory, or URL to files to use to create the resource")
 
 	cmd.Flags().StringSliceVarP(&skipInlining, "skip", "s", filenames,
-		"skip inlining")
+		"skip inlining this task and use them as is (must be present in namespace to be able to use them). multiple values are supported")
 
-	cmd.Flags().BoolVar(&noSecret, "no-secret", false,
-		"skip generating or asking for secrets")
+	cmd.Flags().BoolVar(&noSecret, "no-secret", false, "don't ask if you would like to generate a secret when git_auth_secret is found in the template")
 
 	cmd.Flags().BoolVar(&noGenerateName, "no-generate-name", false,
 		"don't automatically generate a GenerateName for pipelinerun uniqueness")
@@ -169,11 +168,6 @@ func Command(run *params.Run, streams *cli.IOStreams) *cobra.Command {
 	cmd.Flags().BoolVarP(&asv1beta1, "v1beta1", "B", false, "output as tekton v1beta1")
 
 	cmd.Flags().StringVarP(&providerToken, "providerToken", "t", "", "use this token to generate the git-auth secret,\n you can set the environment PAC_PROVIDER_TOKEN to have this set automatically")
-	err := run.Info.Pac.AddFlags(cmd)
-	if err != nil {
-		log.Fatal(err)
-	}
-
 	return cmd
 }
 


### PR DESCRIPTION
We were passing arguments we didn't handle in resolve and wasn't needed. Better help messages.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 A good commit message is important for other reviewers to understand the context of your change. Please refer to [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for more details how to write beautiful commit messages. We rather have the commit message in the PR body and the commit message instead of an external website.
- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
