### PR TITLE
Let incoming webhook define or redefine parameters

### DIFF
--- a/config/300-repositories.yaml
+++ b/config/300-repositories.yaml
@@ -150,6 +150,12 @@ spec:
                         type: string
                         enum:
                           - webhook-url
+                      params:
+                        description: Parameters accepted to be overwritten when posting to the webhook
+                        type: array
+                        items:
+                          description: Parameter
+                          type: string
                       targets:
                         description: List of target branches or ref to trigger webhooks on
                         type: array

--- a/docs/content/docs/guide/authoringprs.md
+++ b/docs/content/docs/guide/authoringprs.md
@@ -2,46 +2,48 @@
 title: Authoring PipelineRun
 weight: 3
 ---
+
 # Authoring PipelineRuns in `.tekton/` directory
 
-* Pipelines-as-Code will always try to be as close to the tekton template as
+- Pipelines-as-Code will always try to be as close to the tekton template as
   possible. Usually you will write your template and save them with a `.yaml`
   extension and Pipelines-as-Code will run them.
 
-* The `.tekton` directory must be at the top level of the repo.
+- The `.tekton` directory must be at the top level of the repo.
   You can reference YAML files in other repos using remote URLs
   (see [Remote HTTP URLs](./resolver.md#remote-http-url) for more information),
   but PipelineRuns will only be triggered by events in the repository containing
   the `.tekton` directory.
 
-* Using its [resolver](../resolver/) Pipelines-as-Code will try to bundle the
+- Using its [resolver](../resolver/) Pipelines-as-Code will try to bundle the
   PipelineRun with all its Task as a single PipelineRun with no external
   dependencies.
 
-* Inside your pipeline you need to be able to check out the commit as
-  received from the webhook by checking it out the repository from that ref. Most of the time
-  you want to reuse the
-  [git-clone](https://github.com/tektoncd/catalog/blob/main/task/git-clone/)
+- Inside your pipeline you need to be able to check out the commit as
+  received from the webhook by checking it out the repository from that Git reference SHA. Most of the time
+  you want to reuse the [git-clone](https://github.com/tektoncd/catalog/blob/main/task/git-clone/)
   task from the [tektoncd/catalog](https://github.com/tektoncd/catalog).
 
-  To be able to specify the parameters of your commit and URL, Pipelines-as-Code
-  allows you to have those "dynamic" variables expanded. Those variables look
-  like this `{{ var }}` and those are the one you can use:
+## Default Parameters
 
-  * `{{event_type}}`: The event type (eg: `pull_request` or `push`).
-  * `{{git_auth_secret}}`: The secret name auto generated with provider token to check out private repos.
-  * `{{pull_request_number}}`: The pull or merge request number, only defined when we are in a `pull_request` event type.
-  * `{{repo_name}}`: The repository name.
-  * `{{repo_owner}}`: The repository owner.
-  * `{{repo_url}}`: The repository full URL.
-  * `{{revision}}`: The commit full sha revision.
-  * `{{sender}}`: The sender username (or accountid on some providers) of the commit.
-  * `{{source_branch}}`: The branch name where the event come from.
-  * `{{source_url}}`: The source repository URL from which the event come from (same as `repo_url` for push events).
-  * `{{target_branch}}`: The branch name on which the event targets (same as `source_branch` for push events).
-  * `{{target_namespace}}`: The target namespace where the Repository has matched and the PipelineRun will be created.
+To be able to specify the parameters of your commit and URL, Pipelines-as-Code
+allows you to have those "dynamic" variables expanded. Those variables look
+like this `{{ var }}` and those are the one you can use:
 
-* For Pipelines-as-Code to process your `PipelineRun`, you must have either an
+- `{{event_type}}`: The event type (eg: `pull_request` or `push`).
+- `{{git_auth_secret}}`: The secret name auto generated with provider token to check out private repos.
+- `{{pull_request_number}}`: The pull or merge request number, only defined when we are in a `pull_request` event type.
+- `{{repo_name}}`: The repository name.
+- `{{repo_owner}}`: The repository owner.
+- `{{repo_url}}`: The repository full URL.
+- `{{revision}}`: The commit full sha revision.
+- `{{sender}}`: The sender username (or accountid on some providers) of the commit.
+- `{{source_branch}}`: The branch name where the event come from.
+- `{{source_url}}`: The source repository URL from which the event come from (same as `repo_url` for push events).
+- `{{target_branch}}`: The branch name on which the event targets (same as `source_branch` for push events).
+- `{{target_namespace}}`: The target namespace where the Repository has matched and the PipelineRun will be created.
+
+- For Pipelines-as-Code to process your `PipelineRun`, you must have either an
   embedded `PipelineSpec` or a separate `Pipeline` object that references a YAML
   file in the `.tekton` directory. The Pipeline object can include `TaskSpecs`,
   which may be defined separately as Tasks in another YAML file in the same
@@ -55,11 +57,11 @@ annotations on the `PipelineRun`. For example when you have these metadatas in
 your `PipelineRun`:
 
 ```yaml
- metadata:
-    name: pipeline-pr-main
- annotations:
-    pipelinesascode.tekton.dev/on-target-branch: "[main]"
-    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+metadata:
+  name: pipeline-pr-main
+annotations:
+  pipelinesascode.tekton.dev/on-target-branch: "[main]"
+  pipelinesascode.tekton.dev/on-event: "[pull_request]"
 ```
 
 `Pipelines-as-Code` will match the pipelinerun `pipeline-pr-main` if the Git
@@ -78,7 +80,7 @@ For example this will match the pipeline when there is a push to a commit in the
 `main` branch :
 
 ```yaml
- metadata:
+metadata:
   name: pipeline-push-on-main
   annotations:
     pipelinesascode.tekton.dev/on-target-branch: "[refs/heads/main]"
@@ -92,11 +94,11 @@ target branch or `refs/tags/1.*` will match all the tags starting from `1.`.
 A full example for a push of a tag :
 
 ```yaml
- metadata:
- name: pipeline-push-on-1.0-tags
- annotations:
-    pipelinesascode.tekton.dev/on-target-branch: "[refs/tags/1.0]"
-    pipelinesascode.tekton.dev/on-event: "[push]"
+metadata:
+name: pipeline-push-on-1.0-tags
+annotations:
+  pipelinesascode.tekton.dev/on-target-branch: "[refs/tags/1.0]"
+  pipelinesascode.tekton.dev/on-event: "[push]"
 ```
 
 This will match the pipeline `pipeline-push-on-1.0-tags` when you push the 1.0
@@ -114,7 +116,7 @@ finishes.
 If you need to do some advanced matching, `Pipelines-as-Code` supports CEL
 filtering.
 
-If you have the ``pipelinesascode.tekton.dev/on-cel-expression`` annotation in
+If you have the `pipelinesascode.tekton.dev/on-cel-expression` annotation in
 your PipelineRun, the CEL expression will be used and the `on-target-branch` or
 `on-target-branch` annotations will then be skipped.
 
@@ -122,8 +124,8 @@ This example will match a `pull_request` event targeting the branch `main`
 coming from a branch called `wip`:
 
 ```yaml
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "pull_request" && target_branch == "main" && source_branch == "wip"
+pipelinesascode.tekton.dev/on-cel-expression: |
+  event == "pull_request" && target_branch == "main" && source_branch == "wip"
 ```
 
 Another example, if you want to have a PipelineRun running only if a path has
@@ -133,30 +135,30 @@ is a concrete example matching every markdown files (as files who has the `.md`
 suffix) in the `docs` directory :
 
 ```yaml
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "pull_request" && "docs/*.md".pathChanged()
+pipelinesascode.tekton.dev/on-cel-expression: |
+  event == "pull_request" && "docs/*.md".pathChanged()
 ```
 
 This example will match all pull request starting with the title `[DOWNSTREAM]`:
 
 ```yaml
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "pull_request && event_title.startsWith("[DOWNSTREAM]")
+pipelinesascode.tekton.dev/on-cel-expression: |
+  event == "pull_request && event_title.startsWith("[DOWNSTREAM]")
 ```
 
 The fields available are :
 
-* `event`: `push` or `pull_request`
-* `target_branch`: The branch we are targeting.
-* `source_branch`: The branch where this pull_request come from. (on `push` this
+- `event`: `push` or `pull_request`
+- `target_branch`: The branch we are targeting.
+- `source_branch`: The branch where this pull_request come from. (on `push` this
   is the same as `target_branch`).
-* `target_url`: The url of the repository we are targeting.
-* `source_url`: The url of the repository where this pull_request come from. (on `push` this
+- `target_url`: The url of the repository we are targeting.
+- `source_url`: The url of the repository where this pull_request come from. (on `push` this
   is the same as `target_url`).
-* `event_title`: Match the title of the event. When doing a push this will match
+- `event_title`: Match the title of the event. When doing a push this will match
   the commit title and when matching on PR it will match the Pull or Merge
   Request title. (only `GitHub`, `Gitlab` and `BitbucketCloud` providers are supported)
-* `.pathChanged`: a suffix function to a string which can be a glob of a path to
+- `.pathChanged`: a suffix function to a string which can be a glob of a path to
   check if changed (only `GitHub` and `Gitlab` provider is supported)
 
 Compared to the simple "on-target" annotation matching, the CEL expression
@@ -166,8 +168,8 @@ For example if I want to have a `PipelineRun` targeting a `pull_request` but
 not the `experimental` branch I would have :
 
 ```yaml
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "pull_request" && target_branch != experimental"
+pipelinesascode.tekton.dev/on-cel-expression: |
+  event == "pull_request" && target_branch != experimental"
 ```
 
 You can find more information about the CEL language spec here :
@@ -188,7 +190,7 @@ task from the [Tekton Hub](https://hub.tekton.dev)
 using a [pipelines as code annotation](../resolver/#remote-http-url):
 
 ```yaml
-  pipelinesascode.tekton.dev/task: "github-add-comment"
+pipelinesascode.tekton.dev/task: "github-add-comment"
 ```
 
 you can then add the task to your [tasks section](https://tekton.dev/docs/pipelines/pipelines/#adding-tasks-to-the-pipeline) (or [finally](https://tekton.dev/docs/pipelines/pipelines/#adding-finally-to-the-pipeline) tasks) of your PipelineRun :
@@ -223,13 +225,12 @@ env:
       secretKeyRef:
         name: "{{ git_auth_secret }}"
         key: "git-provider-token"
-
 ```
 
 {{< hint info >}}
 
-* On GitHub apps the generated installation token [will be available for 8 hours](https://docs.github.com/en/developers/apps/building-github-apps/refreshing-user-to-server-access-tokens)
-* On GitHub apps the token is scoped to the repository the event (payload) come
+- On GitHub apps the generated installation token [will be available for 8 hours](https://docs.github.com/en/developers/apps/building-github-apps/refreshing-user-to-server-access-tokens)
+- On GitHub apps the token is scoped to the repository the event (payload) come
   from unless [configured](/docs/install/settings#pipelines-as-code-configuration-settings) it differently on cluster.
 
 {{< /hint >}}

--- a/docs/content/docs/guide/repositorycrd.md
+++ b/docs/content/docs/guide/repositorycrd.md
@@ -139,7 +139,7 @@ inside a template directly within your PipelineRuns.
 By default, there are
 several variables exposed according to the event. To view all the variables
 exposed by default, refer to the documentation on [Authoring
-PipelineRuns](../authoringprs).
+PipelineRuns](../authoringprs#default-parameters).
 
 With the custom Parameter expansion, you can specify some custom values to be
 replaced inside the template.

--- a/pkg/adapter/incoming_test.go
+++ b/pkg/adapter/incoming_test.go
@@ -2,11 +2,21 @@ package adapter
 
 import (
 	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"reflect"
 	"strings"
 	"testing"
+
+	apincoming "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/incoming"
+	"go.uber.org/zap"
+	zapobserver "go.uber.org/zap/zaptest/observer"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/env"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	rtesting "knative.dev/pkg/reconciler/testing"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
@@ -16,17 +26,11 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketcloud"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketserver"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/gitea"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/github"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/gitlab"
 	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/test/kubernetestint"
-	"go.uber.org/zap"
-	zapobserver "go.uber.org/zap/zaptest/observer"
-	"gotest.tools/v3/assert"
-	"gotest.tools/v3/env"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	rtesting "knative.dev/pkg/reconciler/testing"
 )
 
 const fakePrivateKey = `-----BEGIN RSA PRIVATE KEY-----
@@ -99,13 +103,16 @@ func Test_listener_detectIncoming(t *testing.T) {
 		queryPipelineRun string
 		querySecret      string
 		queryBranch      string
+		queryHeaders     http.Header
+		incomingBody     string
 		secretResult     map[string]string
 	}
 	tests := []struct {
-		name    string
-		args    args
-		want    bool
-		wantErr bool
+		name          string
+		args          args
+		want          bool
+		wantErr       bool
+		wantSubstrErr string
 	}{
 		{
 			name: "good/incoming",
@@ -142,6 +149,102 @@ func Test_listener_detectIncoming(t *testing.T) {
 				queryPipelineRun: "pipelinerun1",
 				queryBranch:      "main",
 			},
+		},
+		{
+			name: "good/incoming with body",
+			want: true,
+			args: args{
+				queryHeaders: http.Header{
+					"Content-Type": []string{"application/json"},
+				},
+				secretResult: map[string]string{"good-secret": "verysecrete"},
+				data: testclient.Data{
+					Repositories: []*v1alpha1.Repository{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "test-good",
+							},
+							Spec: v1alpha1.RepositorySpec{
+								URL: goodURL,
+								Incomings: &[]v1alpha1.Incoming{
+									{
+										Targets: []string{"main"},
+										Secret: v1alpha1.Secret{
+											Name: "good-secret",
+										},
+										Params: []string{"the_best_superhero_is"},
+									},
+								},
+								GitProvider: &v1alpha1.GitProvider{
+									Type: "github",
+								},
+							},
+						},
+					},
+				},
+				method:           "POST",
+				queryURL:         "/incoming",
+				queryRepository:  "test-good",
+				querySecret:      "verysecrete",
+				queryPipelineRun: "pipelinerun1",
+				queryBranch:      "main",
+				incomingBody:     `{"params":{"the_best_superhero_is":"you"}}`,
+			},
+		},
+		{
+			name: "good/incoming with body partial params ",
+			want: true,
+			args: args{
+				queryHeaders: http.Header{
+					"Content-Type": []string{"application/json"},
+				},
+				secretResult: map[string]string{"good-secret": "verysecrete"},
+				data: testclient.Data{
+					Repositories: []*v1alpha1.Repository{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "test-good",
+							},
+							Spec: v1alpha1.RepositorySpec{
+								URL: goodURL,
+								Incomings: &[]v1alpha1.Incoming{
+									{
+										Targets: []string{"main"},
+										Secret: v1alpha1.Secret{
+											Name: "good-secret",
+										},
+										Params: []string{"the_best_superhero_is", "life_is_a_long_and_beautiful_journey"},
+									},
+								},
+								GitProvider: &v1alpha1.GitProvider{
+									Type: "github",
+								},
+							},
+						},
+					},
+				},
+				method:           "POST",
+				queryURL:         "/incoming",
+				queryRepository:  "test-good",
+				querySecret:      "verysecrete",
+				queryPipelineRun: "pipelinerun1",
+				queryBranch:      "main",
+				incomingBody:     `{"params":{"the_best_superhero_is":"you"}}`,
+			},
+		},
+		{
+			name: "invalid incoming body",
+			args: args{
+				method:           "POST",
+				queryURL:         "/incoming",
+				queryRepository:  "test-good",
+				querySecret:      "verysecrete",
+				queryPipelineRun: "pipelinerun1",
+				queryBranch:      "main",
+				incomingBody:     `foobar`,
+			},
+			want:    false,
+			wantErr: true,
 		},
 		{
 			name: "bad/noincomingurl",
@@ -429,6 +532,124 @@ func Test_listener_detectIncoming(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name:          "bad/passed params is not in spec",
+			wantSubstrErr: "is not allowed in incoming webhook CR",
+			args: args{
+				queryHeaders: http.Header{
+					"Content-Type": []string{"application/json"},
+				},
+				secretResult: map[string]string{"good-secret": "verysecrete"},
+				data: testclient.Data{
+					Repositories: []*v1alpha1.Repository{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "test-good",
+							},
+							Spec: v1alpha1.RepositorySpec{
+								URL: goodURL,
+								Incomings: &[]v1alpha1.Incoming{
+									{
+										Targets: []string{"main"},
+										Secret: v1alpha1.Secret{
+											Name: "good-secret",
+										},
+									},
+								},
+								GitProvider: &v1alpha1.GitProvider{
+									Type: "github",
+								},
+							},
+						},
+					},
+				},
+				method:           "POST",
+				queryURL:         "/incoming",
+				queryRepository:  "test-good",
+				querySecret:      "verysecrete",
+				queryPipelineRun: "pipelinerun1",
+				queryBranch:      "main",
+				incomingBody:     `{"params":{"the_best_superhero_is":"you"}}`,
+			},
+		},
+		{
+			name:          "bad/incoming with no accept",
+			wantSubstrErr: "invalid content type, only application/json",
+			args: args{
+				secretResult: map[string]string{"good-secret": "verysecrete"},
+				data: testclient.Data{
+					Repositories: []*v1alpha1.Repository{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "test-good",
+							},
+							Spec: v1alpha1.RepositorySpec{
+								URL: goodURL,
+								Incomings: &[]v1alpha1.Incoming{
+									{
+										Targets: []string{"main"},
+										Secret: v1alpha1.Secret{
+											Name: "good-secret",
+										},
+									},
+								},
+								GitProvider: &v1alpha1.GitProvider{
+									Type: "github",
+								},
+							},
+						},
+					},
+				},
+				method:           "POST",
+				queryURL:         "/incoming",
+				queryRepository:  "test-good",
+				querySecret:      "verysecrete",
+				queryBranch:      "main",
+				queryPipelineRun: "pipelinerun1",
+				incomingBody:     `{"params":{"the_best_superhero_is":"you"}}`,
+			},
+		},
+		{
+			name:          "bad/empty secret",
+			wantSubstrErr: "is empty or key",
+			args: args{
+				queryHeaders: http.Header{
+					"Content-Type": []string{"application/json"},
+				},
+				secretResult: map[string]string{"empty-secret": ""},
+				data: testclient.Data{
+					Repositories: []*v1alpha1.Repository{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "test-good",
+							},
+							Spec: v1alpha1.RepositorySpec{
+								URL: goodURL,
+								Incomings: &[]v1alpha1.Incoming{
+									{
+										Targets: []string{"main"},
+										Secret: v1alpha1.Secret{
+											Name: "empty-secret",
+										},
+										Params: []string{"the_best_superhero_is"},
+									},
+								},
+								GitProvider: &v1alpha1.GitProvider{
+									Type: "github",
+								},
+							},
+						},
+					},
+				},
+				method:           "POST",
+				queryURL:         "/incoming",
+				queryRepository:  "test-good",
+				querySecret:      "verysecrete",
+				queryPipelineRun: "pipelinerun1",
+				queryBranch:      "main",
+				incomingBody:     `{"params":{"the_best_superhero_is":"you"}}`,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -457,13 +678,19 @@ func Test_listener_detectIncoming(t *testing.T) {
 			req := httptest.NewRequest(tt.args.method,
 				fmt.Sprintf("http://localhost%s?repository=%s&secret=%s&pipelinerun=%s&branch=%s", tt.args.queryURL,
 					tt.args.queryRepository, tt.args.querySecret, tt.args.queryPipelineRun, tt.args.queryBranch),
-				strings.NewReader(""))
-			got, _, err := l.detectIncoming(ctx, req, []byte(""))
+				strings.NewReader(tt.args.incomingBody))
+			req.Header = tt.args.queryHeaders
+			got, _, err := l.detectIncoming(ctx, req, []byte(tt.args.incomingBody))
+			if tt.wantSubstrErr != "" {
+				assert.Assert(t, err != nil)
+				assert.ErrorContains(t, err, tt.wantSubstrErr)
+				return
+			}
 			if tt.wantErr {
 				assert.Assert(t, err != nil)
 				return
 			}
-			assert.Equal(t, got, tt.want)
+			assert.Equal(t, got, tt.want, "err = %v", err)
 			assert.Equal(t, l.event.TargetPipelineRun, tt.args.queryPipelineRun)
 		})
 	}
@@ -530,6 +757,20 @@ func Test_listener_processIncoming(t *testing.T) {
 					URL: "https://forge/owner/repo",
 					GitProvider: &v1alpha1.GitProvider{
 						Type: "bitbucket-server",
+					},
+				},
+			},
+		},
+		{
+			name:     "process/gitea",
+			want:     &gitea.Provider{},
+			wantOrg:  "owner",
+			wantRepo: "repo",
+			targetRepo: &v1alpha1.Repository{
+				Spec: v1alpha1.RepositorySpec{
+					URL: "https://forge/owner/repo",
+					GitProvider: &v1alpha1.GitProvider{
+						Type: "gitea",
 					},
 				},
 			},
@@ -608,6 +849,60 @@ func Test_listener_processIncoming(t *testing.T) {
 			assert.Assert(t, reflect.TypeOf(pintf).Elem() == reflect.TypeOf(tt.want).Elem())
 			assert.Assert(t, l.event.Organization == tt.wantOrg)
 			assert.Assert(t, l.event.Repository == tt.wantRepo)
+		})
+	}
+}
+
+func TestApplyIncomingParams(t *testing.T) {
+	tests := []struct {
+		name           string
+		contentType    string
+		payloadBody    []byte
+		params         []string
+		expected       apincoming.Payload
+		expectedErrStr string
+	}{
+		{
+			name:           "Invalid content type",
+			contentType:    "text/plain",
+			payloadBody:    []byte(`{"params": {"key": "value"}}`),
+			params:         []string{"key"},
+			expected:       apincoming.Payload{},
+			expectedErrStr: "invalid content type, only application/json is accepted when posting a body",
+		},
+		{
+			name:           "Invalid payload format",
+			contentType:    "application/json",
+			payloadBody:    []byte(`invalid json`),
+			params:         []string{"key"},
+			expected:       apincoming.Payload{},
+			expectedErrStr: "error parsing incoming payload, not the expected format?: invalid character 'i' looking for beginning of value",
+		},
+		{
+			name:           "Param not allowed",
+			contentType:    "application/json",
+			payloadBody:    []byte(`{"params": {"key": "value", "other": "value"}}`),
+			params:         []string{"key"},
+			expected:       apincoming.Payload{},
+			expectedErrStr: "param other is not allowed in incoming webhook CR",
+		},
+		{
+			name:        "All params allowed",
+			contentType: "application/json",
+			payloadBody: []byte(`{"params": {"key": "value", "other": "value"}}`),
+			params:      []string{"key", "other"},
+			expected:    apincoming.Payload{Params: map[string]interface{}{"key": "value", "other": "value"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &http.Request{Header: http.Header{"Content-Type": []string{tt.contentType}}}
+			actual, err := applyIncomingParams(req, tt.payloadBody, tt.params)
+			assert.DeepEqual(t, tt.expected, actual)
+			if tt.expectedErrStr != "" {
+				assert.ErrorContains(t, err, tt.expectedErrStr)
+			}
 		})
 	}
 }

--- a/pkg/apis/incoming/incoming.go
+++ b/pkg/apis/incoming/incoming.go
@@ -5,7 +5,7 @@ import "encoding/json"
 type (
 	Params  map[string]interface{}
 	Payload struct {
-		Params `json:"params"`
+		Params Params `json:"params"`
 	}
 )
 

--- a/pkg/apis/incoming/incoming.go
+++ b/pkg/apis/incoming/incoming.go
@@ -1,0 +1,20 @@
+package incoming
+
+import "encoding/json"
+
+type (
+	Params  map[string]interface{}
+	Payload struct {
+		Params `json:"params"`
+	}
+)
+
+// parsePayload parses the payload from the incoming webhook, in json format and has only one key params
+func ParseIncomingPayload(payload []byte) (Payload, error) {
+	var incomingPayload Payload
+	err := json.Unmarshal(payload, &incomingPayload)
+	if err != nil {
+		return Payload{}, err
+	}
+	return incomingPayload, nil
+}

--- a/pkg/apis/incoming/incoming_test.go
+++ b/pkg/apis/incoming/incoming_test.go
@@ -1,0 +1,23 @@
+package incoming
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestParseIncomingPayload(t *testing.T) {
+	// Test case where payload is valid JSON
+	payload := []byte(`{"params": {"key": "value"}}`)
+	expected := Payload{map[string]interface{}{"key": "value"}}
+	actual, err := ParseIncomingPayload(payload)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, expected, actual)
+
+	// // Test case where payload is invalid JSON
+	payload = []byte(`invalid json`)
+	emptyExpected := Payload{}
+	actual, err = ParseIncomingPayload(payload)
+	assert.Assert(t, err != nil)
+	assert.DeepEqual(t, emptyExpected, actual)
+}

--- a/pkg/apis/pipelinesascode/v1alpha1/types.go
+++ b/pkg/apis/pipelinesascode/v1alpha1/types.go
@@ -100,6 +100,7 @@ type Params struct {
 type Incoming struct {
 	Type    string   `json:"type"`
 	Secret  Secret   `json:"secret"`
+	Params  []string `json:"params,omitempty"`
 	Targets []string `json:"targets,omitempty"`
 }
 

--- a/pkg/consoleui/custom.go
+++ b/pkg/consoleui/custom.go
@@ -6,12 +6,13 @@ import (
 	"net/url"
 	"strings"
 
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"k8s.io/client-go/dynamic"
+
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/templates"
-	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
-	"k8s.io/client-go/dynamic"
 )
 
 type CustomConsole struct {

--- a/pkg/customparams/customparams.go
+++ b/pkg/customparams/customparams.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	apincoming "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/incoming"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/events"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
@@ -31,6 +32,23 @@ func NewCustomParams(event *info.Event, repo *v1alpha1.Repository, run *params.R
 	}
 }
 
+// applyIncomingParams apply incoming params to an existing map (overwriting existing keys)
+func (p *CustomParams) applyIncomingParams(ret map[string]string) map[string]string {
+	if p.event.Request == nil {
+		return ret
+	}
+	if incomingParams, err := apincoming.ParseIncomingPayload(p.event.Request.Payload); err == nil {
+		for k, v := range incomingParams.Params {
+			if vs, ok := v.(string); ok {
+				ret[k] = vs
+			} else {
+				p.eventEmitter.EmitMessage(p.repo, zap.WarnLevel, "IncomingParamsNotString", fmt.Sprintf("cannot convert incoming param key: %s value: %v as string", k, v))
+			}
+		}
+	}
+	return ret
+}
+
 // GetParams will process the parameters as set in the repo.Spec CR.
 // value can come from a string or from a secretKeyRef or from a string value
 // if both is set we pick the value and issue a warning in the user namespace
@@ -40,7 +58,7 @@ func NewCustomParams(event *info.Event, repo *v1alpha1.Repository, run *params.R
 func (p *CustomParams) GetParams(ctx context.Context) (map[string]string, error) {
 	stdParams := p.makeStandardParamsFromEvent()
 	if p.repo.Spec.Params == nil {
-		return stdParams, nil
+		return p.applyIncomingParams(stdParams), nil
 	}
 	ret := map[string]string{}
 	mapFilters := map[string]string{}
@@ -104,5 +122,5 @@ func (p *CustomParams) GetParams(ctx context.Context) (map[string]string, error)
 		}
 	}
 
-	return ret, nil
+	return p.applyIncomingParams(ret), nil
 }

--- a/pkg/provider/github/app/token.go
+++ b/pkg/provider/github/app/token.go
@@ -27,7 +27,7 @@ func GetAndUpdateInstallationID(ctx context.Context, req *http.Request, run *par
 		return "", "", 0, err
 	}
 
-	installationURL := keys.PublicGithubAPIURL + keys.InstallationURL
+	installationURL := *gh.APIURL + keys.InstallationURL
 	enterpriseURL = req.Header.Get("X-GitHub-Enterprise-Host")
 	if enterpriseURL != "" {
 		installationURL = enterpriseURL + keys.InstallationURL
@@ -36,6 +36,10 @@ func GetAndUpdateInstallationID(ctx context.Context, req *http.Request, run *par
 	res, err := GetReponse(ctx, http.MethodGet, installationURL, jwtToken, run)
 	if err != nil {
 		return "", "", 0, err
+	}
+
+	if res.StatusCode >= 300 {
+		return "", "", 0, fmt.Errorf("Non-OK HTTP status: %d", res.StatusCode)
 	}
 
 	defer res.Body.Close()
@@ -68,6 +72,7 @@ func GetAndUpdateInstallationID(ctx context.Context, req *http.Request, run *par
 		}
 		if exist {
 			installationID = *installationData[i].ID
+			break
 		}
 	}
 	return enterpriseURL, token, installationID, nil

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/google/go-github/v53/github"
 	"github.com/jonboulle/clockwork"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
@@ -57,6 +58,7 @@ type skippedRun struct {
 
 func New() *Provider {
 	return &Provider{
+		APIURL:        github.String(keys.PublicGithubAPIURL),
 		paginedNumber: defaultPaginedNumber,
 		skippedRun: skippedRun{
 			mutex: &sync.Mutex{},

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -5,6 +5,14 @@ import (
 	"fmt"
 	"strings"
 
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	pipelinerunreconciler "github.com/tektoncd/pipeline/pkg/client/injection/reconciler/pipeline/v1/pipelinerun"
+	tektonv1lister "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1"
+	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/logging"
+	pkgreconciler "knative.dev/pkg/reconciler"
+
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/action"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
@@ -19,13 +27,6 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/pipelineascode"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/sync"
-	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
-	pipelinerunreconciler "github.com/tektoncd/pipeline/pkg/client/injection/reconciler/pipeline/v1/pipelinerun"
-	tektonv1lister "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1"
-	"go.uber.org/zap"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/pkg/logging"
-	pkgreconciler "knative.dev/pkg/reconciler"
 )
 
 // Reconciler implements controller.Reconciler for PipelineRun resources.

--- a/pkg/test/github/github.go
+++ b/pkg/test/github/github.go
@@ -14,8 +14,9 @@ import (
 	"testing"
 
 	"github.com/google/go-github/v53/github"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"gotest.tools/v3/assert"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 )
 
 const (

--- a/pkg/test/kubernetestint/kubernetesint.go
+++ b/pkg/test/kubernetestint/kubernetesint.go
@@ -41,8 +41,7 @@ func (k *KinterfaceTest) UpdateSecretWithOwnerRef(_ context.Context, _ *zap.Suga
 }
 
 func (k *KinterfaceTest) GetSecret(_ context.Context, secret ktypes.GetSecretOpt) (string, error) {
-	// check if secret exist in k.GetSecretResult
-	if k.GetSecretResult[secret.Name] == "" {
+	if _, ok := k.GetSecretResult[secret.Name]; !ok {
 		return "", fmt.Errorf("secret %s does not exist", secret.Name)
 	}
 	return k.GetSecretResult[secret.Name], nil

--- a/test/pkg/gitea/test.go
+++ b/test/pkg/gitea/test.go
@@ -132,7 +132,6 @@ func TestPR(t *testing.T, topts *TestOpts) func() {
 	assert.NilError(t, err)
 
 	PushFilesToRefGit(t, topts, entries, topts.DefaultBranch)
-
 	// try multiple times, cause sometime we get this kind of error:
 	// error: failed to push some refs to '/home/gitea/repositories/org-pac-e2e-test-zg6sx/pac-e2e-test-zg6sx.git'
 	for i := 0; i < 5; i++ {

--- a/test/pkg/wait/logs.go
+++ b/test/pkg/wait/logs.go
@@ -31,6 +31,7 @@ func RegexpMatchingInControllerLog(ctx context.Context, clients *params.Run, reg
 func RegexpMatchingInPodLog(ctx context.Context, clients *params.Run, ns, labelselector, containerName string, reg regexp.Regexp, maxNumberOfLoop int) error {
 	var err error
 	output := ""
+	clients.Clients.Log.Infof("looking for regexp %s in %s:%s labelSelector/pod", reg.String(), labelselector, containerName)
 	for i := 0; i <= maxNumberOfLoop; i++ {
 		output, err = tlogs.GetPodLog(ctx, clients.Clients.Kube.CoreV1(), ns, labelselector, containerName)
 		if err != nil {
@@ -44,6 +45,6 @@ func RegexpMatchingInPodLog(ctx context.Context, clients *params.Run, ns, labels
 		}
 		time.Sleep(5 * time.Second)
 	}
-	return fmt.Errorf("could not find a match in %s:%s labelSelector/pod for regexp:\n%s\noutput:\n%s",
+	return fmt.Errorf("could not find a match in %s:%s labelSelector/pod for regexp: '%s' output: '%s'",
 		labelselector, containerName, reg.String(), output)
 }

--- a/test/testdata/pipelinerun-incoming.yaml
+++ b/test/testdata/pipelinerun-incoming.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: "pipelinerun-incoming"
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
+    pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: task
+        taskSpec:
+          steps:
+            - name: task
+              image: registry.access.redhat.com/ubi9/ubi-micro
+              command:
+                [
+                  "/bin/echo",
+                  "-n",
+                  "It's a Bird... It's a Plane... It's {{ the_best_superhero_is }}",
+                ]


### PR DESCRIPTION
Let users pass parameters to the incoming webhook.

We accept now JSON payloads in the incoming webhook and we can pass the params to the pipelinerun dynamically.

Allowed params to be passed need to be explicitly defined in the Repository CR as an extra security layer.

See docs for more informations

### Demo

https://github.com/openshift-pipelines/pipelines-as-code/assets/98980/61eba60c-90d9-499c-aff7-f6440cfcc745



<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [x] 📝 A good commit message is important for other reviewers to understand the context of your change. Please refer to [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for more details how to write beautiful commit messages. We rather have the commit message in the PR body and the commit message instead of an external website.
- [x] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [x] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [x] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [x] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [x] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [x] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
