### PR TITLE
Fix spelling mistake with codespell

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,11 @@ repos:
   rev: v0.19.1
   hooks:
     - id: gitlint
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.2.4
+  hooks:
+  - id: codespell
+    files: '^(docs/content|pkg|test)/.*'
 - repo: local
   hooks:
   - id: black
@@ -68,4 +73,3 @@ repos:
 
 # TODO: add a lint-py when we have the errors fix
 # TODO: add a lint-sh when we have the errors fix
-#

--- a/.tekton/linter.yaml
+++ b/.tekton/linter.yaml
@@ -50,6 +50,22 @@ spec:
           - name: source
             workspace: source
 
+      - name: codespell
+        displayName: "Code Spelling"
+        runAfter:
+          - fetchit
+        workspaces:
+          - name: source
+            workspace: source
+        taskSpec:
+          workspaces:
+            - name: source
+          steps:
+            - name: codespell
+              image: ghcr.io/codespell-project/actions-codespell/stable:v2
+              workingDir: $(workspaces.source.path)
+              script: |
+                codespell -d docs/content pkg test
       - name: gitlint
         displayName: "Git commit linter"
         runAfter:

--- a/docs/content/dev/_index.md
+++ b/docs/content/dev/_index.md
@@ -238,7 +238,7 @@ this will start a hugo server with live preview of the docs on :
 
 <https://localhost:1313>
 
-When we push the release, the docs get rebuilded by CloudFare.
+When we push the release, the docs get rebuilt by CloudFare.
 
 By default the website <https://pipelinesascode.com> only contains the "stable"
 documentation. If you want to preview the dev documentation as from `main` you
@@ -261,6 +261,8 @@ need to have on your system:
 - [black](https://github.com/psf/black) - Python code formatter check
 - [vale](https://github.com/errata-ai/vale) - For grammar check
 - [markdownlint](https://github.com/markdownlint/markdownlint) - For markdown lint
+- [codespell](https://github.com/codespell-project/codespell) - For code spelling
+- [gitlint](https://github.com/jorisroovers/gitlint) - For git commit messages lint
 - [hugo](https://gohugo.io) - For documentation
 - [ko](https://github.com/google/ko) - To rebuild and push change to kube cluster.
 - [kind](https://kind.sigs.k8s.io/) - For local devs

--- a/docs/content/docs/flows/concurrency.md
+++ b/docs/content/docs/flows/concurrency.md
@@ -29,7 +29,7 @@ graph TD
     H --> B
     G --> I(Update status in Repository)
     I --> J(Update state to 'completed')
-    J --> K{Check if concurency was defined?}
+    J --> K{Check if concurrency was defined?}
     K --> |Yes| L(Remove PipelineRun from Queue)
     L --> M(Start the next PipelineRun from Queue)
     M --> N[Done!]

--- a/docs/content/docs/guide/cli.md
+++ b/docs/content/docs/guide/cli.md
@@ -17,7 +17,7 @@ Pipelines-as-Code provide a powerful CLI designed to work as a plug-in to the [T
 * `describe`: describe a Pipelines-as-Code Repository and the runs associated with it.
 * `resolve`: Resolve a pipelinerun as if it were executed by pipelines as code on service.
 * `webhook`: Updates webhook secret.
-* `info`: Show informations (currently only about your installation with `info install`).
+* `info`: Show information (currently only about your installation with `info install`).
 
 ## Install
 
@@ -115,7 +115,7 @@ a custom URL on an
 [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) in a
 Kubernetes cluster.
 
-The OpenShift console is automaticaly detected, on Kubernetes, `tkn-pac` will
+The OpenShift console is automatically detected, on Kubernetes, `tkn-pac` will
 attempt to detect the tekton-dashboard Ingress URL and let you choose to use it
 as the endpoint for the created GitHub application.
 
@@ -135,7 +135,7 @@ will not prompt you unless you explicitly specify the `--force-gosmee` flag
 ### bootstrap github-app
 
 If you only want to create a GitHub application to use with Pipelines-as-Code
-and not the full `bootstrap` excercise, you can use `tkn pac bootstrap
+and not the full `bootstrap` exercise, you can use `tkn pac bootstrap
 github-app` directly which will skip the installation and only create the
 GitHub application and the secret with all the information needed in the
 `pipelines-as-code` namespace.
@@ -307,7 +307,7 @@ ask you to provide a Git provider token.
 If you already have an existing secret created in your namespace matching your
 repository URL it will use it.
 
-You can explicitely provide a token on the command line with the `-t` or
+You can explicitly provide a token on the command line with the `-t` or
 `--providerToken` flag, or you can set the environment variable
 `PAC_PROVIDER_TOKEN` and it will use it instead of asking you.
 

--- a/docs/content/docs/guide/incoming_webhook.md
+++ b/docs/content/docs/guide/incoming_webhook.md
@@ -14,8 +14,8 @@ To use incoming webhooks in Pipelines-as-Code, you must configure the
 incoming field in your Repository CRD. This field references a `Secret`, which
 serves as the shared secret, as well as the branches targeted by the incoming
 webhook. Once configured, Pipelines-as-Code will match `PipelineRuns` located in
-your `.tekton` directory if the `on-event` annotation of the targetted pipelinerun is
-targettting a push or incoming event.
+your `.tekton` directory if the `on-event` annotation of the targeted pipelinerun is
+targeting a push or incoming event.
 
 {{< hint info >}}
 If you are not using the github app provider (ie: webhook based provider) you

--- a/docs/content/docs/guide/policy.md
+++ b/docs/content/docs/guide/policy.md
@@ -21,7 +21,7 @@ the moment).
    issue a `/ok-to-test` comment on a Pull Request to trigger the CI on
    Pipelines-as-Code, this let running the CI on Pull Request contributed by a
    non collaborator of the repository or the organisation. This apply to the
-   `/test` and `/retest` commands as well. This take precendence on the
+   `/test` and `/retest` commands as well. This take precedence on the
    `pull_request` action.
 
 ## Configuring the Policy on the Repository CR

--- a/docs/content/docs/guide/repositorycrd.md
+++ b/docs/content/docs/guide/repositorycrd.md
@@ -38,7 +38,7 @@ out the contents of linda/project to match with the PipelineRun in the .tekton/
 directory.
 
 If the `PipelineRun` matches via its annotations the event, for example on a
-specific branch and event like a `push` or `pull_request`. It wil start the
+specific branch and event like a `push` or `pull_request`. It will start the
 `PipelineRun` where the `Repository` CR has been created. You can only start the
 `PipelineRun` in the namespace where the Repository CR is located.
 
@@ -362,7 +362,7 @@ creation of the GitHub token fails with the following error message:
 the CI process does not run. This includes cases where the same repository is listed in the global or repository level configuration,
 and the scoping fails for the repository level configuration because the repository is not in the same namespace as the `Repository` custom resource.
 
-  In the following example, the `owner5/project5` repository is listed in both the global configuration and in tyhe repository level configuration:
+  In the following example, the `owner5/project5` repository is listed in both the global configuration and in the repository level configuration:
 
   ```yaml
   apiVersion: v1

--- a/docs/content/docs/guide/running.md
+++ b/docs/content/docs/guide/running.md
@@ -116,7 +116,7 @@ entire suite of checks once again.
 
 ### Gitops command on pull or merge request
 
-If you are targetting a pull or merge request you can use `GitOps` comment
+If you are targeting a pull or merge request you can use `GitOps` comment
 inside your pull request, to restart all or specific Pipelines.
 
 For example you want to restart all your pipeline you can add a comment starting

--- a/docs/content/docs/guide/statuses.md
+++ b/docs/content/docs/guide/statuses.md
@@ -46,7 +46,7 @@ To prevent exposing secrets, Pipelines-as-Code analyze the PipelineRun and
 replace secret values with hidden characters. This is achieved by retrieving
 all secrets from the environment variables associated with tasks and steps, and
 searching for matches of these values in the output snippet. These matches are
-then replaced with a `"*****"` placeholder hidding these secrets.
+then replaced with a `"*****"` placeholder hiding these secrets.
 
 The hiding of the secret does not support concealing secrets from `workspaces`
 and

--- a/docs/content/docs/install/settings.md
+++ b/docs/content/docs/install/settings.md
@@ -11,7 +11,7 @@ There is a few things you can configure through the config map
 * `application-name`
 
   The name of the application for example when showing the results of the
-  pipelinerun. If youre using the GitHub App you will
+  pipelinerun. If you're using the GitHub App you will
   need to customize the label on the github app setting as well. .  Default to
   `Pipelines-as-Code CI`
 
@@ -79,7 +79,7 @@ There is a few things you can configure through the config map
 * `bitbucket-cloud-additional-source-ip`
 
   Let you add extra IPS to allow bitbucket clouds, you can do a specific IP:
-  `127.0.0.1` or a networks `127.0.0.0/16`. Multile of them can be specified
+  `127.0.0.1` or a networks `127.0.0.0/16`. Multiple of them can be specified
   separated by commas.
 
 * `max-keep-run-upper-limit`
@@ -256,7 +256,7 @@ A few settings are available to configure this feature:
   shown when the PipelineRun is started so the user can follow execution on your
   console or when to see more details about the pipelinerun on result.
 
-  The URL suports all the standard variables as exposed on the Pipelinerun (refer to
+  The URL supports all the standard variables as exposed on the Pipelinerun (refer to
   the documentation on [Authoring PipelineRuns](../authoringprs)) with the added
   variable:
 
@@ -282,7 +282,7 @@ A few settings are available to configure this feature:
 
   the `{{ custom }}` tag in the URL is expanded as `value`.
 
-  This let operator to add specific informations like a `UUID` about a user as
+  This let operator to add specific information like a `UUID` about a user as
   parameter in their repo CR and let it link to the console.
 
 * `custom-console-url-pr-tasklog`
@@ -290,7 +290,7 @@ A few settings are available to configure this feature:
   Set this to the URL where to view the log of the taskrun of the `PipelineRun`. This is
   shown when we post a result of the task breakdown to link to the logs of the taskrun.
 
-  The URL suports custom parameter on Repo CR and the standard parameters as
+  The URL supports custom parameter on Repo CR and the standard parameters as
   described in the `custom-console-url-pr-details` setting and as well those added
   values:
 
@@ -307,7 +307,7 @@ A few settings are available to configure this feature:
   There are a settings exposed through a config map for which any authenticated
   user can access to know about the Pipelines-as-Code status. This Configmap
   will be automatically created with the [OpenShift Pipelines Operator](https://docs.openshift.com/container-platform/latest/cicd/pipelines/understanding-openshift-pipelines.html)
-  or when installing with [tkn pac boostrap](../../guide/cli/#bootstrap) command.
+  or when installing with [tkn pac bootstrap](../../guide/cli/#bootstrap) command.
 
 * `version`
 

--- a/pkg/adapter/incoming_test.go
+++ b/pkg/adapter/incoming_test.go
@@ -60,7 +60,7 @@ func Test_compareSecret(t *testing.T) {
 		want bool
 	}{
 		{
-			name: "good/secret comparaison",
+			name: "good/secret comparison",
 			args: args{
 				incomingSecret: "foo",
 				secretValue:    "foo",
@@ -68,7 +68,7 @@ func Test_compareSecret(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "bad/secret comparaison",
+			name: "bad/secret comparison",
 			args: args{
 				incomingSecret: "foo",
 				secretValue:    "bar",

--- a/pkg/cmd/tknpac/bootstrap/install.go
+++ b/pkg/cmd/tknpac/bootstrap/install.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 	"net/url"
 	"os"
@@ -10,13 +11,11 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/google/go-github/v53/github"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli/prompt"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/random"
-
-	_ "embed"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 //go:embed templates/gosmee.yaml
@@ -96,17 +95,17 @@ func getDashboardURL(ctx context.Context, opts *bootstrapOpts, run *params.Run) 
 		}
 	}
 
-	var ans string
+	var answer string
 	qs := &survey.Input{
 		Message: "Enter your Tekton Dashboard URL: ",
 	}
-	if err := prompt.SurveyAskOne(qs, &ans); err != nil {
+	if err := prompt.SurveyAskOne(qs, &answer); err != nil {
 		return err
 	}
-	if _, err := url.ParseRequestURI(ans); err != nil {
+	if _, err := url.ParseRequestURI(answer); err != nil {
 		return fmt.Errorf("invalid url: %w", err)
 	}
-	opts.dashboardURL = ans
+	opts.dashboardURL = answer
 	return nil
 }
 
@@ -190,7 +189,7 @@ func installPac(ctx context.Context, run *params.Run, opts *bootstrapOpts) error
 		if err := getDashboardURL(ctx, opts, run); err != nil {
 			return err
 		}
-		// only updating for now here since we don't have any other stuff to udpate yet in there
+		// only updating for now here since we don't have any other stuff to update yet in there
 		// maybe we will have to move this to a different function in the future
 		return updatePACConfigMap(ctx, run, opts)
 	}

--- a/pkg/cmd/tknpac/create/testdata/TestGenerateTemplate.golden
+++ b/pkg/cmd/tknpac/create/testdata/TestGenerateTemplate.golden
@@ -59,6 +59,7 @@ spec:
       # Customize this task if you like, or just do a taskRef
       # to one of the hub task.
       - name: noop-task
+        displayName: Task with no effect
         runAfter:
           - fetch-repository
         workspaces:

--- a/pkg/cmd/tknpac/describe/describe.go
+++ b/pkg/cmd/tknpac/describe/describe.go
@@ -204,12 +204,12 @@ func describe(ctx context.Context, cs *params.Run, clock clockwork.Clock, opts *
 			return err
 		}
 		for _, pr := range prs.Items {
-			pevents, err := kinteract.GetEvents(ctx, repository.GetNamespace(), "PipelineRun", pr.GetName())
+			prevents, err := kinteract.GetEvents(ctx, repository.GetNamespace(), "PipelineRun", pr.GetName())
 			if err != nil {
 				continue
 			}
-			for i := range pevents.Items {
-				runTimeObj = append(runTimeObj, &pevents.Items[i])
+			for i := range prevents.Items {
+				runTimeObj = append(runTimeObj, &prevents.Items[i])
 			}
 		}
 		sort.ByField(creationTimestamp, runTimeObj)

--- a/pkg/cmd/tknpac/generate/generate.go
+++ b/pkg/cmd/tknpac/generate/generate.go
@@ -96,7 +96,7 @@ func Command(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&gopt.FileName, "file-name", "f", "",
 		"The file name location")
 	cmd.PersistentFlags().BoolVar(&gopt.overwrite, "overwrite", false,
-		"Wether to overwrite the file if it exist")
+		"Whether to overwrite the file if it exist")
 	cmd.PersistentFlags().StringVarP(&gopt.language, "language", "l", "",
 		"Generate for this programming language")
 	cmd.PersistentFlags().BoolVarP(&gopt.generateWithClusterTask, "use-clustertasks", "", false,

--- a/pkg/cmd/tknpac/generate/generate_test.go
+++ b/pkg/cmd/tknpac/generate/generate_test.go
@@ -6,13 +6,14 @@ import (
 	"regexp"
 	"testing"
 
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/fs"
+
 	apipac "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli/prompt"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/git"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
-	"gotest.tools/v3/assert"
-	"gotest.tools/v3/fs"
 )
 
 func TestGenerateTemplate(t *testing.T) {
@@ -138,16 +139,16 @@ func TestGenerateTemplate(t *testing.T) {
 			}
 			io, _, _, _ := cli.IOTest()
 
-			nd := fs.NewDir(t, "TestGenerate")
-			defer nd.Remove()
-			tt.gitinfo.TopLevelPath = nd.Path()
+			newdir := fs.NewDir(t, "TestGenerate")
+			defer newdir.Remove()
+			tt.gitinfo.TopLevelPath = newdir.Path()
 
 			for key, value := range tt.addExtraFilesInRepo {
 				// make sure the dir is created
-				err := os.MkdirAll(filepath.Dir(nd.Join(key)), os.ModePerm)
-				assert.NilError(t, err, "failed to create dir: %s", filepath.Dir(nd.Join(key)))
+				err := os.MkdirAll(filepath.Dir(newdir.Join(key)), os.ModePerm)
+				assert.NilError(t, err, "failed to create dir: %s", filepath.Dir(newdir.Join(key)))
 
-				err = os.WriteFile(nd.Join(key), []byte(value), 0o600)
+				err = os.WriteFile(newdir.Join(key), []byte(value), 0o600)
 				assert.NilError(t, err, "failed to create file", key)
 			}
 
@@ -162,12 +163,12 @@ func TestGenerateTemplate(t *testing.T) {
 			// check if file has been generated
 			if tt.checkGeneratedFile != "" {
 				// check if file exists
-				_, err := os.Stat(nd.Join(tt.checkGeneratedFile))
+				_, err := os.Stat(newdir.Join(tt.checkGeneratedFile))
 				assert.Assert(t, !os.IsNotExist(err))
 			}
 			if tt.checkRegInGeneratedFile != nil {
 				// check if file contains the expected strings
-				b, err := os.ReadFile(nd.Join(tt.checkGeneratedFile))
+				b, err := os.ReadFile(newdir.Join(tt.checkGeneratedFile))
 				assert.NilError(t, err)
 				for _, s := range tt.checkRegInGeneratedFile {
 					// check if regexp matches

--- a/pkg/cmd/tknpac/resolve/resolve_test.go
+++ b/pkg/cmd/tknpac/resolve/resolve_test.go
@@ -40,7 +40,7 @@ func TestSplitArgsInMap(t *testing.T) {
 	ret := splitArgsInMap(args)
 
 	if _, ok := ret["ride"]; !ok {
-		t.Error("args hasn't been splitted")
+		t.Error("args hasn't been split")
 	}
 }
 

--- a/pkg/formatting/vcs_test.go
+++ b/pkg/formatting/vcs_test.go
@@ -99,7 +99,7 @@ func TestGetRepoOwnerFromGHURL(t *testing.T) {
 		{
 			name: "repoowner",
 			args: args{
-				ghURL: "https://allo/hello/moto",
+				ghURL: "https://allow/hello/moto",
 			},
 			want:    "hello/moto",
 			wantErr: false,
@@ -107,7 +107,7 @@ func TestGetRepoOwnerFromGHURL(t *testing.T) {
 		{
 			name: "repoowner with capital letters",
 			args: args{
-				ghURL: "https://allo/HELLO/moto",
+				ghURL: "https://allow/HELLO/moto",
 			},
 			want:    "hello/moto",
 			wantErr: false,

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -80,9 +80,9 @@ func TestGetGitInfo(t *testing.T) {
 				"PATH": "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
 			})()
 
-			nd := fs.NewDir(t, "TestGetGitInfo")
-			defer nd.Remove()
-			gitDir := nd.Path()
+			newdir := fs.NewDir(t, "TestGetGitInfo")
+			defer newdir.Remove()
+			gitDir := newdir.Path()
 			var err error
 
 			_, err = RunGit(gitDir, "init")
@@ -96,7 +96,7 @@ func TestGetGitInfo(t *testing.T) {
 
 			_, err = RunGit(gitDir, "remote", "add", tt.remoteTarget, tt.gitURL)
 			assert.NilError(t, err)
-			_, err = RunGit(gitDir, "commit", "--allow-empty", "-m", "Empty Commmit")
+			_, err = RunGit(gitDir, "commit", "--allow-empty", "-m", "Empty Commit")
 			assert.NilError(t, err)
 			if tt.want.Branch != "" {
 				_, _ = RunGit(gitDir, "checkout", "-b", tt.want.Branch)

--- a/pkg/matcher/annotation_matcher.go
+++ b/pkg/matcher/annotation_matcher.go
@@ -73,16 +73,16 @@ func getAnnotationValues(annotation string) ([]string, error) {
 	}
 
 	// Split all tasks by comma and make sure to trim spaces in there
-	splitted := strings.Split(re.FindStringSubmatch(annotation)[1], ",")
-	for i := range splitted {
-		splitted[i] = strings.TrimSpace(splitted[i])
+	split := strings.Split(re.FindStringSubmatch(annotation)[1], ",")
+	for i := range split {
+		split[i] = strings.TrimSpace(split[i])
 	}
 
-	if splitted[0] == "" {
+	if split[0] == "" {
 		return nil, fmt.Errorf("annotation \"%s\" has empty values", annotation)
 	}
 
-	return splitted, nil
+	return split, nil
 }
 
 func getTargetBranch(prun *tektonv1.PipelineRun, logger *zap.SugaredLogger, event *info.Event) (bool, string, string, error) {

--- a/pkg/matcher/annotation_tasks_install.go
+++ b/pkg/matcher/annotation_tasks_install.go
@@ -68,7 +68,7 @@ func (rt RemoteTasks) convertToPipeline(ctx context.Context, uri, data string) (
 }
 
 // nolint: dupl
-// golint has decided that it is a duplication with convertToPipeline but i swear it isnt does two are different function
+// golint has decided that it is a duplication with convertToPipeline but i swear it isn't does two are different function
 // and not even sure this is possible to do this with generic crazyness
 func (rt RemoteTasks) convertTotask(ctx context.Context, uri, data string) (*tektonv1.Task, error) {
 	decoder := k8scheme.Codecs.UniversalDeserializer()

--- a/pkg/params/cli.go
+++ b/pkg/params/cli.go
@@ -27,6 +27,6 @@ func NewCliOptions() *PacCliOpts {
 	}
 }
 
-func (c *PacCliOpts) Ask(qss []*survey.Question, ans interface{}) error {
-	return survey.Ask(qss, ans, c.AskOpts)
+func (c *PacCliOpts) Ask(qss []*survey.Question, answer interface{}) error {
+	return survey.Ask(qss, answer, c.AskOpts)
 }

--- a/pkg/pipelineascode/template_test.go
+++ b/pkg/pipelineascode/template_test.go
@@ -263,7 +263,7 @@ func TestProcessTemplates(t *testing.T) {
 			},
 		},
 		{
-			name:     "params/unnown secret skipped",
+			name:     "params/unknown secret skipped",
 			template: `No {{ customparams }}`,
 			expected: "No {{ customparams }}",
 			event:    &info.Event{EventType: "push"},

--- a/pkg/provider/bitbucketcloud/parse_payload.go
+++ b/pkg/provider/bitbucketcloud/parse_payload.go
@@ -19,8 +19,8 @@ const bitbucketCloudIPrangesList = "https://ip-ranges.atlassian.com/"
 // lastForwarderForIP get last ip from the X-Forwarded-For chain
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
 func lastForwarderForIP(xff string) string {
-	splitted := strings.Split(xff, ",")
-	return splitted[len(splitted)-1]
+	split := strings.Split(xff, ",")
+	return split[len(split)-1]
 }
 
 // checkFromPublicCloudIPS Grab public IP from public cloud and make sure we match it

--- a/pkg/provider/bitbucketserver/test/test.go
+++ b/pkg/provider/bitbucketserver/test/test.go
@@ -114,7 +114,7 @@ func MakeEvent(event *info.Event) *info.Event {
 func MuxDirContent(t *testing.T, mux *http.ServeMux, event *info.Event, testDir, targetDirName string) {
 	files, err := os.ReadDir(testDir)
 	if err != nil {
-		// no error just disapointed
+		// no error just disappointed
 		return
 	}
 	filenames := make([]string, 0, len(files))

--- a/pkg/provider/gitea/gitea.go
+++ b/pkg/provider/gitea/gitea.go
@@ -279,7 +279,7 @@ func (v *Provider) GetFileInsideRepo(_ context.Context, runevent *info.Event, pa
 
 func (v *Provider) GetCommitInfo(_ context.Context, runevent *info.Event) error {
 	if v.Client == nil {
-		return fmt.Errorf("no gitea client has been initiliazed, " +
+		return fmt.Errorf("no gitea client has been initialized, " +
 			"exiting... (hint: did you forget setting a secret on your repo?)")
 	}
 

--- a/pkg/provider/gitea/structs/repo_wiki.go
+++ b/pkg/provider/gitea/structs/repo_wiki.go
@@ -7,7 +7,7 @@ package structs
 type WikiCommit struct {
 	ID        string      `json:"sha"`
 	Author    *CommitUser `json:"author"`
-	Committer *CommitUser `json:"commiter"`
+	Committer *CommitUser `json:"committer"`
 	Message   string      `json:"message"`
 }
 

--- a/pkg/provider/github/acl.go
+++ b/pkg/provider/github/acl.go
@@ -13,7 +13,7 @@ import (
 )
 
 // CheckPolicyAllowing check that policy is allowing the event to be processed
-// we  check the membership of the team alloed
+// we  check the membership of the team allowed
 // if the team is not found we explicitly disallow the policy, user have to correct the setting
 func (v *Provider) CheckPolicyAllowing(ctx context.Context, event *info.Event, allowedTeams []string) (bool, string) {
 	for _, team := range allowedTeams {

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -86,22 +86,22 @@ func splitGithubURL(event *info.Event, uri string) (string, string, string, stri
 	if pURL.RawPath != "" {
 		path = pURL.RawPath
 	}
-	splitted := strings.Split(path, "/")
-	if len(splitted) <= 3 {
+	split := strings.Split(path, "/")
+	if len(split) <= 3 {
 		return "", "", "", "", fmt.Errorf("URL %s does not seem to be a proper provider url: %w", uri, err)
 	}
 	var spOrg, spRepo, spRef, spPath string
 	switch {
-	case (pURL.Host == publicRawURLHost || detectGHERawURL(event, pURL.Host)) && len(splitted) >= 5:
-		spOrg = splitted[1]
-		spRepo = splitted[2]
-		spRef = splitted[3]
-		spPath = strings.Join(splitted[4:], "/")
-	case splitted[3] == "blob" && len(splitted) >= 5:
-		spOrg = splitted[1]
-		spRepo = splitted[2]
-		spRef = splitted[4]
-		spPath = strings.Join(splitted[5:], "/")
+	case (pURL.Host == publicRawURLHost || detectGHERawURL(event, pURL.Host)) && len(split) >= 5:
+		spOrg = split[1]
+		spRepo = split[2]
+		spRef = split[3]
+		spPath = strings.Join(split[4:], "/")
+	case split[3] == "blob" && len(split) >= 5:
+		spOrg = split[1]
+		spRepo = split[2]
+		spRef = split[4]
+		spPath = strings.Join(split[5:], "/")
 	default:
 		return "", "", "", "", fmt.Errorf("cannot recognize task as a Github URL to fetch: %s", uri)
 	}
@@ -331,7 +331,7 @@ func (v *Provider) GetTektonDir(ctx context.Context, runevent *info.Event, path,
 // be run after sewebhook while we already matched a token.
 func (v *Provider) GetCommitInfo(ctx context.Context, runevent *info.Event) error {
 	if v.Client == nil {
-		return fmt.Errorf("no github client has been initiliazed, " +
+		return fmt.Errorf("no github client has been initialized, " +
 			"exiting... (hint: did you forget setting a secret on your repo?)")
 	}
 
@@ -488,7 +488,7 @@ func (v *Provider) getObject(ctx context.Context, sha string, runevent *info.Eve
 // ListRepos lists all the repos for a particular token
 func ListRepos(ctx context.Context, v *Provider) ([]string, error) {
 	if v.Client == nil {
-		return []string{}, fmt.Errorf("no github client has been initiliazed, " +
+		return []string{}, fmt.Errorf("no github client has been initialized, " +
 			"exiting... (hint: did you forget setting a secret on your repo?)")
 	}
 

--- a/pkg/provider/github/github_test.go
+++ b/pkg/provider/github/github_test.go
@@ -517,7 +517,7 @@ func TestGithubGetCommitInfo(t *testing.T) {
 		{
 			name:     "noclient",
 			event:    &info.Event{},
-			wantErr:  "no github client has been initiliazed",
+			wantErr:  "no github client has been initialized",
 			noclient: true,
 		},
 	}

--- a/pkg/provider/github/parse_payload_test.go
+++ b/pkg/provider/github/parse_payload_test.go
@@ -92,7 +92,7 @@ func TestParsePayLoad(t *testing.T) {
 		targetCancelPipelinerun string
 	}{
 		{
-			name:          "bad/unknow event",
+			name:          "bad/unknown event",
 			wantErrString: "unknown X-Github-Event",
 			eventType:     "unknown",
 			triggerTarget: "unknown",

--- a/pkg/provider/github/status_test.go
+++ b/pkg/provider/github/status_test.go
@@ -270,7 +270,7 @@ func TestGithubProviderCreateStatus(t *testing.T) {
 				runevent:    runEvent,
 				status:      "completed",
 				conclusion:  "neutral",
-				text:        "Je sais pas ce qui se passe wesh",
+				text:        "Je says pas ce qui se passe wesh",
 				detailsURL:  "https://cireport.com",
 				titleSubstr: "Unknown",
 				githubApps:  true,

--- a/pkg/provider/gitlab/acl.go
+++ b/pkg/provider/gitlab/acl.go
@@ -65,7 +65,7 @@ func (v *Provider) checkOkToTestCommentFromApprovedMember(event *info.Event, pag
 
 func (v *Provider) IsAllowed(_ context.Context, event *info.Event, _ *info.PacOpts) (bool, error) {
 	if v.Client == nil {
-		return false, fmt.Errorf("no github client has been initiliazed, " +
+		return false, fmt.Errorf("no github client has been initialized, " +
 			"exiting... (hint: did you forget setting a secret on your repo?)")
 	}
 	if v.checkMembership(event, v.userID) {

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -154,7 +154,7 @@ func (v *Provider) CreateStatus(_ context.Context, _ versioned.Interface, event 
 ) error {
 	var detailsURL string
 	if v.Client == nil {
-		return fmt.Errorf("no gitlab client has been initiliazed, " +
+		return fmt.Errorf("no gitlab client has been initialized, " +
 			"exiting... (hint: did you forget setting a secret on your repo?)")
 	}
 	switch statusOpts.Conclusion {
@@ -212,7 +212,7 @@ func (v *Provider) CreateStatus(_ context.Context, _ versioned.Interface, event 
 
 func (v *Provider) GetTektonDir(_ context.Context, event *info.Event, path, provenance string) (string, error) {
 	if v.Client == nil {
-		return "", fmt.Errorf("no gitlab client has been initiliazed, " +
+		return "", fmt.Errorf("no gitlab client has been initialized, " +
 			"exiting... (hint: did you forget setting a secret on your repo?)")
 	}
 	// default set provenance from head
@@ -286,7 +286,7 @@ func (v *Provider) GetFileInsideRepo(_ context.Context, runevent *info.Event, pa
 
 func (v *Provider) GetCommitInfo(_ context.Context, runevent *info.Event) error {
 	if v.Client == nil {
-		return fmt.Errorf("no gitlab client has been initiliazed, " +
+		return fmt.Errorf("no gitlab client has been initialized, " +
 			"exiting... (hint: did you forget setting a secret on your repo?)")
 	}
 
@@ -307,7 +307,7 @@ func (v *Provider) GetCommitInfo(_ context.Context, runevent *info.Event) error 
 
 func (v *Provider) GetFiles(_ context.Context, runevent *info.Event) ([]string, error) {
 	if v.Client == nil {
-		return []string{}, fmt.Errorf("no gitlab client has been initiliazed, " +
+		return []string{}, fmt.Errorf("no gitlab client has been initialized, " +
 			"exiting... (hint: did you forget setting a secret on your repo?)")
 	}
 	if runevent.TriggerTarget == "pull_request" {

--- a/pkg/resolve/resolve.go
+++ b/pkg/resolve/resolve.go
@@ -191,11 +191,11 @@ func Resolve(ctx context.Context, cs *params.Run, logger *zap.SugaredLogger, pro
 	for _, pipelinerun := range types.PipelineRuns {
 		// Resolve {Finally/Task}Ref inside PipelineSpec inside PipelineRun
 		if pipelinerun.Spec.PipelineSpec != nil {
-			truns, err := inlineTasks(pipelinerun.Spec.PipelineSpec.Tasks, ropt, types)
+			turns, err := inlineTasks(pipelinerun.Spec.PipelineSpec.Tasks, ropt, types)
 			if err != nil {
 				return nil, err
 			}
-			pipelinerun.Spec.PipelineSpec.Tasks = truns
+			pipelinerun.Spec.PipelineSpec.Tasks = turns
 
 			fruns, err := inlineTasks(pipelinerun.Spec.PipelineSpec.Finally, ropt, types)
 			if err != nil {

--- a/test/README.md
+++ b/test/README.md
@@ -9,7 +9,7 @@ Most E2E tests has this basic flow :
 - Create a temporary Namespace
 - Create a Repository CR into it
 - Create a Branch on a GitHUB repo
-- Create a commmit with files like pipelinerun inside that branch, the pipelinerun with have the namespace annotation to
+- Create a commit with files like pipelinerun inside that branch, the pipelinerun with have the namespace annotation to
   force the repository match on the namespace we have created and not catching other CR that may matching it.
 - Wait that the Repository is updated.
 - Some other stuff are done directly on the controller sink, bypassing a bit the GitHUB apis and generating the
@@ -79,7 +79,7 @@ We run those as nightly via github action on kind.
 You can use `make test-e2e-nightly` if you want to run those manually as long
 as you have all the env variables set.
 
-If you are writing a test targetting a nightly test you need to check for the env variable:
+If you are writing a test targeting a nightly test you need to check for the env variable:
 
 ```go
     if os.Getenv("NIGHTLY_E2E_TEST") != "true" {

--- a/test/fixtures/pull-req.json
+++ b/test/fixtures/pull-req.json
@@ -33,7 +33,7 @@
       "type": "User",
       "site_admin": false
     },
-    "body": "Since trigger bugs out everytime when passing the whole body and when we\r\nhave quotes, we defines our own triggertemplates for it and regenerate\r\na json with the payload we need to be parsed.\r\n\r\nThis works but this is stupid :\\",
+    "body": "Since trigger bugs out every time when passing the whole body and when we\r\nhave quotes, we defines our own triggertemplates for it and regenerate\r\na json with the payload we need to be parsed.\r\n\r\nThis works but this is stupid :\\",
     "created_at": "2021-05-21T09:26:19Z",
     "updated_at": "2021-05-21T09:26:19Z",
     "closed_at": null,

--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -569,7 +569,7 @@ func TestGiteaErrorSnippetWithSecret(t *testing.T) {
 }
 
 // TestGiteaNotExistingClusterTask checks that the pipeline run fails if the clustertask does not exist
-// This willl test properly if we error the reason in UI see bug #1160
+// This will test properly if we error the reason in UI see bug #1160
 func TestGiteaNotExistingClusterTask(t *testing.T) {
 	topts := &tgitea.TestOpts{
 		Regexp:      regexp.MustCompile(`.*clustertasks.tekton.dev "foo-bar" not found`),
@@ -584,7 +584,7 @@ func TestGiteaNotExistingClusterTask(t *testing.T) {
 }
 
 // TestGiteaBadLinkOfTask checks that we fail properly with the error from the
-// tekton pipelines controlller. We check on the UI interface that we display
+// tekton pipelines controller. We check on the UI interface that we display
 // and inside the pac controller.
 func TestGiteaBadLinkOfTask(t *testing.T) {
 	topts := &tgitea.TestOpts{

--- a/test/pkg/bitbucketcloud/setup.go
+++ b/test/pkg/bitbucketcloud/setup.go
@@ -31,15 +31,15 @@ func Setup(ctx context.Context) (*params.Run, options.E2E, bitbucketcloud.Provid
 		}
 	}
 
-	splitted := strings.Split(bitbucketWSOwner, "/")
+	split := strings.Split(bitbucketWSOwner, "/")
 
 	run := &params.Run{}
 	if err := run.Clients.NewClients(ctx, &run.Info); err != nil {
 		return nil, options.E2E{}, bitbucketcloud.Provider{}, err
 	}
 	e2eoptions := options.E2E{
-		Organization: splitted[0],
-		Repo:         splitted[1],
+		Organization: split[0],
+		Repo:         split[1],
 	}
 	bbc := bitbucketcloud.Provider{}
 	event := info.NewEvent()

--- a/test/pkg/gitea/setup.go
+++ b/test/pkg/gitea/setup.go
@@ -56,19 +56,19 @@ func Setup(ctx context.Context) (*params.Run, options.E2E, gitea.Provider, error
 		}
 	}
 
-	var splitted []string
+	var split []string
 	if giteaURL == "" || giteaPassword == "" || giteaRepoOwner == "" {
 		return nil, options.E2E{}, gitea.Provider{}, fmt.Errorf("TEST_GITEA_API_URL TEST_GITEA_PASSWORD TEST_GITEA_REPO_OWNER need to be set")
 	}
-	splitted = strings.Split(giteaRepoOwner, "/")
+	split = strings.Split(giteaRepoOwner, "/")
 
 	run := &params.Run{}
 	if err := run.Clients.NewClients(ctx, &run.Info); err != nil {
 		return nil, options.E2E{}, gitea.Provider{}, fmt.Errorf("cannot create new client: %w", err)
 	}
 	// Repo is actually not used
-	e2eoptions := options.E2E{Organization: splitted[0], Repo: splitted[1]}
-	gprovider, err := CreateProvider(ctx, giteaURL, splitted[0], giteaPassword)
+	e2eoptions := options.E2E{Organization: split[0], Repo: split[1]}
+	gprovider, err := CreateProvider(ctx, giteaURL, split[0], giteaPassword)
 	if err != nil {
 		return nil, options.E2E{}, gitea.Provider{}, fmt.Errorf("cannot set client: %w", err)
 	}

--- a/test/pkg/github/setup.go
+++ b/test/pkg/github/setup.go
@@ -36,19 +36,19 @@ func Setup(ctx context.Context, viaDirectWebhook bool) (*params.Run, options.E2E
 		}
 	}
 
-	var splitted []string
+	var split []string
 	if !viaDirectWebhook {
 		if githubURL == "" || githubRepoOwnerGithubApp == "" {
 			return nil, options.E2E{}, github.New(), fmt.Errorf("TEST_GITHUB_API_URL TEST_GITHUB_REPO_OWNER_GITHUBAPP need to be set")
 		}
-		splitted = strings.Split(githubRepoOwnerGithubApp, "/")
+		split = strings.Split(githubRepoOwnerGithubApp, "/")
 	}
 	if viaDirectWebhook {
 		githubToken = os.Getenv("TEST_GITHUB_TOKEN")
 		if githubURL == "" || githubToken == "" || githubRepoOwnerDirectWebhook == "" {
 			return nil, options.E2E{}, github.New(), fmt.Errorf("TEST_GITHUB_API_URL TEST_GITHUB_TOKEN TEST_GITHUB_REPO_OWNER_WEBHOOK need to be set")
 		}
-		splitted = strings.Split(githubRepoOwnerDirectWebhook, "/")
+		split = strings.Split(githubRepoOwnerDirectWebhook, "/")
 	}
 
 	run := &params.Run{}
@@ -61,7 +61,7 @@ func Setup(ctx context.Context, viaDirectWebhook bool) (*params.Run, options.E2E
 		return nil, options.E2E{}, github.New(), fmt.Errorf("TEST_EL_URL variable is required, cannot continue")
 	}
 
-	e2eoptions := options.E2E{Organization: splitted[0], Repo: splitted[1], DirectWebhook: viaDirectWebhook, ControllerURL: controllerURL}
+	e2eoptions := options.E2E{Organization: split[0], Repo: split[1], DirectWebhook: viaDirectWebhook, ControllerURL: controllerURL}
 	gprovider := github.New()
 	event := info.NewEvent()
 


### PR DESCRIPTION
Introducing codespell in our lint pipelines, you can install and run manually with:

```codespell -w -i2 pkg docs/content/ test```

or (should) use the pre-commit hook :

`pre-commit run -a`

enforced in ci with a task in the linter pipeline

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 A good commit message is important for other reviewers to understand the context of your change. Please refer to [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for more details how to write beautiful commit messages. We rather have the commit message in the PR body and the commit message instead of an external website.
- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
The go tests was not running in the commit introducing this change and
it was failing without us knowing.