### PR TITLE
Fix verification of duplicate name and generateName in .tekton directory

### DIFF
--- a/pkg/resolve/resolve.go
+++ b/pkg/resolve/resolve.go
@@ -250,11 +250,22 @@ func Resolve(ctx context.Context, cs *params.Run, logger *zap.SugaredLogger, pro
 func pipelineRunsWithSameName(prs []*tektonv1.PipelineRun) error {
 	prNames := map[string]bool{}
 	for _, pr := range prs {
-		_, exist := prNames[pr.GetName()]
-		if exist {
-			return fmt.Errorf("found multiple pipelinerun in .tekton with same name: %v, please update", pr.GetName())
+		name := pr.GetName()
+		generateName := pr.GetGenerateName()
+
+		if name != "" {
+			if _, exist := prNames[name]; exist {
+				return fmt.Errorf("found multiple pipelinerun in .tekton with the same name: %v, please update", name)
+			}
+			prNames[name] = true
 		}
-		prNames[pr.GetName()] = true
+
+		if generateName != "" {
+			if _, exist := prNames[generateName]; exist {
+				return fmt.Errorf("found multiple pipelinerun in .tekton with the same generateName: %v, please update", generateName)
+			}
+			prNames[generateName] = true
+		}
 	}
 	return nil
 }

--- a/pkg/resolve/resolve_test.go
+++ b/pkg/resolve/resolve_test.go
@@ -281,10 +281,58 @@ func TestPipelineRunsWithSameName(t *testing.T) {
 					},
 				},
 			},
-			err: "found multiple pipelinerun in .tekton with same name: pipelinerun-abc, please update",
+			err: "found multiple pipelinerun in .tekton with the same name: pipelinerun-abc, please update",
 		},
 		{
-			name: "doesn't exists",
+			name: "same name and generateName pipelineruns exists",
+			prs: []*tektonv1.PipelineRun{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pipelinerun-abc",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "pipelinerun-abc",
+					},
+				},
+			},
+			err: "found multiple pipelinerun in .tekton with the same generateName: pipelinerun-abc, please update",
+		},
+		{
+			name: "same generateName pipelineruns exists",
+			prs: []*tektonv1.PipelineRun{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "pipelinerun-abc-",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "pipelinerun-abc-",
+					},
+				},
+			},
+			err: "found multiple pipelinerun in .tekton with the same generateName: pipelinerun-abc-, please update",
+		},
+		{
+			name: "different pipelineruns exists",
+			prs: []*tektonv1.PipelineRun{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "pipelinerun-abc-",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pipelinerun-bcd",
+					},
+				},
+			},
+			err: "",
+		},
+		{
+			name: "doesn't pipelinerun name exists",
 			prs: []*tektonv1.PipelineRun{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -294,6 +342,22 @@ func TestPipelineRunsWithSameName(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "pipelinerun-bcd",
+					},
+				},
+			},
+			err: "",
+		},
+		{
+			name: "doesn't pipelinerun generateName exists",
+			prs: []*tektonv1.PipelineRun{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "pipelinerun-abc",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "pipelinerun-bcd",
 					},
 				},
 			},


### PR DESCRIPTION
In pac pipelineRunsWithSameName function checks for
pipelinerun name duplication in .tekton directory,
This commit fixes duplication check for Pipeinerun name and generateName
by ignoring when Pipeinerun name or generateName is empty
    
Signed-off-by: Savita Ashture <sashture@redhat.com>


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 A good commit message is important for other reviewers to understand the context of your change. Please refer to [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for more details how to write beautiful commit messages. We rather have the commit message in the PR body and the commit message instead of an external website.
- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
