### PR TITLE
fix e2e races and failures

### DIFF
--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -76,9 +76,8 @@ func TestGetGitInfo(t *testing.T) {
 			tmpFile := fs.NewFile(t, "gitconfig-")
 			defer tmpFile.Remove()
 			defer env.PatchAll(t, map[string]string{
-				"HOME":  tmpFile.Path(),
-				"PATH":  "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
-				"EMAIL": "foo@foo.com",
+				"HOME": tmpFile.Path(),
+				"PATH": "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
 			})()
 
 			nd := fs.NewDir(t, "TestGetGitInfo")
@@ -88,6 +87,13 @@ func TestGetGitInfo(t *testing.T) {
 
 			_, err = RunGit(gitDir, "init")
 			assert.NilError(t, err)
+
+			_, err = RunGit(gitDir, "config", "--local", "user.email", "foo@foo.com")
+			assert.NilError(t, err)
+
+			_, err = RunGit(gitDir, "config", "--local", "user.name", "Mister Ze Foo")
+			assert.NilError(t, err)
+
 			_, err = RunGit(gitDir, "remote", "add", tt.remoteTarget, tt.gitURL)
 			assert.NilError(t, err)
 			_, err = RunGit(gitDir, "commit", "--allow-empty", "-m", "Empty Commmit")

--- a/test/github_pullrequest_concurrency_test.go
+++ b/test/github_pullrequest_concurrency_test.go
@@ -96,6 +96,11 @@ func TestGithubPullRequestConcurrency(t *testing.T) {
 	for i := 0; i < 15; i++ {
 		checkruns, _, err := ghcnx.Client.Checks.ListCheckRunsForRef(ctx, opts.Organization, opts.Repo, targetRefName, &github.ListCheckRunsOptions{})
 		assert.NilError(t, err)
+		if checkruns.Total == nil || *checkruns.Total < numberOfPipelineRuns {
+			t.Logf("Waiting for all checks to be created: %d/%d", *checkruns.Total, numberOfPipelineRuns)
+			time.Sleep(5 * time.Second)
+			continue
+		}
 		assert.Assert(t, *checkruns.Total >= numberOfPipelineRuns)
 		for _, checkrun := range checkruns.CheckRuns {
 			cname := checkrun.GetName()

--- a/test/github_push_test.go
+++ b/test/github_push_test.go
@@ -70,7 +70,7 @@ func TestGithubPush(t *testing.T) {
 		waitOpts := twait.Opts{
 			RepoName:        targetNS,
 			Namespace:       targetNS,
-			MinNumberStatus: 0,
+			MinNumberStatus: 1,
 			PollTimeout:     twait.DefaultTimeout,
 			TargetSHA:       sha,
 		}

--- a/test/github_scope_token_to_list_of_private_public_repos_test.go
+++ b/test/github_scope_token_to_list_of_private_public_repos_test.go
@@ -13,6 +13,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/tektoncd/pipeline/pkg/names"
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	pacv1alpha1 "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/configmap"
@@ -21,10 +26,6 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
 	trepo "github.com/openshift-pipelines/pipelines-as-code/test/pkg/repository"
 	twait "github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
-	"github.com/tektoncd/pipeline/pkg/names"
-	"gotest.tools/v3/assert"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestGithubPullRequestScopeTokenToListOfRepos(t *testing.T) {
@@ -36,14 +37,14 @@ func TestGithubPullRequestScopeTokenToListOfRepos(t *testing.T) {
 	if os.Getenv("TEST_GITHUB_PRIVATE_TASK_URL") != "" {
 		remoteTaskURL = os.Getenv("TEST_GITHUB_PRIVATE_TASK_URL")
 	} else {
-		t.Error("Env TEST_GITHUB_PRIVATE_TASK_URL not provided")
+		t.Skip("Env TEST_GITHUB_PRIVATE_TASK_URL not provided")
 		return
 	}
 
 	if os.Getenv("TEST_GITHUB_PRIVATE_TASK_NAME") != "" {
 		remoteTaskName = os.Getenv("TEST_GITHUB_PRIVATE_TASK_NAME")
 	} else {
-		t.Error("Env TEST_GITHUB_PRIVATE_TASK_NAME not provided")
+		t.Skip("Env TEST_GITHUB_PRIVATE_TASK_NAME not provided")
 		return
 	}
 
@@ -61,14 +62,14 @@ func TestGithubPullRequestScopeTokenToListOfReposByGlobalConfiguration(t *testin
 	if os.Getenv("TEST_GITHUB_PRIVATE_TASK_URL") != "" {
 		remoteTaskURL = os.Getenv("TEST_GITHUB_PRIVATE_TASK_URL")
 	} else {
-		t.Error("Env TEST_GITHUB_PRIVATE_TASK_URL not provided")
+		t.Skip("Env TEST_GITHUB_PRIVATE_TASK_URL not provided")
 		return
 	}
 
 	if os.Getenv("TEST_GITHUB_PRIVATE_TASK_NAME") != "" {
 		remoteTaskName = os.Getenv("TEST_GITHUB_PRIVATE_TASK_NAME")
 	} else {
-		t.Error("Env TEST_GITHUB_PRIVATE_TASK_NAME not provided")
+		t.Skip("Env TEST_GITHUB_PRIVATE_TASK_NAME not provided")
 		return
 	}
 

--- a/test/pkg/gitea/setup.go
+++ b/test/pkg/gitea/setup.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-github/v53/github"
 	"gotest.tools/v3/assert"
@@ -81,6 +82,7 @@ func TearDown(ctx context.Context, t *testing.T, topts *TestOpts) {
 		topts.ParamsRun.Clients.Log.Infof("Not cleaning up and closing PR since TEST_NOCLEANUP is set")
 		return
 	}
+	time.Sleep(5 * time.Second)
 	repository.NSTearDown(ctx, t, topts.ParamsRun, topts.TargetNS)
 	_, err := topts.GiteaCNX.Client.DeleteRepo(topts.Opts.Organization, topts.TargetNS)
 	assert.NilError(t, err)

--- a/test/pkg/github/pr.go
+++ b/test/pkg/github/pr.go
@@ -9,13 +9,14 @@ import (
 	"testing"
 
 	"github.com/google/go-github/v53/github"
+	"github.com/tektoncd/pipeline/pkg/names"
+	"gotest.tools/v3/assert"
+
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	ghprovider "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/github"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
-	"github.com/tektoncd/pipeline/pkg/names"
-	"gotest.tools/v3/assert"
 )
 
 func PushFilesToRef(ctx context.Context, client *github.Client, commitMessage, baseBranch, targetRef, owner, repo string, files map[string]string) (string, error) {

--- a/test/pkg/github/setup.go
+++ b/test/pkg/github/setup.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	ghlib "github.com/google/go-github/v53/github"
 	"gotest.tools/v3/assert"
@@ -105,6 +106,8 @@ func TearDown(ctx context.Context, t *testing.T, runcnx *params.Run, ghprovider 
 		runcnx.Clients.Log.Infof("Not cleaning up and closing PR since TEST_NOCLEANUP is set")
 		return
 	}
+	runcnx.Clients.Log.Infof("Sleeping 5 seconds just for giggles and CI flakes")
+	time.Sleep(5 * time.Second)
 	runcnx.Clients.Log.Infof("Closing PR %d", prNumber)
 	if prNumber != -1 {
 		state := "closed"


### PR DESCRIPTION
- Fix E2E races and failures
  Fixed some races waiting for updated by looping until success
  Don't error out when ENV variable are not set but skip the test for
  TEST_GITHUB_PRIVATE_TASK_URL and TEST_GITHUB_PRIVATE_TASK_NAM

- Fix TestGetGitInfo unit test
  I am not sure how that worked before, this is the fail:

  ```
  --- FAIL: TestGetGitInfo (0.05s)
    --- FAIL: TestGetGitInfo/Get_git_info (0.01s)
        git_test.go:95: assertion failed: error is not nil: error running, [commit --allow-empty -m Empty Commmit], output: Author identity unknown

            *** Please tell me who you are.

            Run

              git config --global user.email "you@example.com"
              git config --global user.name "Your Name"

            to set your account's default identity.
            Omit --global to set the identity only in this repository.

            fatal: empty ident name (for <chmouel@ibra.local>) not allowed
             error: exit status 128
  ```

  fix that test by setting the git config locally in the test which should
  be more robust.
  
