### PR TITLE
Remove  gitea-sdk 0.15.1 pinned dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,6 @@ require (
 )
 
 replace (
-	code.gitea.io/sdk/gitea => code.gitea.io/sdk/gitea v0.15.1-0.20230509035020-970776d1c1e9
 	k8s.io/api => k8s.io/api v0.25.9
 	k8s.io/apimachinery => k8s.io/apimachinery v0.26.5
 	k8s.io/client-go => k8s.io/client-go v0.25.9
@@ -142,7 +141,7 @@ require (
 	google.golang.org/api v0.147.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/grpc v1.58.3 // indirect
-	google.golang.org/protobuf v1.31.0 // indirect
+	google.golang.org/protobuf v1.31.0
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/apiextensions-apiserver v0.28.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -594,8 +594,8 @@ cloud.google.com/go/workflows v1.7.0/go.mod h1:JhSrZuVZWuiDfKEFxU0/F1PQjmpnpcoIS
 cloud.google.com/go/workflows v1.8.0/go.mod h1:ysGhmEajwZxGn1OhGOGKsTXc5PyxOc0vfKf5Af+to4M=
 cloud.google.com/go/workflows v1.9.0/go.mod h1:ZGkj1aFIOd9c8Gerkjjq7OW7I5+l6cSvT3ujaO/WwSA=
 cloud.google.com/go/workflows v1.10.0/go.mod h1:fZ8LmRmZQWacon9UCX1r/g/DfAXx5VcPALq2CxzdePw=
-code.gitea.io/sdk/gitea v0.15.1-0.20230509035020-970776d1c1e9 h1:ZF0njUGyWjjJPEM7kmX4Bj8DJSElLGUHILutTVwOpQE=
-code.gitea.io/sdk/gitea v0.15.1-0.20230509035020-970776d1c1e9/go.mod h1:ndkDk99BnfiUCCYEUhpNzi0lpmApXlwRFqClBlOlEBg=
+code.gitea.io/sdk/gitea v0.16.0 h1:gAfssETO1Hv9QbE+/nhWu7EjoFQYKt6kPoyDytQgw00=
+code.gitea.io/sdk/gitea v0.16.0/go.mod h1:ndkDk99BnfiUCCYEUhpNzi0lpmApXlwRFqClBlOlEBg=
 contrib.go.opencensus.io/exporter/ocagent v0.7.1-0.20200907061046-05415f1de66d h1:LblfooH1lKOpp1hIhukktmSAxFkqMPFk9KR6iZ0MJNI=
 contrib.go.opencensus.io/exporter/ocagent v0.7.1-0.20200907061046-05415f1de66d/go.mod h1:IshRmMJBhDfFj5Y67nVhMYTTIze91RUeT73ipWKs/GY=
 contrib.go.opencensus.io/exporter/prometheus v0.4.2 h1:sqfsYl5GIY/L570iT+l93ehxaWJs2/OwXtiWwew3oAg=

--- a/vendor/code.gitea.io/sdk/gitea/oauth2.go
+++ b/vendor/code.gitea.io/sdk/gitea/oauth2.go
@@ -13,12 +13,13 @@ import (
 
 // Oauth2 represents an Oauth2 Application
 type Oauth2 struct {
-	ID           int64     `json:"id"`
-	Name         string    `json:"name"`
-	ClientID     string    `json:"client_id"`
-	ClientSecret string    `json:"client_secret"`
-	RedirectURIs []string  `json:"redirect_uris"`
-	Created      time.Time `json:"created"`
+	ID                 int64     `json:"id"`
+	Name               string    `json:"name"`
+	ClientID           string    `json:"client_id"`
+	ClientSecret       string    `json:"client_secret"`
+	RedirectURIs       []string  `json:"redirect_uris"`
+	ConfidentialClient bool      `json:"confidential_client"`
+	Created            time.Time `json:"created"`
 }
 
 // ListOauth2Option for listing Oauth2 Applications
@@ -29,8 +30,8 @@ type ListOauth2Option struct {
 // CreateOauth2Option required options for creating an Application
 type CreateOauth2Option struct {
 	Name               string   `json:"name"`
-	RedirectURIs       []string `json:"redirect_uris"`
 	ConfidentialClient bool     `json:"confidential_client"`
+	RedirectURIs       []string `json:"redirect_uris"`
 }
 
 // CreateOauth2 create an Oauth2 Application and returns a completed Oauth2 object.

--- a/vendor/code.gitea.io/sdk/gitea/org_action.go
+++ b/vendor/code.gitea.io/sdk/gitea/org_action.go
@@ -1,0 +1,29 @@
+// Copyright 2023 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package gitea
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// ListOrgMembershipOption list OrgMembership options
+type ListOrgActionSecretOption struct {
+	ListOptions
+}
+
+// ListOrgMembership list an organization's members
+func (c *Client) ListOrgActionSecret(org string, opt ListOrgActionSecretOption) ([]*Secret, *Response, error) {
+	if err := escapeValidatePathSegments(&org); err != nil {
+		return nil, nil, err
+	}
+	opt.setDefaults()
+	secrets := make([]*Secret, 0, opt.PageSize)
+
+	link, _ := url.Parse(fmt.Sprintf("/orgs/%s/actions/secrets", org))
+	link.RawQuery = opt.getURLQuery().Encode()
+	resp, err := c.getParsedResponse("GET", link.String(), jsonHeader, nil, &secrets)
+	return secrets, resp, err
+}

--- a/vendor/code.gitea.io/sdk/gitea/org_team.go
+++ b/vendor/code.gitea.io/sdk/gitea/org_team.go
@@ -43,6 +43,8 @@ const (
 	RepoUnitReleases RepoUnitType = "repo.releases"
 	// RepoUnitProjects represent projects of a repository
 	RepoUnitProjects RepoUnitType = "repo.projects"
+	// RepoUnitPackages represents packages of a repository
+	RepoUnitPackages RepoUnitType = "repo.packages"
 )
 
 // ListTeamsOptions options for listing teams

--- a/vendor/code.gitea.io/sdk/gitea/package.go
+++ b/vendor/code.gitea.io/sdk/gitea/package.go
@@ -1,0 +1,93 @@
+// Copyright 2023 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package gitea
+
+import (
+	"fmt"
+	"time"
+)
+
+// Package represents a package
+type Package struct {
+	// the package's id
+	ID int64 `json:"id"`
+	// the package's owner
+	Owner User `json:"owner"`
+	// the repo this package belongs to (if any)
+	Repository *string `json:"repository"`
+	// the package's creator
+	Creator User `json:"creator"`
+	// the type of package:
+	Type string `json:"type"`
+	// the name of the package
+	Name string `json:"name"`
+	// the version of the package
+	Version string `json:"version"`
+	// the date the package was uploaded
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// PackageFile represents a file from a package
+type PackageFile struct {
+	// the file's ID
+	ID int64 `json:"id"`
+	// the size of the file in bytes
+	Size int64 `json:"size"`
+	// the name of the file
+	Name string `json:"name"`
+	// the md5 hash of the file
+	MD5 string `json:"md5"`
+	// the sha1 hash of the file
+	SHA1 string `json:"sha1"`
+	// the sha256 hash of the file
+	SHA256 string `json:"sha256"`
+	// the sha512 hash of the file
+	SHA512 string `json:"sha512"`
+}
+
+// ListPackagesOptions options for listing packages
+type ListPackagesOptions struct {
+	ListOptions
+}
+
+// ListPackages lists all the packages owned by a given owner (user, organisation)
+func (c *Client) ListPackages(owner string, opt ListPackagesOptions) ([]*Package, *Response, error) {
+	if err := escapeValidatePathSegments(&owner); err != nil {
+		return nil, nil, err
+	}
+	opt.setDefaults()
+	packages := make([]*Package, 0, opt.PageSize)
+	resp, err := c.getParsedResponse("GET", fmt.Sprintf("/packages/%s?%s", owner, opt.getURLQuery().Encode()), nil, nil, &packages)
+	return packages, resp, err
+}
+
+// GetPackage gets the details of a specific package version
+func (c *Client) GetPackage(owner, packageType, name, version string) (*Package, *Response, error) {
+	if err := escapeValidatePathSegments(&owner, &packageType, &name, &version); err != nil {
+		return nil, nil, err
+	}
+	foundPackage := new(Package)
+	resp, err := c.getParsedResponse("GET", fmt.Sprintf("/packages/%s/%s/%s/%s", owner, packageType, name, version), nil, nil, foundPackage)
+	return foundPackage, resp, err
+}
+
+// DeletePackage deletes a specific package version
+func (c *Client) DeletePackage(owner, packageType, name, version string) (*Response, error) {
+	if err := escapeValidatePathSegments(&owner, &packageType, &name, &version); err != nil {
+		return nil, err
+	}
+	_, resp, err := c.getResponse("DELETE", fmt.Sprintf("/packages/%s/%s/%s/%s", owner, packageType, name, version), nil, nil)
+	return resp, err
+}
+
+// ListPackageFiles lists the files within a package
+func (c *Client) ListPackageFiles(owner, packageType, name, version string) ([]*PackageFile, *Response, error) {
+	if err := escapeValidatePathSegments(&owner, &packageType, &name, &version); err != nil {
+		return nil, nil, err
+	}
+	packageFiles := make([]*PackageFile, 0)
+	resp, err := c.getParsedResponse("GET", fmt.Sprintf("/packages/%s/%s/%s/%s/files", owner, packageType, name, version), nil, nil, &packageFiles)
+	return packageFiles, resp, err
+}

--- a/vendor/code.gitea.io/sdk/gitea/pull.go
+++ b/vendor/code.gitea.io/sdk/gitea/pull.go
@@ -231,6 +231,8 @@ type MergePullRequestOption struct {
 	Message                string     `json:"MergeMessageField"`
 	DeleteBranchAfterMerge bool       `json:"delete_branch_after_merge"`
 	ForceMerge             bool       `json:"force_merge"`
+	HeadCommitId           string     `json:"head_commit_id"`
+	MergeWhenChecksSucceed bool       `json:"merge_when_checks_succeed"`
 }
 
 // Validate the MergePullRequestOption struct

--- a/vendor/code.gitea.io/sdk/gitea/repo_branch_protection.go
+++ b/vendor/code.gitea.io/sdk/gitea/repo_branch_protection.go
@@ -15,6 +15,7 @@ import (
 // BranchProtection represents a branch protection for a repository
 type BranchProtection struct {
 	BranchName                    string    `json:"branch_name"`
+	RuleName                      string    `json:"rule_name"`
 	EnablePush                    bool      `json:"enable_push"`
 	EnablePushWhitelist           bool      `json:"enable_push_whitelist"`
 	PushWhitelistUsernames        []string  `json:"push_whitelist_usernames"`
@@ -35,6 +36,7 @@ type BranchProtection struct {
 	DismissStaleApprovals         bool      `json:"dismiss_stale_approvals"`
 	RequireSignedCommits          bool      `json:"require_signed_commits"`
 	ProtectedFilePatterns         string    `json:"protected_file_patterns"`
+	UnprotectedFilePatterns       string    `json:"unprotected_file_patterns"`
 	Created                       time.Time `json:"created_at"`
 	Updated                       time.Time `json:"updated_at"`
 }
@@ -42,6 +44,7 @@ type BranchProtection struct {
 // CreateBranchProtectionOption options for creating a branch protection
 type CreateBranchProtectionOption struct {
 	BranchName                    string   `json:"branch_name"`
+	RuleName                      string   `json:"rule_name"`
 	EnablePush                    bool     `json:"enable_push"`
 	EnablePushWhitelist           bool     `json:"enable_push_whitelist"`
 	PushWhitelistUsernames        []string `json:"push_whitelist_usernames"`
@@ -62,6 +65,7 @@ type CreateBranchProtectionOption struct {
 	DismissStaleApprovals         bool     `json:"dismiss_stale_approvals"`
 	RequireSignedCommits          bool     `json:"require_signed_commits"`
 	ProtectedFilePatterns         string   `json:"protected_file_patterns"`
+	UnprotectedFilePatterns       string   `json:"unprotected_file_patterns"`
 }
 
 // EditBranchProtectionOption options for editing a branch protection
@@ -86,6 +90,7 @@ type EditBranchProtectionOption struct {
 	DismissStaleApprovals         *bool    `json:"dismiss_stale_approvals"`
 	RequireSignedCommits          *bool    `json:"require_signed_commits"`
 	ProtectedFilePatterns         *string  `json:"protected_file_patterns"`
+	UnprotectedFilePatterns       *string  `json:"unprotected_file_patterns"`
 }
 
 // ListBranchProtectionsOptions list branch protection options

--- a/vendor/code.gitea.io/sdk/gitea/secret.go
+++ b/vendor/code.gitea.io/sdk/gitea/secret.go
@@ -1,0 +1,14 @@
+// Copyright 2023 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package gitea
+
+import "time"
+
+type Secret struct {
+	// the secret's name
+	Name string `json:"name"`
+	// Date and Time of secret creation
+	Created time.Time `json:"created_at"`
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# code.gitea.io/sdk/gitea v0.16.0 => code.gitea.io/sdk/gitea v0.15.1-0.20230509035020-970776d1c1e9
+# code.gitea.io/sdk/gitea v0.16.0
 ## explicit; go 1.13
 code.gitea.io/sdk/gitea
 # contrib.go.opencensus.io/exporter/ocagent v0.7.1-0.20200907061046-05415f1de66d
@@ -1177,7 +1177,6 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# code.gitea.io/sdk/gitea => code.gitea.io/sdk/gitea v0.15.1-0.20230509035020-970776d1c1e9
 # k8s.io/api => k8s.io/api v0.25.9
 # k8s.io/apimachinery => k8s.io/apimachinery v0.26.5
 # k8s.io/client-go => k8s.io/client-go v0.25.9


### PR DESCRIPTION
We were pinning dependency to a particular commit of the gitea-sdk, since we now have a 0.16.0 release we can remove this pin.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 A good commit message is important for other reviewers to understand the context of your change. Please refer to [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for more details how to write beautiful commit messages. We rather have the commit message in the PR body and the commit message instead of an external website.
- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
