### PR TITLE
Add e2e tests to test fallback to owners on policy

### DIFF
--- a/test/testdata/OWNERS
+++ b/test/testdata/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+  - \\ .Approver //
+
+# vim: ft=yaml
+# Local Variables:
+# mode: yaml
+# End:


### PR DESCRIPTION
Test should fail as reported by @savitaashture :

```yaml
When i send a Pull_request from savitaanother user it works because its
in ci-users team But when i send a Pull_request from savitaashture user
CI is not running with below error There was an issue validating the
commit: "policy check: pull_request, user: savitaashture is not a member
of any of the allowed teams: [ci-users]" But actually CI should run
right as `savitaashture is in OWNERS file isn't it
```

![image](https://github.com/openshift-pipelines/pipelines-as-code/assets/98980/a4f988a6-64af-48fa-8c21-d365fc16ada9)


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 A good commit message is important for other reviewers to understand the context of your change. Please refer to [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for more details how to write beautiful commit messages. We rather have the commit message in the PR body and the commit message instead of an external website.
- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
