### PR TITLE
Make sure the map is not nil before accessing it

### DIFF
--- a/pkg/consoleui/custom.go
+++ b/pkg/consoleui/custom.go
@@ -61,6 +61,11 @@ func (o *CustomConsole) DetailURL(pr *tektonv1.PipelineRun) string {
 		return fmt.Sprintf("https://detailurl.setting.%s.is.not.configured", settings.CustomConsolePRDetailKey)
 	}
 	nm := o.params
+	// make sure the map is not nil before setting this up
+	// there is a case where SetParams is not called before DetailURL and this would crash the container
+	if nm == nil {
+		nm = make(map[string]string)
+	}
 	nm["namespace"] = pr.GetNamespace()
 	nm["pr"] = pr.GetName()
 	return o.generateURL(o.Info.Pac.CustomConsolePRdetail, nm)
@@ -80,6 +85,11 @@ func (o *CustomConsole) TaskLogURL(pr *tektonv1.PipelineRun, taskRunStatus *tekt
 	}
 
 	nm := o.params
+	// make sure the map is not nil before setting this up
+	// there is a case where SetParams is not called before DetailURL and this would crash the container
+	if nm == nil {
+		nm = make(map[string]string)
+	}
 	nm["namespace"] = pr.GetNamespace()
 	nm["pr"] = pr.GetName()
 	nm["task"] = taskRunStatus.PipelineTaskName

--- a/pkg/consoleui/custom_test.go
+++ b/pkg/consoleui/custom_test.go
@@ -87,6 +87,21 @@ func TestCustomGood(t *testing.T) {
 	f.SetParams(map[string]string{})
 	assert.Assert(t, strings.Contains(c.DetailURL(pr), consoleURL))
 	assert.Assert(t, strings.Contains(c.TaskLogURL(pr, trStatus), consoleURL))
+
+	o := CustomConsole{
+		Info: &info.Info{
+			Pac: &info.PacOpts{
+				Settings: &settings.Settings{
+					CustomConsoleName:      consoleName,
+					CustomConsoleURL:       consoleURL,
+					CustomConsolePRdetail:  "{{ notthere}}",
+					CustomConsolePRTaskLog: "{{ notthere}}",
+				},
+			},
+		},
+	}
+	assert.Assert(t, strings.Contains(o.DetailURL(pr), consoleURL))
+	assert.Assert(t, strings.Contains(o.TaskLogURL(pr, trStatus), consoleURL))
 }
 
 func TestCustomBad(t *testing.T) {


### PR DESCRIPTION
There is a case where SetParams is not called before DetailURL and this would crash the container.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 A good commit message is important for other reviewers to understand the context of your change. Please refer to [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for more details how to write beautiful commit messages. We rather have the commit message in the PR body and the commit message instead of an external website.
- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
