### PR TITLE
fix(gitlab/webhooks): revision when there are multiple commits

### DIFF
--- a/pkg/provider/gitlab/parse_payload.go
+++ b/pkg/provider/gitlab/parse_payload.go
@@ -57,13 +57,14 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 		processedEvent.SourceProjectID = gitEvent.ObjectAttributes.SourceProjectID
 		processedEvent.TargetProjectID = gitEvent.Project.ID
 	case *gitlab.TagEvent:
+		lastCommitIdx := len(gitEvent.Commits) - 1
 		processedEvent = info.NewEvent()
 		processedEvent.Sender = gitEvent.UserUsername
 		processedEvent.DefaultBranch = gitEvent.Project.DefaultBranch
 		processedEvent.URL = gitEvent.Project.WebURL
-		processedEvent.SHA = gitEvent.Commits[0].ID
-		processedEvent.SHAURL = gitEvent.Commits[0].URL
-		processedEvent.SHATitle = gitEvent.Commits[0].Title
+		processedEvent.SHA = gitEvent.Commits[lastCommitIdx].ID
+		processedEvent.SHAURL = gitEvent.Commits[lastCommitIdx].URL
+		processedEvent.SHATitle = gitEvent.Commits[lastCommitIdx].Title
 		processedEvent.HeadBranch = gitEvent.Ref
 		processedEvent.BaseBranch = gitEvent.Ref
 		processedEvent.HeadURL = gitEvent.Project.WebURL
@@ -80,13 +81,14 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 		if len(gitEvent.Commits) == 0 {
 			return nil, fmt.Errorf("no commits attached to this push event")
 		}
+		lastCommitIdx := len(gitEvent.Commits) - 1
 		processedEvent = info.NewEvent()
 		processedEvent.Sender = gitEvent.UserUsername
 		processedEvent.DefaultBranch = gitEvent.Project.DefaultBranch
 		processedEvent.URL = gitEvent.Project.WebURL
-		processedEvent.SHA = gitEvent.Commits[0].ID
-		processedEvent.SHAURL = gitEvent.Commits[0].URL
-		processedEvent.SHATitle = gitEvent.Commits[0].Title
+		processedEvent.SHA = gitEvent.Commits[lastCommitIdx].ID
+		processedEvent.SHAURL = gitEvent.Commits[lastCommitIdx].URL
+		processedEvent.SHATitle = gitEvent.Commits[lastCommitIdx].Title
 		processedEvent.HeadBranch = gitEvent.Ref
 		processedEvent.BaseBranch = gitEvent.Ref
 		processedEvent.HeadURL = gitEvent.Project.WebURL


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fixes: #1443  issue with webhook providing oldest revision when there are multiple commits as part of the same push / tag event.

# Submitter Checklist

- [x] 📝 A good commit message is important for other reviewers to understand the context of your change. Please refer to [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for more details how to write beautiful commit messages. We rather have the commit message in the PR body and the commit message instead of an external website.
- [x] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
