### PR TITLE
Fix append issue to avoid duplication of pipelineruns

### DIFF
--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -221,7 +221,8 @@ func (p *PacRun) getPipelineRunsFromRepo(ctx context.Context, repo *v1alpha1.Rep
 		types.PipelineRuns = nil
 		for _, match := range matchedPRs {
 			for pr := range pipelineRuns {
-				if match.PipelineRun.Name == pipelineRuns[pr].Name {
+				if match.PipelineRun.GetName() == "" && match.PipelineRun.GetGenerateName() == pipelineRuns[pr].GenerateName ||
+					match.PipelineRun.GetName() != "" && match.PipelineRun.GetName() == pipelineRuns[pr].Name {
 					types.PipelineRuns = append(types.PipelineRuns, pipelineRuns[pr])
 				}
 			}

--- a/pkg/pipelineascode/match_test.go
+++ b/pkg/pipelineascode/match_test.go
@@ -4,12 +4,24 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-github/v53/github"
 	apipac "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/consoleui"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
+	ghprovider "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/github"
+	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
+	ghtesthelper "github.com/openshift-pipelines/pipelines-as-code/pkg/test/github"
+	kitesthelper "github.com/openshift-pipelines/pipelines-as-code/pkg/test/kubernetestint"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"go.uber.org/zap"
+	zapobserver "go.uber.org/zap/zaptest/observer"
 	"gotest.tools/v3/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	rtesting "knative.dev/pkg/reconciler/testing"
 )
 
 func TestPacRun_checkNeedUpdate(t *testing.T) {
@@ -76,4 +88,97 @@ func TestFilterRunningPipelineRunOnTargetTest(t *testing.T) {
 	prs = []*tektonv1.PipelineRun{}
 	ret = filterRunningPipelineRunOnTargetTest(testPipeline, prs)
 	assert.Assert(t, ret == nil)
+}
+
+func TestGetPipelineRunsFromRepo(t *testing.T) {
+	tests := []struct {
+		name                  string
+		repositories          *v1alpha1.Repository
+		tektondir             string
+		expectedNumberOfPruns int
+	}{
+		{
+			name: "more than one pipelinerun in .tekton dir",
+			repositories: &v1alpha1.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testrepo",
+					Namespace: "test",
+				},
+				Spec: v1alpha1.RepositorySpec{},
+			},
+			tektondir:             "testdata/pull_request_multiplepipelineruns",
+			expectedNumberOfPruns: 2,
+		},
+		{
+			name: "single pipelinerun in .tekton dir",
+			repositories: &v1alpha1.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testrepo",
+					Namespace: "test",
+				},
+				Spec: v1alpha1.RepositorySpec{},
+			},
+			tektondir:             "testdata/pull_request",
+			expectedNumberOfPruns: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			observer, _ := zapobserver.New(zap.InfoLevel)
+			logger := zap.New(observer).Sugar()
+			ctx, _ := rtesting.SetupFakeContext(t)
+			fakeclient, mux, _, teardown := ghtesthelper.SetupGH()
+			defer teardown()
+
+			runevent := &info.Event{
+				SHA:           "principale",
+				Organization:  "organizationes",
+				Repository:    "lagaffe",
+				URL:           "https://service/documentation",
+				HeadBranch:    "main",
+				BaseBranch:    "main",
+				Sender:        "fantasio",
+				EventType:     "pull_request",
+				TriggerTarget: "pull_request",
+			}
+			if tt.tektondir != "" {
+				ghtesthelper.SetupGitTree(t, mux, tt.tektondir, runevent, false)
+			}
+
+			stdata, _ := testclient.SeedTestData(t, ctx, testclient.Data{})
+			cs := &params.Run{
+				Clients: clients.Clients{
+					PipelineAsCode: stdata.PipelineAsCode,
+					Log:            logger,
+					Kube:           stdata.Kube,
+					Tekton:         stdata.Pipeline,
+					ConsoleUI:      consoleui.FallBackConsole{},
+				},
+				Info: info.Info{
+					Pac: &info.PacOpts{
+						Settings: &settings.Settings{
+							SecretAutoCreation: true,
+							RemoteTasks:        true,
+						},
+					},
+				},
+			}
+			k8int := &kitesthelper.KinterfaceTest{
+				ConsoleURL: "https://console.url",
+			}
+			vcx := &ghprovider.Provider{
+				Client: fakeclient,
+				Token:  github.String("None"),
+				Logger: logger,
+			}
+			p := NewPacs(runevent, vcx, cs, k8int, logger)
+			matchedPRs, err := p.getPipelineRunsFromRepo(ctx, tt.repositories)
+			assert.NilError(t, err)
+			matchedPRNames := []string{}
+			for i := range matchedPRs {
+				matchedPRNames = append(matchedPRNames, matchedPRs[i].PipelineRun.GetGenerateName())
+			}
+			assert.Equal(t, len(matchedPRNames), tt.expectedNumberOfPruns)
+		})
+	}
 }

--- a/pkg/pipelineascode/testdata/pull_request_multiplepipelineruns/.tekton/run.yaml
+++ b/pkg/pipelineascode/testdata/pull_request_multiplepipelineruns/.tekton/run.yaml
@@ -1,0 +1,50 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: pull_request-test1
+  annotations:
+    pipelinesascode.tekton.dev/on-target-branch: "[main]"
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: max
+        taskSpec:
+          steps:
+            - name: success
+              image: registry.access.redhat.com/ubi9/ubi-minimal
+              script: 'exit 0'
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateNameame: pull_request-test2
+  annotations:
+    pipelinesascode.tekton.dev/on-target-branch: "[main]"
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: max
+        taskSpec:
+          steps:
+            - name: success
+              image: registry.access.redhat.com/ubi9/ubi-minimal
+              script: 'exit 0'
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: pull_request-test3
+  annotations:
+    pipelinesascode.tekton.dev/on-target-branch: "[main]"
+    pipelinesascode.tekton.dev/on-event: "[incoming]"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: max
+        taskSpec:
+          steps:
+            - name: success
+              image: registry.access.redhat.com/ubi9/ubi-minimal
+              script: 'exit 0'


### PR DESCRIPTION
based on name match just appending pipelineruns leading duplication of pipelineruns and because of that we face 
below issue

```
match_test.go:185: assertion failed: error is not nil: 
found multiple pipelinerun in .tekton with the same generateName: 
pull_request-test1, please update
```

Issue : https://github.com/openshift-pipelines/pipelines-as-code/issues/1447 

As part of this commit fixing the if condition so
that there won't be append for duplicate pipelineruns

Signed-off-by: Savita Ashture <sashture@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 A good commit message is important for other reviewers to understand the context of your change. Please refer to [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for more details how to write beautiful commit messages. We rather have the commit message in the PR body and the commit message instead of an external website.
- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
