### PR TITLE
Rename config-logging configmap to be consistent with others

### DIFF
--- a/config/301-config-logging.yaml
+++ b/config/301-config-logging.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: pac-config-logging
+  name: pipelines-as-code-config-logging
   namespace: pipelines-as-code
   labels:
     app.kubernetes.io/instance: default

--- a/config/400-controller.yaml
+++ b/config/400-controller.yaml
@@ -77,7 +77,7 @@ spec:
             timeoutSeconds: 1
           env:
             - name: CONFIG_LOGGING_NAME
-              value: pac-config-logging
+              value: pipelines-as-code-config-logging
             - name: TLS_KEY
               value: "key"
             - name: TLS_CERT

--- a/config/500-watcher.yaml
+++ b/config/500-watcher.yaml
@@ -49,7 +49,7 @@ spec:
           imagePullPolicy: Always
           env:
           - name: CONFIG_LOGGING_NAME
-            value: pac-config-logging
+            value: pipelines-as-code-config-logging
           - name: SYSTEM_NAMESPACE
             valueFrom:
               fieldRef:

--- a/config/600-webhook.yaml
+++ b/config/600-webhook.yaml
@@ -47,7 +47,7 @@ spec:
           image: "ko://github.com/openshift-pipelines/pipelines-as-code/cmd/pipelines-as-code-webhook"
           env:
             - name: CONFIG_LOGGING_NAME
-              value: pac-config-logging
+              value: pipelines-as-code-config-logging
             - name: SYSTEM_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/docs/content/docs/install/settings.md
+++ b/docs/content/docs/install/settings.md
@@ -332,19 +332,19 @@ A few settings are available to configure this feature:
 
 ## Logging Configuration
 
-  Pipelines-as-Code uses the ConfigMap named `pac-config-logging` in the same namespace (`pipelines-as-code` by default) as the controllers. To get the ConfigMap use the following command:
+  Pipelines-as-Code uses the ConfigMap named `pipelines-as-code-config-logging` in the same namespace (`pipelines-as-code` by default) as the controllers. To get the ConfigMap use the following command:
 
   ```bash
-  $ kubectl get configmap pac-config-logging -n pipelines-as-code
+  $ kubectl get configmap pipelines-as-code-config-logging -n pipelines-as-code
 
   NAME                 DATA   AGE
-  pac-config-logging   4      9m44s
+  pipelines-as-code-config-logging   4      9m44s
   ```
 
   To retrieve the content of the ConfigMap:
 
   ```bash
-  $ kubectl get configmap pac-config-logging -n pipelines-as-code -o yaml
+  $ kubectl get configmap pipelines-as-code-config-logging -n pipelines-as-code -o yaml
 
   apiVersion: v1
   kind: ConfigMap
@@ -352,7 +352,7 @@ A few settings are available to configure this feature:
     labels:
       app.kubernetes.io/instance: default
       app.kubernetes.io/part-of: pipelines-as-code
-    name: pac-config-logging
+    name: pipelines-as-code-config-logging
     namespace: pipelines-as-code
   data:
     loglevel.pac-watcher: info
@@ -394,14 +394,14 @@ A few settings are available to configure this feature:
   You can change the log level from `info` to `debug` or any other supported values. For example, select the `debug` log level for the pipelines-as-code-watcher component:
 
   ```bash
-  kubectl patch configmap pac-config-logging -n pipelines-as-code --type json -p '[{"op": "replace", "path": "/data/loglevel.pac-watcher", "value":"debug"}]'
+  kubectl patch configmap pipelines-as-code-config-logging -n pipelines-as-code --type json -p '[{"op": "replace", "path": "/data/loglevel.pac-watcher", "value":"debug"}]'
   ```
 
   After this command, the controller gets a new log level value.
   If you want to use the same log level for all Pipelines-as-Code components, delete `level.*` values from configmap:
 
   ```bash
-  kubectl patch configmap pac-config-logging -n pipelines-as-code --type json -p '[  {"op": "remove", "path": "/data/loglevel.pac-watcher"},  {"op": "remove", "path": "/data/loglevel.pipelines-as-code-webhook"},  {"op": "remove", "path": "/data/loglevel.pipelinesascode"}]'
+  kubectl patch configmap pipelines-as-code-config-logging -n pipelines-as-code --type json -p '[  {"op": "remove", "path": "/data/loglevel.pac-watcher"},  {"op": "remove", "path": "/data/loglevel.pipelines-as-code-webhook"},  {"op": "remove", "path": "/data/loglevel.pipelinesascode"}]'
   ```
 
   In this case, all Pipelines-as-Code components get a common log level from `zap-logger-config` - `level` field from the json.


### PR DESCRIPTION
changes configmap name to be consistent with others. `pac-` might not maken sense for new users and when it is installed in some other namespace with other apps.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [x] 📝 A good commit message is important for other reviewers to understand the context of your change. Please refer to [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for more details how to write beautiful commit messages. We rather have the commit message in the PR body and the commit message instead of an external website.
- [x] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [x] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [x] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [x] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [x] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [x] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
