### PR TITLE
Add support for body and headers  in parameters and CEL filtering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,12 @@ html-coverage: ## generate html coverage
 
 .PHONY: docs-dev
 docs-dev: ## preview live your docs with hugo
-	@hugo server -s docs/
+	@hugo server -s docs/ &
+	if type -p xdg-open 2>/dev/null >/dev/null; then \
+		xdg-open http://localhost:1313; \
+	elif type -p open 2>/dev/null >/dev/null; then \
+		open http://localhost:1313; \
+	fi
 
 check-generated: # vendor update-golden
 	@git status -uno |grep -E "modified:[ ]*(vendor/|.*.golden$)" && \

--- a/docs/content/docs/guide/authoringprs.md
+++ b/docs/content/docs/guide/authoringprs.md
@@ -29,20 +29,22 @@ weight: 3
   allows you to have those "dynamic" variables expanded. Those variables look
   like this `{{ var }}` and those are the one you can use:
 
-  - `{{body}}`: The full payload body available directly or as a CEL expression (see [below](#using-the-body-and-headers-in-a-pipelines-as-code-parameter))
-  - `{{headers}}`: The payload request headers available directly or as a CEL expression (see [below](#using-the-body-and-headers-in-a-pipelines-as-code-parameter)).
-  - `{{event_type}}`: The event type (eg: `pull_request` or `push`).
-  - `{{git_auth_secret}}`: The secret name auto generated with provider token to check out private repos.
-  - `{{pull_request_number}}`: The pull or merge request number, only defined when we are in a `pull_request` event type.
-  - `{{repo_name}}`: The repository name.
-  - `{{repo_owner}}`: The repository owner.
-  - `{{repo_url}}`: The repository full URL.
-  - `{{revision}}`: The commit full sha revision.
-  - `{{sender}}`: The sender username (or accountid on some providers) of the commit.
-  - `{{source_branch}}`: The branch name where the event come from.
-  - `{{source_url}}`: The source repository URL from which the event come from (same as `repo_url` for push events).
-  - `{{target_branch}}`: The branch name on which the event targets (same as `source_branch` for push events).
-  - `{{target_namespace}}`: The target namespace where the Repository has matched and the PipelineRun will be created.
+| Variable            | Description                                                                                       | Example                             | Example Output               |
+|---------------------|---------------------------------------------------------------------------------------------------|-------------------------------------|------------------------------|
+| body                | The full payload body (see [below](#using-the-body-and-headers-in-a-pipelines-as-code-parameter)) | `{{body.pull_request.user.email }}` | <email@domain.com>             |
+| event_type          | The event type (eg: `pull_request` or `push`)                                                     | `{{event_type}}`                    | pull_request                 |
+| git_auth_secret     | The secret name auto generated with provider token to check out private repos.                    | `{{git_auth_secret}}`               | pac-gitauth-xkxkx            |
+| headers             | The request headers (see [below](#using-the-body-and-headers-in-a-pipelines-as-code-parameter))   | `{{headers['x-github-event']}}`     | push                         |
+| pull_request_number | The pull or merge request number, only defined when we are in a `pull_request` event type.        | `{{pull_request_number}}`           | 1                            |
+| repo_name           | The repository name.                                                                              | `{{repo_name}}`                     | pipelines-as-code            |
+| repo_owner          | The repository owner.                                                                             | `{{repo_owner}}`                    | openshift-pipelines          |
+| repo_url            | The repository full URL.                                                                          | `{{repo_url}}`                      | https:/github.com/repo/owner |
+| revision            | The commit full sha revision.                                                                     | `{{revision}}`                      | 1234567890abcdef             |
+| sender              | The sender username (or accountid on some providers) of the commit.                               | `{{sender}}`                        | johndoe                      |
+| source_branch       | The branch name where the event come from.                                                        | `{{source_branch}}`                 | main                         |
+| source_url          | The source repository URL from which the event come from (same as `repo_url` for push events).    | `{{source_url}}`                    | https:/github.com/repo/owner |
+| target_branch       | The branch name on which the event targets (same as `source_branch` for push events).             | `{{target_branch}}`                 | main                         |
+| target_namespace    | The target namespace where the Repository has matched and the PipelineRun will be created.        | `{{target_namespace}}`              | my-namespace                 |
 
 - For Pipelines-as-Code to process your `PipelineRun`, you must have either an
   embedded `PipelineSpec` or a separate `Pipeline` object that references a YAML

--- a/docs/content/docs/guide/authoringprs.md
+++ b/docs/content/docs/guide/authoringprs.md
@@ -2,23 +2,24 @@
 title: Authoring PipelineRun
 weight: 3
 ---
+
 # Authoring PipelineRuns in `.tekton/` directory
 
-* Pipelines-as-Code will always try to be as close to the tekton template as
+- Pipelines-as-Code will always try to be as close to the tekton template as
   possible. Usually you will write your template and save them with a `.yaml`
   extension and Pipelines-as-Code will run them.
 
-* The `.tekton` directory must be at the top level of the repo.
+- The `.tekton` directory must be at the top level of the repo.
   You can reference YAML files in other repos using remote URLs
   (see [Remote HTTP URLs](./resolver.md#remote-http-url) for more information),
   but PipelineRuns will only be triggered by events in the repository containing
   the `.tekton` directory.
 
-* Using its [resolver](../resolver/) Pipelines-as-Code will try to bundle the
+- Using its [resolver](../resolver/) Pipelines-as-Code will try to bundle the
   PipelineRun with all its Task as a single PipelineRun with no external
   dependencies.
 
-* Inside your pipeline you need to be able to check out the commit as
+- Inside your pipeline you need to be able to check out the commit as
   received from the webhook by checking it out the repository from that ref. Most of the time
   you want to reuse the
   [git-clone](https://github.com/tektoncd/catalog/blob/main/task/git-clone/)
@@ -28,20 +29,21 @@ weight: 3
   allows you to have those "dynamic" variables expanded. Those variables look
   like this `{{ var }}` and those are the one you can use:
 
-  * `{{event_type}}`: The event type (eg: `pull_request` or `push`).
-  * `{{git_auth_secret}}`: The secret name auto generated with provider token to check out private repos.
-  * `{{pull_request_number}}`: The pull or merge request number, only defined when we are in a `pull_request` event type.
-  * `{{repo_name}}`: The repository name.
-  * `{{repo_owner}}`: The repository owner.
-  * `{{repo_url}}`: The repository full URL.
-  * `{{revision}}`: The commit full sha revision.
-  * `{{sender}}`: The sender username (or accountid on some providers) of the commit.
-  * `{{source_branch}}`: The branch name where the event come from.
-  * `{{source_url}}`: The source repository URL from which the event come from (same as `repo_url` for push events).
-  * `{{target_branch}}`: The branch name on which the event targets (same as `source_branch` for push events).
-  * `{{target_namespace}}`: The target namespace where the Repository has matched and the PipelineRun will be created.
-
-* For Pipelines-as-Code to process your `PipelineRun`, you must have either an
+  - `{{event_type}}`: The event type (eg: `pull_request` or `push`).
+  - `{{git_auth_secret}}`: The secret name auto generated with provider token to check out private repos.
+  - `{{pull_request_number}}`: The pull or merge request number, only defined when we are in a `pull_request` event type.
+  - `{{repo_name}}`: The repository name.
+  - `{{repo_owner}}`: The repository owner.
+  - `{{repo_url}}`: The repository full URL.
+  - `{{revision}}`: The commit full sha revision.
+  - `{{sender}}`: The sender username (or accountid on some providers) of the commit.
+  - `{{source_branch}}`: The branch name where the event come from.
+  - `{{source_url}}`: The source repository URL from which the event come from (same as `repo_url` for push events).
+  - `{{target_branch}}`: The branch name on which the event targets (same as `source_branch` for push events).
+  - `{{target_namespace}}`: The target namespace where the Repository has matched and the PipelineRun will be created.
+  - `{{body}}`: The full payload body available as a CEL expression (see [below](#using-the-body-and-headers-in-a-pipelines-as-code-parameter)).
+  - `{{headers}}`: The payload request headers available as a CEL expression (see [below](#using-the-body-and-headers-in-a-pipelines-as-code-parameter)).
+- For Pipelines-as-Code to process your `PipelineRun`, you must have either an
   embedded `PipelineSpec` or a separate `Pipeline` object that references a YAML
   file in the `.tekton` directory. The Pipeline object can include `TaskSpecs`,
   which may be defined separately as Tasks in another YAML file in the same
@@ -55,11 +57,11 @@ annotations on the `PipelineRun`. For example when you have these metadatas in
 your `PipelineRun`:
 
 ```yaml
- metadata:
-    name: pipeline-pr-main
- annotations:
-    pipelinesascode.tekton.dev/on-target-branch: "[main]"
-    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+metadata:
+  name: pipeline-pr-main
+annotations:
+  pipelinesascode.tekton.dev/on-target-branch: "[main]"
+  pipelinesascode.tekton.dev/on-event: "[pull_request]"
 ```
 
 `Pipelines-as-Code` will match the pipelinerun `pipeline-pr-main` if the Git
@@ -78,7 +80,7 @@ For example this will match the pipeline when there is a push to a commit in the
 `main` branch :
 
 ```yaml
- metadata:
+metadata:
   name: pipeline-push-on-main
   annotations:
     pipelinesascode.tekton.dev/on-target-branch: "[refs/heads/main]"
@@ -92,11 +94,11 @@ target branch or `refs/tags/1.*` will match all the tags starting from `1.`.
 A full example for a push of a tag :
 
 ```yaml
- metadata:
- name: pipeline-push-on-1.0-tags
- annotations:
-    pipelinesascode.tekton.dev/on-target-branch: "[refs/tags/1.0]"
-    pipelinesascode.tekton.dev/on-event: "[push]"
+metadata:
+name: pipeline-push-on-1.0-tags
+annotations:
+  pipelinesascode.tekton.dev/on-target-branch: "[refs/tags/1.0]"
+  pipelinesascode.tekton.dev/on-event: "[push]"
 ```
 
 This will match the pipeline `pipeline-push-on-1.0-tags` when you push the 1.0
@@ -114,7 +116,7 @@ finishes.
 If you need to do some advanced matching, `Pipelines-as-Code` supports CEL
 filtering.
 
-If you have the ``pipelinesascode.tekton.dev/on-cel-expression`` annotation in
+If you have the `pipelinesascode.tekton.dev/on-cel-expression` annotation in
 your PipelineRun, the CEL expression will be used and the `on-target-branch` or
 `on-target-branch` annotations will then be skipped.
 
@@ -122,8 +124,8 @@ This example will match a `pull_request` event targeting the branch `main`
 coming from a branch called `wip`:
 
 ```yaml
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "pull_request" && target_branch == "main" && source_branch == "wip"
+pipelinesascode.tekton.dev/on-cel-expression: |
+  event == "pull_request" && target_branch == "main" && source_branch == "wip"
 ```
 
 Another example, if you want to have a PipelineRun running only if a path has
@@ -133,30 +135,30 @@ is a concrete example matching every markdown files (as files who has the `.md`
 suffix) in the `docs` directory :
 
 ```yaml
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "pull_request" && "docs/*.md".pathChanged()
+pipelinesascode.tekton.dev/on-cel-expression: |
+  event == "pull_request" && "docs/*.md".pathChanged()
 ```
 
 This example will match all pull request starting with the title `[DOWNSTREAM]`:
 
 ```yaml
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "pull_request && event_title.startsWith("[DOWNSTREAM]")
+pipelinesascode.tekton.dev/on-cel-expression: |
+  event == "pull_request && event_title.startsWith("[DOWNSTREAM]")
 ```
 
 The fields available are :
 
-* `event`: `push` or `pull_request`
-* `target_branch`: The branch we are targeting.
-* `source_branch`: The branch where this pull_request come from. (on `push` this
+- `event`: `push` or `pull_request`
+- `target_branch`: The branch we are targeting.
+- `source_branch`: The branch where this pull_request come from. (on `push` this
   is the same as `target_branch`).
-* `target_url`: The url of the repository we are targeting.
-* `source_url`: The url of the repository where this pull_request come from. (on `push` this
+- `target_url`: The URL of the repository we are targeting.
+- `source_url`: The URL of the repository where this pull_request come from. (on `push` this
   is the same as `target_url`).
-* `event_title`: Match the title of the event. When doing a push this will match
+- `event_title`: Match the title of the event. When doing a push this will match
   the commit title and when matching on PR it will match the Pull or Merge
   Request title. (only `GitHub`, `Gitlab` and `BitbucketCloud` providers are supported)
-* `.pathChanged`: a suffix function to a string which can be a glob of a path to
+- `.pathChanged`: a suffix function to a string which can be a glob of a path to
   check if changed (only `GitHub` and `Gitlab` provider is supported)
 
 Compared to the simple "on-target" annotation matching, the CEL expression
@@ -166,13 +168,73 @@ For example if I want to have a `PipelineRun` targeting a `pull_request` but
 not the `experimental` branch I would have :
 
 ```yaml
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "pull_request" && target_branch != experimental"
+pipelinesascode.tekton.dev/on-cel-expression: |
+  event == "pull_request" && target_branch != experimental"
 ```
 
 You can find more information about the CEL language spec here :
 
 <https://github.com/google/cel-spec/blob/master/doc/langdef.md>
+
+## Using the body and headers in a Pipelines-as-Code parameter
+
+Pipelines-as-Code let you access the full body and headers of the request as a CEL expression.
+
+This allows you to go beyond the standard variables and even play with multiple
+conditions and variable to output values.
+
+For example if you want to get the title of the Pull Request in your PipelineRun you can simply access it like this:
+
+```go
+{{ body.pull_request.title }}
+```
+
+You can then get creative and for example mix the variable inside a python
+script to evaluate the json.
+
+This task for example is using python and will check the labels on the PR,
+`exit 0` if it has the label called 'bug' on the pull request or `exit 1` if it
+doesn't:
+
+```yaml
+taskSpec:
+  steps:
+    - name: check-label
+      image: registry.access.redhat.com/ubi9/ubi
+      script: |
+        #!/usr/bin/env python3
+        import json
+        labels=json.loads("""{{ body.pull_request.labels }}""")
+        for label in labels:
+            if label['name'] == 'bug':
+              print('This is a PR targeting a BUG')
+              exit(0)
+        print('This is not a PR targeting a BUG :(')
+        exit(1)
+```
+
+The expression are CEL expressions so you can as well make some conditional:
+
+```yaml
+- name: bash
+  image: registry.access.redhat.com/ubi9/ubi
+  script: |
+    if {{ body.pull_request.state == "open" }}; then
+      echo "PR is Open"
+    fi
+```
+
+if the PR is open the condition then return `true` and the shell script see this
+as a valid boolean.
+
+Headers from the payload body can be accessed from the `headers` keyword, for
+example
+
+```yaml
+{{ headers['x-github-event'] }}
+```
+
+and then you can do the same conditional or access as described above for the `body` keyword.
 
 ## Using the temporary GitHub APP Token for GitHub API operations
 
@@ -188,7 +250,7 @@ task from the [Tekton Hub](https://hub.tekton.dev)
 using a [pipelines as code annotation](../resolver/#remote-http-url):
 
 ```yaml
-  pipelinesascode.tekton.dev/task: "github-add-comment"
+pipelinesascode.tekton.dev/task: "github-add-comment"
 ```
 
 you can then add the task to your [tasks section](https://tekton.dev/docs/pipelines/pipelines/#adding-tasks-to-the-pipeline) (or [finally](https://tekton.dev/docs/pipelines/pipelines/#adding-finally-to-the-pipeline) tasks) of your PipelineRun :
@@ -223,13 +285,12 @@ env:
       secretKeyRef:
         name: "{{ git_auth_secret }}"
         key: "git-provider-token"
-
 ```
 
 {{< hint info >}}
 
-* On GitHub apps the generated installation token [will be available for 8 hours](https://docs.github.com/en/developers/apps/building-github-apps/refreshing-user-to-server-access-tokens)
-* On GitHub apps the token is scoped to the repository the event (payload) come
+- On GitHub apps the generated installation token [will be available for 8 hours](https://docs.github.com/en/developers/apps/building-github-apps/refreshing-user-to-server-access-tokens)
+- On GitHub apps the token is scoped to the repository the event (payload) come
   from unless [configured](/docs/install/settings#pipelines-as-code-configuration-settings) it differently on cluster.
 
 {{< /hint >}}

--- a/docs/content/docs/guide/cli.md
+++ b/docs/content/docs/guide/cli.md
@@ -1,6 +1,6 @@
 ---
 title: CLI tkn-pac
-weight: 10
+weight: 100
 ---
 # Pipelines-as-Code CLI
 

--- a/docs/content/docs/guide/customparams.md
+++ b/docs/content/docs/guide/customparams.md
@@ -1,0 +1,110 @@
+---
+title: Custom Parameters
+weight: 50
+---
+## Custom Parameters
+
+Using the `{{ param }}` syntax, Pipelines-as-Code let you expand a variable or
+the payload body inside a template within your PipelineRun.
+
+By default, there are several variables exposed according to the event. To view
+all the variables exposed by default, refer to the documentation on [Authoring
+PipelineRuns](../authoringprs#default-parameters).
+
+With the custom parameter, you can specify some custom values to be
+replaced inside the template.
+
+{{< hint warning >}}
+Utilizing the Tekton PipelineRun parameters feature may generally be the
+preferable approach, and custom params expansion should only be used in specific
+scenarios where Tekton params cannot be used.
+{{< /hint >}}
+
+As an example here is a custom variable in the Repository CR `spec`:
+
+```yaml
+spec:
+  params:
+    - name: company
+      value: "My Beautiful Company"
+```
+
+The variable name `{{ company }}` will be replaced by `My Beautiful Company`
+anywhere inside your `PipelineRun` (including the remotely fetched task).
+
+Alternatively, the value can be retrieved from a Kubernetes Secret.
+For instance, the following code will retrieve the value for the company
+`parameter` from a secret named `my-secret` and the key `companyname`:
+
+```yaml
+spec:
+  params:
+    - name: company
+      secret_ref:
+        name: my-secret
+        key: companyname
+```
+
+{{< hint info >}}
+
+- If you have a `value` and a `secret_ref` defined, the `value` will be used.
+- If you don't have a `value` or a `secret_ref` the parameter will not be
+  parsed, it will be shown as `{{ param }}` in the `PipelineRun`.
+- If you don't have a `name` in the `params` the parameter will not parsed.
+- If you have multiple `params` with the same `name` the last one will be used.
+{{< /hint >}}
+
+### CEL filtering on custom parameters
+
+You can define a `param` to only apply the custom parameters expansion when some
+conditions has been matched on a `filter`:
+
+```yaml
+spec:
+  params:
+    - name: company
+      value: "My Beautiful Company"
+      filter: pac.event_type == "pull_request"
+```
+
+The `pac` prefix contains all the values as set by default in the templates
+variables. Refer to the [Authoring PipelineRuns](../authoringprs) documentation
+for all the variable exposed by default.
+
+The body of the payload is exposed inside the `body` prefix.
+
+For example if you are running a Pull Request on GitHub pac will receive a
+payload which has this kind of json:
+
+```json
+{
+  "action": "opened",
+  "number": 79,
+  // .... more data
+}
+```
+
+The filter can then do something like this:
+
+```yaml
+spec:
+  params:
+    - name: company
+      value: "My Beautiful Company"
+      filter: body.action == "opened" && pac.event_type == "pull_request"
+```
+
+The payload of the event contains much more information that can be used with
+the CEL filter. To see the specific payload content for your provider, refer to
+the API documentation
+
+You can have multiple `params` with the same name and different filters, the
+first param that matches the filter will be picked up. This let you have
+different output according to different event, and for example combine a push
+and a pull request event.
+
+{{< hint info >}}
+
+- [GitHub Documentation for webhook events](https://docs.github.com/webhooks-and-events/webhooks/webhook-events-and-payloads?actionType=auto_merge_disabled#pull_request)
+- [Gitlab Documentation for webhook events](https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html)
+{{< /hint >}}

--- a/docs/content/docs/guide/incoming_webhook.md
+++ b/docs/content/docs/guide/incoming_webhook.md
@@ -1,5 +1,6 @@
 ---
 title: Incoming Webhook
+weight: 50
 ---
 
 # Incoming webhook

--- a/docs/content/docs/guide/policy.md
+++ b/docs/content/docs/guide/policy.md
@@ -1,6 +1,6 @@
 ---
 title: Policy on actions
-weight: 9
+weight: 50
 ---
 # Policy on Pipelines-as-Code actions
 

--- a/docs/content/docs/guide/repositorycrd.md
+++ b/docs/content/docs/guide/repositorycrd.md
@@ -11,9 +11,9 @@ The Repository CR serves the following purposes:
 - Referencing an API secret, username, or API URL if necessary for Git provider
   platforms that require it (e.g., when using webhooks instead of the GitHub
   application).
-- Providing the last `PipelineRun`statuses for that repository (5 by default).
-- Allowing for configuration of custom parameters within the `PipelineRun`that
-  can be expanded based on certain filters.
+- Providing the last `PipelineRun`statuses for the repository (5 by default).
+- Let you declare [custom parameters]({{< relref "/docs/guide/customparams" >}})
+  within the `PipelineRun`that can be expanded based on certain filters.
 
 The process involves creating a Repository CR inside the target namespace
 my-pipeline-ci, using the tkn pac CLI or another method.
@@ -131,115 +131,7 @@ of the pipelineruns will be executed in alphabetical order, one after the
 other. At any given time, only one pipeline run will be in the running state,
 while the rest will be queued.
 
-## Custom Parameter Expansion
-
-Using the `{{ param }}` syntax, Pipelines-as-Code let you expand a variable
-inside a template directly within your PipelineRuns.
-
-By default, there are
-several variables exposed according to the event. To view all the variables
-exposed by default, refer to the documentation on [Authoring
-PipelineRuns](../authoringprs#default-parameters).
-
-With the custom Parameter expansion, you can specify some custom values to be
-replaced inside the template.
-
-{{< hint warning >}}
-Utilizing the Tekton PipelineRun parameters feature may generally be the
-preferable approach, and custom params expansion should only be used in specific
-scenarios where Tekton params cannot be used.
-{{< /hint >}}
-
-As an example here is a custom variable in the Repository CR `spec`:
-
-```yaml
-spec:
-  params:
-    - name: company
-      value: "My Beautiful Company"
-```
-
-The variable name `{{ company }}` will be replaced by `My Beautiful Company`
-anywhere inside your `PipelineRun` (including the remotely fetched task).
-
-Alternatively, the value can be retrieved from a Kubernetes Secret.
-For instance, the following code will retrieve the value for the company
-`parameter` from a secret named `my-secret` and the key `companyname`:
-
-```yaml
-spec:
-  params:
-    - name: company
-      secret_ref:
-        name: my-secret
-        key: companyname
-```
-
-{{< hint info >}}
-
-- If you have a `value` and a `secret_ref` defined, the `value` will be used.
-- If you don't have a `value` or a `secret_ref` the parameter will not be
-  parsed, it will be shown as `{{ param }}` in the `PipelineRun`.
-- If you don't have a `name` in the `params` the parameter will not parsed.
-- If you have multiple `params` with the same `name` the last one will be used.
-{{< /hint >}}
-
-### CEL filtering on custom parameters
-
-You can define a `param` to only apply the custom parameters expansion when some
-conditions has been matched on a `filter`:
-
-```yaml
-spec:
-  params:
-    - name: company
-      value: "My Beautiful Company"
-      filter: pac.event_type == "pull_request"
-```
-
-The `pac` prefix contains all the values as set by default in the templates
-variables. Refer to the [Authoring PipelineRuns](../authoringprs) documentation
-for all the variable exposed by default.
-
-The body of the payload is exposed inside the `body` prefix.
-
-For example if you are running a Pull Request on GitHub pac will receive a
-payload which has this kind of json:
-
-```json
-{
-  "action": "opened",
-  "number": 79,
-  // .... more data
-}
-```
-
-The filter can then do something like this:
-
-```yaml
-spec:
-  params:
-    - name: company
-      value: "My Beautiful Company"
-      filter: body.action == "opened" && pac.event_type == "pull_request"
-```
-
-The payload of the event contains much more information that can be used with
-the CEL filter. To see the specific payload content for your provider, refer to
-the API documentation
-
-You can have multiple `params` with the same name and different filters, the
-first param that matches the filter will be picked up. This let you have
-different output according to different event, and for example combine a push
-and a pull request event.
-
-{{< hint info >}}
-
-- [GitHub Documentation for webhook events](https://docs.github.com/webhooks-and-events/webhooks/webhook-events-and-payloads?actionType=auto_merge_disabled#pull_request)
-- [Gitlab Documentation for webhook events](https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html)
-{{< /hint >}}
-
-## Scope GitHub token to a list of private and public repositories within and outside namespaces
+## Scoping GitHub token to a list of private and public repositories within and outside namespaces
 
 By default, the GitHub token that Pipelines-as-Code generates is scoped only to the repository where the payload comes from.
 However, in some cases, the developer team might want the token to allow control over additional repositories.
@@ -321,7 +213,7 @@ a `github_app_token_scope_repos` spec configuration in the `Repository` custom r
     kind: ConfigMap
     metadata:
       name: pipelines-as-code
-      namespace: pipelines-as-code    
+      namespace: pipelines-as-code
     data:
       secret-github-app-scope-extra-repos: "owner2/project2, owner3/project3"
     ```
@@ -337,7 +229,7 @@ a `github_app_token_scope_repos` spec configuration in the `Repository` custom r
      spec:
        url: "https://github.com/linda/project"
        settings:
-         github_app_token_scope_repos: 
+         github_app_token_scope_repos:
          - "owner/project"
          - "owner1/project1"
     ```
@@ -369,7 +261,7 @@ and the scoping fails for the repository level configuration because the reposit
   kind: ConfigMap
   metadata:
     name: pipelines-as-code
-    namespace: pipelines-as-code  
+    namespace: pipelines-as-code
   data:
     secret-github-app-scope-extra-repos: "owner5/project5"
   ```

--- a/pkg/cmd/tknpac/resolve/resolve.go
+++ b/pkg/cmd/tknpac/resolve/resolve.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -202,7 +203,7 @@ func resolveFilenames(ctx context.Context, cs *params.Run, filenames []string, p
 	}
 
 	// TODO: flags
-	allTheYamls = templates.ReplacePlaceHoldersVariables(allTheYamls, params)
+	allTheYamls = templates.ReplacePlaceHoldersVariables(allTheYamls, params, nil, http.Header{})
 	// We use github here but since we don't do remotetask we would not care
 	providerintf := github.New()
 	event := info.NewEvent()

--- a/pkg/consoleui/custom.go
+++ b/pkg/consoleui/custom.go
@@ -43,7 +43,7 @@ func (o *CustomConsole) URL() string {
 // return the default URL if there it's not become a proper url or that it has
 // some of the templates like {{}} left
 func (o *CustomConsole) generateURL(urlTmpl string, dict map[string]string) string {
-	newurl := templates.ReplacePlaceHoldersVariables(urlTmpl, dict)
+	newurl := templates.ReplacePlaceHoldersVariables(urlTmpl, dict, nil, nil)
 	// trim new line because yaml parser adds new line at the end of the string
 	newurl = strings.TrimSpace(strings.TrimSuffix(newurl, "\n"))
 	if _, err := url.ParseRequestURI(newurl); err != nil {

--- a/pkg/customparams/customparams_test.go
+++ b/pkg/customparams/customparams_test.go
@@ -281,6 +281,22 @@ func TestProcessTemplates(t *testing.T) {
 			},
 		},
 		{
+			name:               "params/not a condition",
+			expectedLogSnippet: "skipping params name params, filter condition is not a boolean",
+			event:              &info.Event{EventType: "push"},
+			repository: &v1alpha1.Repository{
+				Spec: v1alpha1.RepositorySpec{
+					Params: &[]v1alpha1.Params{
+						{
+							Name:   "params",
+							Value:  "batman",
+							Filter: `pac.event_type`,
+						},
+					},
+				},
+			},
+		},
+		{
 			name:               "params/two filters same name, match first",
 			expected:           map[string]string{"params": "batman1", "event_type": "pull_request"},
 			event:              &info.Event{EventType: "pull_request"},

--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -278,7 +278,7 @@ func changeSecret(prs []*tektonv1.PipelineRun) error {
 		name := secrets.GenerateBasicAuthSecretName()
 		processed := templates.ReplacePlaceHoldersVariables(string(b), map[string]string{
 			"git_auth_secret": name,
-		})
+		}, nil, nil)
 
 		var np *tektonv1.PipelineRun
 		err = json.Unmarshal([]byte(processed), &np)

--- a/pkg/pipelineascode/template.go
+++ b/pkg/pipelineascode/template.go
@@ -3,6 +3,7 @@ package pipelineascode
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/customparams"
@@ -25,5 +26,11 @@ func (p *PacRun) makeTemplate(ctx context.Context, repo *v1alpha1.Repository, te
 		maptemplate["pull_request_number"] = fmt.Sprintf("%d", p.event.PullRequestNumber)
 	}
 
-	return templates.ReplacePlaceHoldersVariables(template, maptemplate)
+	// replace placeholders variable as well as evaluate cel expressions
+	headers := http.Header{}
+	if p.event.Request != nil && p.event.Request.Header != nil {
+		headers = p.event.Request.Header
+	}
+
+	return templates.ReplacePlaceHoldersVariables(template, maptemplate, p.event.Event, headers)
 }

--- a/pkg/provider/github/repository.go
+++ b/pkg/provider/github/repository.go
@@ -109,5 +109,5 @@ func generateNamespaceName(nsTemplate string, gitEvent *github.RepositoryEvent) 
 		"repo_owner": repoOwner,
 		"repo_name":  repoName,
 	}
-	return templates.ReplacePlaceHoldersVariables(nsTemplate, maptemplate), nil
+	return templates.ReplacePlaceHoldersVariables(nsTemplate, maptemplate, nil, http.Header{}), nil
 }

--- a/pkg/templates/templating.go
+++ b/pkg/templates/templating.go
@@ -1,16 +1,103 @@
 package templates
 
 import (
+	"encoding/json"
+	"net/http"
+	"reflect"
 	"strings"
 
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/traits"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
+	customparams "github.com/openshift-pipelines/pipelines-as-code/pkg/cel"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+var (
+	structType = reflect.TypeOf(&structpb.Value{})
+	listType   = reflect.TypeOf(&structpb.ListValue{})
+	mapType    = reflect.TypeOf(&structpb.Struct{})
 )
 
 // ReplacePlaceHoldersVariables Replace those {{var}} placeholders to the runinfo variable
-func ReplacePlaceHoldersVariables(template string, dico map[string]string) string {
+func ReplacePlaceHoldersVariables(template string, dico map[string]string, rawEvent any, headers http.Header) string {
 	return keys.ParamsRe.ReplaceAllStringFunc(template, func(s string) string {
 		parts := keys.ParamsRe.FindStringSubmatch(s)
 		key := strings.TrimSpace(parts[1])
+		if strings.HasPrefix(key, "body") || strings.HasPrefix(key, "headers") {
+			if rawEvent != nil && headers != nil {
+				// convert headers to map[string]string
+				headerMap := make(map[string]string)
+				for k, v := range headers {
+					headerMap[k] = v[0]
+				}
+				val, err := customparams.CelValue(key, rawEvent, headerMap, map[string]string{})
+				if err != nil {
+					return s
+				}
+				var raw interface{}
+				var b []byte
+
+				switch val.(type) {
+				case types.String:
+					if v, ok := val.Value().(string); ok {
+						b = []byte(v)
+					}
+				case types.Bytes:
+					raw, err = val.ConvertToNative(structType)
+					if err == nil {
+						b, err = raw.(*structpb.Value).MarshalJSON()
+						if err != nil {
+							b = []byte{}
+						}
+					}
+				case types.Double, types.Int:
+					raw, err = val.ConvertToNative(structType)
+					if err == nil {
+						b, err = raw.(*structpb.Value).MarshalJSON()
+						if err != nil {
+							b = []byte{}
+						}
+					}
+				case traits.Lister:
+					raw, err = val.ConvertToNative(listType)
+					if err == nil {
+						s, err := protojson.Marshal(raw.(proto.Message))
+						if err == nil {
+							b = s
+						}
+					}
+				case traits.Mapper:
+					raw, err = val.ConvertToNative(mapType)
+					if err == nil {
+						s, err := protojson.Marshal(raw.(proto.Message))
+						if err == nil {
+							b = s
+						}
+					}
+				case types.Bool:
+					raw, err = val.ConvertToNative(structType)
+					if err == nil {
+						b, err = json.Marshal(raw.(*structpb.Value).GetBoolValue())
+						if err != nil {
+							b = []byte{}
+						}
+					}
+
+				default:
+					raw, err = val.ConvertToNative(reflect.TypeOf([]byte{}))
+					if err == nil {
+						if v, ok := raw.([]byte); ok {
+							b = v
+						}
+					}
+				}
+				return string(b)
+			}
+			return s
+		}
 		if _, ok := dico[key]; !ok {
 			return s
 		}

--- a/test/gitea_params_test.go
+++ b/test/gitea_params_test.go
@@ -1,0 +1,214 @@
+//go:build e2e
+// +build e2e
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"testing"
+	"time"
+
+	"code.gitea.io/sdk/gitea"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/configmap"
+	tgitea "github.com/openshift-pipelines/pipelines-as-code/test/pkg/gitea"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
+	pacrepo "github.com/openshift-pipelines/pipelines-as-code/test/pkg/repository"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/secret"
+	twait "github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
+	"github.com/tektoncd/pipeline/pkg/names"
+	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGiteaParamsStandardCheckForPushAndPullEvent(t *testing.T) {
+	var (
+		repoURL      string
+		sourceURL    string
+		sourceBranch string
+		targetBranch string
+	)
+	topts := &tgitea.TestOpts{
+		Regexp:      successRegexp,
+		TargetEvent: "pull_request, push",
+		YAMLFiles: map[string]string{
+			".tekton/pr.yaml": "testdata/pipelinerun-standard-params-display.yaml",
+		},
+		CheckForStatus: "success",
+		ExpectEvents:   false,
+	}
+	defer tgitea.TestPR(t, topts)()
+	merged, resp, err := topts.GiteaCNX.Client.MergePullRequest(topts.Opts.Organization, topts.Opts.Repo, topts.PullRequest.Index,
+		gitea.MergePullRequestOption{
+			Title: "Merged with Panache",
+			Style: "merge",
+		},
+	)
+	assert.NilError(t, err)
+	assert.Assert(t, resp.StatusCode < 400, resp)
+	assert.Assert(t, merged)
+	tgitea.WaitForStatus(t, topts, topts.PullRequest.Head.Sha, "", false)
+	time.Sleep(5 * time.Second)
+
+	// get standard parameter info for pull_request
+	_, _, sourceBranch, targetBranch = tgitea.GetStandardParams(t, topts, "pull_request")
+	// sourceBranch and targetBranch are different for pull_request
+	if sourceBranch == targetBranch {
+		assert.Error(t, fmt.Errorf(`source_branch %s is same as target_branch %s for pull_request`, sourceBranch, targetBranch), fmt.Sprintf(`source_branch %s should be different from target_branch %s for pull_request`, sourceBranch, targetBranch))
+	}
+
+	// get standard parameter info for push
+	repoURL, sourceURL, sourceBranch, targetBranch = tgitea.GetStandardParams(t, topts, "push")
+	// sourceBranch and targetBranch are same for push
+	if sourceBranch != targetBranch {
+		assert.Error(t, fmt.Errorf(`source_branch %s is different from target_branch %s for push`, sourceBranch, targetBranch), fmt.Sprintf(`source_branch %s is same as target_branch %s for push`, sourceBranch, targetBranch))
+	}
+	// sourceURL and repoURL are same for push
+	if repoURL != sourceURL {
+		assert.Error(t, fmt.Errorf(`source_url %s is different from repo_url %s for push`, repoURL, sourceURL), fmt.Sprintf(`source_url %s is same as repo_url %s for push`, repoURL, sourceURL))
+	}
+}
+
+func TestGiteaParamsOnRepoCRWithCustomConsole(t *testing.T) {
+	t.Skip("Skipping test changing the global config map for now")
+	ctx := context.Background()
+	topts := &tgitea.TestOpts{
+		CheckForStatus:  "success",
+		SkipEventsCheck: true,
+		TargetEvent:     options.PullRequestEvent,
+		YAMLFiles: map[string]string{
+			".tekton/pr.yaml": "testdata/params.yaml",
+		},
+		RepoCRParams: &[]v1alpha1.Params{
+			{
+				Name:  "custom",
+				Value: "myconsole",
+			},
+		},
+		StatusOnlyLatest: true,
+	}
+	topts.TargetRefName = names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test")
+	topts.TargetNS = topts.TargetRefName
+	topts.ParamsRun, topts.Opts, topts.GiteaCNX, _ = tgitea.Setup(ctx)
+	assert.NilError(t, topts.ParamsRun.Clients.NewClients(ctx, &topts.ParamsRun.Info))
+	assert.NilError(t, pacrepo.CreateNS(ctx, topts.TargetNS, topts.ParamsRun))
+
+	cfgMapData := map[string]string{
+		"custom-console-name":           "Custom Console",
+		"custom-console-url":            "https://url",
+		"custom-console-url-pr-details": "https://url/detail/{{ custom }}",
+		"custom-console-url-pr-tasklog": "https://url/log/{{ custom }}",
+		"tekton-dashboard-url":          "",
+	}
+	defer configmap.ChangeGlobalConfig(ctx, t, topts.ParamsRun, cfgMapData)()
+	defer tgitea.TestPR(t, topts)()
+	// topts.Regexp = regexp.MustCompile(`(?m).*Custom Console.*https://url/detail/myconsole.*https://url/log/myconsole`)
+	topts.Regexp = regexp.MustCompile(`(?m).*Custom Console.*https://url/detail/myconsole`)
+	tgitea.WaitForPullRequestCommentMatch(t, topts)
+	topts.Regexp = regexp.MustCompile(`(?m).*https://url/log/myconsole`)
+	tgitea.WaitForPullRequestCommentMatch(t, topts)
+}
+
+func TestGiteaParamsOnRepoCR(t *testing.T) {
+	topts := &tgitea.TestOpts{
+		CheckForStatus:  "success",
+		SkipEventsCheck: true,
+		TargetEvent:     options.PullRequestEvent,
+		YAMLFiles: map[string]string{
+			".tekton/pr.yaml": "testdata/params.yaml",
+		},
+		RepoCRParams: &[]v1alpha1.Params{
+			{
+				Name:  "no_filter",
+				Value: "Follow me on my ig #nofilter",
+			},
+			{
+				Name:   "event_type_match",
+				Value:  "I am the most Kawaī params",
+				Filter: `pac.event_type == "pull_request"`,
+			},
+			{
+				Name:   "event_type_match",
+				Value:  "Nobody should see me, i am superseded by the previous params with same name 😠",
+				Filter: `pac.event_type == "pull_request"`,
+			},
+			{
+				Name:   "no_match",
+				Value:  "Am I being ignored?",
+				Filter: `pac.event_type == "xxxxxxx"`,
+			},
+			{
+				Name:   "filter_on_body",
+				Value:  "Hey I show up from a payload match",
+				Filter: `body.action == "opened"`,
+			},
+			{
+				Name: "secret value",
+				SecretRef: &v1alpha1.Secret{
+					Name: "param-secret",
+					Key:  "secret",
+				},
+			},
+			{
+				Name: "secret_nothere",
+				SecretRef: &v1alpha1.Secret{
+					Name: "param-secret-not-present",
+					Key:  "unknowsecret",
+				},
+			},
+		},
+	}
+	topts.TargetRefName = names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test")
+	topts.TargetNS = topts.TargetRefName
+
+	ctx := context.Background()
+	topts.ParamsRun, topts.Opts, topts.GiteaCNX, _ = tgitea.Setup(ctx)
+	assert.NilError(t, topts.ParamsRun.Clients.NewClients(ctx, &topts.ParamsRun.Info))
+	assert.NilError(t, pacrepo.CreateNS(ctx, topts.TargetNS, topts.ParamsRun))
+	assert.NilError(t, secret.Create(ctx, topts.ParamsRun, map[string]string{"secret": "SHHHHHHH"}, topts.TargetNS,
+		"param-secret"))
+
+	defer tgitea.TestPR(t, topts)()
+
+	repo, err := topts.ParamsRun.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(topts.TargetNS).Get(context.Background(), topts.TargetNS, metav1.GetOptions{})
+	assert.NilError(t, err)
+	assert.Assert(t, len(repo.Status) != 0)
+	assert.NilError(t,
+		twait.RegexpMatchingInPodLog(context.Background(),
+			topts.ParamsRun,
+			topts.TargetNS,
+			fmt.Sprintf("tekton.dev/pipelineRun=%s,tekton.dev/pipelineTask=params",
+				repo.Status[0].PipelineRunName),
+			"step-test-params-value", *regexp.MustCompile(
+				"I am the most Kawaī params\nSHHHHHHH\nFollow me on my ig #nofilter\n{{ no_match }}\nHey I show up from a payload match\n{{ secret_nothere }}"), 2))
+}
+
+// TestParamshBodyHeadersCEL Test that we can access the body and headers in params as a CEL expression
+func TestParamshBodyHeadersCEL(t *testing.T) {
+	topts := &tgitea.TestOpts{
+		Regexp:      successRegexp,
+		TargetEvent: "pull_request, push",
+		YAMLFiles: map[string]string{
+			".tekton/pr.yaml": "testdata/pipelinerun-cel-params.yaml",
+		},
+		CheckForStatus: "success",
+		ExpectEvents:   false,
+	}
+	defer tgitea.TestPR(t, topts)()
+
+	repo, err := topts.ParamsRun.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(topts.TargetNS).Get(context.Background(), topts.TargetNS, metav1.GetOptions{})
+	assert.NilError(t, err)
+	assert.Assert(t, len(repo.Status) != 0)
+
+	output := `Look mum I know that we are acting on a pull_request
+my email is a true beauty and like groot, I AM pac`
+	err = twait.RegexpMatchingInPodLog(context.Background(),
+		topts.ParamsRun,
+		topts.TargetNS,
+		fmt.Sprintf("tekton.dev/pipelineRun=%s,tekton.dev/pipelineTask=cel-params",
+			repo.Status[0].PipelineRunName),
+		"step-test-cel-params-value", *regexp.MustCompile(output), 2)
+	assert.NilError(t, err)
+}

--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
 	tknpactest "github.com/openshift-pipelines/pipelines-as-code/test/pkg/cli"
-	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/configmap"
 	tgitea "github.com/openshift-pipelines/pipelines-as-code/test/pkg/gitea"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
@@ -602,121 +601,6 @@ func TestGiteaBadLinkOfTask(t *testing.T) {
 }
 
 // TestGiteaParamsOnRepoCR test gitea params on CR and its filters
-func TestGiteaParamsOnRepoCR(t *testing.T) {
-	topts := &tgitea.TestOpts{
-		CheckForStatus:  "success",
-		SkipEventsCheck: true,
-		TargetEvent:     options.PullRequestEvent,
-		YAMLFiles: map[string]string{
-			".tekton/pr.yaml": "testdata/params.yaml",
-		},
-		RepoCRParams: &[]v1alpha1.Params{
-			{
-				Name:  "no_filter",
-				Value: "Follow me on my ig #nofilter",
-			},
-			{
-				Name:   "event_type_match",
-				Value:  "I am the most Kawaī params",
-				Filter: `pac.event_type == "pull_request"`,
-			},
-			{
-				Name:   "event_type_match",
-				Value:  "Nobody should see me, i am superseded by the previous params with same name 😠",
-				Filter: `pac.event_type == "pull_request"`,
-			},
-			{
-				Name:   "no_match",
-				Value:  "Am I being ignored?",
-				Filter: `pac.event_type == "xxxxxxx"`,
-			},
-			{
-				Name:   "filter_on_body",
-				Value:  "Hey I show up from a payload match",
-				Filter: `body.action == "opened"`,
-			},
-			{
-				Name: "secret value",
-				SecretRef: &v1alpha1.Secret{
-					Name: "param-secret",
-					Key:  "secret",
-				},
-			},
-			{
-				Name: "secret_nothere",
-				SecretRef: &v1alpha1.Secret{
-					Name: "param-secret-not-present",
-					Key:  "unknowsecret",
-				},
-			},
-		},
-	}
-	topts.TargetRefName = names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test")
-	topts.TargetNS = topts.TargetRefName
-
-	ctx := context.Background()
-	topts.ParamsRun, topts.Opts, topts.GiteaCNX, _ = tgitea.Setup(ctx)
-	assert.NilError(t, topts.ParamsRun.Clients.NewClients(ctx, &topts.ParamsRun.Info))
-	assert.NilError(t, pacrepo.CreateNS(ctx, topts.TargetNS, topts.ParamsRun))
-	assert.NilError(t, secret.Create(ctx, topts.ParamsRun, map[string]string{"secret": "SHHHHHHH"}, topts.TargetNS,
-		"param-secret"))
-
-	defer tgitea.TestPR(t, topts)()
-
-	repo, err := topts.ParamsRun.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(topts.TargetNS).Get(context.Background(), topts.TargetNS, metav1.GetOptions{})
-	assert.NilError(t, err)
-
-	// Checking repo status length to avoid index out of range [0] with length 0 issue
-	assert.Assert(t, len(repo.Status) != 0)
-	assert.NilError(t,
-		twait.RegexpMatchingInPodLog(context.Background(),
-			topts.ParamsRun,
-			topts.TargetNS,
-			fmt.Sprintf("tekton.dev/pipelineRun=%s,tekton.dev/pipelineTask=params",
-				repo.Status[0].PipelineRunName),
-			"step-test-params-value", *regexp.MustCompile(
-				"I am the most Kawaī params\nSHHHHHHH\nFollow me on my ig #nofilter\n{{ no_match }}\nHey I show up from a payload match\n{{ secret_nothere }}"), 2))
-}
-
-func TestGiteaParamsOnRepoCRWithCustomConsole(t *testing.T) {
-	t.Skip("Skipping test changing the global config map for now")
-	ctx := context.Background()
-	topts := &tgitea.TestOpts{
-		CheckForStatus:  "success",
-		SkipEventsCheck: true,
-		TargetEvent:     options.PullRequestEvent,
-		YAMLFiles: map[string]string{
-			".tekton/pr.yaml": "testdata/params.yaml",
-		},
-		RepoCRParams: &[]v1alpha1.Params{
-			{
-				Name:  "custom",
-				Value: "myconsole",
-			},
-		},
-		StatusOnlyLatest: true,
-	}
-	topts.TargetRefName = names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test")
-	topts.TargetNS = topts.TargetRefName
-	topts.ParamsRun, topts.Opts, topts.GiteaCNX, _ = tgitea.Setup(ctx)
-	assert.NilError(t, topts.ParamsRun.Clients.NewClients(ctx, &topts.ParamsRun.Info))
-	assert.NilError(t, pacrepo.CreateNS(ctx, topts.TargetNS, topts.ParamsRun))
-
-	cfgMapData := map[string]string{
-		"custom-console-name":           "Custom Console",
-		"custom-console-url":            "https://url",
-		"custom-console-url-pr-details": "https://url/detail/{{ custom }}",
-		"custom-console-url-pr-tasklog": "https://url/log/{{ custom }}",
-		"tekton-dashboard-url":          "",
-	}
-	defer configmap.ChangeGlobalConfig(ctx, t, topts.ParamsRun, cfgMapData)()
-	defer tgitea.TestPR(t, topts)()
-	// topts.Regexp = regexp.MustCompile(`(?m).*Custom Console.*https://url/detail/myconsole.*https://url/log/myconsole`)
-	topts.Regexp = regexp.MustCompile(`(?m).*Custom Console.*https://url/detail/myconsole`)
-	tgitea.WaitForPullRequestCommentMatch(t, topts)
-	topts.Regexp = regexp.MustCompile(`(?m).*https://url/log/myconsole`)
-	tgitea.WaitForPullRequestCommentMatch(t, topts)
-}
 
 func TestGiteaProvenance(t *testing.T) {
 	topts := &tgitea.TestOpts{
@@ -850,54 +734,6 @@ func TestGiteaClusterTasks(t *testing.T) {
 
 	topts.CheckForStatus = "success"
 	tgitea.WaitForStatus(t, topts, topts.TargetRefName, "", true)
-}
-
-func TestGiteaStandardParamsCheckForPushAndPullEvent(t *testing.T) {
-	var (
-		repoURL      string
-		sourceURL    string
-		sourceBranch string
-		targetBranch string
-	)
-	topts := &tgitea.TestOpts{
-		Regexp:      successRegexp,
-		TargetEvent: "pull_request, push",
-		YAMLFiles: map[string]string{
-			".tekton/pr.yaml": "testdata/pipelinerun-standard-params-display.yaml",
-		},
-		CheckForStatus: "success",
-		ExpectEvents:   false,
-	}
-	defer tgitea.TestPR(t, topts)()
-	merged, resp, err := topts.GiteaCNX.Client.MergePullRequest(topts.Opts.Organization, topts.Opts.Repo, topts.PullRequest.Index,
-		gitea.MergePullRequestOption{
-			Title: "Merged with Panache",
-			Style: "merge",
-		},
-	)
-	assert.NilError(t, err)
-	assert.Assert(t, resp.StatusCode < 400, resp)
-	assert.Assert(t, merged)
-	tgitea.WaitForStatus(t, topts, topts.PullRequest.Head.Sha, "", false)
-	time.Sleep(5 * time.Second)
-
-	// get standard parameter info for pull_request
-	_, _, sourceBranch, targetBranch = tgitea.GetStandardParams(t, topts, "pull_request")
-	// sourceBranch and targetBranch are different for pull_request
-	if sourceBranch == targetBranch {
-		assert.Error(t, fmt.Errorf(`source_branch %s is same as target_branch %s for pull_request`, sourceBranch, targetBranch), fmt.Sprintf(`source_branch %s should be different from target_branch %s for pull_request`, sourceBranch, targetBranch))
-	}
-
-	// get standard parameter info for push
-	repoURL, sourceURL, sourceBranch, targetBranch = tgitea.GetStandardParams(t, topts, "push")
-	// sourceBranch and targetBranch are same for push
-	if sourceBranch != targetBranch {
-		assert.Error(t, fmt.Errorf(`source_branch %s is different from target_branch %s for push`, sourceBranch, targetBranch), fmt.Sprintf(`source_branch %s is same as target_branch %s for push`, sourceBranch, targetBranch))
-	}
-	// sourceURL and repoURL are same for push
-	if repoURL != sourceURL {
-		assert.Error(t, fmt.Errorf(`source_url %s is different from repo_url %s for push`, repoURL, sourceURL), fmt.Sprintf(`source_url %s is same as repo_url %s for push`, repoURL, sourceURL))
-	}
 }
 
 // Local Variables:

--- a/test/pkg/gitea/test.go
+++ b/test/pkg/gitea/test.go
@@ -379,8 +379,11 @@ func GetStandardParams(t *testing.T, topts *TestOpts, eventType string) (repoURL
 		prs.Items[0].Name), "step-test-standard-params-value")
 	assert.NilError(t, err)
 	assert.Assert(t, out != "")
-
+	out = strings.TrimSpace(out)
 	outputDataForPR := strings.Split(out, "--")
+	if len(outputDataForPR) != 5 {
+		t.Fatalf("expected 5 values in outputDataForPR, got %d: %v", len(outputDataForPR), outputDataForPR)
+	}
 
 	repoURL = outputDataForPR[0]
 	sourceURL = strings.TrimPrefix(outputDataForPR[1], "\n")

--- a/test/testdata/pipelinerun-cel-params-pullrequest.yaml
+++ b/test/testdata/pipelinerun-cel-params-pullrequest.yaml
@@ -5,8 +5,11 @@ metadata:
   name: "\\ .PipelineName //"
   annotations:
     pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
-    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
-    pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      target_branch == "\\ .TargetBranch //" &&
+        event == "\\ .TargetEvent //" &&
+        body.pull_request.user.login == "pac" &&
+        headers['x-gitea-event-type'] == 'pull_request'
 spec:
   params:
     - name: repo_url
@@ -24,7 +27,7 @@ spec:
       - name: source_branch
       - name: target_branch
     tasks:
-      - name: cel-params
+      - name: cel-pullrequest-params
         taskSpec:
           steps:
             - name: test-cel-params-value

--- a/test/testdata/pipelinerun-cel-params-push.yaml
+++ b/test/testdata/pipelinerun-cel-params-push.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: "\\ .PipelineName //"
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      target_branch == "\\ .TargetBranch //" &&
+        headers['x-gitea-event-type'] == 'push'
+spec:
+  params:
+    - name: repo_url
+      value: "{{ repo_url }}"
+    - name: source_url
+      value: "{{ source_url }}"
+    - name: source_branch
+      value: "{{ source_branch }}"
+    - name: target_branch
+      value: "{{ target_branch }}"
+  pipelineSpec:
+    params:
+      - name: repo_url
+      - name: source_url
+      - name: source_branch
+      - name: target_branch
+    tasks:
+      - name: cel-push-params
+        taskSpec:
+          steps:
+            - name: test-cel-params-value
+              image: registry.access.redhat.com/ubi9/ubi-micro
+              script: |
+                # reply Should be:
+                # Look mum I know that we are acting on a push
+                # my email is a true beauty and you can call me pacman
+                cat <<EOF
+                Look mum I know that we are acting on a {{ headers['X-Gitea-Event-Type'] }}
+                my email is a {{ body.sender.email == 'pac@pac.com' }} beauty and you can call me {{ body.sender.username }}man
+                EOF

--- a/test/testdata/pipelinerun-cel-params.yaml
+++ b/test/testdata/pipelinerun-cel-params.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: "\\ .PipelineName //"
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
+    pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
+spec:
+  params:
+    - name: repo_url
+      value: "{{ repo_url }}"
+    - name: source_url
+      value: "{{ source_url }}"
+    - name: source_branch
+      value: "{{ source_branch }}"
+    - name: target_branch
+      value: "{{ target_branch }}"
+  pipelineSpec:
+    params:
+      - name: repo_url
+      - name: source_url
+      - name: source_branch
+      - name: target_branch
+    tasks:
+      - name: cel-params
+        taskSpec:
+          steps:
+            - name: test-cel-params-value
+              image: registry.access.redhat.com/ubi9/ubi-micro
+              script: |
+                # reply Should be:
+                # Look mum I know that we are acting on a pull_request
+                # my email is a true beauty and like groot, I AM pac
+                cat <<EOF
+                Look mum I know that we are acting on a {{ headers['X-Gitea-Event-Type'] }}
+                my email is a {{ body.pull_request.user.email == 'pac@pac.com' }} beauty and like groot, I AM {{ body.pull_request.user.login }}
+                EOF


### PR DESCRIPTION
We are now able to access the full body and headers from the template variable and CEL filtering as CEL expression.

This allow to output  or filter anything GitHub or others send you in your PipelineRun

See doc for more details

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 A good commit message is important for other reviewers to understand the context of your change. Please refer to [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for more details how to write beautiful commit messages. We rather have the commit message in the PR body and the commit message instead of an external website.
- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
