### PR TITLE
Add source repo url information to standard parameters

### DIFF
--- a/docs/content/docs/guide/authoringprs.md
+++ b/docs/content/docs/guide/authoringprs.md
@@ -28,17 +28,18 @@ weight: 3
   allows you to have those "dynamic" variables expanded. Those variables look
   like this `{{ var }}` and those are the one you can use:
 
-  * `{{repo_owner}}`: The repository owner.
-  * `{{event_type}}`: The event type (eg: `pull_request` or `push`)
+  * `{{event_type}}`: The event type (eg: `pull_request` or `push`).
+  * `{{git_auth_secret}}`: The secret name auto generated with provider token to check out private repos.
+  * `{{pull_request_number}}`: The pull or merge request number, only defined when we are in a `pull_request` event type.
   * `{{repo_name}}`: The repository name.
+  * `{{repo_owner}}`: The repository owner.
   * `{{repo_url}}`: The repository full URL.
-  * `{{target_namespace}}`: The target namespace where the Repository has matched and the PipelineRun will be created.
   * `{{revision}}`: The commit full sha revision.
   * `{{sender}}`: The sender username (or accountid on some providers) of the commit.
   * `{{source_branch}}`: The branch name where the event come from.
+  * `{{source_url}}`: The source repository URL from which the event come from (same as `repo_url` for push events).
   * `{{target_branch}}`: The branch name on which the event targets (same as `source_branch` for push events).
-  * `{{pull_request_number}}`: The pull or merge request number, only defined when we are in a `pull_request` event type.
-  * `{{git_auth_secret}}`: The secret name auto generated with provider token to check out private repos.
+  * `{{target_namespace}}`: The target namespace where the Repository has matched and the PipelineRun will be created.
 
 * For Pipelines-as-Code to process your `PipelineRun`, you must have either an
   embedded `PipelineSpec` or a separate `Pipeline` object that references a YAML

--- a/pkg/customparams/standard.go
+++ b/pkg/customparams/standard.go
@@ -22,6 +22,7 @@ func (p *CustomParams) makeStandardParamsFromEvent() map[string]string {
 		"repo_name":        strings.ToLower(p.event.Repository),
 		"target_branch":    formatting.SanitizeBranch(p.event.BaseBranch),
 		"source_branch":    formatting.SanitizeBranch(p.event.HeadBranch),
+		"source_url":       p.event.HeadURL,
 		"sender":           strings.ToLower(p.event.Sender),
 		"target_namespace": p.repo.GetNamespace(),
 		"event_type":       p.event.EventType,

--- a/pkg/customparams/standard_test.go
+++ b/pkg/customparams/standard_test.go
@@ -19,6 +19,7 @@ func TestMakeStandardParamsFromEvent(t *testing.T) {
 		EventType:    "pull_request",
 		Sender:       "SENDER",
 		URL:          "https://paris.com",
+		HeadURL:      "https://india.com",
 	}
 
 	result := map[string]string{
@@ -26,6 +27,7 @@ func TestMakeStandardParamsFromEvent(t *testing.T) {
 		"repo_name":        "repo",
 		"repo_owner":       "org",
 		"repo_url":         "https://paris.com",
+		"source_url":       "https://india.com",
 		"revision":         "1234567890",
 		"sender":           "sender",
 		"source_branch":    "foo",

--- a/test/testdata/pipelinerun-standard-params-display.yaml
+++ b/test/testdata/pipelinerun-standard-params-display.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: "\\ .PipelineName //"
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
+    pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
+spec:
+  params:
+    - name: repo_url
+      value: "{{ repo_url }}"
+    - name: source_url
+      value: "{{ source_url }}"
+    - name: source_branch
+      value: "{{ source_branch }}"
+    - name: target_branch
+      value: "{{ target_branch }}"
+  pipelineSpec:
+    params:
+      - name: repo_url
+      - name: source_url
+      - name: source_branch
+      - name: target_branch
+    tasks:
+      - name: params
+        taskSpec:
+          steps:
+            - name: test-standard-params-value
+              image: registry.access.redhat.com/ubi9/ubi-micro
+              script: |
+                echo "{{ repo_url }}--"
+                echo "{{ source_url }}--"
+                echo "{{ source_branch }}--"
+                echo "{{ target_branch }}--"


### PR DESCRIPTION
Users can now use `source_repo_url` in pipelinerun template to get the information from which forked repo the event (Pull Request / Push) is coming from

Ex:

```
spec:
  params:
    - name: source_repo_url
      value: "{{ source_repo_url }}"      
  pipelineSpec:
    params:
      - name: source_repo_url  
  ...
```
       
Signed-off-by: Savita Ashture <sashture@redhat.com>"

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 A good commit message is important for other reviewers to understand the context of your change. Please refer to [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for more details how to write beautiful commit messages. We rather have the commit message in the PR body and the commit message instead of an external website.
- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
