### PR TITLE
Revert "Simplify branchMatch function"

### DIFF
--- a/pkg/matcher/annotation_matcher.go
+++ b/pkg/matcher/annotation_matcher.go
@@ -25,31 +25,31 @@ const (
 )
 
 func branchMatch(prunBranch, baseBranch string) bool {
-	// Helper function to match glob pattern
-	matchGlob := func(pattern, branch string) bool {
-		g := glob.MustCompile(pattern)
-		return g.Match(branch)
-	}
-
+	// if target is refs/heads/.. and base is without ref (for pullRequest action)
 	if strings.HasPrefix(prunBranch, "refs/heads/") {
-		// Case: target is refs/heads/..
 		ref := baseBranch
 		if !strings.HasPrefix(baseBranch, "refs/heads/") {
-			// If base is without refs/heads/ prefix, add it
 			ref = "refs/heads/" + baseBranch
 		}
-		// Match the prunBranch pattern with the modified baseBranch
-		return matchGlob(prunBranch, ref)
+		g := glob.MustCompile(prunBranch)
+		if g.Match(ref) {
+			return true
+		}
+	} else {
+		// if base is refs/heads/.. and target is without ref (for push request action)
+		prunRef := prunBranch
+		if !strings.HasPrefix(prunBranch, "refs/heads/") {
+			prunRef = "refs/heads/" + prunBranch
+		}
+		g := glob.MustCompile(prunRef)
+		if g.Match(baseBranch) {
+			return true
+		}
 	}
 
-	// Case: base is refs/heads/..
-	prunRef := prunBranch
-	if !strings.HasPrefix(prunBranch, "refs/heads/") {
-		// If prunBranch is without refs/heads/ prefix, add it
-		prunRef = "refs/heads/" + prunBranch
-	}
-	// Match the prunRef pattern with the baseBranch
-	return matchGlob(prunRef, baseBranch)
+	// match globs like refs/tags/0.*
+	g := glob.MustCompile(prunBranch)
+	return g.Match(baseBranch)
 }
 
 // TODO: move to another file since it's common to all annotations_* files


### PR DESCRIPTION
This reverts commit 9e3a84cc75881fef42b5f3c3b2f8ec38536c0d7d since it breaks branch matching on tags...

tested as working : 

<img width="1440" alt="image" src="https://github.com/openshift-pipelines/pipelines-as-code/assets/98980/5509e456-22fd-4618-abfc-4fd5540ae138">


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 A good commit message is important for other reviewers to understand the context of your change. Please refer to [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for more details how to write beautiful commit messages. We rather have the commit message in the PR body and the commit message instead of an external website.
- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
