### PR TITLE
Fix using gitclone clustertask when detected avail

### DIFF
--- a/pkg/cmd/tknpac/create/testdata/TestGenerateTemplate.golden
+++ b/pkg/cmd/tknpac/create/testdata/TestGenerateTemplate.golden
@@ -45,7 +45,6 @@ spec:
       - name: fetch-repository
         taskRef:
           name: git-clone
-          kind: ClusterTask
         workspaces:
           - name: output
             workspace: source

--- a/pkg/cmd/tknpac/generate/generate.go
+++ b/pkg/cmd/tknpac/generate/generate.go
@@ -62,17 +62,20 @@ func Command(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
 			gopt.CLIOpts = cli.NewCliOptions()
 			gopt.IOStreams.SetColorEnabled(!gopt.CLIOpts.NoColoring)
 
-			if !gopt.generateWithClusterTask {
+			if gopt.generateWithClusterTask {
 				if err := run.Clients.NewClients(ctx, &run.Info); err != nil {
 					// if we don't have access to the cluster we can't do much about it
 					gopt.generateWithClusterTask = false
 				} else {
 					// NOTE(chmou): This is for v1beta1, we need to figure out how to do this for v1.
 					// Trying to find resolver with that same name?
-					_, err := run.Clients.Tekton.TektonV1beta1().ClusterTasks().Get(ctx, gitCloneClusterTaskName,
+					_, err := run.Clients.Tekton.TektonV1beta1().ClusterTasks().Get(ctx,
+						gitCloneClusterTaskName,
 						metav1.GetOptions{})
 					if err == nil {
 						gopt.generateWithClusterTask = true
+					} else {
+						gopt.generateWithClusterTask = false
 					}
 				}
 			}
@@ -99,8 +102,8 @@ func Command(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
 		"Whether to overwrite the file if it exist")
 	cmd.PersistentFlags().StringVarP(&gopt.language, "language", "l", "",
 		"Generate for this programming language")
-	cmd.PersistentFlags().BoolVarP(&gopt.generateWithClusterTask, "use-clustertasks", "", false,
-		"By default we will generate the pipeline using task from hub. If you want to use cluster tasks, set this flag")
+	cmd.PersistentFlags().BoolVarP(&gopt.generateWithClusterTask, "use-clustertasks", "", true,
+		"By default we try to use the clustertasks unless not available")
 	return cmd
 }
 

--- a/pkg/cmd/tknpac/generate/template.go
+++ b/pkg/cmd/tknpac/generate/template.go
@@ -94,5 +94,10 @@ func (o *Opts) genTmpl() (*bytes.Buffer, error) {
 	tmplB = bytes.ReplaceAll(tmplB, []byte(fmt.Sprintf("name: pipelinerun-%s", lang)),
 		[]byte(fmt.Sprintf("name: %s", prName)))
 
+	if o.generateWithClusterTask {
+		tmplB = bytes.ReplaceAll(tmplB, []byte(fmt.Sprintf("name: %s", gitCloneClusterTaskName)),
+			[]byte(fmt.Sprintf("name: %s\n          kind: ClusterTask", gitCloneClusterTaskName)))
+	}
+
 	return bytes.NewBuffer(tmplB), nil
 }

--- a/pkg/cmd/tknpac/generate/templates/generic.yaml
+++ b/pkg/cmd/tknpac/generate/templates/generic.yaml
@@ -45,7 +45,6 @@ spec:
       - name: fetch-repository
         taskRef:
           name: git-clone
-          kind: ClusterTask
         workspaces:
           - name: output
             workspace: source


### PR DESCRIPTION
We now detect cluster task by default (unless user set it to false) for the git-clone if available we use it. If not we use the hub task.

We cannot use templates in here because the console consumes those directly (which sucks).

We could have a post job generating all templates in release/nightly like we do for release.yaml and have the console uses it maybe but that's for another day.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 A good commit message is important for other reviewers to understand the context of your change. Please refer to [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for more details how to write beautiful commit messages. We rather have the commit message in the PR body and the commit message instead of an external website.
- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
