### PR TITLE
Use displayName if set for showing task status

### DIFF
--- a/.tekton/linter.yaml
+++ b/.tekton/linter.yaml
@@ -32,6 +32,7 @@ spec:
             workspace: source
 
       - name: generate-release-yaml
+        displayName: "Generate release.yaml"
         runAfter:
           - fetchit
         taskSpec:
@@ -50,6 +51,7 @@ spec:
             workspace: source
 
       - name: gitlint
+        displayName: "Git commit linter"
         runAfter:
           - fetchit
         workspaces:
@@ -67,6 +69,7 @@ spec:
                 gitlint --commit "$(git log --format=format:%H --no-merges -1)"
 
       - name: yamllint
+        generateName: "YAML Linter"
         runAfter:
           - generate-release-yaml
         taskSpec:
@@ -84,6 +87,7 @@ spec:
             workspace: source
 
       - name: pylint
+        generateName: "Python Linter"
         runAfter:
           - fetchit
         taskSpec:
@@ -100,6 +104,7 @@ spec:
             workspace: source
 
       - name: black
+        generateName: "Python Formatter check"
         runAfter:
           - pylint
         taskSpec:
@@ -116,6 +121,7 @@ spec:
             workspace: source
 
       - name: markdownlint
+        generateName: "Markdown Linter"
         runAfter:
           - fetchit
         taskSpec:
@@ -132,6 +138,7 @@ spec:
             workspace: source
 
       - name: vale
+        generateName: "Spelling and Grammar"
         runAfter:
           - fetchit
         taskSpec:

--- a/docs/content/docs/guide/statuses.md
+++ b/docs/content/docs/guide/statuses.md
@@ -2,13 +2,19 @@
 title: PipelineRun status
 weight: 6
 ---
+
 # Status
 
 ## GitHub apps
 
-After the pipeline has finished, its status will be shown in the GitHub Check
-tabs, along with a concise overview of the duration of each task in the
-pipeline. If any step fails, a small portion of the log from that step will
+After the `PipelineRun` has finished, its status will be
+shown in the GitHub Check tabs, along with a concise overview
+of the status the name and the duration of each task in the pipeline. If the task has a
+[displayName](https://tekton.dev/docs/pipelines/tasks/#specifying-a-display-name)
+it will use it as the description of the task or otherwise just the task
+name.
+
+If any step fails, a small portion of the log from that step will
 also be included in the output.
 
 In case an error is encountered while creating the `PipelineRun` on the cluster,
@@ -104,7 +110,7 @@ NAME                  URL                                                       
 pipelines-as-code-ci   https://github.com/openshift-pipelines/pipelines-as-code   pipelines-as-code-ci   True        Succeeded   59m         56m
 ```
 
-Using the tkn pac describe command from the [cli](../cli/)  you can easily view
+Using the tkn pac describe command from the [cli](../cli/) you can easily view
 all of the statuses of the PipelineRuns associated with your repository, as
 well as their metadata.
 

--- a/pkg/apis/pipelinesascode/v1alpha1/types.go
+++ b/pkg/apis/pipelinesascode/v1alpha1/types.go
@@ -65,6 +65,7 @@ type TaskInfos struct {
 	Message        string
 	LogSnippet     string
 	Reason         string
+	DisplayName    string
 	CompletionTime *metav1.Time
 }
 

--- a/pkg/cmd/tknpac/describe/describe_test.go
+++ b/pkg/cmd/tknpac/describe/describe_test.go
@@ -159,8 +159,9 @@ func TestDescribe(t *testing.T) {
 						},
 						CollectedTaskInfos: &map[string]v1alpha1.TaskInfos{
 							"task1": {
-								Reason:     tektonv1.PipelineRunReasonFailed.String(),
-								LogSnippet: "Error error miss robinson",
+								Reason:      tektonv1.PipelineRunReasonFailed.String(),
+								DisplayName: "And here's to you, Mrs. Robinson",
+								LogSnippet:  "We'd like to help you learn to help yourself",
 							},
 
 							"task2": {

--- a/pkg/cmd/tknpac/describe/templates/describe.tmpl
+++ b/pkg/cmd/tknpac/describe/templates/describe.tmpl
@@ -24,7 +24,7 @@
 
 {{ $.ColorScheme.Underline "Failures:" }}
 {{ range $taskName, $task := $status.CollectedTaskInfos }}
-{{ $.ColorScheme.Bold "•" }} {{ $taskName }}:{{if ne $task.Reason "Failed"}} {{$.ColorScheme.Dimmed $task.Reason}}{{end}}
+{{ $.ColorScheme.Bold "•" }} {{if ne $task.DisplayName ""}}{{ $task.DisplayName }}{{ else }}{{ $taskName }}{{ end }}:{{if ne $task.Reason "Failed"}} {{$.ColorScheme.Dimmed $task.Reason}}{{end}}
 {{ if eq $task.LogSnippet ""}}  {{ $task.Message }}{{ else }}{{ formatError $.ColorScheme $task.LogSnippet }}{{end}}
 {{ end }}
 {{- end }}

--- a/pkg/cmd/tknpac/describe/testdata/TestDescribe-collect_failures.golden
+++ b/pkg/cmd/tknpac/describe/testdata/TestDescribe-collect_failures.golden
@@ -13,8 +13,8 @@ Duration:       1 minute
 
 Failures:
 
-• task1:
-  Error error miss robinson
+• And here's to you, Mrs. Robinson:
+  We'd like to help you learn to help yourself
 
 • task2: PipelineRunTimeout
   I was sleeping and I forgot to wake up

--- a/pkg/reconciler/status.go
+++ b/pkg/reconciler/status.go
@@ -95,7 +95,11 @@ func (r *Reconciler) getFailureSnippet(ctx context.Context, pr *tektonv1.Pipelin
 	if text == "" {
 		text = sortedTaskInfos[0].Message
 	}
-	return fmt.Sprintf("task <b>%s</b> has the status <b>\"%s\"</b>:\n<pre>%s</pre>", sortedTaskInfos[0].Name, sortedTaskInfos[0].Reason, text)
+	name := sortedTaskInfos[0].Name
+	if sortedTaskInfos[0].DisplayName != "" {
+		name = strings.ToLower(sortedTaskInfos[0].DisplayName)
+	}
+	return fmt.Sprintf("task <b>%s</b> has the status <b>\"%s\"</b>:\n<pre>%s</pre>", name, sortedTaskInfos[0].Reason, text)
 }
 
 func (r *Reconciler) postFinalStatus(ctx context.Context, logger *zap.SugaredLogger, vcx provider.Interface, event *info.Event, createdPR *tektonv1.PipelineRun) (*tektonv1.PipelineRun, error) {

--- a/pkg/sort/task_status.go
+++ b/pkg/sort/task_status.go
@@ -18,7 +18,11 @@ type tkr struct {
 }
 
 func (t tkr) ConsoleLogURL() string {
-	return fmt.Sprintf("[%s](%s)", t.PipelineTaskName, t.taskLogURL)
+	name := t.PipelineTaskName
+	if t.Status != nil && t.Status.TaskSpec != nil && t.Status.TaskSpec.DisplayName != "" {
+		name = t.Status.TaskSpec.DisplayName
+	}
+	return fmt.Sprintf("[%s](%s)", name, t.taskLogURL)
 }
 
 type taskrunList []tkr

--- a/pkg/sort/task_status_test.go
+++ b/pkg/sort/task_status_test.go
@@ -27,9 +27,9 @@ func TestStatusTmpl(t *testing.T) {
 			wantErr: true,
 			tmpl:    "{{.XXX}}",
 			prTaskRunStatus: map[string]*tektonv1.PipelineRunTaskRunStatus{
-				"first":  tektontest.MakePrTrStatus("first", 5),
-				"last":   tektontest.MakePrTrStatus("last", 15),
-				"middle": tektontest.MakePrTrStatus("middle", 10),
+				"first":  tektontest.MakePrTrStatus("first", "", 5),
+				"last":   tektontest.MakePrTrStatus("last", "", 15),
+				"middle": tektontest.MakePrTrStatus("middle", "", 10),
 			},
 		},
 		{
@@ -37,9 +37,19 @@ func TestStatusTmpl(t *testing.T) {
 			wantRegexp: regexp.MustCompile(".*first.*middle.*last.*"),
 			tmpl:       flattedTmpl,
 			prTaskRunStatus: map[string]*tektonv1.PipelineRunTaskRunStatus{
-				"first":  tektontest.MakePrTrStatus("first", 5),
-				"last":   tektontest.MakePrTrStatus("last", 15),
-				"middle": tektontest.MakePrTrStatus("middle", 10),
+				"first":  tektontest.MakePrTrStatus("first", "", 5),
+				"last":   tektontest.MakePrTrStatus("last", "", 15),
+				"middle": tektontest.MakePrTrStatus("middle", "", 10),
+			},
+		},
+		{
+			name:       "sorted with displayname",
+			wantRegexp: regexp.MustCompile(".*Primo.*Median.*Ultimo"),
+			tmpl:       flattedTmpl,
+			prTaskRunStatus: map[string]*tektonv1.PipelineRunTaskRunStatus{
+				"first":  tektontest.MakePrTrStatus("first", "Primo", 5),
+				"last":   tektontest.MakePrTrStatus("last", "Ultimo", 15),
+				"middle": tektontest.MakePrTrStatus("middle", "Median", 10),
 			},
 		},
 		{
@@ -47,9 +57,9 @@ func TestStatusTmpl(t *testing.T) {
 			wantRegexp: regexp.MustCompile(".*notcompleted.*first.*last.*"),
 			tmpl:       flattedTmpl,
 			prTaskRunStatus: map[string]*tektonv1.PipelineRunTaskRunStatus{
-				"first":  tektontest.MakePrTrStatus("first", 5),
-				"last":   tektontest.MakePrTrStatus("last", 15),
-				"middle": tektontest.MakePrTrStatus("notcompleted", -1),
+				"first":  tektontest.MakePrTrStatus("first", "", 5),
+				"last":   tektontest.MakePrTrStatus("last", "", 15),
+				"middle": tektontest.MakePrTrStatus("notcompleted", "", -1),
 			},
 		},
 		{

--- a/pkg/test/tekton/genz.go
+++ b/pkg/test/tekton/genz.go
@@ -13,7 +13,7 @@ import (
 	knativeduckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
-func MakePrTrStatus(ptaskname string, completionmn int) *tektonv1.PipelineRunTaskRunStatus {
+func MakePrTrStatus(ptaskname, displayName string, completionmn int) *tektonv1.PipelineRunTaskRunStatus {
 	clock := clockwork.NewFakeClock()
 
 	completionTime := &metav1.Time{}
@@ -34,6 +34,9 @@ func MakePrTrStatus(ptaskname string, completionmn int) *tektonv1.PipelineRunTas
 			TaskRunStatusFields: tektonv1.TaskRunStatusFields{
 				StartTime:      &metav1.Time{Time: clock.Now().Add(time.Duration(completionmn+10) * time.Minute)},
 				CompletionTime: completionTime,
+				TaskSpec: &tektonv1.TaskSpec{
+					DisplayName: displayName,
+				},
 			},
 			Status: conditionTrue,
 		},

--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -62,6 +62,22 @@ func TestGiteaPullRequestTaskAnnotations(t *testing.T) {
 	defer tgitea.TestPR(t, topts)()
 }
 
+func TestGiteaUseDisplayName(t *testing.T) {
+	topts := &tgitea.TestOpts{
+		Regexp:      regexp.MustCompile(`.*The Task name is Task.*`),
+		TargetEvent: options.PullRequestEvent,
+		YAMLFiles: map[string]string{
+			".tekton/pr.yaml": "testdata/pipelinerun.yaml",
+		},
+		CheckForStatus: "success",
+		ExtraArgs: map[string]string{
+			"RemoteTaskURL":  options.RemoteTaskURL,
+			"RemoteTaskName": options.RemoteTaskName,
+		},
+	}
+	defer tgitea.TestPR(t, topts)()
+}
+
 func TestGiteaPullRequestPipelineAnnotations(t *testing.T) {
 	topts := &tgitea.TestOpts{
 		Regexp:      successRegexp,

--- a/test/testdata/pipelinerun.yaml
+++ b/test/testdata/pipelinerun.yaml
@@ -11,6 +11,7 @@ spec:
   pipelineSpec:
     tasks:
       - name: task
+        displayName: "The Task name is Task"
         taskSpec:
           steps:
             - name: task


### PR DESCRIPTION
The displayName field has been introduced since [Tekton Pipeline 0.47.x](https://github.com/tektoncd/pipeline/pull/6294), use this when showing the task breakdown status.

Screenshot, assuming a pipelineSpecs looking like this:

```yaml
  pipelineSpec:
    tasks:
      - name: noop-task
        displayName: "A failure"
        taskSpec:
          steps:
            - name: noop-task
              image: registry.access.redhat.com/ubi9/ubi-micro
              script: |
                echo "hello from main"
                exit 1
      - name: noop-task2
        displayName: "A success"
        taskSpec:
          steps:
            - name: noop-task
              image: registry.access.redhat.com/ubi9/ubi-micro
              script: |
                exit 0
      - name: no-display-name
        taskSpec:
          steps:
            - name: noop-task
              image: registry.access.redhat.com/ubi9/ubi-micro
              script: |
                exit 0
```

It would show the displayName if set or fallback to just taskName otherwise:

![image](https://github.com/openshift-pipelines/pipelines-as-code/assets/98980/ab29ddee-f9c2-4acd-8ebb-8b4d10417116)
![image](https://github.com/openshift-pipelines/pipelines-as-code/assets/98980/9db9e01d-f6d2-443e-b878-9b552ae47dcc)



<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 A good commit message is important for other reviewers to understand the context of your change. Please refer to [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for more details how to write beautiful commit messages. We rather have the commit message in the PR body and the commit message instead of an external website.
- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
