### PR TITLE
Fix secret cleanup issue

### DIFF
--- a/pkg/kubeinteraction/cleanups.go
+++ b/pkg/kubeinteraction/cleanups.go
@@ -44,9 +44,9 @@ func (k Interaction) CleanupPipelines(ctx context.Context, logger *zap.SugaredLo
 				return err
 			}
 
-			// Try to Delete the secret created for git-clone basic-auth, it should have been created with a owneref on the pipelinerun and due being deleted when the pipelinerun is deleted
-			// but in some cases of conflicts and the ownerRef not being set, the secret is not deleted and we need to delete it manually.
-			if secretName, ok := pr.GetAnnotations()[keys.GitAuthSecret]; ok {
+			// Try to Delete the secret created for git-clone basic-auth, it should have been created with a ownerRef on the pipelinerun and due being deleted when the pipelinerun is deleted
+			// but in some cases of conflicts and the ownerRef not being set, the secret is not deleted, and we need to delete it manually.
+			if secretName, ok := prun.GetAnnotations()[keys.GitAuthSecret]; ok {
 				err = k.Run.Clients.Kube.CoreV1().Secrets(repo.GetNamespace()).Delete(ctx, secretName, metav1.DeleteOptions{})
 				if err == nil {
 					logger.Infof("secret %s attached to pipelinerun %s has been deleted", secretName, prun.GetName())


### PR DESCRIPTION
When max-keep-runs is exceeded, The GitHub basic auth secret for the latest pipelineRun is deleted.

For example, if max-keep-runs is set to 1, kick off a pipelineRun. when it's done, kick off another instance of the same pipelineRun. When the second pipelineRun is done and pac performs a cleanup to delete the first pipelineRun, the deletion is proper for first pipelinerun, but it also deletes the secret associated with the second pipeline run

Signed-off-by: Savita Ashture <sashture@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 A good commit message is important for other reviewers to understand the context of your change. Please refer to [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for more details how to write beautiful commit messages. We rather have the commit message in the PR body and the commit message instead of an external website.
- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
