### PR TITLE
Fix multiple creation of Pipelinerun for incoming event

### DIFF
--- a/docs/content/docs/guide/incoming_webhook.md
+++ b/docs/content/docs/guide/incoming_webhook.md
@@ -87,7 +87,7 @@ stringData:
 After setting this up, you will be able to start the PipelineRun with a POST
 request sent to the controller URL appended with /incoming. The request
 includes the very-secure-shared-secret, the repository name (repo), the target
-branch (main), and the PipelineRun name (target_pipelinerun).
+branch (main), and the PipelineRun name (or the generateName if used) (target_pipelinerun).
 
 As an example here is a curl snippet starting the PipelineRun:
 
@@ -141,7 +141,7 @@ spec:
 and here is a curl snippet passing the `pull_request_number` value:
 
 ```shell
-curl -H "Content-Type: application/json" -X POST "http://conteoller.pac.url:8080/incoming?repository=repo&branch=main&secret=foo&pipelinerun=manual-pipelinerun" -d '{"params": {"pull_request_number": "12345"}}'
+curl -H "Content-Type: application/json" -X POST "https://control.pac.url/incoming?repository=repo&branch=main&secret=very-secure-shared-secret&pipelinerun=target_pipelinerun" -d '{"params": {"pull_request_number": "12345"}}'
 ```
 
 The parameter value of `pull_request_number` will be set to `12345` when using the variable `{{pull_request_number}}` in your PipelineRun.

--- a/pkg/matcher/annotation_matcher.go
+++ b/pkg/matcher/annotation_matcher.go
@@ -232,3 +232,22 @@ func matchOnAnnotation(annotations string, eventType []string, branchMatching bo
 	}
 	return true, nil
 }
+
+func MatchRunningPipelineRunForIncomingWebhook(eventType, incomingPipelineRun string, prs []*tektonv1.PipelineRun) []*tektonv1.PipelineRun {
+	// return all pipelineruns if EventType is not incoming or TargetPipelineRun is ""
+	if eventType != "incoming" || incomingPipelineRun == "" {
+		return prs
+	}
+
+	for _, pr := range prs {
+		// check incomingPipelineRun with pr name
+		if incomingPipelineRun == pr.GetName() {
+			return []*tektonv1.PipelineRun{pr}
+		}
+		// check incomingPipelineRun with pr generateName
+		if incomingPipelineRun == strings.TrimSuffix(pr.GetGenerateName(), "-") {
+			return []*tektonv1.PipelineRun{pr}
+		}
+	}
+	return nil
+}

--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -193,6 +193,14 @@ func (p *PacRun) getPipelineRunsFromRepo(ctx context.Context, repo *v1alpha1.Rep
 		return nil, nil
 	}
 
+	// if event type is incoming then filter out the pipelineruns related to incoming event
+	pipelineRuns = matcher.MatchRunningPipelineRunForIncomingWebhook(p.event.EventType, p.event.TargetPipelineRun, pipelineRuns)
+	if pipelineRuns == nil {
+		msg := fmt.Sprintf("cannot find pipelinerun %s for matching an incoming event in this repository", p.event.TargetPipelineRun)
+		p.eventEmitter.EmitMessage(repo, zap.InfoLevel, "RepositoryCannotLocatePipelineRunForIncomingEvent", msg)
+		return nil, nil
+	}
+
 	// if /test command is used then filter out the pipelinerun
 	pipelineRuns = filterRunningPipelineRunOnTargetTest(p.event.TargetTestPipelineRun, pipelineRuns)
 	if pipelineRuns == nil {

--- a/test/testdata/pipelinerun-incoming-generatename.yaml
+++ b/test/testdata/pipelinerun-incoming-generatename.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: "pipelinerun-incoming-"
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
+    pipelinesascode.tekton.dev/on-event: "[incoming]"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: task
+        taskSpec:
+          steps:
+            - name: task
+              image: registry.access.redhat.com/ubi9/ubi-micro
+              command:
+                [
+                  "/bin/echo",
+                  "-n",
+                  "It's a Bird... It's a Plane... It's {{ the_best_superhero_is }}",
+                ]


### PR DESCRIPTION
Issue:
In a repo if .tekton directory have two pipelineruns one with pull_request event and another with incoming event if request sent to incoming event then both pipelineruns getting triggered instead of one Pipelinerun
where the incoming event matches.

Fix:
The commit add changes to fix the issue and now when incoming event request comes only that pipelinerun will be triggered

Signed-off-by: Savita Ashture <sashture@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 A good commit message is important for other reviewers to understand the context of your change. Please refer to [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for more details how to write beautiful commit messages. We rather have the commit message in the PR body and the commit message instead of an external website.
- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
