### PR TITLE
improve get changed files

### DIFF
--- a/pkg/customparams/customparams.go
+++ b/pkg/customparams/customparams.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	sectypes "github.com/openshift-pipelines/pipelines-as-code/pkg/secrets/types"
 	"go.uber.org/zap"
 )
@@ -19,15 +20,17 @@ type CustomParams struct {
 	k8int        kubeinteraction.Interface
 	eventEmitter *events.EventEmitter
 	repo         *v1alpha1.Repository
+	vcx          provider.Interface
 }
 
-func NewCustomParams(event *info.Event, repo *v1alpha1.Repository, run *params.Run, k8int kubeinteraction.Interface, eventEmitter *events.EventEmitter) CustomParams {
+func NewCustomParams(event *info.Event, repo *v1alpha1.Repository, run *params.Run, k8int kubeinteraction.Interface, eventEmitter *events.EventEmitter, prov provider.Interface) CustomParams {
 	return CustomParams{
 		event:        event,
 		repo:         repo,
 		run:          run,
 		k8int:        k8int,
 		eventEmitter: eventEmitter,
+		vcx:          prov,
 	}
 }
 
@@ -38,7 +41,7 @@ func NewCustomParams(event *info.Event, repo *v1alpha1.Repository, run *params.R
 // if multiple params name has a filter we pick up the first one that has
 // matched true.
 func (p *CustomParams) GetParams(ctx context.Context) (map[string]string, error) {
-	stdParams := p.makeStandardParamsFromEvent()
+	stdParams := p.makeStandardParamsFromEvent(ctx)
 	if p.repo.Spec.Params == nil {
 		return stdParams, nil
 	}

--- a/pkg/customparams/customparams_test.go
+++ b/pkg/customparams/customparams_test.go
@@ -280,7 +280,7 @@ func TestProcessTemplates(t *testing.T) {
 			if tt.event == nil {
 				tt.event = &info.Event{}
 			}
-			p := NewCustomParams(tt.event, repo, run, &kitesthelper.KinterfaceTest{GetSecretResult: tt.secretData}, nil)
+			p := NewCustomParams(tt.event, repo, run, &kitesthelper.KinterfaceTest{GetSecretResult: tt.secretData}, nil, nil)
 			stdata, _ := testclient.SeedTestData(t, ctx, testclient.Data{})
 			p.eventEmitter = events.NewEventEmitter(stdata.Kube, logger)
 			ret, err := p.GetParams(ctx)

--- a/pkg/customparams/standard.go
+++ b/pkg/customparams/standard.go
@@ -1,30 +1,51 @@
 package customparams
 
 import (
+	"context"
+	"fmt"
 	"strings"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
+	"go.uber.org/zap"
 )
 
+func (p *CustomParams) getChangedFiles(ctx context.Context) provider.ChangedFiles {
+	if p.vcx == nil {
+		return provider.ChangedFiles{}
+	}
+	changedFiles, err := p.vcx.GetFiles(ctx, p.event)
+	if err != nil {
+		p.eventEmitter.EmitMessage(p.repo, zap.ErrorLevel, "ParamsError", fmt.Sprintf("error getting changed files: %s", err.Error()))
+	}
+
+	return changedFiles
+}
+
 // makeStandardParamsFromEvent will create a map of standard params out of the event
-func (p *CustomParams) makeStandardParamsFromEvent() map[string]string {
+func (p *CustomParams) makeStandardParamsFromEvent(ctx context.Context) map[string]string {
 	repoURL := p.event.URL
 	// On bitbucket server you are have a special url for checking it out, they
 	// seemed to fix it in 2.0 but i guess we have to live with this until then.
 	if p.event.CloneURL != "" {
 		repoURL = p.event.CloneURL
 	}
-
+	changedFiles := p.getChangedFiles(ctx)
 	return map[string]string{
-		"revision":         p.event.SHA,
-		"repo_url":         repoURL,
-		"repo_owner":       strings.ToLower(p.event.Organization),
-		"repo_name":        strings.ToLower(p.event.Repository),
-		"target_branch":    formatting.SanitizeBranch(p.event.BaseBranch),
-		"source_branch":    formatting.SanitizeBranch(p.event.HeadBranch),
-		"source_url":       p.event.HeadURL,
-		"sender":           strings.ToLower(p.event.Sender),
-		"target_namespace": p.repo.GetNamespace(),
-		"event_type":       p.event.EventType,
+		"revision":          p.event.SHA,
+		"repo_url":          repoURL,
+		"repo_owner":        strings.ToLower(p.event.Organization),
+		"repo_name":         strings.ToLower(p.event.Repository),
+		"target_branch":     formatting.SanitizeBranch(p.event.BaseBranch),
+		"source_branch":     formatting.SanitizeBranch(p.event.HeadBranch),
+		"source_url":        p.event.HeadURL,
+		"sender":            strings.ToLower(p.event.Sender),
+		"target_namespace":  p.repo.GetNamespace(),
+		"event_type":        p.event.EventType,
+		"all_changed_files": strings.Join(formatting.UniqueStringArray(changedFiles.All), ","),
+		"added_files":       strings.Join(formatting.UniqueStringArray(changedFiles.Added), ","),
+		"deleted_files":     strings.Join(formatting.UniqueStringArray(changedFiles.Deleted), ","),
+		"modified_files":    strings.Join(formatting.UniqueStringArray(changedFiles.Modified), ","),
+		"renamed_files":     strings.Join(formatting.UniqueStringArray(changedFiles.Renamed), ","),
 	}
 }

--- a/pkg/customparams/standard_test.go
+++ b/pkg/customparams/standard_test.go
@@ -5,8 +5,10 @@ import (
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	testprovider "github.com/openshift-pipelines/pipelines-as-code/pkg/test/provider"
 	"gotest.tools/v3/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	rectesting "knative.dev/pkg/reconciler/testing"
 )
 
 func TestMakeStandardParamsFromEvent(t *testing.T) {
@@ -23,16 +25,21 @@ func TestMakeStandardParamsFromEvent(t *testing.T) {
 	}
 
 	result := map[string]string{
-		"event_type":       "pull_request",
-		"repo_name":        "repo",
-		"repo_owner":       "org",
-		"repo_url":         "https://paris.com",
-		"source_url":       "https://india.com",
-		"revision":         "1234567890",
-		"sender":           "sender",
-		"source_branch":    "foo",
-		"target_branch":    "main",
-		"target_namespace": "myns",
+		"event_type":        "pull_request",
+		"repo_name":         "repo",
+		"repo_owner":        "org",
+		"repo_url":          "https://paris.com",
+		"source_url":        "https://india.com",
+		"revision":          "1234567890",
+		"sender":            "sender",
+		"source_branch":     "foo",
+		"target_branch":     "main",
+		"target_namespace":  "myns",
+		"all_changed_files": "added.go,deleted.go,modified.go,renamed.go",
+		"added_files":       "added.go",
+		"deleted_files":     "deleted.go",
+		"modified_files":    "modified.go",
+		"renamed_files":     "renamed.go",
 	}
 
 	repo := &v1alpha1.Repository{
@@ -42,15 +49,24 @@ func TestMakeStandardParamsFromEvent(t *testing.T) {
 		},
 	}
 
-	p := NewCustomParams(event, repo, nil, nil, nil)
-	params := p.makeStandardParamsFromEvent()
+	ctx, _ := rectesting.SetupFakeContext(t)
+	vcx := &testprovider.TestProviderImp{
+		WantAllChangedFiles: []string{"added.go", "deleted.go", "modified.go", "renamed.go"},
+		WantAddedFiles:      []string{"added.go"},
+		WantDeletedFiles:    []string{"deleted.go"},
+		WantModifiedFiles:   []string{"modified.go"},
+		WantRenamedFiles:    []string{"renamed.go"},
+	}
+
+	p := NewCustomParams(event, repo, nil, nil, nil, vcx)
+	params := p.makeStandardParamsFromEvent(ctx)
 	assert.DeepEqual(t, params, result)
 
 	nevent := &info.Event{}
 	event.DeepCopyInto(nevent)
 	nevent.CloneURL = "https://blahblah"
 	p.event = nevent
-	nparams := p.makeStandardParamsFromEvent()
+	nparams := p.makeStandardParamsFromEvent(ctx)
 	result["repo_url"] = nevent.CloneURL
 	assert.DeepEqual(t, nparams, result)
 }

--- a/pkg/formatting/array.go
+++ b/pkg/formatting/array.go
@@ -1,0 +1,13 @@
+package formatting
+
+func UniqueStringArray(slice []string) []string {
+	keys := make(map[string]bool)
+	list := []string{}
+	for _, entry := range slice {
+		if _, value := keys[entry]; !value {
+			keys[entry] = true
+			list = append(list, entry)
+		}
+	}
+	return list
+}

--- a/pkg/formatting/array_test.go
+++ b/pkg/formatting/array_test.go
@@ -1,0 +1,40 @@
+package formatting
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestUniqueStringArray(t *testing.T) {
+	type args struct {
+		slice []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "no duplicates",
+			args: args{
+				slice: []string{"1", "2"},
+			},
+			want: []string{"1", "2"},
+		},
+
+		{
+			name: "with duplicates",
+			args: args{
+				slice: []string{"1", "2", "1", "2", "1", "2", "3", "2", "5", "5"},
+			},
+			want: []string{"1", "2", "3", "5"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := UniqueStringArray(tt.args.slice); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("UniqueStringArray() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/matcher/cel.go
+++ b/pkg/matcher/cel.go
@@ -3,6 +3,7 @@ package matcher
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/gobwas/glob"
@@ -10,8 +11,15 @@ import (
 	"github.com/google/cel-go/checker/decls"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
+)
+
+const (
+	// Utilizing this regex, the GetFiles function will be selectively executed exclusively when a property
+	// such as 'all_changed_files' or 'added_files' is specified within the CEL expression
+	changedFilesTags = "all_changed_files|added_files|deleted_files|modified_files|renamed_files"
 )
 
 func celEvaluate(ctx context.Context, expr string, event *info.Event, vcx provider.Interface) (ref.Val, error) {
@@ -38,13 +46,28 @@ func celEvaluate(ctx context.Context, expr string, event *info.Event, vcx provid
 		}
 	}
 
+	r := regexp.MustCompile(changedFilesTags)
+	changedFiles := provider.ChangedFiles{}
+	var err error
+	if r.MatchString(expr) {
+		changedFiles, err = vcx.GetFiles(ctx, event)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	data := map[string]interface{}{
-		"event":         event.TriggerTarget,
-		"event_title":   eventTitle,
-		"target_branch": event.BaseBranch,
-		"source_branch": event.HeadBranch,
-		"target_url":    event.BaseURL,
-		"source_url":    event.HeadURL,
+		"event":             event.TriggerTarget,
+		"event_title":       eventTitle,
+		"target_branch":     event.BaseBranch,
+		"source_branch":     event.HeadBranch,
+		"target_url":        event.BaseURL,
+		"source_url":        event.HeadURL,
+		"all_changed_files": strings.Join(formatting.UniqueStringArray(changedFiles.All), ","),
+		"added_files":       strings.Join(formatting.UniqueStringArray(changedFiles.Added), ","),
+		"deleted_files":     strings.Join(formatting.UniqueStringArray(changedFiles.Deleted), ","),
+		"modified_files":    strings.Join(formatting.UniqueStringArray(changedFiles.Modified), ","),
+		"renamed_files":     strings.Join(formatting.UniqueStringArray(changedFiles.Renamed), ","),
 	}
 
 	env, err := cel.NewEnv(
@@ -55,7 +78,12 @@ func celEvaluate(ctx context.Context, expr string, event *info.Event, vcx provid
 			decls.NewVar("target_branch", decls.String),
 			decls.NewVar("source_branch", decls.String),
 			decls.NewVar("target_url", decls.String),
-			decls.NewVar("source_url", decls.String)))
+			decls.NewVar("source_url", decls.String),
+			decls.NewVar("all_changed_files", decls.String),
+			decls.NewVar("added_files", decls.String),
+			decls.NewVar("deleted_files", decls.String),
+			decls.NewVar("modified_files", decls.String),
+			decls.NewVar("renamed_files", decls.String)))
 	if err != nil {
 		return nil, err
 	}
@@ -94,14 +122,14 @@ func (t celPac) ProgramOptions() []cel.ProgramOption {
 
 func (t celPac) pathChanged(vals ref.Val) ref.Val {
 	var match types.Bool
-	fileList, err := t.vcx.GetFiles(t.ctx, t.event)
+	changedFiles, err := t.vcx.GetFiles(t.ctx, t.event)
 	if err != nil {
 		return types.Bool(false)
 	}
-	for i := range fileList {
+	for i := range changedFiles.All {
 		if v, ok := vals.Value().(string); ok {
 			g := glob.MustCompile(v)
-			if g.Match(fileList[i]) {
+			if g.Match(changedFiles.All[i]) {
 				return types.Bool(true)
 			}
 		}

--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -66,7 +66,7 @@ func (p *PacRun) Run(ctx context.Context) error {
 	}
 
 	// set params for the console driver, only used for the custom console ones
-	cp := customparams.NewCustomParams(p.event, repo, p.run, p.k8int, p.eventEmitter)
+	cp := customparams.NewCustomParams(p.event, repo, p.run, p.k8int, p.eventEmitter, p.vcx)
 	maptemplate, err := cp.GetParams(ctx)
 	if err != nil {
 		p.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "ParamsError",

--- a/pkg/pipelineascode/template.go
+++ b/pkg/pipelineascode/template.go
@@ -13,7 +13,7 @@ import (
 // makeTemplate will process all templates replacing the value from the event and from the
 // params as set on Repo CR
 func (p *PacRun) makeTemplate(ctx context.Context, repo *v1alpha1.Repository, template string) string {
-	cp := customparams.NewCustomParams(p.event, repo, p.run, p.k8int, p.eventEmitter)
+	cp := customparams.NewCustomParams(p.event, repo, p.run, p.k8int, p.eventEmitter, p.vcx)
 	maptemplate, err := cp.GetParams(ctx)
 	if err != nil {
 		p.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "ParamsError",

--- a/pkg/provider/bitbucketcloud/bitbucket.go
+++ b/pkg/provider/bitbucketcloud/bitbucket.go
@@ -275,8 +275,8 @@ func (v *Provider) getBlob(runevent *info.Event, ref, path string) (string, erro
 	return blob.String(), nil
 }
 
-func (v *Provider) GetFiles(_ context.Context, _ *info.Event) ([]string, error) {
-	return []string{}, nil
+func (v *Provider) GetFiles(_ context.Context, _ *info.Event) (provider.ChangedFiles, error) {
+	return provider.ChangedFiles{}, nil
 }
 
 func (v *Provider) CreateToken(_ context.Context, _ []string, _ *params.Run, _ *info.Event) (string, error) {

--- a/pkg/provider/bitbucketserver/bitbucketserver.go
+++ b/pkg/provider/bitbucketserver/bitbucketserver.go
@@ -270,8 +270,8 @@ func (v *Provider) GetConfig() *info.ProviderConfig {
 	}
 }
 
-func (v *Provider) GetFiles(_ context.Context, _ *info.Event) ([]string, error) {
-	return []string{}, nil
+func (v *Provider) GetFiles(_ context.Context, _ *info.Event) (provider.ChangedFiles, error) {
+	return provider.ChangedFiles{}, nil
 }
 
 func (v *Provider) CreateToken(_ context.Context, _ []string, _ *params.Run, _ *info.Event) (string, error) {

--- a/pkg/provider/gitea/gitea.go
+++ b/pkg/provider/gitea/gitea.go
@@ -310,9 +310,9 @@ func (v *Provider) GetCommitInfo(_ context.Context, runevent *info.Event) error 
 	return nil
 }
 
-func (v *Provider) GetFiles(_ context.Context, _ *info.Event) ([]string, error) {
+func (v *Provider) GetFiles(_ context.Context, _ *info.Event) (provider.ChangedFiles, error) {
 	// TODO: figure out a way
-	return []string{}, fmt.Errorf("GetFiles is not supported on Gitea")
+	return provider.ChangedFiles{}, nil
 }
 
 func (v *Provider) CreateToken(_ context.Context, _ []string, _ *params.Run, _ *info.Event) (string, error) {

--- a/pkg/provider/github/github_test.go
+++ b/pkg/provider/github/github_test.go
@@ -656,10 +656,14 @@ func TestValidate(t *testing.T) {
 
 func TestGetFiles(t *testing.T) {
 	tests := []struct {
-		name        string
-		event       *info.Event
-		commitFiles []*github.CommitFile
-		commit      *github.RepositoryCommit
+		name                   string
+		event                  *info.Event
+		commitFiles            []*github.CommitFile
+		commit                 *github.RepositoryCommit
+		wantAddedFilesCount    int
+		wantDeletedFilesCount  int
+		wantModifiedFilesCount int
+		wantRenamedFilesCount  int
 	}{
 		{
 			name: "pull-request",
@@ -671,11 +675,23 @@ func TestGetFiles(t *testing.T) {
 			},
 			commitFiles: []*github.CommitFile{
 				{
-					Filename: ptr.String("first.yaml"),
+					Filename: ptr.String("modified.yaml"),
+					Status:   ptr.String("modified"),
 				}, {
-					Filename: ptr.String("second.doc"),
+					Filename: ptr.String("added.doc"),
+					Status:   ptr.String("added"),
+				}, {
+					Filename: ptr.String("removed.yaml"),
+					Status:   ptr.String("removed"),
+				}, {
+					Filename: ptr.String("renamed.doc"),
+					Status:   ptr.String("renamed"),
 				},
 			},
+			wantAddedFilesCount:    1,
+			wantDeletedFilesCount:  1,
+			wantModifiedFilesCount: 1,
+			wantRenamedFilesCount:  1,
 		},
 		{
 			name: "push",
@@ -688,25 +704,62 @@ func TestGetFiles(t *testing.T) {
 			commit: &github.RepositoryCommit{
 				Files: []*github.CommitFile{
 					{
-						Filename: ptr.String("first.yaml"),
+						Filename: ptr.String("modified.yaml"),
+						Status:   ptr.String("modified"),
 					}, {
-						Filename: ptr.String("second.doc"),
+						Filename: ptr.String("added.doc"),
+						Status:   ptr.String("added"),
+					}, {
+						Filename: ptr.String("removed.yaml"),
+						Status:   ptr.String("removed"),
+					}, {
+						Filename: ptr.String("renamed.doc"),
+						Status:   ptr.String("renamed"),
 					},
 				},
 			},
+			wantAddedFilesCount:    1,
+			wantDeletedFilesCount:  1,
+			wantModifiedFilesCount: 1,
+			wantRenamedFilesCount:  1,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeclient, mux, _, teardown := ghtesthelper.SetupGH()
 			defer teardown()
-			commitFiles := []*github.CommitFile{
+			prCommitFiles := []*github.CommitFile{
 				{
-					Filename: ptr.String("first.yaml"),
+					Filename: ptr.String("modified.yaml"),
+					Status:   ptr.String("modified"),
 				}, {
-					Filename: ptr.String("second.doc"),
+					Filename: ptr.String("added.doc"),
+					Status:   ptr.String("added"),
+				}, {
+					Filename: ptr.String("removed.yaml"),
+					Status:   ptr.String("removed"),
+				}, {
+					Filename: ptr.String("renamed.doc"),
+					Status:   ptr.String("renamed"),
 				},
 			}
+
+			pushCommitFiles := []*github.CommitFile{
+				{
+					Filename: ptr.String("modified.yaml"),
+					Status:   ptr.String("modified"),
+				}, {
+					Filename: ptr.String("added.doc"),
+					Status:   ptr.String("added"),
+				}, {
+					Filename: ptr.String("removed.yaml"),
+					Status:   ptr.String("removed"),
+				}, {
+					Filename: ptr.String("renamed.doc"),
+					Status:   ptr.String("renamed"),
+				},
+			}
+
 			if tt.event.TriggerTarget == "pull_request" {
 				mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/pulls/%d/files",
 					tt.event.Organization, tt.event.Repository, tt.event.PullRequestNumber), func(rw http.ResponseWriter, r *http.Request) {
@@ -714,7 +767,7 @@ func TestGetFiles(t *testing.T) {
 						rw.Header().Add("Link", fmt.Sprintf("<https://api.github.com/repos/%s/%s/pulls/%d/files?page=2>; rel=\"next\"", tt.event.Organization, tt.event.Repository, tt.event.PullRequestNumber))
 						fmt.Fprint(rw, "[]")
 					} else {
-						b, _ := json.Marshal(commitFiles)
+						b, _ := json.Marshal(prCommitFiles)
 						fmt.Fprint(rw, string(b))
 					}
 				})
@@ -723,7 +776,7 @@ func TestGetFiles(t *testing.T) {
 				mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/commits/%s",
 					tt.event.Organization, tt.event.Repository, tt.event.SHA), func(rw http.ResponseWriter, r *http.Request) {
 					c := &github.RepositoryCommit{
-						Files: commitFiles,
+						Files: pushCommitFiles,
 					}
 					b, _ := json.Marshal(c)
 					fmt.Fprint(rw, string(b))
@@ -735,16 +788,22 @@ func TestGetFiles(t *testing.T) {
 				Client:        fakeclient,
 				paginedNumber: 1,
 			}
-			fileData, err := provider.GetFiles(ctx, tt.event)
+			changedFiles, err := provider.GetFiles(ctx, tt.event)
 			assert.NilError(t, err, nil)
+
+			assert.Equal(t, tt.wantAddedFilesCount, len(changedFiles.Added))
+			assert.Equal(t, tt.wantDeletedFilesCount, len(changedFiles.Deleted))
+			assert.Equal(t, tt.wantModifiedFilesCount, len(changedFiles.Modified))
+			assert.Equal(t, tt.wantRenamedFilesCount, len(changedFiles.Renamed))
+
 			if tt.event.TriggerTarget == "pull_request" {
-				for i := range fileData {
-					assert.Equal(t, *tt.commitFiles[i].Filename, fileData[i])
+				for i := range changedFiles.All {
+					assert.Equal(t, *tt.commitFiles[i].Filename, changedFiles.All[i])
 				}
 			}
 			if tt.event.TriggerTarget == "push" {
-				for i := range fileData {
-					assert.Equal(t, *tt.commit.Files[i].Filename, fileData[i])
+				for i := range changedFiles.All {
+					assert.Equal(t, *tt.commit.Files[i].Filename, changedFiles.All[i])
 				}
 			}
 		})

--- a/pkg/provider/interface.go
+++ b/pkg/provider/interface.go
@@ -36,10 +36,18 @@ type Interface interface {
 	SetClient(context.Context, *params.Run, *info.Event, *v1alpha1.Settings) error
 	GetCommitInfo(context.Context, *info.Event) error
 	GetConfig() *info.ProviderConfig
-	GetFiles(context.Context, *info.Event) ([]string, error)
+	GetFiles(context.Context, *info.Event) (ChangedFiles, error)
 	GetTaskURI(ctx context.Context, params *params.Run, event *info.Event, uri string) (bool, string, error)
 	CreateToken(context.Context, []string, *params.Run, *info.Event) (string, error)
 	CheckPolicyAllowing(context.Context, *info.Event, []string) (bool, string)
 }
 
 const DefaultProviderAPIUser = "git"
+
+type ChangedFiles struct {
+	All      []string
+	Added    []string
+	Deleted  []string
+	Modified []string
+	Renamed  []string
+}

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -100,7 +100,7 @@ func (r *Reconciler) reportFinalStatus(ctx context.Context, logger *zap.SugaredL
 		return nil, fmt.Errorf("reportFinalStatus: %w", err)
 	}
 
-	cp := customparams.NewCustomParams(event, repo, r.run, r.kinteract, r.eventEmitter)
+	cp := customparams.NewCustomParams(event, repo, r.run, r.kinteract, r.eventEmitter, nil)
 	maptemplate, err := cp.GetParams(ctx)
 	if err != nil {
 		r.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "ParamsError",

--- a/pkg/test/provider/testwebvcs.go
+++ b/pkg/test/provider/testwebvcs.go
@@ -23,6 +23,11 @@ type TestProviderImp struct {
 	FilesInsideRepo        map[string]string
 	WantProviderRemoteTask bool
 	PolicyDisallowing      bool
+	WantAllChangedFiles    []string
+	WantAddedFiles         []string
+	WantDeletedFiles       []string
+	WantModifiedFiles      []string
+	WantRenamedFiles       []string
 }
 
 func (v *TestProviderImp) CheckPolicyAllowing(_ context.Context, _ *info.Event, _ []string) (bool, string) {
@@ -88,8 +93,14 @@ func (v *TestProviderImp) GetFileInsideRepo(_ context.Context, _ *info.Event, fi
 	return "", fmt.Errorf("could not find %s in tests", file)
 }
 
-func (v *TestProviderImp) GetFiles(_ context.Context, _ *info.Event) ([]string, error) {
-	return []string{}, nil
+func (v *TestProviderImp) GetFiles(_ context.Context, _ *info.Event) (provider.ChangedFiles, error) {
+	return provider.ChangedFiles{
+		All:      v.WantAllChangedFiles,
+		Added:    v.WantAddedFiles,
+		Deleted:  v.WantDeletedFiles,
+		Modified: v.WantModifiedFiles,
+		Renamed:  v.WantRenamedFiles,
+	}, nil
 }
 
 func (v *TestProviderImp) CreateToken(_ context.Context, _ []string, _ *params.Run, _ *info.Event) (string, error) {


### PR DESCRIPTION
# Changes

This change will add support for separating the files by the change type i.e. added, modified, deleted and renamed for a giving source control event. This provides the ability to target only added files or only renamed files. Note that this change still supports all changed files in case specifics types of changes are not needed.

In addition, this change will also allow the changed file information to be passed down using templating variables. The following templated variables have been added

- {{all_changed_files}}
- {{added_files}}
- {{deleted_files}}
- {{modified_files}}
- {{renamed_files}}
