### PR TITLE
Set no cleanup for gitea

### DIFF
--- a/test/pkg/gitea/setup.go
+++ b/test/pkg/gitea/setup.go
@@ -9,13 +9,11 @@ import (
 	"time"
 
 	"github.com/google/go-github/v53/github"
-	"gotest.tools/v3/assert"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/gitea"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
-	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/repository"
 )
 
 func CreateProvider(ctx context.Context, giteaURL, user, password string) (gitea.Provider, error) {
@@ -77,13 +75,15 @@ func Setup(ctx context.Context) (*params.Run, options.E2E, gitea.Provider, error
 	return run, e2eoptions, gprovider, nil
 }
 
-func TearDown(ctx context.Context, t *testing.T, topts *TestOpts) {
+func TearDown(_ context.Context, _ *testing.T, topts *TestOpts) {
 	if os.Getenv("TEST_NOCLEANUP") == "true" {
 		topts.ParamsRun.Clients.Log.Infof("Not cleaning up and closing PR since TEST_NOCLEANUP is set")
 		return
 	}
+	topts.ParamsRun.Clients.Log.Infof("Waiting for 5 seconds before going to the next one")
 	time.Sleep(5 * time.Second)
-	repository.NSTearDown(ctx, t, topts.ParamsRun, topts.TargetNS)
-	_, err := topts.GiteaCNX.Client.DeleteRepo(topts.Opts.Organization, topts.TargetNS)
-	assert.NilError(t, err)
+	// disable for now
+	// repository.NSTearDown(ctx, t, topts.ParamsRun, topts.TargetNS)
+	// _, err := topts.GiteaCNX.Client.DeleteRepo(topts.Opts.Organization, topts.TargetNS)
+	// assert.NilError(t, err)
 }


### PR DESCRIPTION
I still wonder why TestGiteaNotExistingClusterTask fail all the time, let's try this before disabling it!

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 A good commit message is important for other reviewers to understand the context of your change. Please refer to [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for more details how to write beautiful commit messages. We rather have the commit message in the PR body and the commit message instead of an external website.
- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
