### PR TITLE
Fix policy settings

### DIFF
--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -116,7 +116,7 @@ is that what you want? make sure you use -n when generating the secret, eg: echo
 
 	// Check if the submitter is allowed to run this.
 	if p.event.TriggerTarget != "push" {
-		allowed, err := p.vcx.IsAllowed(ctx, p.event, p.run.Info.Pac)
+		allowed, err := p.vcx.IsAllowed(ctx, p.event)
 		if err != nil {
 			return repo, err
 		}

--- a/pkg/provider/bitbucketcloud/acl.go
+++ b/pkg/provider/bitbucketcloud/acl.go
@@ -11,7 +11,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketcloud/types"
 )
 
-func (v *Provider) IsAllowed(ctx context.Context, event *info.Event, _ *info.PacOpts) (bool, error) {
+func (v *Provider) IsAllowed(ctx context.Context, event *info.Event) (bool, error) {
 	// Check first if the user is in the owner file or part of the workspace
 	allowed, err := v.checkMember(ctx, event)
 	if err != nil {

--- a/pkg/provider/bitbucketcloud/acl_test.go
+++ b/pkg/provider/bitbucketcloud/acl_test.go
@@ -180,10 +180,7 @@ func TestIsAllowed(t *testing.T) {
 			bbcloudtest.MuxFiles(t, mux, tt.event, tt.fields.filescontents, "")
 
 			v := &Provider{Client: bbclient}
-
-			pacopts := info.PacOpts{}
-
-			got, err := v.IsAllowed(ctx, tt.event, &pacopts)
+			got, err := v.IsAllowed(ctx, tt.event)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Provider.IsAllowed() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/provider/bitbucketserver/acl.go
+++ b/pkg/provider/bitbucketserver/acl.go
@@ -14,7 +14,7 @@ import (
 
 type activitiesTypes struct{ Values []*bbv1.Activity }
 
-func (v *Provider) IsAllowed(ctx context.Context, event *info.Event, _ *info.PacOpts) (bool, error) {
+func (v *Provider) IsAllowed(ctx context.Context, event *info.Event) (bool, error) {
 	allowed, err := v.checkMemberShip(ctx, event)
 	if err != nil {
 		return false, err

--- a/pkg/provider/bitbucketserver/acl.go
+++ b/pkg/provider/bitbucketserver/acl.go
@@ -14,8 +14,8 @@ import (
 
 type activitiesTypes struct{ Values []*bbv1.Activity }
 
-func (v *Provider) IsAllowed(_ context.Context, event *info.Event, _ *info.PacOpts) (bool, error) {
-	allowed, err := v.checkMemberShip(event)
+func (v *Provider) IsAllowed(ctx context.Context, event *info.Event, _ *info.PacOpts) (bool, error) {
+	allowed, err := v.checkMemberShip(ctx, event)
 	if err != nil {
 		return false, err
 	}
@@ -24,11 +24,13 @@ func (v *Provider) IsAllowed(_ context.Context, event *info.Event, _ *info.PacOp
 	}
 
 	// Check then from comment if there is a approved user that has done a /ok-to-test
-	return v.checkOkToTestCommentFromApprovedMember(event)
+	return v.checkOkToTestCommentFromApprovedMember(ctx, event)
 }
 
-func (v *Provider) isAllowedFromOwnerFile(event *info.Event) (bool, error) {
-	ownerContent, err := v.GetFileInsideRepo(context.TODO(), event, "OWNERS", event.DefaultBranch)
+// IsAllowedOwnersFile get the owner file from main branch and check if we have
+// explicitly allowed the user in there.
+func (v *Provider) IsAllowedOwnersFile(ctx context.Context, event *info.Event) (bool, error) {
+	ownerContent, err := v.GetFileInsideRepo(ctx, event, "OWNERS", event.DefaultBranch)
 	if err != nil {
 		return false, err
 	}
@@ -36,7 +38,7 @@ func (v *Provider) isAllowedFromOwnerFile(event *info.Event) (bool, error) {
 	return acl.UserInOwnerFile(ownerContent, event.AccountID)
 }
 
-func (v *Provider) checkOkToTestCommentFromApprovedMember(event *info.Event) (bool, error) {
+func (v *Provider) checkOkToTestCommentFromApprovedMember(ctx context.Context, event *info.Event) (bool, error) {
 	allPages, err := paginate(func(nextPage int) (*bbv1.APIResponse, error) {
 		localVarOptionals := map[string]interface{}{
 			"fromType": "COMMENT",
@@ -71,7 +73,7 @@ func (v *Provider) checkOkToTestCommentFromApprovedMember(event *info.Event) (bo
 				commenterEvent.Repository = event.Repository
 				commenterEvent.Organization = v.projectKey
 				commenterEvent.DefaultBranch = event.DefaultBranch
-				allowed, err := v.checkMemberShip(commenterEvent)
+				allowed, err := v.checkMemberShip(ctx, commenterEvent)
 				if err != nil {
 					return false, err
 				}
@@ -104,7 +106,7 @@ func (v *Provider) checkMemberShipResults(results []interface{}, event *info.Eve
 	return false, nil
 }
 
-func (v *Provider) checkMemberShip(event *info.Event) (bool, error) {
+func (v *Provider) checkMemberShip(ctx context.Context, event *info.Event) (bool, error) {
 	// Get permissions from project
 	allValues, err := paginate(func(nextPage int) (*bbv1.APIResponse, error) {
 		localVarOptionals := map[string]interface{}{}
@@ -148,7 +150,7 @@ func (v *Provider) checkMemberShip(event *info.Event) (bool, error) {
 	// in the 'main' branch Silently ignore error, which should be fine it
 	// probably means the OWNERS file is not created. If we had another error
 	// (ie: like API) we probably would have hit it already.
-	allowed, err = v.isAllowedFromOwnerFile(event)
+	allowed, err = v.IsAllowedOwnersFile(ctx, event)
 	if allowed {
 		return true, err
 	}

--- a/pkg/provider/bitbucketserver/acl_test.go
+++ b/pkg/provider/bitbucketserver/acl_test.go
@@ -217,9 +217,7 @@ func TestIsAllowed(t *testing.T) {
 				projectKey:                tt.event.Organization,
 			}
 
-			pacopts := info.PacOpts{}
-
-			got, err := v.IsAllowed(ctx, tt.event, &pacopts)
+			got, err := v.IsAllowed(ctx, tt.event)
 			if tt.wantErrSubstr != "" {
 				assert.ErrorContains(t, err, tt.wantErrSubstr)
 				return

--- a/pkg/provider/gitea/acl_test.go
+++ b/pkg/provider/gitea/acl_test.go
@@ -9,6 +9,7 @@ import (
 
 	"code.gitea.io/sdk/gitea"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
 	giteaStructs "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/gitea/structs"
@@ -79,9 +80,11 @@ func TestCheckPolicyAllowing(t *testing.T) {
 			ctx, _ := rtesting.SetupFakeContext(t)
 			observer, _ := zapobserver.New(zap.InfoLevel)
 			logger := zap.New(observer).Sugar()
-			repo := &v1alpha1.Repository{Spec: v1alpha1.RepositorySpec{
-				Settings: &v1alpha1.Settings{},
-			}}
+			repo := &v1alpha1.Repository{
+				Spec: v1alpha1.RepositorySpec{
+					Settings: &v1alpha1.Settings{},
+				},
+			}
 			gprovider := Provider{
 				Client: fakeclient,
 				repo:   repo,
@@ -286,14 +289,17 @@ func TestOkToTestComment(t *testing.T) {
 			gprovider := Provider{
 				Client: fakeclient,
 				Logger: logger,
-			}
-			pacopts := info.PacOpts{
-				Settings: &settings.Settings{
-					RememberOKToTest: tt.rememberOkToTest,
+				run: &params.Run{
+					Info: info.Info{
+						Pac: &info.PacOpts{
+							Settings: &settings.Settings{
+								RememberOKToTest: tt.rememberOkToTest,
+							},
+						},
+					},
 				},
 			}
-
-			isAllowed, err := gprovider.IsAllowed(ctx, &tt.runevent, &pacopts)
+			isAllowed, err := gprovider.IsAllowed(ctx, &tt.runevent)
 			if tt.wantErr {
 				assert.Assert(t, err != nil)
 			} else {

--- a/pkg/provider/gitea/gitea.go
+++ b/pkg/provider/gitea/gitea.go
@@ -48,6 +48,7 @@ type Provider struct {
 	Password     string
 	repo         *v1alpha1.Repository
 	eventEmitter *events.EventEmitter
+	run          *params.Run
 }
 
 // GetTaskURI TODO: Implement ME
@@ -82,7 +83,7 @@ func (v *Provider) GetConfig() *info.ProviderConfig {
 	}
 }
 
-func (v *Provider) SetClient(_ context.Context, _ *params.Run, runevent *info.Event, repo *v1alpha1.Repository, emitter *events.EventEmitter) error {
+func (v *Provider) SetClient(_ context.Context, run *params.Run, runevent *info.Event, repo *v1alpha1.Repository, emitter *events.EventEmitter) error {
 	var err error
 	apiURL := runevent.Provider.URL
 	// password is not exposed to CRD, it's only used from the e2e tests
@@ -100,6 +101,7 @@ func (v *Provider) SetClient(_ context.Context, _ *params.Run, runevent *info.Ev
 	v.giteaInstanceURL = runevent.Provider.URL
 	v.eventEmitter = emitter
 	v.repo = repo
+	v.run = run
 	return nil
 }
 

--- a/pkg/provider/github/acl.go
+++ b/pkg/provider/github/acl.go
@@ -61,7 +61,7 @@ func (v *Provider) IsAllowedOwnersFile(ctx context.Context, event *info.Event) (
 	return acl.UserInOwnerFile(ownerContent, event.Sender)
 }
 
-func (v *Provider) IsAllowed(ctx context.Context, event *info.Event, _ *info.PacOpts) (bool, error) {
+func (v *Provider) IsAllowed(ctx context.Context, event *info.Event) (bool, error) {
 	aclPolicy := policy.Policy{
 		Repository:   v.repo,
 		EventEmitter: v.eventEmitter,

--- a/pkg/provider/github/acl_test.go
+++ b/pkg/provider/github/acl_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/go-github/v55/github"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
 	ghtesthelper "github.com/openshift-pipelines/pipelines-as-code/pkg/test/github"
@@ -319,20 +320,20 @@ func TestOkToTestComment(t *testing.T) {
 			repo := &v1alpha1.Repository{Spec: v1alpha1.RepositorySpec{
 				Settings: &v1alpha1.Settings{},
 			}}
+			pacopts := &info.PacOpts{
+				Settings: &settings.Settings{
+					RememberOKToTest: tt.rememberOkToTest,
+				},
+			}
 			gprovider := Provider{
 				Client:        fakeclient,
 				repo:          repo,
 				Logger:        logger,
 				paginedNumber: 1,
+				Run:           &params.Run{Info: info.Info{Pac: pacopts}},
 			}
 
-			pacopts := info.PacOpts{
-				Settings: &settings.Settings{
-					RememberOKToTest: tt.rememberOkToTest,
-				},
-			}
-
-			got, err := gprovider.IsAllowed(ctx, &tt.runevent, &pacopts)
+			got, err := gprovider.IsAllowed(ctx, &tt.runevent, pacopts)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("aclCheck() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/provider/github/acl_test.go
+++ b/pkg/provider/github/acl_test.go
@@ -333,7 +333,7 @@ func TestOkToTestComment(t *testing.T) {
 				Run:           &params.Run{Info: info.Info{Pac: pacopts}},
 			}
 
-			got, err := gprovider.IsAllowed(ctx, &tt.runevent, pacopts)
+			got, err := gprovider.IsAllowed(ctx, &tt.runevent)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("aclCheck() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/provider/gitlab/acl.go
+++ b/pkg/provider/gitlab/acl.go
@@ -65,7 +65,7 @@ func (v *Provider) checkOkToTestCommentFromApprovedMember(ctx context.Context, e
 	return false, nil
 }
 
-func (v *Provider) IsAllowed(ctx context.Context, event *info.Event, _ *info.PacOpts) (bool, error) {
+func (v *Provider) IsAllowed(ctx context.Context, event *info.Event) (bool, error) {
 	if v.Client == nil {
 		return false, fmt.Errorf("no github client has been initialized, " +
 			"exiting... (hint: did you forget setting a secret on your repo?)")

--- a/pkg/provider/gitlab/acl_test.go
+++ b/pkg/provider/gitlab/acl_test.go
@@ -115,8 +115,7 @@ func TestIsAllowed(t *testing.T) {
 
 				defer tearDown()
 			}
-			pacopts := info.PacOpts{}
-			got, err := v.IsAllowed(ctx, tt.args.event, &pacopts)
+			got, err := v.IsAllowed(ctx, tt.args.event)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("IsAllowed() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/provider/interface.go
+++ b/pkg/provider/interface.go
@@ -31,6 +31,7 @@ type Interface interface {
 	Detect(*http.Request, string, *zap.SugaredLogger) (bool, bool, *zap.SugaredLogger, string, error)
 	ParsePayload(context.Context, *params.Run, *http.Request, string) (*info.Event, error)
 	IsAllowed(context.Context, *info.Event, *info.PacOpts) (bool, error)
+	IsAllowedOwnersFile(context.Context, *info.Event) (bool, error)
 	CreateStatus(context.Context, versioned.Interface, *info.Event, *info.PacOpts, StatusOpts) error
 	GetTektonDir(context.Context, *info.Event, string, string) (string, error)      // ctx, event, path, provenance
 	GetFileInsideRepo(context.Context, *info.Event, string, string) (string, error) // ctx, event, path, branch

--- a/pkg/provider/interface.go
+++ b/pkg/provider/interface.go
@@ -30,7 +30,7 @@ type Interface interface {
 	Validate(ctx context.Context, params *params.Run, event *info.Event) error
 	Detect(*http.Request, string, *zap.SugaredLogger) (bool, bool, *zap.SugaredLogger, string, error)
 	ParsePayload(context.Context, *params.Run, *http.Request, string) (*info.Event, error)
-	IsAllowed(context.Context, *info.Event, *info.PacOpts) (bool, error)
+	IsAllowed(context.Context, *info.Event) (bool, error)
 	IsAllowedOwnersFile(context.Context, *info.Event) (bool, error)
 	CreateStatus(context.Context, versioned.Interface, *info.Event, *info.PacOpts, StatusOpts) error
 	GetTektonDir(context.Context, *info.Event, string, string) (string, error)      // ctx, event, path, provenance

--- a/pkg/test/provider/testwebvcs.go
+++ b/pkg/test/provider/testwebvcs.go
@@ -24,6 +24,7 @@ type TestProviderImp struct {
 	FilesInsideRepo        map[string]string
 	WantProviderRemoteTask bool
 	PolicyDisallowing      bool
+	AllowedInOwnersFile    bool
 }
 
 func (v *TestProviderImp) CheckPolicyAllowing(_ context.Context, _ *info.Event, _ []string) (bool, string) {
@@ -31,6 +32,10 @@ func (v *TestProviderImp) CheckPolicyAllowing(_ context.Context, _ *info.Event, 
 		return false, "policy disallowing"
 	}
 	return true, ""
+}
+
+func (v *TestProviderImp) IsAllowedOwnersFile(_ context.Context, _ *info.Event) (bool, error) {
+	return v.AllowedInOwnersFile, nil
 }
 
 func (v *TestProviderImp) SetLogger(_ *zap.SugaredLogger) {

--- a/pkg/test/provider/testwebvcs.go
+++ b/pkg/test/provider/testwebvcs.go
@@ -65,7 +65,7 @@ func (v *TestProviderImp) SetClient(_ context.Context, _ *params.Run, _ *info.Ev
 	return nil
 }
 
-func (v *TestProviderImp) IsAllowed(_ context.Context, _ *info.Event, _ *info.PacOpts) (bool, error) {
+func (v *TestProviderImp) IsAllowed(_ context.Context, _ *info.Event) (bool, error) {
 	if v.AllowIT {
 		return true, nil
 	}


### PR DESCRIPTION
Policy setting was broken, this would always get the other ACLs check to run even when the user was not there.

The tests was also not testing the policy setting properly.

The E2E tests is hard to test on GitHub since we need to create another two others users and another organisation with a bunch of teams to test it properly. Hopefully if we can get our own GitHub enterprise instance we would be able to do those in the future.

I have done those tests manually:

An organisation with three users:

chmouel
sam
rubben

A team with the users sam and chmouel in there but not rubben.

I have created a repo CR with the policy settings like this:

```yaml
  settings:
    policy:
      pull_request:
      - pull_request
```

the user sam gets allowed to run CI but the user rubben get disallowed.

If I issue a comment with /ok-to-test from the user sam on the rubben PR it will be disallowed (since it only to run the pr and not issue ok-to-test).

I changed the policy on the repo settings with the ok-to-test section allowing the group pull_request:

```yaml
  settings:
    policy:
      ok_to_test:
      - pull_request
      pull_request:
      - pull_request
```

and then I can issue /ok-to-test from the user sam on the user rubben and it will be tested.

another thing to test and make sure is that the PR shows up as queued and not as error...

Youtube video:

https://youtu.be/Zfp6p3Cfgvw
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 A good commit message is important for other reviewers to understand the context of your change. Please refer to [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for more details how to write beautiful commit messages. We rather have the commit message in the PR body and the commit message instead of an external website.
- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
