### PR TITLE
Add tool to create repo on gitea and fix a makefile error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ GO_TEST_FLAGS +=
 SHELL := bash
 
 
-PY_FILES := $(shell find . -type f -regex ".*py" -print)
+PY_FILES := $(shell find . -type f -regex ".*\.py" -print)
 YAML_FILES := $(shell find . -type f -regex ".*y[a]ml" -print)
 MD_FILES := $(shell find . -type f -regex ".*md"  -not -regex '^./vendor/.*'  -not -regex '^./.vale/.*'  -not -regex "^./docs/themes/.*" -not -regex "^./.git/.*" -print)
 

--- a/hack/dev/kind/gitea/create-repo/main.go
+++ b/hack/dev/kind/gitea/create-repo/main.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/git"
+	tgitea "github.com/openshift-pipelines/pipelines-as-code/test/pkg/gitea"
+	pacrepo "github.com/openshift-pipelines/pipelines-as-code/test/pkg/repository"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type Args struct {
+	name      *string
+	onOrg     *bool
+	targetNS  *string
+	localRepo *string
+}
+
+func create(ctx context.Context, args *Args) error {
+	run, e2eOpts, provider, err := tgitea.Setup(ctx)
+	if err != nil {
+		return err
+	}
+	hookURL := os.Getenv("TEST_GITEA_SMEEURL")
+
+	if _, err = provider.Client.DeleteRepo(e2eOpts.Organization, *args.name); err == nil {
+		run.Clients.Log.Infof("repository %s/%s deleted", e2eOpts.Organization, *args.name)
+	}
+
+	repoInfo, err := tgitea.CreateGiteaRepo(
+		provider.Client,
+		e2eOpts.Organization,
+		*args.name,
+		hookURL,
+		*args.onOrg,
+		run.Clients.Log)
+	if err != nil {
+		return err
+	}
+
+	parsed, _ := url.Parse(repoInfo.HTMLURL)
+	userPasswordURL := fmt.Sprintf("http://git:%s@%s%s", *provider.Token, parsed.Host, parsed.Path)
+
+	targetNS := *args.targetNS
+	if targetNS == "" {
+		targetNS = *args.name
+	}
+
+	topts := &tgitea.TestOpts{
+		ParamsRun:        run,
+		TargetNS:         targetNS,
+		InternalGiteaURL: os.Getenv("TEST_GITEA_INTERNAL_URL"),
+	}
+	if topts.InternalGiteaURL == "" {
+		topts.InternalGiteaURL = "http://gitea.gitea:3000"
+	}
+
+	_ = pacrepo.CreateNS(ctx, topts.TargetNS, topts.ParamsRun)
+	err = run.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(topts.TargetNS).Delete(
+		ctx, targetNS, metav1.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+	_ = run.Clients.Kube.CoreV1().Secrets(topts.TargetNS).Delete(ctx, "gitea-secret", metav1.DeleteOptions{})
+	if err := tgitea.CreateCRD(ctx, topts); err != nil {
+		return err
+	}
+
+	localRepoCheckout := "/tmp/" + *args.name
+	if *args.localRepo != "" {
+		localRepoCheckout = *args.localRepo
+	}
+
+	// check  if directory exist
+	if _, err := os.Stat(localRepoCheckout); !os.IsNotExist(err) {
+		return nil
+	}
+
+	_, _ = git.RunGit("/tmp", "clone", userPasswordURL, localRepoCheckout)
+	if err := os.Chdir(localRepoCheckout); err != nil {
+		return err
+	}
+	if err := exec.CommandContext(ctx, "tkn", "pac", "generate", "--event-type", "pull_request", "--branch", "main").Run(); err != nil {
+		return err
+	}
+
+	_, _ = git.RunGit(localRepoCheckout, "checkout", "-b", "tektonci")
+	_, _ = git.RunGit(localRepoCheckout, "commit", "-am", "Tekton FTW")
+
+	fmt.Fprintf(os.Stdout, "Local Checkout Directory: %s\n", localRepoCheckout)
+	fmt.Fprintf(os.Stdout, "Gitea Repositoyr URL: %s\n", repoInfo.HTMLURL)
+	return nil
+}
+
+func main() {
+	// check for args repo name was passed
+	opts := &Args{}
+	opts.name = flag.String("repo", "test-repo", "repository name to create")
+	opts.targetNS = flag.String("targetNS", "", "namespace target")
+	opts.localRepo = flag.String("localRepo", "", "name of the local repo to clone")
+	opts.onOrg = flag.Bool("onOrg", false, "create repo on organization")
+	flag.Parse()
+	ctx := context.Background()
+	if err := create(ctx, opts); err != nil {
+		fmt.Fprintf(os.Stdout, "Error: %v\n", err)
+	}
+}

--- a/test/pkg/gitea/setup.go
+++ b/test/pkg/gitea/setup.go
@@ -33,7 +33,7 @@ func CreateProvider(ctx context.Context, giteaURL, user, password string) (gitea
 		Token: password,
 	}
 	if err := gprovider.SetClient(ctx, nil, event, nil); err != nil {
-		return gitea.Provider{}, fmt.Errorf("cannot set client: %w", err)
+		return gitea.Provider{}, err
 	}
 	return gprovider, nil
 }

--- a/test/pkg/repository/create.go
+++ b/test/pkg/repository/create.go
@@ -11,9 +11,11 @@ import (
 
 func CreateNS(ctx context.Context, targetNS string, cs *params.Run) error {
 	nsSpec := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: targetNS}}
-	_, err := cs.Clients.Kube.CoreV1().Namespaces().Create(ctx, nsSpec, metav1.CreateOptions{})
+	if _, err := cs.Clients.Kube.CoreV1().Namespaces().Create(ctx, nsSpec, metav1.CreateOptions{}); err != nil {
+		return err
+	}
 	cs.Clients.Log.Infof("Namespace %s created", targetNS)
-	return err
+	return nil
 }
 
 func CreateRepo(ctx context.Context, targetNS string, cs *params.Run, repository *pacv1alpha1.Repository) error {


### PR DESCRIPTION
- Fix getting python file for Makefile target
- 
We were getting this error:

```shell
% make lint-py
Linting python files...
************* Module remove-repeated-deploy-py
.git/logs/refs/remotes/savitaashture/remove-repeated-deploy-py:1:43: E0001: Parsing failed: 'invalid decimal literal (<unknown>, line 1)' (syntax-error)
.git/refs/remotes/savitaashture/remove-repeated-deploy-py:1:2: E0001: Parsing failed: 'invalid decimal literal (<unknown>, line 1)' (syntax-error)
```

Since the globing was too greedy and should have checked for the
actual files

- Add a helper tool to create gitea repo

Add a simple binary helper tool to be able to easily create a gitea repo
ready to go to iterate and test some PaC features.

Simply use it:

```shell
go run test/pkg/gitea/create-repo
```

Signed-off-by: Chmouel Boudjnah <chmouel@chmouel.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 A good commit message is important for other reviewers to understand the context of your change. Please refer to [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for more details how to write beautiful commit messages. We rather have the commit message in the PR body and the commit message instead of an external website.
- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
