### PR TITLE
Revert "sleep between running tests"

### DIFF
--- a/.tekton/linter.yaml
+++ b/.tekton/linter.yaml
@@ -65,9 +65,10 @@ spec:
               image: jorisroovers/gitlint
               workingDir: $(workspaces.source.path)
               script: |
+                set -x
                 git config --global --add safe.directory /workspace/source
                 # don't lint merge commit
-                git log -1 |grep -q '^Merge:' && exit 0
+                git log -1 |grep -E -q '^Merge:' && exit 0
                 gitlint --commit "$(git log --format=format:%H --no-merges -1)" --ignore "Merge branch"
 
       - name: yamllint

--- a/test/gitea_access_control_test.go
+++ b/test/gitea_access_control_test.go
@@ -10,13 +10,14 @@ import (
 	"regexp"
 	"testing"
 
+	"gotest.tools/v3/assert"
+
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/configmap"
 	tgitea "github.com/openshift-pipelines/pipelines-as-code/test/pkg/gitea"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
-	"gotest.tools/v3/assert"
 )
 
 const okToTestComment = "/ok-to-test"
@@ -256,6 +257,8 @@ func TestGiteaACLCommentsAllowing(t *testing.T) {
 // the status of CI shows as success. Now non authorized user pushes to PR, the CI will again go to pending
 // and require /ok-to-test again from authorized user.
 func TestGiteaACLCommentsAllowingRememberOkToTestFalse(t *testing.T) {
+	t.Skip("Skipping test changing the global config map for now")
+
 	ctx := context.Background()
 	topts := &tgitea.TestOpts{
 		TargetEvent: options.PullRequestEvent,

--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -679,6 +679,7 @@ func TestGiteaParamsOnRepoCR(t *testing.T) {
 }
 
 func TestGiteaParamsOnRepoCRWithCustomConsole(t *testing.T) {
+	t.Skip("Skipping test changing the global config map for now")
 	ctx := context.Background()
 	topts := &tgitea.TestOpts{
 		CheckForStatus:  "success",

--- a/test/github_scope_token_to_list_of_private_public_repos_test.go
+++ b/test/github_scope_token_to_list_of_private_public_repos_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestGithubPullRequestScopeTokenToListOfRepos(t *testing.T) {
+	t.Skip("Skipping test changing the global config map for now")
 	if os.Getenv("NIGHTLY_E2E_TEST") != "true" {
 		t.Skip("Skipping test since only enabled for nightly")
 	}
@@ -54,6 +55,7 @@ func TestGithubPullRequestScopeTokenToListOfRepos(t *testing.T) {
 }
 
 func TestGithubPullRequestScopeTokenToListOfReposByGlobalConfiguration(t *testing.T) {
+	t.Skip("Skipping test changing the global config map for now")
 	if os.Getenv("NIGHTLY_E2E_TEST") != "true" {
 		t.Skip("Skipping test since only enabled for nightly")
 	}

--- a/test/pkg/gitea/setup.go
+++ b/test/pkg/gitea/setup.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/google/go-github/v53/github"
 	"gotest.tools/v3/assert"
@@ -82,7 +81,6 @@ func TearDown(ctx context.Context, t *testing.T, topts *TestOpts) {
 		topts.ParamsRun.Clients.Log.Infof("Not cleaning up and closing PR since TEST_NOCLEANUP is set")
 		return
 	}
-	time.Sleep(5 * time.Second)
 	repository.NSTearDown(ctx, t, topts.ParamsRun, topts.TargetNS)
 	_, err := topts.GiteaCNX.Client.DeleteRepo(topts.Opts.Organization, topts.TargetNS)
 	assert.NilError(t, err)

--- a/test/pkg/github/pr.go
+++ b/test/pkg/github/pr.go
@@ -9,14 +9,13 @@ import (
 	"testing"
 
 	"github.com/google/go-github/v53/github"
-	"github.com/tektoncd/pipeline/pkg/names"
-	"gotest.tools/v3/assert"
-
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	ghprovider "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/github"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
+	"github.com/tektoncd/pipeline/pkg/names"
+	"gotest.tools/v3/assert"
 )
 
 func PushFilesToRef(ctx context.Context, client *github.Client, commitMessage, baseBranch, targetRef, owner, repo string, files map[string]string) (string, error) {

--- a/test/pkg/github/setup.go
+++ b/test/pkg/github/setup.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	ghlib "github.com/google/go-github/v53/github"
 	"gotest.tools/v3/assert"
@@ -106,8 +105,6 @@ func TearDown(ctx context.Context, t *testing.T, runcnx *params.Run, ghprovider 
 		runcnx.Clients.Log.Infof("Not cleaning up and closing PR since TEST_NOCLEANUP is set")
 		return
 	}
-	runcnx.Clients.Log.Infof("Sleeping 5 seconds just for giggles and CI flakes")
-	time.Sleep(5 * time.Second)
 	runcnx.Clients.Log.Infof("Closing PR %d", prNumber)
 	if prNumber != -1 {
 		state := "closed"


### PR DESCRIPTION
reverts commit f697eeb.


Skip e2e changes the global ConfigMap for now
It has been too buggy lately and we need to fix it in a different way,
by launching them explicitly and sequentially from the test runner.



<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 A good commit message is important for other reviewers to understand the context of your change. Please refer to [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for more details how to write beautiful commit messages. We rather have the commit message in the PR body and the commit message instead of an external website.
- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
