### PR TITLE
Images updates, pre-commit updates and use ruff in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ default_install_hook_types: ["pre-push"]
 exclude: '(^docs/themes/hugo-book|^vendor|.*golden$|^\.vale)'
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
+  rev: v4.5.0
   hooks:
   - id: check-added-large-files
   - id: check-toml
@@ -18,7 +18,7 @@ repos:
   hooks:
     - id: gitlint
 - repo: https://github.com/codespell-project/codespell
-  rev: v2.2.4
+  rev: v2.2.6
   hooks:
   - id: codespell
     files: '^(docs/content|pkg|test)/.*'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,10 @@ repos:
   hooks:
   - id: codespell
     files: '^(docs/content|pkg|test)/.*'
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.1.2
+  hooks:
+    - id: ruff
 - repo: local
   hooks:
   - id: black
@@ -29,12 +33,6 @@ repos:
     language: system
     entry: black
     name: "Python check code Formatter"
-  - id: pylint
-    name: "Python linter"
-    entry: pylint
-    language: system
-    types: [python]
-    args: ["-rn", "-sn"]
   - id: lint-markdown
     name: "Lint Markdown"
     entry: make

--- a/.tekton/e2e-tests.yaml
+++ b/.tekton/e2e-tests.yaml
@@ -41,7 +41,7 @@ spec:
           workspaces:
             - name: source
           steps:
-            - image: registry.access.redhat.com/ubi9/go-toolset@sha256:d55ff49e9b6907d5f50290f8bcffa15657470da009a5f982202780c4122ce2dd
+            - image: registry.access.redhat.com/ubi9/go-toolset@sha256:82d9bc5d3ceb43635288880f26207201e55d1c688a60ebbfff4f54d4963a62a1
               env:
                 - name: GOCACHE
                   value: $(workspaces.source.path)/go-build-cache/cache

--- a/.tekton/generate-coverage-release.yaml
+++ b/.tekton/generate-coverage-release.yaml
@@ -41,7 +41,7 @@ spec:
           workspaces:
             - name: source
           steps:
-            - image: registry.access.redhat.com/ubi9/go-toolset@sha256:d55ff49e9b6907d5f50290f8bcffa15657470da009a5f982202780c4122ce2dd
+            - image: registry.access.redhat.com/ubi9/go-toolset@sha256:82d9bc5d3ceb43635288880f26207201e55d1c688a60ebbfff4f54d4963a62a1
               name: get-cache
               workingDir: $(workspaces.source.path)
               env:
@@ -64,7 +64,7 @@ spec:
                 curl http://uploader:8080/golang-cache.tar.gz|tar -z -x -f- || \
                    curl -X DELETE -F "file=golang-cache.tar.gz" http://uploader:8080/upload
             - name: unittest
-              image: registry.access.redhat.com/ubi9/go-toolset@sha256:d55ff49e9b6907d5f50290f8bcffa15657470da009a5f982202780c4122ce2dd
+              image: registry.access.redhat.com/ubi9/go-toolset@sha256:82d9bc5d3ceb43635288880f26207201e55d1c688a60ebbfff4f54d4963a62a1
               workingDir: $(workspaces.source.path)
               env:
                 - name: GOCACHE
@@ -87,7 +87,7 @@ spec:
           steps:
             - name: codecov-run
               # Has everything we need in there and we already fetched it!
-              image: registry.access.redhat.com/ubi9/go-toolset@sha256:d55ff49e9b6907d5f50290f8bcffa15657470da009a5f982202780c4122ce2dd
+              image: registry.access.redhat.com/ubi9/go-toolset@sha256:82d9bc5d3ceb43635288880f26207201e55d1c688a60ebbfff4f54d4963a62a1
               workingDir: $(workspaces.source.path)
               env:
                 - name: CODECOV_TOKEN

--- a/.tekton/go.yaml
+++ b/.tekton/go.yaml
@@ -38,7 +38,7 @@ spec:
           workspaces:
             - name: source
           steps:
-            - image: registry.access.redhat.com/ubi9/go-toolset@sha256:d55ff49e9b6907d5f50290f8bcffa15657470da009a5f982202780c4122ce2dd
+            - image: registry.access.redhat.com/ubi9/go-toolset@sha256:82d9bc5d3ceb43635288880f26207201e55d1c688a60ebbfff4f54d4963a62a1
               env:
                 - name: GOCACHE
                   value: $(workspaces.source.path)/go-build-cache/cache
@@ -72,7 +72,7 @@ spec:
             - name: unittest
               # we get bumped out when usingh the official image with docker.io
               # ratelimit so workaround this.
-              image: registry.access.redhat.com/ubi9/go-toolset@sha256:d55ff49e9b6907d5f50290f8bcffa15657470da009a5f982202780c4122ce2dd
+              image: registry.access.redhat.com/ubi9/go-toolset@sha256:82d9bc5d3ceb43635288880f26207201e55d1c688a60ebbfff4f54d4963a62a1
               env:
                 - name: GOCACHE
                   value: $(workspaces.source.path)/go-build-cache/cache
@@ -89,7 +89,7 @@ spec:
             - name: coverage
               # we get bumped out when usingh the official image with docker.io
               # ratelimit so workaround this.
-              image: registry.access.redhat.com/ubi9/go-toolset@sha256:d55ff49e9b6907d5f50290f8bcffa15657470da009a5f982202780c4122ce2dd
+              image: registry.access.redhat.com/ubi9/go-toolset@sha256:82d9bc5d3ceb43635288880f26207201e55d1c688a60ebbfff4f54d4963a62a1
               env:
                 - name: CODECOV_TOKEN
                   valueFrom:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset@sha256:a2bdd33c7fc0cda56eb3745e80820c1ee29efeaac720f7c52a59224a39003261 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:82d9bc5d3ceb43635288880f26207201e55d1c688a60ebbfff4f54d4963a62a1 AS builder
 
 ARG BINARY_NAME=pipelines-as-code-controller
 COPY . /src


### PR DESCRIPTION
# Changes

* Update container images SHA256 to the latest
  Using https://github.com/chmouel/waashup to update the containers to the
  latest container image

* pre-commit rule update
   Updating all pre-commit with pre-commit autoupdate.

* Use ruff in pre-commit
  We did move from pylint to ruff for the linter pipelinerun.
  This commit updates the pre-commit to use ruff instead of pylint.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 A good commit message is important for other reviewers to understand the context of your change. Please refer to [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for more details how to write beautiful commit messages. We rather have the commit message in the PR body and the commit message instead of an external website.
- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
