### PR TITLE
[WIP] Add Interceptor service to pipelines-as-code

### DIFF
--- a/pkg/interceptor/interceptor.go
+++ b/pkg/interceptor/interceptor.go
@@ -1,0 +1,135 @@
+package interceptor
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+)
+
+type Data struct {
+	EventType    string `json:"eventType,omitempty"`
+	BaseBranch   string `json:"baseBranch,omitempty"`
+	HeadBranch   string `json:"headBranch,omitempty"`
+	BaseURL      string `json:"baseURL,omitempty"`
+	HeadURL      string `json:"headURL,omitempty"`
+	SHA          string `json:"sha,omitempty"`
+	Organization string `json:"organization,omitempty"`
+	Repository   string `json:"repository,omitempty"`
+	URL          string `json:"URL,omitempty"`
+
+	// GitHub
+	GithubInstallationID int64 `json:"githubInstallationID,omitempty"`
+
+	// GHE
+	GHEURL string `json:"gheURL,omitempty"`
+
+	// Bitbucket Cloud
+	BitBucketAccountID string `json:"bitBucketAccountID,omitempty"`
+
+	// Bitbucket Server
+	BitBucketCloneURL string `json:"bitBucketCloneURL,omitempty"`
+
+	// Gitlab
+	GitlabSourceProjectID int `json:"gitlabSourceProjectID,omitempty"`
+	GitlabTargetProjectID int `json:"gitlabTargetProjectID,omitempty"`
+
+	// scm providers
+	// this info is needed if auto generation is suported for different scm
+	Provider string `json:"provider,omitempty"`
+}
+
+type InterceptorRequest struct {
+	Data  string `json:"data"`
+	Token string `json:"token"`
+}
+
+type InterceptorResponse struct {
+	PipelineRuns string `json:"pipelineruns"`
+}
+
+func GetPipelineRunsFromInterceptorService(ctx context.Context, request *InterceptorRequest, url string) (string, error) {
+	marshalledRequest, err := json.Marshal(request)
+	if err != nil {
+		return "", fmt.Errorf("unable to marshal interceptorRequest struct: %s", err.Error())
+	}
+
+	// Create a HTTP post request
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(marshalledRequest))
+	if err != nil {
+		return "", fmt.Errorf("unable to create http request with url %s : %s", url, err.Error())
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	// create http client
+	// do not forget to set timeout; otherwise, no timeout!
+	client := http.Client{Timeout: 10 * time.Second}
+	// send the request
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("unable to make post http request to url %s : %s", url, err.Error())
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("received response %v ", resp.StatusCode)
+	}
+
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	var interceptorResponse InterceptorResponse
+	if err := json.Unmarshal(body, &interceptorResponse); err != nil {
+		return "", fmt.Errorf("unable to unmarshal the response %s", err.Error())
+	}
+	return interceptorResponse.PipelineRuns, nil
+}
+
+func GetInterceptorRequest(providerType, url string, event *info.Event) (*InterceptorRequest, error) {
+	data := getData(providerType, url, event)
+	encodedData, err := encodeToBase64(data)
+	if err != nil {
+		return nil, err
+	}
+	request := InterceptorRequest{
+		Data:  encodedData,
+		Token: event.Provider.Token,
+	}
+	return &request, nil
+}
+
+func encodeToBase64(v interface{}) (string, error) {
+	var buf bytes.Buffer
+	encoder := base64.NewEncoder(base64.StdEncoding, &buf)
+	err := json.NewEncoder(encoder).Encode(v)
+	if err != nil {
+		return "", err
+	}
+	encoder.Close()
+	return buf.String(), nil
+}
+
+func getData(providerType, url string, event *info.Event) Data {
+	return Data{
+		EventType:             event.EventType,
+		BaseBranch:            event.BaseBranch,
+		HeadBranch:            event.HeadBranch,
+		BaseURL:               event.BaseURL,
+		HeadURL:               event.HeadURL,
+		SHA:                   event.SHA,
+		Organization:          event.Organization,
+		Repository:            event.Repository,
+		GithubInstallationID:  event.InstallationID,
+		GHEURL:                event.GHEURL,
+		BitBucketAccountID:    event.AccountID,
+		BitBucketCloneURL:     event.CloneURL,
+		GitlabSourceProjectID: event.SourceProjectID,
+		GitlabTargetProjectID: event.TargetProjectID,
+		Provider:              providerType,
+		URL:                   url,
+	}
+}

--- a/pkg/kubeinteraction/labels.go
+++ b/pkg/kubeinteraction/labels.go
@@ -79,6 +79,15 @@ func AddLabelsAndAnnotations(event *info.Event, pipelineRun *tektonv1.PipelineRu
 		annotations[keys.TargetProjectID] = strconv.Itoa(event.TargetProjectID)
 	}
 
+	// Don't overwrite the labels if there is some who already exist set by the user in repo
+	if pipelineRun.GetLabels() == nil {
+		pipelineRun.Labels = map[string]string{}
+	}
+	// Don't overwrite the annotation if there is some who already exist set by the user in repo
+	if pipelineRun.GetAnnotations() == nil {
+		pipelineRun.Annotations = map[string]string{}
+	}
+
 	for k, v := range labels {
 		pipelineRun.Labels[k] = v
 	}

--- a/pkg/params/settings/config.go
+++ b/pkg/params/settings/config.go
@@ -57,6 +57,8 @@ const (
 
 	RememberOKToTestKey   = "remember-ok-to-test"
 	rememberOKToTestValue = "true"
+
+	PacInterceptorURLKey = "pac-interceptor-url"
 )
 
 var (
@@ -99,6 +101,8 @@ type Settings struct {
 	CustomConsolePRTaskLog string
 
 	RememberOKToTest bool
+
+	PacInterceptorURL string
 }
 
 func ConfigToSettings(logger *zap.SugaredLogger, setting *Settings, config map[string]string) error {
@@ -235,6 +239,11 @@ func ConfigToSettings(logger *zap.SugaredLogger, setting *Settings, config map[s
 	if setting.RememberOKToTest != rememberOKToTest {
 		logger.Infof("CONFIG: setting remember ok-to-test to %v", rememberOKToTest)
 		setting.RememberOKToTest = rememberOKToTest
+	}
+
+	if setting.PacInterceptorURL != config[PacInterceptorURLKey] {
+		logger.Infof("CONFIG: setting pac interceptor url to %v", config[PacInterceptorURLKey])
+		setting.PacInterceptorURL = config[PacInterceptorURLKey]
 	}
 
 	return nil

--- a/pkg/params/settings/default.go
+++ b/pkg/params/settings/default.go
@@ -135,4 +135,8 @@ func SetDefaults(config map[string]string) {
 	if rememberOKToTest, ok := config[RememberOKToTestKey]; !ok || rememberOKToTest == "" {
 		config[RememberOKToTestKey] = rememberOKToTestValue
 	}
+
+	if v, ok := config[PacInterceptorURLKey]; !ok || v == "" {
+		config[PacInterceptorURLKey] = v
+	}
 }

--- a/pkg/params/settings/validation.go
+++ b/pkg/params/settings/validation.go
@@ -90,6 +90,12 @@ func Validate(config map[string]string) error {
 		}
 	}
 
+	if v, ok := config[PacInterceptorURLKey]; ok && v != "" {
+		if _, err := url.ParseRequestURI(v); err != nil {
+			return fmt.Errorf("invalid value for key %v, invalid url: %w", PacInterceptorURLKey, err)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
The PAC interceptor service will detect programming languages and trigger continuous integration (CI) with default pipelineruns without the need to add a .tekton folder to the project.

This feature helps to begeners to start with Tekton without configuring any additional stuff

This feature is designed to help beginners start with Tekton without having to configure additional stuff.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 A good commit message is important for other reviewers to understand the context of your change. Please refer to [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for more details how to write beautiful commit messages. We rather have the commit message in the PR body and the commit message instead of an external website.
- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
