### PR TITLE
Make sure we check for the exact number of status

### DIFF
--- a/docs/content/dev/_index.md
+++ b/docs/content/dev/_index.md
@@ -1,6 +1,7 @@
 ---
 title: Developer Resources
 ---
+
 # How to get started developing for the Pipelines-as-Code project
 
 ## Please read the Code of conduct
@@ -29,6 +30,7 @@ $GOPATH/src/github.com/openshift-pipelines/pipelines-as-code, if you want to
 override it you can set the `PAC_DIRS` environment variable.
 
 - It will deploy under the nip.io domain reflector, the URL will be :
+
   - <http://controller.paac-127-0-0-1.nip.io>
   - <http://dashboard.paac-127-0-0-1.nip.io>
 
@@ -130,10 +132,24 @@ The defaults are :
 
 The E2E tests will automatically create repo using the admin username for each tests.
 
+## Debugging E2E
+
+As long you have the secrets setup you should be able to run the e2e tests properly.
+Gitea are the easiest to run (since they are self contained), for the other you
+will need to setup some environment variables.
+
+See the [e2e on kind
+workflow](https://github.com/openshift-pipelines/pipelines-as-code/blob/8f990bf5f348f6529deaa3693257907b42287a35/.github/workflows/kind-e2e-tests.yaml#L90)
+for all the variables set by provider.
+
+By default the E2E tests cleanups after themselves if you want to keep the
+PR/MR opens and the namespace where the test has been created you can set the
+`TEST_NOCLEANUP` environment variable to `true`.
+
 ## Debugging controller
 
 Create a [hook](https://hook.pipelinesascode.com) URL and point your app/webhook to it. Use
-[gosmee](https://github.com/chmouel/gosmee) to forward the requests from github
+[gosmee](https://github.com/chmouel/gosmee) to forward the requests from GitHub
 to your locally installed controller (this can be either run on your debugger or
 inside kind).
 
@@ -143,7 +159,7 @@ the request that was sent directly to the controller without having to go throug
 another push.
 
 Use [snazy](https://github.com/chmouel/snazy) to watch the logs, it support pac
-by adding some context like which github provider.
+by adding some context like which GitHub provider.
 
 ![snazy screenshot](/images/pac-snazy.png)
 
@@ -187,7 +203,7 @@ pre-commit install
 ```
 
 This will run several `hooks` on the files that has been changed before you
-*push* to your remote branch. If you need to skip the verification (for whatever
+_push_ to your remote branch. If you need to skip the verification (for whatever
 reason), you can do :
 
 ```shell

--- a/pkg/provider/gitlab/detect.go
+++ b/pkg/provider/gitlab/detect.go
@@ -37,7 +37,7 @@ func (v *Provider) Detect(req *http.Request, payload string, logger *zap.Sugared
 
 	switch gitEvent := eventInt.(type) {
 	case *gitlab.MergeEvent:
-		if provider.Valid(gitEvent.ObjectAttributes.Action, []string{"open", "update", "reopen"}) {
+		if provider.Valid(gitEvent.ObjectAttributes.Action, []string{"open", "reopen"}) {
 			return setLoggerAndProceed(true, "", nil)
 		}
 		return setLoggerAndProceed(false, fmt.Sprintf("not a merge event we care about: \"%s\"",

--- a/test/gitea_access_control_test.go
+++ b/test/gitea_access_control_test.go
@@ -10,12 +10,13 @@ import (
 	"regexp"
 	"testing"
 
+	"gotest.tools/v3/assert"
+
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/configmap"
 	tgitea "github.com/openshift-pipelines/pipelines-as-code/test/pkg/gitea"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
-	"gotest.tools/v3/assert"
 )
 
 const okToTestComment = "/ok-to-test"
@@ -33,9 +34,10 @@ const okToTestComment = "/ok-to-test"
 // is not much gitea specifics compared to github
 func TestGiteaPolicyPullRequest(t *testing.T) {
 	topts := &tgitea.TestOpts{
-		OnOrg:           true,
-		SkipEventsCheck: true,
-		TargetEvent:     options.PullRequestEvent,
+		OnOrg:                true,
+		SkipEventsCheck:      true,
+		CheckForNumberStatus: 2,
+		TargetEvent:          options.PullRequestEvent,
 		Settings: &v1alpha1.Settings{
 			Policy: &v1alpha1.Policy{
 				PullRequest: []string{"pull_requester"},
@@ -167,8 +169,9 @@ func TestGiteaACLOrgAllowed(t *testing.T) {
 		YAMLFiles: map[string]string{
 			".tekton/pr.yaml": "testdata/pipelinerun.yaml",
 		},
-		NoCleanup:    true,
-		ExpectEvents: false,
+		NoCleanup:            true,
+		ExpectEvents:         false,
+		CheckForNumberStatus: 2,
 	}
 	defer tgitea.TestPR(t, topts)()
 	secondcnx, _, err := tgitea.CreateGiteaUserSecondCnx(topts, topts.TargetRefName, topts.GiteaPassword)

--- a/test/pkg/bitbucketcloud/setup.go
+++ b/test/pkg/bitbucketcloud/setup.go
@@ -8,12 +8,13 @@ import (
 	"testing"
 
 	"github.com/ktrysmt/go-bitbucket"
+	"gotest.tools/v3/assert"
+
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketcloud"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/repository"
-	"gotest.tools/v3/assert"
 )
 
 func Setup(ctx context.Context) (*params.Run, options.E2E, bitbucketcloud.Provider, error) {
@@ -54,6 +55,10 @@ func Setup(ctx context.Context) (*params.Run, options.E2E, bitbucketcloud.Provid
 }
 
 func TearDown(ctx context.Context, t *testing.T, runcnx *params.Run, bprovider bitbucketcloud.Provider, opts options.E2E, prNumber int, ref, targetNS string) {
+	if os.Getenv("TEST_NOCLEANUP") == "true" {
+		runcnx.Clients.Log.Infof("Not cleaning up and closing PR since TEST_NOCLEANUP is set")
+		return
+	}
 	runcnx.Clients.Log.Infof("Closing PR #%d", prNumber)
 	_, err := bprovider.Client.Repositories.PullRequests.Decline(&bitbucket.PullRequestsOptions{
 		ID:       fmt.Sprintf("%d", prNumber),

--- a/test/pkg/gitea/scm.go
+++ b/test/pkg/gitea/scm.go
@@ -16,13 +16,14 @@ import (
 
 	"code.gitea.io/sdk/gitea"
 	"github.com/google/go-github/v53/github"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/git"
-	pgitea "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/gitea"
-	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
 	"go.uber.org/zap"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/env"
 	"gotest.tools/v3/fs"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/git"
+	pgitea "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/gitea"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
 )
 
 func InitGitRepo(t *testing.T) (string, func()) {
@@ -92,6 +93,8 @@ func PushFilesToRefGit(t *testing.T, topts *TestOpts, entries map[string]string,
 	for {
 		if _, err = git.RunGit(path, "push", "origin", topts.TargetRefName); err == nil {
 			topts.ParamsRun.Clients.Log.Infof("Pushed files to repo %s branch %s", topts.GitHTMLURL, topts.TargetRefName)
+			// trying to avoid the multiple events at the time of creation we have a sync
+			time.Sleep(5 * time.Second)
 			return
 		}
 		count++

--- a/test/pkg/gitea/setup.go
+++ b/test/pkg/gitea/setup.go
@@ -8,12 +8,13 @@ import (
 	"testing"
 
 	"github.com/google/go-github/v53/github"
+	"gotest.tools/v3/assert"
+
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/gitea"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/repository"
-	"gotest.tools/v3/assert"
 )
 
 func CreateProvider(ctx context.Context, giteaURL, user, password string) (gitea.Provider, error) {
@@ -76,6 +77,10 @@ func Setup(ctx context.Context) (*params.Run, options.E2E, gitea.Provider, error
 }
 
 func TearDown(ctx context.Context, t *testing.T, topts *TestOpts) {
+	if os.Getenv("TEST_NOCLEANUP") == "true" {
+		topts.ParamsRun.Clients.Log.Infof("Not cleaning up and closing PR since TEST_NOCLEANUP is set")
+		return
+	}
 	repository.NSTearDown(ctx, t, topts.ParamsRun, topts.TargetNS)
 	_, err := topts.GiteaCNX.Client.DeleteRepo(topts.Opts.Organization, topts.TargetNS)
 	assert.NilError(t, err)

--- a/test/pkg/github/setup.go
+++ b/test/pkg/github/setup.go
@@ -102,6 +102,7 @@ func Setup(ctx context.Context, viaDirectWebhook bool) (*params.Run, options.E2E
 
 func TearDown(ctx context.Context, t *testing.T, runcnx *params.Run, ghprovider *github.Provider, prNumber int, ref, targetNS string, opts options.E2E) {
 	if os.Getenv("TEST_NOCLEANUP") == "true" {
+		runcnx.Clients.Log.Infof("Not cleaning up and closing PR since TEST_NOCLEANUP is set")
 		return
 	}
 	runcnx.Clients.Log.Infof("Closing PR %d", prNumber)

--- a/test/pkg/gitlab/setup.go
+++ b/test/pkg/gitlab/setup.go
@@ -7,13 +7,14 @@ import (
 	"strconv"
 	"testing"
 
+	gitlab2 "github.com/xanzy/go-gitlab"
+	"gotest.tools/v3/assert"
+
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/gitlab"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/repository"
-	gitlab2 "github.com/xanzy/go-gitlab"
-	"gotest.tools/v3/assert"
 )
 
 func Setup(ctx context.Context) (*params.Run, options.E2E, gitlab.Provider, error) {
@@ -65,6 +66,10 @@ func Setup(ctx context.Context) (*params.Run, options.E2E, gitlab.Provider, erro
 }
 
 func TearDown(ctx context.Context, t *testing.T, runcnx *params.Run, glprovider gitlab.Provider, mrNumber int, ref, targetNS string, projectid int) {
+	if os.Getenv("TEST_NOCLEANUP") == "true" {
+		runcnx.Clients.Log.Infof("Not cleaning up and closing PR since TEST_NOCLEANUP is set")
+		return
+	}
 	runcnx.Clients.Log.Infof("Closing PR %d", mrNumber)
 	if mrNumber != -1 {
 		_, _, err := glprovider.Client.MergeRequests.UpdateMergeRequest(projectid, mrNumber,


### PR DESCRIPTION
and make the tests a bit more robust in general.
we add some timeout to avoid some of the annoying double events.
add a feature to Don't cleanup tests when TEST_NOCLEANUP is set

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 A good commit message is important for other reviewers to understand the context of your change. Please refer to [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for more details how to write beautiful commit messages. We rather have the commit message in the PR body and the commit message instead of an external website.
- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
