### PR TITLE
update stabe tags only when releasing latest ver

### DIFF
--- a/.tekton/release-pipeline.yaml
+++ b/.tekton/release-pipeline.yaml
@@ -72,11 +72,16 @@ spec:
                     exit
                 }
                 stable_tag=${version%.*}.x
-                allversions=$(echo -n "nightly,stable,";for i in $(git tag -l|grep '^v'|sort -rn);do echo -n "$i,";done|sed 's/,$//')
+                alltags=$(for i in $(git tag -l|grep '^v'|sort -rn);do echo -n "$i,";done|sed 's/,$//'))
+                allversions="nightly,stable,$alltags"
                 git config --global user.email "pac-dev@redhat.com"
                 git config --global user.name "Pipelines as Code CI Robot"
 
-                for target in release-${version} release-${stable_tag} stable;do
+                target_tags="release-${version} release-${stable_tag}"
+                # if the current version is higher than all the other ones then tag it as the current stable
+                pip3 install packaging
+                [[ $(./hack/compare-versions.py $version $alltags) == true ]] && target_tags="${target_tags} stable"
+                for target in ${target_tags};do
                   export PAC_VERSION=${version}
                   export TARGET_BRANCH=${target//release-}
                   ./hack/generate-releaseyaml.sh > release.k8s.yaml

--- a/hack/compare-versions.py
+++ b/hack/compare-versions.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# Take a version as first argument (current)
+# Take a set of version delimited by commas as second argument
+# If the current is higher than all other versions return true otherwise false
+# example:
+# % python3 ./hack/compare-versions.py v1.1.0 v0.1.1,v0.2.2,v1.0.1
+# true
+# % python3 ./hack/compare-versions.py 0.1.0 0.1.1,0.2.2,1.0.1
+# false
+# semantic numbers with v is supported
+import sys
+
+from packaging import version
+
+if len(sys.argv[1]) == 0:
+    print("Usage compare-versions.py <current> <all versions separated by comma>")
+    sys.exit(1)
+
+current = sys.argv[1]
+all_versions = sys.argv[2].split(",")
+
+for i in all_versions:
+    if version.parse(current) < version.parse(i):
+        print("false")
+        sys.exit(1)
+
+print("true")


### PR DESCRIPTION
We were updating the stable tags every time even on minor versions, now make the tags only when we are sure it's the latest version.

Add a small python script with the help of the packaging module to work this comparaison out.

Fixes #1391 

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 A good commit message is important for other reviewers to understand the context of your change. Please refer to [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for more details how to write beautiful commit messages. We rather have the commit message in the PR body and the commit message instead of an external website.
- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
