### PR TITLE
Add a better status message

### DIFF
--- a/docs/content/docs/install/settings.md
+++ b/docs/content/docs/install/settings.md
@@ -250,6 +250,18 @@ A few settings are available to configure this feature:
 
   Set this to the root URL of your custom console. example: `https://mycorp.com`
 
+* `custom-console-url-namespace`
+
+  Set this to the URL where to view the details of the `Namespace`.
+
+  The URL supports all the standard variables as exposed on the Pipelinerun (refer to
+  the documentation on [Authoring PipelineRuns](../authoringprs)) with the added
+  variable:
+
+  * `{{ namespace }}`: The target namespace where the pipelinerun is executed
+
+  example: `https://mycorp.com/ns/{{ namespace }}`
+
 * `custom-console-url-pr-details`
 
   Set this to the URL where to view the details of the `PipelineRun`. This is

--- a/pkg/consoleui/custom.go
+++ b/pkg/consoleui/custom.go
@@ -71,6 +71,20 @@ func (o *CustomConsole) DetailURL(pr *tektonv1.PipelineRun) string {
 	return o.generateURL(o.Info.Pac.CustomConsolePRdetail, nm)
 }
 
+func (o *CustomConsole) NamespaceURL(pr *tektonv1.PipelineRun) string {
+	if o.Info.Pac.CustomConsoleNamespaceURL == "" {
+		return fmt.Sprintf("https://detailurl.setting.%s.is.not.configured", settings.CustomConsoleNamespaceURLKey)
+	}
+	nm := o.params
+	// make sure the map is not nil before setting this up
+	// there is a case where SetParams is not called before DetailURL and this would crash the container
+	if nm == nil {
+		nm = make(map[string]string)
+	}
+	nm["namespace"] = pr.GetNamespace()
+	return o.generateURL(o.Info.Pac.CustomConsoleNamespaceURL, nm)
+}
+
 func (o *CustomConsole) TaskLogURL(pr *tektonv1.PipelineRun, taskRunStatus *tektonv1.PipelineRunTaskRunStatus) string {
 	if o.Info.Pac.CustomConsolePRTaskLog == "" {
 		return fmt.Sprintf("https://tasklogurl.setting.%s.is.not.configured", settings.CustomConsolePRTaskLogKey)

--- a/pkg/consoleui/custom_test.go
+++ b/pkg/consoleui/custom_test.go
@@ -92,16 +92,18 @@ func TestCustomGood(t *testing.T) {
 		Info: &info.Info{
 			Pac: &info.PacOpts{
 				Settings: &settings.Settings{
-					CustomConsoleName:      consoleName,
-					CustomConsoleURL:       consoleURL,
-					CustomConsolePRdetail:  "{{ notthere}}",
-					CustomConsolePRTaskLog: "{{ notthere}}",
+					CustomConsoleName:         consoleName,
+					CustomConsoleURL:          consoleURL,
+					CustomConsolePRdetail:     "{{ notthere}}",
+					CustomConsolePRTaskLog:    "{{ notthere}}",
+					CustomConsoleNamespaceURL: "https://mycorp.console/{{ namespace }}",
 				},
 			},
 		},
 	}
 	assert.Assert(t, strings.Contains(o.DetailURL(pr), consoleURL))
 	assert.Assert(t, strings.Contains(o.TaskLogURL(pr, trStatus), consoleURL))
+	assert.Assert(t, strings.Contains(o.NamespaceURL(pr), "https://mycorp.console/ns"))
 }
 
 func TestCustomBad(t *testing.T) {
@@ -122,4 +124,5 @@ func TestCustomBad(t *testing.T) {
 	assert.Assert(t, strings.Contains(c.URL(), "is.not.configured"))
 	assert.Assert(t, strings.Contains(c.DetailURL(pr), "is.not.configured"))
 	assert.Assert(t, strings.Contains(c.TaskLogURL(pr, nil), "is.not.configured"))
+	assert.Assert(t, strings.Contains(c.NamespaceURL(pr), "is.not.configured"), c.NamespaceURL(pr))
 }

--- a/pkg/consoleui/interface.go
+++ b/pkg/consoleui/interface.go
@@ -13,6 +13,7 @@ const consoleIsnotConfiguredURL = "https://dashboard.is.not.configured"
 type Interface interface {
 	DetailURL(pr *tektonv1.PipelineRun) string
 	TaskLogURL(pr *tektonv1.PipelineRun, taskRunStatusstatus *tektonv1.PipelineRunTaskRunStatus) string
+	NamespaceURL(pr *tektonv1.PipelineRun) string
 	UI(ctx context.Context, kdyn dynamic.Interface) error
 	URL() string
 	GetName() string
@@ -30,6 +31,10 @@ func (f FallBackConsole) DetailURL(_ *tektonv1.PipelineRun) string {
 }
 
 func (f FallBackConsole) TaskLogURL(_ *tektonv1.PipelineRun, _ *tektonv1.PipelineRunTaskRunStatus) string {
+	return consoleIsnotConfiguredURL
+}
+
+func (f FallBackConsole) NamespaceURL(_ *tektonv1.PipelineRun) string {
 	return consoleIsnotConfiguredURL
 }
 

--- a/pkg/consoleui/openshift.go
+++ b/pkg/consoleui/openshift.go
@@ -11,14 +11,15 @@ import (
 )
 
 const (
-	openShiftConsoleNS             = "openshift-console"
-	openShiftConsoleRouteName      = "console"
-	openShiftPipelineDetailViewURL = "https://%s/k8s/ns/%s/tekton.dev~v1beta1~PipelineRun/%s"
-	openShiftPipelineTaskLogURL    = "%s/logs/%s"
-	openShiftRouteGroup            = "route.openshift.io"
-	openShiftRouteVersion          = "v1"
-	openShiftRouteResource         = "routes"
-	openshiftConsoleName           = "OpenShift Console"
+	openShiftConsoleNS                = "openshift-console"
+	openShiftConsoleRouteName         = "console"
+	openShiftPipelineNamespaceViewURL = "https://%s/pipelines/ns/%s/pipeline-runs"
+	openShiftPipelineDetailViewURL    = "https://%s/k8s/ns/%s/tekton.dev~v1beta1~PipelineRun/%s"
+	openShiftPipelineTaskLogURL       = "%s/logs/%s"
+	openShiftRouteGroup               = "route.openshift.io"
+	openShiftRouteVersion             = "v1"
+	openShiftRouteResource            = "routes"
+	openshiftConsoleName              = "OpenShift Console"
 )
 
 type OpenshiftConsole struct {
@@ -42,6 +43,10 @@ func (o *OpenshiftConsole) DetailURL(pr *tektonv1.PipelineRun) string {
 
 func (o *OpenshiftConsole) TaskLogURL(pr *tektonv1.PipelineRun, taskRunStatus *tektonv1.PipelineRunTaskRunStatus) string {
 	return fmt.Sprintf(openShiftPipelineTaskLogURL, o.DetailURL(pr), taskRunStatus.PipelineTaskName)
+}
+
+func (o *OpenshiftConsole) NamespaceURL(pr *tektonv1.PipelineRun) string {
+	return fmt.Sprintf(openShiftPipelineNamespaceViewURL, o.host, pr.GetNamespace())
 }
 
 // UI use dynamic client to get the route of the openshift

--- a/pkg/consoleui/openshift_test.go
+++ b/pkg/consoleui/openshift_test.go
@@ -103,15 +103,16 @@ func TestOpenshiftConsoleUI(t *testing.T) {
 func TestOpenshiftConsoleURLs(t *testing.T) {
 	pr := &tektonv1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "ns",
+			Namespace: "theNS",
 			Name:      "pr",
 		},
 	}
 	trStatus := &tektonv1.PipelineRunTaskRunStatus{
 		PipelineTaskName: "task",
 	}
-	o := OpenshiftConsole{host: "http://fakeconsole"}
-	assert.Assert(t, o.URL() != "")
-	assert.Assert(t, o.DetailURL(pr) != "")
-	assert.Assert(t, o.TaskLogURL(pr, trStatus) != "")
+	o := OpenshiftConsole{host: "fakeconsole"}
+	assert.Equal(t, o.URL(), "https://fakeconsole")
+	assert.Equal(t, o.DetailURL(pr), "https://fakeconsole/k8s/ns/theNS/tekton.dev~v1beta1~PipelineRun/pr")
+	assert.Equal(t, o.TaskLogURL(pr, trStatus), "https://fakeconsole/k8s/ns/theNS/tekton.dev~v1beta1~PipelineRun/pr/logs/task")
+	assert.Equal(t, o.NamespaceURL(pr), "https://fakeconsole/pipelines/ns/theNS/pipeline-runs")
 }

--- a/pkg/consoleui/tektondashboard.go
+++ b/pkg/consoleui/tektondashboard.go
@@ -22,6 +22,10 @@ func (t *TektonDashboard) DetailURL(pr *tektonv1.PipelineRun) string {
 	return fmt.Sprintf("%s/#/namespaces/%s/pipelineruns/%s", t.BaseURL, pr.GetNamespace(), pr.GetName())
 }
 
+func (t *TektonDashboard) NamespaceURL(pr *tektonv1.PipelineRun) string {
+	return fmt.Sprintf("%s/#/namespaces/%s/pipelineruns", t.BaseURL, pr.GetNamespace())
+}
+
 func (t *TektonDashboard) TaskLogURL(pr *tektonv1.PipelineRun, taskRunStatus *tektonv1.PipelineRunTaskRunStatus) string {
 	return fmt.Sprintf("%s?pipelineTask=%s", t.DetailURL(pr), taskRunStatus.PipelineTaskName)
 }

--- a/pkg/formatting/starting.go
+++ b/pkg/formatting/starting.go
@@ -12,18 +12,24 @@ var StartingPipelineRunText string
 //go:embed templates/queuing.go.tmpl
 var QueuingPipelineRunText string
 
+//go:embed templates/pipelinerunstatus.tmpl
+var PipelineRunStatusText string
+
 type MessageTemplate struct {
 	PipelineRunName string
 	Namespace       string
+	NamespaceURL    string
 	ConsoleName     string
 	ConsoleURL      string
 	TknBinary       string
 	TknBinaryURL    string
+	TaskStatus      string
+	FailureSnippet  string
 }
 
-func (mt MessageTemplate) MakeTemplate(msg string) (string, error) {
+func (mt MessageTemplate) MakeTemplate(tmpl string) (string, error) {
 	outputBuffer := bytes.Buffer{}
-	t := template.Must(template.New("Message").Parse(msg))
+	t := template.Must(template.New("Message").Parse(tmpl))
 	data := struct{ Mt MessageTemplate }{Mt: mt}
 	if err := t.Execute(&outputBuffer, data); err != nil {
 		return "", err

--- a/pkg/formatting/starting_test.go
+++ b/pkg/formatting/starting_test.go
@@ -12,6 +12,7 @@ func TestMessageTemplate_MakeTemplate(t *testing.T) {
 		ConsoleURL:      "https://test-console-url.com",
 		TknBinary:       "test-tkn",
 		TknBinaryURL:    "https://test-tkn-url.com",
+		FailureSnippet:  "such a failure",
 	}
 
 	tests := []struct {
@@ -32,6 +33,12 @@ func TestMessageTemplate_MakeTemplate(t *testing.T) {
 			mt:      mt,
 			msg:     "Starting Pipelinerun {{.Mt.PipelineRunName}} in namespace {{.FOOOBAR }}",
 			wantErr: true,
+		},
+		{
+			name: "Failure template",
+			mt:   mt,
+			msg:  "I am {{ .Mt.FailureSnippet }}",
+			want: "I am such a failure",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/formatting/templates/pipelinerunstatus.tmpl
+++ b/pkg/formatting/templates/pipelinerunstatus.tmpl
@@ -1,0 +1,12 @@
+<ul>
+<li><b>Namespace</b>: <a href="{{ .Mt.NamespaceURL }}">{{ .Mt.Namespace }}</a></li>
+<li><b>PipelineRun:</b> <a href="{{ .Mt.ConsoleURL }}">{{ .Mt.PipelineRunName }}</a></li>
+</ul>
+<hr>
+<h4>Task Statuses:</h4>
+{{ .Mt.TaskStatus }}
+{{- if not (eq .Mt.FailureSnippet "")}}
+<hr>
+<h4>Failure snippet:</h4>
+{{ .Mt.FailureSnippet }}
+{{- end }}

--- a/pkg/formatting/templates/starting.go.tmpl
+++ b/pkg/formatting/templates/starting.go.tmpl
@@ -1,5 +1,5 @@
 Starting Pipelinerun <b>{{ .Mt.PipelineRunName }}</b> in namespace<b> {{ .Mt.Namespace }}</b><br>
 You can monitor the execution using the [{{ .Mt.ConsoleName }}]({{ .Mt.ConsoleURL }}) PipelineRun viewer or through the command line by
 using the [{{ .Mt.TknBinary }}]({{ .Mt.TknBinaryURL }}) CLI with the following command:
-<br>
+
 <code>{{ .Mt.TknBinary }} pr logs -n {{ .Mt.Namespace }} {{ .Mt.PipelineRunName }} -f</code>

--- a/pkg/kubeinteraction/status/task_status.go
+++ b/pkg/kubeinteraction/status/task_status.go
@@ -89,8 +89,11 @@ func CollectFailedTasksLogSnippet(ctx context.Context, cs *params.Run, kinteract
 			Message:        reasonMessageReplacementRegexp.ReplaceAllString(task.Status.Conditions[0].Message, ""),
 			CompletionTime: task.Status.CompletionTime,
 			Reason:         task.Status.Conditions[0].Reason,
-			DisplayName:    task.Status.TaskSpec.DisplayName,
 		}
+		if task.Status.TaskSpec != nil {
+			ti.DisplayName = task.Status.TaskSpec.DisplayName
+		}
+		// don't check for pod logs into those
 		if ti.Reason == "TaskRunValidationFailed" || ti.Reason == tektonv1.TaskRunReasonCancelled.String() || ti.Reason == tektonv1.TaskRunReasonTimedOut.String() || ti.Reason == tektonv1.TaskRunReasonImagePullFailed.String() {
 			failureReasons[task.PipelineTaskName] = ti
 			continue

--- a/pkg/params/settings/config.go
+++ b/pkg/params/settings/config.go
@@ -24,10 +24,11 @@ const (
 	AutoConfigureNewGitHubRepoKey         = "auto-configure-new-github-repo"
 	AutoConfigureRepoNamespaceTemplateKey = "auto-configure-repo-namespace-template"
 
-	CustomConsoleNameKey      = "custom-console-name"
-	CustomConsoleURLKey       = "custom-console-url"
-	CustomConsolePRDetailKey  = "custom-console-url-pr-details"
-	CustomConsolePRTaskLogKey = "custom-console-url-pr-tasklog"
+	CustomConsoleNameKey         = "custom-console-name"
+	CustomConsoleURLKey          = "custom-console-url"
+	CustomConsolePRDetailKey     = "custom-console-url-pr-details"
+	CustomConsolePRTaskLogKey    = "custom-console-url-pr-tasklog"
+	CustomConsoleNamespaceURLKey = "custom-console-url-namespace"
 
 	SecretAutoCreateKey                          = "secret-auto-create"
 	secretAutoCreateDefaultValue                 = "true"
@@ -94,10 +95,11 @@ type Settings struct {
 	ErrorDetectionNumberOfLines int
 	ErrorDetectionSimpleRegexp  string
 
-	CustomConsoleName      string
-	CustomConsoleURL       string
-	CustomConsolePRdetail  string
-	CustomConsolePRTaskLog string
+	CustomConsoleName         string
+	CustomConsoleURL          string
+	CustomConsolePRdetail     string
+	CustomConsolePRTaskLog    string
+	CustomConsoleNamespaceURL string
 
 	RememberOKToTest bool
 }
@@ -225,6 +227,11 @@ func ConfigToSettings(logger *zap.SugaredLogger, setting *Settings, config map[s
 	if setting.CustomConsolePRdetail != config[CustomConsolePRDetailKey] {
 		logger.Infof("CONFIG: setting custom console pr detail URL to %v", config[CustomConsolePRDetailKey])
 		setting.CustomConsolePRdetail = config[CustomConsolePRDetailKey]
+	}
+
+	if setting.CustomConsoleNamespaceURL != config[CustomConsoleNamespaceURLKey] {
+		logger.Infof("CONFIG: setting custom console namespace URL to %v", config[CustomConsoleNamespaceURLKey])
+		setting.CustomConsoleNamespaceURL = config[CustomConsoleNamespaceURLKey]
 	}
 
 	if setting.CustomConsolePRTaskLog != config[CustomConsolePRTaskLogKey] {

--- a/pkg/reconciler/testdata/TestReconciler_ReconcileKind-failed_pipelinerun.golden
+++ b/pkg/reconciler/testdata/TestReconciler_ReconcileKind-failed_pipelinerun.golden
@@ -1,0 +1,21 @@
+<ul>
+<li><b>Namespace</b>: <a href="https://dashboard.is.not.configured">ns</a></li>
+<li><b>PipelineRun:</b> <a href="https://dashboard.is.not.configured">pipeline-newest</a></li>
+</ul>
+<hr>
+<h4>Task Statuses:</h4>
+
+<table>
+  <tr><th>Status</th><th>Duration</th><th>Name</th></tr>
+<tr>
+<td>❌ Failed</td>
+<td>-25 minutes</td><td>
+
+[task1](https://dashboard.is.not.configured)
+
+</td></tr>
+</table>
+<hr>
+<h4>Failure snippet:</h4>
+task <b>task1</b> has the status <b>"Failed"</b>:
+<pre>fake logs</pre>

--- a/pkg/reconciler/testdata/TestReconciler_ReconcileKind-success_pipelinerun.golden
+++ b/pkg/reconciler/testdata/TestReconciler_ReconcileKind-success_pipelinerun.golden
@@ -1,0 +1,17 @@
+<ul>
+<li><b>Namespace</b>: <a href="https://dashboard.is.not.configured">ns</a></li>
+<li><b>PipelineRun:</b> <a href="https://dashboard.is.not.configured">pipeline-newest</a></li>
+</ul>
+<hr>
+<h4>Task Statuses:</h4>
+
+<table>
+  <tr><th>Status</th><th>Duration</th><th>Name</th></tr>
+<tr>
+<td>✅ Succeeded</td>
+<td>-25 minutes</td><td>
+
+[task1](https://dashboard.is.not.configured)
+
+</td></tr>
+</table>


### PR DESCRIPTION
We are adding a better status message that will include the Namespace and the PipelineRun.

We link the Namespace to the Namespace view in the consoles.

Introducing a new setting for that `custom-console-url-namespace` that would need to be setup when using a custom console.

![image](https://github.com/openshift-pipelines/pipelines-as-code/assets/98980/41f0d487-7a09-46b5-afef-4774feee0139)

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 A good commit message is important for other reviewers to understand the context of your change. Please refer to [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for more details how to write beautiful commit messages. We rather have the commit message in the PR body and the commit message instead of an external website.
- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
