### PR TITLE
Add support of remote task on remote Pipeline

### DIFF
--- a/pkg/action/patch_test.go
+++ b/pkg/action/patch_test.go
@@ -22,7 +22,7 @@ func TestPatchPipelineRun(t *testing.T) {
 	observer, _ := zapobserver.New(zap.InfoLevel)
 	logger := zap.New(observer).Sugar()
 
-	testPR := tektontest.MakePR("namespace", "force-me", []pipelinev1.ChildStatusReference{
+	testPR := tektontest.MakePRStatus("namespace", "force-me", []pipelinev1.ChildStatusReference{
 		tektontest.MakeChildStatusReference("first"),
 		tektontest.MakeChildStatusReference("last"),
 		tektontest.MakeChildStatusReference("middle"),

--- a/pkg/matcher/annotation_tasks_install.go
+++ b/pkg/matcher/annotation_tasks_install.go
@@ -216,7 +216,7 @@ func (rt RemoteTasks) GetTaskFromAnnotations(ctx context.Context, annotations ma
 
 // GetPipelineFromAnnotations Get pipeline remotely if they are on Annotations
 // TODO: merge in a generic between the two
-func (rt RemoteTasks) GetPipelineFromAnnotations(ctx context.Context, annotations map[string]string) ([]*tektonv1.Pipeline, error) {
+func (rt RemoteTasks) GetPipelineFromAnnotations(ctx context.Context, annotations map[string]string) (*tektonv1.Pipeline, error) {
 	ret := []*tektonv1.Pipeline{}
 	pipelinesAnnotation, err := grabValuesFromAnnotations(annotations, pipelineAnnotationsRegexp)
 	if err != nil {
@@ -224,6 +224,9 @@ func (rt RemoteTasks) GetPipelineFromAnnotations(ctx context.Context, annotation
 	}
 	if len(pipelinesAnnotation) > 1 {
 		return nil, fmt.Errorf("only one pipeline is allowed on remote resolution, we have received multiple of them: %+v", pipelinesAnnotation)
+	}
+	if len(pipelinesAnnotation) == 0 {
+		return nil, nil
 	}
 	for _, v := range pipelinesAnnotation {
 		data, err := rt.getRemote(ctx, v, false)
@@ -239,7 +242,7 @@ func (rt RemoteTasks) GetPipelineFromAnnotations(ctx context.Context, annotation
 		}
 		ret = append(ret, pipeline)
 	}
-	return ret, nil
+	return ret[0], nil
 }
 
 // getTaskFromLocalFS get task locally if file exist

--- a/pkg/matcher/annotation_tasks_install_test.go
+++ b/pkg/matcher/annotation_tasks_install_test.go
@@ -463,10 +463,10 @@ func TestGetPipelineFromAnnotations(t *testing.T) {
 				assert.Assert(t, len(fakelog.FilterMessageSnippet(tt.wantLog).TakeAll()) > 0, "could not find log message: got ", fakelog)
 			}
 			assert.NilError(t, err)
-			assert.Assert(t, len(got) > 0, "GetPipelineFromAnnotations() error no pipelines has been processed")
+			assert.Assert(t, got != nil, "GetPipelineFromAnnotations() error no pipelines has been processed")
 
 			if tt.gotPipelineName != "" {
-				assert.Equal(t, tt.gotPipelineName, got[0].GetName())
+				assert.Equal(t, tt.gotPipelineName, got.GetName())
 			}
 		})
 	}

--- a/pkg/pipelineascode/pipelineascode_test.go
+++ b/pkg/pipelineascode/pipelineascode_test.go
@@ -517,7 +517,7 @@ func TestRun(t *testing.T) {
 				},
 				Repositories: tt.repositories,
 				PipelineRuns: []*pipelinev1.PipelineRun{
-					tektontest.MakePR("namespace", "force-me", []pipelinev1.ChildStatusReference{
+					tektontest.MakePRStatus("namespace", "force-me", []pipelinev1.ChildStatusReference{
 						tektontest.MakeChildStatusReference("first"),
 						tektontest.MakeChildStatusReference("last"),
 						tektontest.MakeChildStatusReference("middle"),

--- a/pkg/reconciler/controller_test.go
+++ b/pkg/reconciler/controller_test.go
@@ -33,7 +33,7 @@ func TestCheckStateAndEnqueue(t *testing.T) {
 	})
 
 	// Create a new PipelineRun object with the "started" state label.
-	testPR := tektontest.MakePR("namespace", "force-me", []pipelinev1.ChildStatusReference{
+	testPR := tektontest.MakePRStatus("namespace", "force-me", []pipelinev1.ChildStatusReference{
 		tektontest.MakeChildStatusReference("first"),
 		tektontest.MakeChildStatusReference("last"),
 		tektontest.MakeChildStatusReference("middle"),

--- a/pkg/resolve/remote.go
+++ b/pkg/resolve/remote.go
@@ -1,0 +1,105 @@
+package resolve
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/matcher"
+)
+
+type NamedItem interface {
+	GetName() string
+}
+
+func alreadySeen[T NamedItem](items []T, item T) bool {
+	for _, value := range items {
+		if value.GetName() == item.GetName() {
+			return true
+		}
+	}
+	return false
+}
+
+// getRemotes will get remote tasks or Pipelines from annotations.
+//
+// It already has some tasks or pipeline coming from the tekton directory stored in [types]
+//
+// The precedence logic for tasks is in this order:
+//
+// * Tasks from the PipelineRun annotations
+// * Tasks from the Pipeline annotations
+// * Tasks from the Tekton directory
+//
+// The precedence logic for Pipeline is first from PipelineRun annotations and
+// then from Tekton directory
+func getRemotes(ctx context.Context, rt *matcher.RemoteTasks, types TektonTypes) (TektonTypes, error) {
+	remoteType := &TektonTypes{}
+	for _, pipelinerun := range types.PipelineRuns {
+		if len(pipelinerun.GetObjectMeta().GetAnnotations()) == 0 {
+			continue
+		}
+
+		// get first all the tasks from the pipelinerun annotations
+		remoteTasks, err := rt.GetTaskFromAnnotations(ctx, pipelinerun.GetObjectMeta().GetAnnotations())
+		if err != nil {
+			return TektonTypes{}, fmt.Errorf("error getting remote task from pipelinerun annotations: %w", err)
+		}
+
+		for _, task := range remoteTasks {
+			if alreadySeen(remoteType.Tasks, task) {
+				rt.Logger.Infof("skipping duplicated task %s in annotations on pipelinerun %s", task.GetName(), pipelinerun.GetName())
+				continue
+			}
+			remoteType.Tasks = append(remoteType.Tasks, task)
+		}
+
+		// get the pipeline from the remote annotation if any
+		remotePipeline, err := rt.GetPipelineFromAnnotations(ctx, pipelinerun.GetObjectMeta().GetAnnotations())
+		if err != nil {
+			return TektonTypes{}, fmt.Errorf("error getting remote pipeline from pipelinerun annotation: %w", err)
+		}
+
+		if remotePipeline != nil {
+			remoteType.Pipelines = append(remoteType.Pipelines, remotePipeline)
+		}
+	}
+
+	// grab the tasks from the remote pipeline
+	for _, pipeline := range remoteType.Pipelines {
+		if pipeline.GetObjectMeta().GetAnnotations() == nil {
+			continue
+		}
+		remoteTasks, err := rt.GetTaskFromAnnotations(ctx, pipeline.GetObjectMeta().GetAnnotations())
+		if err != nil {
+			return TektonTypes{}, fmt.Errorf("error getting remote tasks from remote pipeline %s: %w", pipeline.GetName(), err)
+		}
+
+		for _, remoteTask := range remoteTasks {
+			if alreadySeen(remoteType.Tasks, remoteTask) {
+				rt.Logger.Infof("skipping remote task %s from remote pipeline %s as already defined in pipelinerun", remoteTask.GetName(), pipeline.GetName())
+				continue
+			}
+			remoteType.Tasks = append(remoteType.Tasks, remoteTask)
+		}
+	}
+
+	ret := TektonTypes{
+		PipelineRuns: types.PipelineRuns,
+	}
+	// first get the remote types and then the local ones so remote takes precedence
+	for _, task := range append(remoteType.Tasks, types.Tasks...) {
+		if alreadySeen(ret.Tasks, task) {
+			rt.Logger.Infof("overriding task %s coming from tekton directory by an annotation task on the pipeline or pipelinerun", task.GetName())
+			continue
+		}
+		ret.Tasks = append(ret.Tasks, task)
+	}
+	for _, remotePipeline := range append(remoteType.Pipelines, types.Pipelines...) {
+		if alreadySeen(ret.Pipelines, remotePipeline) {
+			rt.Logger.Infof("overriding pipeline %s coming from tekton directory by the annotation pipelinerun", remotePipeline.GetName())
+			continue
+		}
+		ret.Pipelines = append(ret.Pipelines, remotePipeline)
+	}
+	return ret, nil
+}

--- a/pkg/resolve/remote_test.go
+++ b/pkg/resolve/remote_test.go
@@ -1,0 +1,356 @@
+package resolve
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	apipac "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/matcher"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
+	httptesthelper "github.com/openshift-pipelines/pipelines-as-code/pkg/test/http"
+	testprovider "github.com/openshift-pipelines/pipelines-as-code/pkg/test/provider"
+	ttkn "github.com/openshift-pipelines/pipelines-as-code/pkg/test/tekton"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"go.uber.org/zap"
+	zapobserver "go.uber.org/zap/zaptest/observer"
+	"gotest.tools/v3/assert"
+	rtesting "knative.dev/pkg/reconciler/testing"
+	"sigs.k8s.io/yaml"
+)
+
+func TestRemote(t *testing.T) {
+	randomPipelineRunName := "pipelinerun-abc"
+	remotePipelineName := "remote-pipeline"
+	remotePipelineURL := "http://remote/" + remotePipelineName
+
+	taskFromPipelineRunName := "task-from-pipelinerun"
+	taskFromPipelineRunURL := "http://remote/" + taskFromPipelineRunName
+
+	remoteTaskName := "remote-task"
+	remoteTaskURL := "http://remote/" + remoteTaskName
+	taskFromPipelineSpec := tektonv1.TaskSpec{
+		Steps: []tektonv1.Step{
+			{
+				Name:    "step1",
+				Image:   "scratch",
+				Command: []string{"true"},
+			},
+		},
+	}
+	taskFromPipelineRunSpec := tektonv1.TaskSpec{
+		Steps: []tektonv1.Step{
+			{
+				Name:    "frompipelinerun",
+				Image:   "scratch",
+				Command: []string{"false"},
+			},
+		},
+	}
+	pipelineTaskEmbedded := []tektonv1.PipelineTask{
+		{
+			Name: "embedded",
+			TaskSpec: &tektonv1.EmbeddedTask{
+				TaskSpec: taskFromPipelineSpec,
+			},
+		},
+	}
+	pipelinewithTaskEmbedded := ttkn.MakePipeline(remotePipelineName, pipelineTaskEmbedded, nil)
+	pipelinewithTaskEmbeddedB, err := yaml.Marshal(pipelinewithTaskEmbedded)
+	assert.NilError(t, err)
+
+	pipelineTaskRef := []tektonv1.PipelineTask{
+		{
+			Name: remoteTaskName,
+		},
+	}
+	pipelinewithTaskRef := ttkn.MakePipeline(remotePipelineName, pipelineTaskRef, map[string]string{
+		apipac.Task: remoteTaskURL,
+	})
+	pipelinewithTaskRefYamlB, err := yaml.Marshal(pipelinewithTaskRef)
+	assert.NilError(t, err)
+
+	singleTask := ttkn.MakeTask(remoteTaskName, taskFromPipelineSpec)
+	singleTaskB, err := yaml.Marshal(singleTask)
+	assert.NilError(t, err)
+
+	taskFromPipelineRun := ttkn.MakeTask(remoteTaskName, taskFromPipelineRunSpec)
+	taskFromPipelineRunB, err := yaml.Marshal(taskFromPipelineRun)
+	assert.NilError(t, err)
+
+	tests := []struct {
+		name                   string
+		pipelineruns           []*tektonv1.PipelineRun
+		tasks                  []*tektonv1.Task
+		pipelines              []*tektonv1.Pipeline
+		wantErrSnippet         string
+		remoteURLS             map[string]map[string]string
+		expectedLogsSnippets   []string
+		expectedTaskSpec       tektonv1.TaskSpec
+		expectedPipelinesFetch int
+		expectedTaskFetch      int
+	}{
+		{
+			name: "remote pipeline with remote task from pipeline",
+			pipelineruns: []*tektonv1.PipelineRun{
+				ttkn.MakePR(randomPipelineRunName, map[string]string{
+					apipac.Pipeline: remotePipelineURL,
+				},
+					tektonv1.PipelineRunSpec{
+						PipelineRef: &tektonv1.PipelineRef{
+							Name: "remote-pipeline",
+						},
+					},
+				),
+			},
+			remoteURLS: map[string]map[string]string{
+				"http://remote/embedpipeline": {
+					"body": string(pipelinewithTaskEmbeddedB),
+					"code": "200",
+				},
+				remotePipelineURL: {
+					"body": string(pipelinewithTaskRefYamlB),
+					"code": "200",
+				},
+				remoteTaskURL: {
+					"body": string(singleTaskB),
+					"code": "200",
+				},
+			},
+			expectedTaskSpec: taskFromPipelineSpec,
+			expectedLogsSnippets: []string{
+				fmt.Sprintf("successfully fetched %s from remote https url", remotePipelineURL),
+				fmt.Sprintf("successfully fetched %s from remote https url", remoteTaskURL),
+			},
+			expectedPipelinesFetch: 1,
+			expectedTaskFetch:      1,
+		},
+		{
+			name: "remote pipeline with remote task in pipeline overridden from pipelinerun",
+			pipelineruns: []*tektonv1.PipelineRun{
+				ttkn.MakePR(randomPipelineRunName, map[string]string{
+					apipac.Pipeline: remotePipelineURL,
+					apipac.Task:     taskFromPipelineRunURL,
+				},
+					tektonv1.PipelineRunSpec{
+						PipelineRef: &tektonv1.PipelineRef{
+							Name: "remote-pipeline",
+						},
+					},
+				),
+			},
+			expectedTaskSpec: taskFromPipelineRunSpec,
+			remoteURLS: map[string]map[string]string{
+				remotePipelineURL: {
+					"body": string(pipelinewithTaskRefYamlB),
+					"code": "200",
+				},
+				remoteTaskURL: {
+					"body": string(singleTaskB),
+					"code": "200",
+				},
+				taskFromPipelineRunURL: {
+					"body": string(taskFromPipelineRunB),
+					"code": "200",
+				},
+			},
+			expectedLogsSnippets: []string{
+				fmt.Sprintf("successfully fetched %s from remote https url", taskFromPipelineRunURL),
+				fmt.Sprintf("successfully fetched %s from remote https url", remotePipelineURL),
+			},
+			expectedPipelinesFetch: 1,
+			expectedTaskFetch:      1,
+		},
+		{
+			name: "remote pipelinerun no annotations",
+			pipelineruns: []*tektonv1.PipelineRun{
+				ttkn.MakePR(randomPipelineRunName, map[string]string{},
+					tektonv1.PipelineRunSpec{
+						PipelineRef: &tektonv1.PipelineRef{
+							Name: "remote-pipeline",
+						},
+					},
+				),
+			},
+		},
+		{
+			name:           "error/remote pipelinerun is 404",
+			wantErrSnippet: "error getting remote pipeline " + remotePipelineURL,
+			pipelineruns: []*tektonv1.PipelineRun{
+				ttkn.MakePR(randomPipelineRunName, map[string]string{
+					apipac.Pipeline: remotePipelineURL,
+				},
+					tektonv1.PipelineRunSpec{
+						PipelineRef: &tektonv1.PipelineRef{
+							Name: "remote-pipeline",
+						},
+					},
+				),
+			},
+		},
+		{
+			name: "skipping/multiple tasks of the same name from pipelinerun annotations and pipeline annotation",
+			pipelineruns: []*tektonv1.PipelineRun{
+				ttkn.MakePR(randomPipelineRunName, map[string]string{
+					apipac.Pipeline:    remotePipelineURL,
+					apipac.Task:        remoteTaskURL,
+					apipac.Task + "-1": remoteTaskURL,
+				},
+					tektonv1.PipelineRunSpec{
+						PipelineRef: &tektonv1.PipelineRef{
+							Name: "remote-pipeline",
+						},
+					},
+				),
+			},
+			remoteURLS: map[string]map[string]string{
+				remotePipelineURL: {
+					"body": string(pipelinewithTaskRefYamlB),
+					"code": "200",
+				},
+				remoteTaskURL: {
+					"body": string(singleTaskB),
+					"code": "200",
+				},
+			},
+			expectedTaskSpec: taskFromPipelineSpec,
+			expectedLogsSnippets: []string{
+				fmt.Sprintf("successfully fetched %s from remote https url", remoteTaskURL),
+				fmt.Sprintf("successfully fetched %s from remote https url", remoteTaskURL),
+				fmt.Sprintf("skipping duplicated task %s in annotations on pipelinerun %s", remoteTaskName, randomPipelineRunName),
+				fmt.Sprintf("successfully fetched %s from remote https url", remotePipelineURL),
+				fmt.Sprintf("successfully fetched %s from remote https url", remoteTaskURL),
+				fmt.Sprintf("skipping remote task %s from remote pipeline %s as already defined in pipelinerun", remoteTaskName, remotePipelineName),
+			},
+			expectedPipelinesFetch: 1,
+			expectedTaskFetch:      1,
+		},
+		{
+			name: "skipping/multiple tasks of the same name from pipelinerun annotations and tektondir",
+			pipelineruns: []*tektonv1.PipelineRun{
+				ttkn.MakePR(randomPipelineRunName, map[string]string{
+					apipac.Pipeline: remotePipelineURL,
+					apipac.Task:     remoteTaskURL,
+				},
+					tektonv1.PipelineRunSpec{
+						PipelineRef: &tektonv1.PipelineRef{
+							Name: "remote-pipeline",
+						},
+					},
+				),
+			},
+			tasks: []*tektonv1.Task{
+				singleTask,
+			},
+			remoteURLS: map[string]map[string]string{
+				remotePipelineURL: {
+					"body": string(pipelinewithTaskRefYamlB),
+					"code": "200",
+				},
+				remoteTaskURL: {
+					"body": string(singleTaskB),
+					"code": "200",
+				},
+			},
+			expectedTaskSpec: taskFromPipelineSpec,
+			expectedLogsSnippets: []string{
+				fmt.Sprintf("successfully fetched %s from remote https url", remoteTaskURL),
+				fmt.Sprintf("successfully fetched %s from remote https url", remotePipelineURL),
+				fmt.Sprintf("successfully fetched %s from remote https url", remoteTaskURL),
+				fmt.Sprintf("skipping remote task %s from remote pipeline %s as already defined in pipelinerun", remoteTaskName, remotePipelineName),
+				fmt.Sprintf("overriding task %s coming from tekton directory by an annotation task on the pipeline or pipelinerun", remoteTaskName),
+			},
+			expectedPipelinesFetch: 1,
+			expectedTaskFetch:      1,
+		},
+		{
+			name: "skipping/multiple pipelines of the same name from pipelinerun annotations and tektondir",
+			pipelineruns: []*tektonv1.PipelineRun{
+				ttkn.MakePR(randomPipelineRunName, map[string]string{
+					apipac.Pipeline: remotePipelineURL,
+					apipac.Task:     remoteTaskURL,
+				},
+					tektonv1.PipelineRunSpec{
+						PipelineRef: &tektonv1.PipelineRef{
+							Name: "remote-pipeline",
+						},
+					},
+				),
+			},
+			pipelines: []*tektonv1.Pipeline{
+				pipelinewithTaskEmbedded,
+			},
+			remoteURLS: map[string]map[string]string{
+				remotePipelineURL: {
+					"body": string(pipelinewithTaskRefYamlB),
+					"code": "200",
+				},
+				remoteTaskURL: {
+					"body": string(singleTaskB),
+					"code": "200",
+				},
+			},
+			expectedTaskSpec: taskFromPipelineSpec,
+			expectedLogsSnippets: []string{
+				fmt.Sprintf("successfully fetched %s from remote https url", remoteTaskURL),
+				fmt.Sprintf("successfully fetched %s from remote https url", remotePipelineURL),
+				fmt.Sprintf("successfully fetched %s from remote https url", remoteTaskURL),
+				fmt.Sprintf("skipping remote task %s from remote pipeline %s as already defined in pipelinerun", remoteTaskName, remotePipelineName),
+				fmt.Sprintf("overriding pipeline %s coming from tekton directory by the annotation pipelinerun", remotePipelineName),
+			},
+			expectedPipelinesFetch: 1,
+			expectedTaskFetch:      1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			observer, log := zapobserver.New(zap.InfoLevel)
+			logger := zap.New(observer).Sugar()
+			ctx, _ := rtesting.SetupFakeContext(t)
+			tktype := TektonTypes{
+				Pipelines:    tt.pipelines,
+				Tasks:        tt.tasks,
+				PipelineRuns: tt.pipelineruns,
+			}
+
+			tprovider := &testprovider.TestProviderImp{}
+			httpTestClient := httptesthelper.MakeHTTPTestClient(tt.remoteURLS)
+			rt := &matcher.RemoteTasks{
+				ProviderInterface: tprovider,
+				Logger:            logger,
+				Run: &params.Run{
+					Clients: clients.Clients{
+						HTTP: *httpTestClient,
+					},
+				},
+			}
+			ret, err := getRemotes(ctx, rt, tktype)
+			if tt.wantErrSnippet != "" {
+				assert.ErrorContains(t, err, tt.wantErrSnippet)
+				return
+			}
+			assert.NilError(t, err)
+
+			allPipelinesNames := []string{}
+			for _, task := range ret.Pipelines {
+				allPipelinesNames = append(allPipelinesNames, task.GetName())
+			}
+			assert.Equal(t, len(ret.Pipelines), tt.expectedPipelinesFetch, allPipelinesNames)
+
+			allTasksNames := []string{}
+			for _, task := range ret.Tasks {
+				allTasksNames = append(allTasksNames, task.GetName())
+			}
+			assert.Equal(t, len(ret.Tasks), tt.expectedTaskFetch, allTasksNames)
+
+			for k, snippet := range tt.expectedLogsSnippets {
+				logmsg := log.AllUntimed()[k].Message
+				assert.Assert(t, strings.Contains(logmsg, snippet), "\n on index: %d\n we want: %s\n we  got: %s", k, snippet, logmsg)
+			}
+			if tt.expectedTaskFetch > 0 {
+				assert.DeepEqual(t, tt.expectedTaskSpec, ret.Tasks[0].Spec)
+			}
+		})
+	}
+}

--- a/pkg/test/tekton/genz.go
+++ b/pkg/test/tekton/genz.go
@@ -50,7 +50,7 @@ func MakeChildStatusReference(name string) tektonv1.ChildStatusReference {
 	}
 }
 
-func MakePR(namespace, name string, childStatus []tektonv1.ChildStatusReference, status *knativeduckv1.Status) *tektonv1.PipelineRun {
+func MakePRStatus(namespace, name string, childStatus []tektonv1.ChildStatusReference, status *knativeduckv1.Status) *tektonv1.PipelineRun {
 	if status == nil {
 		status = &knativeduckv1.Status{}
 	}
@@ -65,6 +65,20 @@ func MakePR(namespace, name string, childStatus []tektonv1.ChildStatusReference,
 				ChildReferences: childStatus,
 			},
 		},
+	}
+}
+
+func MakePR(name string, annotations map[string]string, spec tektonv1.PipelineRunSpec) *tektonv1.PipelineRun {
+	return &tektonv1.PipelineRun{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "PipelineRun",
+			APIVersion: "tekton.dev/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Annotations: annotations,
+		},
+		Spec: spec,
 	}
 }
 
@@ -107,6 +121,33 @@ func MakePRCompletion(clock clockwork.FakeClock, name, namespace, runstatus stri
 				CompletionTime: &metav1.Time{Time: clock.Now().Add(endtime)},
 			},
 		},
+	}
+}
+
+func MakePipeline(name string, tasks []tektonv1.PipelineTask, annotations map[string]string) *tektonv1.Pipeline {
+	return &tektonv1.Pipeline{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pipeline",
+			APIVersion: "tekton.dev/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Annotations: annotations,
+		},
+		Spec: tektonv1.PipelineSpec{
+			Tasks: tasks,
+		},
+	}
+}
+
+func MakeTask(name string, taskSpec tektonv1.TaskSpec) *tektonv1.Task {
+	return &tektonv1.Task{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Task",
+			APIVersion: "tekton.dev/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       taskSpec,
 	}
 }
 


### PR DESCRIPTION
We now support remote tasks on remote Pipeline, allowing to share a remote Pipeline across multiple repositories.

User can override tasks from the remote pipeline by adding a task with the same name.

Demo here:  https://youtu.be/PetZInZTbM8?si=4P6VoYnl_dSbMAjG

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 A good commit message is important for other reviewers to understand the context of your change. Please refer to [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for more details how to write beautiful commit messages. We rather have the commit message in the PR body and the commit message instead of an external website.
- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
