### PR TITLE
Really fix not linting merge commits

### DIFF
--- a/.tekton/linter.yaml
+++ b/.tekton/linter.yaml
@@ -65,12 +65,9 @@ spec:
               image: jorisroovers/gitlint
               workingDir: $(workspaces.source.path)
               script: |
-                set -x
                 git config --global --add safe.directory /workspace/source
-                # don't lint merge commit
-                git log -1 |grep -E -q '^Merge:' && exit 0
+                git log -1 --format=format:%s |grep -E -q '^Merge branch' && exit 0
                 gitlint --commit "$(git log --format=format:%H --no-merges -1)" --ignore "Merge branch"
-
       - name: yamllint
         generateName: "YAML Linter"
         runAfter:


### PR DESCRIPTION
It was silly of me to not test this properly. The merge commit should be ignored.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 A good commit message is important for other reviewers to understand the context of your change. Please refer to [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for more details how to write beautiful commit messages. We rather have the commit message in the PR body and the commit message instead of an external website.
- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
