### PR TITLE
Refactor provider Interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,8 @@ lint-md: ${MD_FILES} ## runs markdownlint and vale on all markdown files
 	@markdownlint $(MD_FILES)
 	@echo "Grammar check with vale of documentation..."
 	@vale docs/content *.md --minAlertLevel=error --output=line
+	@echo "CodeSpell on docs content"
+	@codespell docs/content
 
 .PHONY: fix-markdownlint
 fix-markdownlint: ${MD_FILES} ## run markdownlint and fix on all markdown file

--- a/cmd/pipelines-as-code-webhook/main.go
+++ b/cmd/pipelines-as-code-webhook/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"os"
 
-	validation_webhook "github.com/openshift-pipelines/pipelines-as-code/pkg/webhook"
+	validationWebhook "github.com/openshift-pipelines/pipelines-as-code/pkg/webhook"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/injection"
@@ -40,7 +40,7 @@ func main() {
 }
 
 func newValidationAdmissionController(ctx context.Context, _ configmap.Watcher) *controller.Impl {
-	return validation_webhook.NewAdmissionController(ctx,
+	return validationWebhook.NewAdmissionController(ctx,
 
 		// Name of the resource webhook.
 		"validation.pipelinesascode.tekton.dev",

--- a/docs/content/dev/_index.md
+++ b/docs/content/dev/_index.md
@@ -257,8 +257,7 @@ need to have on your system:
 
 - [golangci-lint](https://github.com/golangci/golangci-lint) - For golang lint
 - [yamllint](https://github.com/adrienverge/yamllint) - For YAML lint
-- [pylint](https://readthedocs.org/projects/pylint/) - Python linter
-- [black](https://github.com/psf/black) - Python code formatter check
+- [ruff](https://github.com/astral-sh/ruff) - Python code formatter check
 - [vale](https://github.com/errata-ai/vale) - For grammar check
 - [markdownlint](https://github.com/markdownlint/markdownlint) - For markdown lint
 - [codespell](https://github.com/codespell-project/codespell) - For code spelling

--- a/docs/content/dev/_index.md
+++ b/docs/content/dev/_index.md
@@ -36,7 +36,7 @@ override it you can set the `PAC_DIRS` environment variable.
 
 - You will need to create secret yourself, if you have the [pass cli](https://www.passwordstore.org/)
   installed you can point to a folder which contains : github-application-id github-private-key webhook.secret
-  As configured from your GitHub application. Configre `PAC_PASS_SECRET_FOLDER`
+  As configured from your GitHub application. Configure `PAC_PASS_SECRET_FOLDER`
   environment variable to point to it.
   For example :
 

--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -248,6 +248,7 @@ func (l listener) detectProvider(req *http.Request, reqBody string) (provider.In
 	}
 
 	bitCloud := &bitbucketcloud.Provider{}
+
 	isBitCloud, processReq, logger, reason, err := bitCloud.Detect(req, reqBody, &log)
 	if isBitCloud {
 		return l.processRes(processReq, bitCloud, logger, reason, err)

--- a/pkg/apis/incoming/incoming.go
+++ b/pkg/apis/incoming/incoming.go
@@ -9,7 +9,7 @@ type (
 	}
 )
 
-// parsePayload parses the payload from the incoming webhook, in json format and has only one key params
+// ParseIncomingPayload parses the payload from the incoming webhook, in json format and has only one key params
 func ParseIncomingPayload(payload []byte) (Payload, error) {
 	var incomingPayload Payload
 	err := json.Unmarshal(payload, &incomingPayload)

--- a/pkg/apis/pipelinesascode/keys/keys.go
+++ b/pkg/apis/pipelinesascode/keys/keys.go
@@ -52,9 +52,9 @@ const (
 	MaxKeepRuns     = pipelinesascode.GroupName + "/max-keep-runs"
 	LogURL          = pipelinesascode.GroupName + "/log-url"
 	ExecutionOrder  = pipelinesascode.GroupName + "/execution-order"
-	// default is "https://api.github.com" but it can be overridden by X-GitHub-Enterprise-Host header
+	// PublicGithubAPIURL default is "https://api.github.com" but it can be overridden by X-GitHub-Enterprise-Host header
 	PublicGithubAPIURL = "https://api.github.com"
-	// installationURL give us the Installation ID
+	// InstallationURL gives us the Installation ID for the GitHub Application
 	InstallationURL     = "/app/installations"
 	GithubApplicationID = "github-application-id"
 	GithubPrivateKey    = "github-private-key"

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -7,7 +7,8 @@ import (
 	"github.com/AlecAivazis/survey/v2/terminal"
 )
 
-// TODO: move to context, and use context to pass around
+// PacCliOpts is the struct that holds all the options for the CLI
+// TODO: Pass this to a context
 type PacCliOpts struct {
 	NoColoring    bool
 	AllNameSpaces bool

--- a/pkg/cmd/tknpac/bootstrap/web.go
+++ b/pkg/cmd/tknpac/bootstrap/web.go
@@ -69,7 +69,7 @@ func startWebServer(ctx context.Context, opts *bootstrapOpts, run *params.Run, j
 	if err := info.UpdateInfoConfigMap(ctx, run, &info.Options{
 		TargetNamespace: opts.targetNamespace,
 		ControllerURL:   opts.RouteName,
-		Provider:        provider.ProviderGitHubApp,
+		Provider:        provider.GitHubApp,
 	}); err != nil {
 		return err
 	}

--- a/pkg/matcher/annotation_tasks_install.go
+++ b/pkg/matcher/annotation_tasks_install.go
@@ -100,7 +100,7 @@ func (rt RemoteTasks) convertTotask(ctx context.Context, uri, data string) (*tek
 }
 
 func (rt RemoteTasks) getRemote(ctx context.Context, uri string, fromHub bool) (string, error) {
-	if fetchedFromURIFromProvider, task, err := rt.ProviderInterface.GetTaskURI(ctx, rt.Run, rt.Event, uri); fetchedFromURIFromProvider {
+	if fetchedFromURIFromProvider, task, err := rt.ProviderInterface.GetTaskURI(ctx, rt.Event, uri); fetchedFromURIFromProvider {
 		return task, err
 	}
 

--- a/pkg/params/settings/config.go
+++ b/pkg/params/settings/config.go
@@ -73,9 +73,7 @@ type HubCatalog struct {
 }
 
 type Settings struct {
-	ApplicationName string
-	// HubURL                             string
-	// HubCatalogName                     string
+	ApplicationName                    string
 	HubCatalogs                        *sync.Map
 	RemoteTasks                        bool
 	MaxKeepRunsUpperLimit              int

--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -134,7 +134,7 @@ is that what you want? make sure you use -n when generating the secret, eg: echo
 				Text:       msg,
 				DetailsURL: p.event.URL,
 			}
-			if err := p.vcx.CreateStatus(ctx, p.run.Clients.Tekton, p.event, p.run.Info.Pac, status); err != nil {
+			if err := p.vcx.CreateStatus(ctx, p.event, status); err != nil {
 				return repo, fmt.Errorf("failed to run create status, user is not allowed to run: %w", err)
 			}
 			return nil, nil

--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -49,7 +49,7 @@ func NewPacs(event *info.Event, vcx provider.Interface, run *params.Run, k8int k
 func (p *PacRun) Run(ctx context.Context) error {
 	matchedPRs, repo, err := p.matchRepoPR(ctx)
 	if err != nil {
-		createStatusErr := p.vcx.CreateStatus(ctx, p.run.Clients.Tekton, p.event, p.run.Info.Pac, provider.StatusOpts{
+		createStatusErr := p.vcx.CreateStatus(ctx, p.event, provider.StatusOpts{
 			Status:     "completed",
 			Conclusion: "failure",
 			Text:       fmt.Sprintf("There was an issue validating the commit: %q", err),
@@ -90,7 +90,7 @@ func (p *PacRun) Run(ctx context.Context) error {
 				errMsg := fmt.Sprintf("There was an error starting the PipelineRun %s, %s", match.PipelineRun.GetGenerateName(), err.Error())
 				errMsgM := fmt.Sprintf("There was an error creating the PipelineRun: <b>%s</b>\n\n%s", match.PipelineRun.GetGenerateName(), err.Error())
 				p.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "RepositoryPipelineRun", errMsg)
-				createStatusErr := p.vcx.CreateStatus(ctx, p.run.Clients.Tekton, p.event, p.run.Info.Pac, provider.StatusOpts{
+				createStatusErr := p.vcx.CreateStatus(ctx, p.event, provider.StatusOpts{
 					Status:     "completed",
 					Conclusion: "failure",
 					Text:       errMsgM,
@@ -202,7 +202,7 @@ func (p *PacRun) startPR(ctx context.Context, match matcher.Match) (*tektonv1.Pi
 		}
 	}
 
-	if err := p.vcx.CreateStatus(ctx, p.run.Clients.Tekton, p.event, p.run.Info.Pac, status); err != nil {
+	if err := p.vcx.CreateStatus(ctx, p.event, status); err != nil {
 		// we still return the created PR with error, and allow caller to decide what to do with the PR, and avoid
 		// unneeded SIGSEGV's
 		return pr, fmt.Errorf("cannot use the API on the provider platform to create a in_progress status: %w", err)

--- a/pkg/pipelineascode/pipelineascode_test.go
+++ b/pkg/pipelineascode/pipelineascode_test.go
@@ -579,6 +579,7 @@ func TestRun(t *testing.T) {
 
 			vcx := &ghprovider.Provider{
 				Client: fakeclient,
+				Run:    params.New(),
 				Token:  github.String("None"),
 				Logger: logger,
 			}
@@ -606,7 +607,7 @@ func TestRun(t *testing.T) {
 				// validate logURL label
 				for i := range prs.Items {
 					pr := prs.Items[i]
-					// skip existing seed pipelineRuns
+					// skip existing seeded PipelineRuns
 					if pr.GetName() == "force-me" {
 						continue
 					}

--- a/pkg/provider/bitbucketcloud/bitbucket_test.go
+++ b/pkg/provider/bitbucketcloud/bitbucket_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/ktrysmt/go-bitbucket"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	bbcloudtest "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketcloud/test"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketcloud/types"
@@ -286,7 +286,10 @@ func TestCreateStatus(t *testing.T) {
 			ctx, _ := rtesting.SetupFakeContext(t)
 			bbclient, mux, tearDown := bbcloudtest.SetupBBCloudClient(t)
 			defer tearDown()
-			v := &Provider{Client: bbclient}
+			v := &Provider{
+				Client: bbclient,
+				run:    params.New(),
+			}
 			event := bbcloudtest.MakeEvent(nil)
 			event.EventType = "pull_request"
 			event.Provider.Token = "token"
@@ -294,11 +297,7 @@ func TestCreateStatus(t *testing.T) {
 			bbcloudtest.MuxCreateCommitstatus(t, mux, event, tt.expectedDescSubstr, tt.status)
 			bbcloudtest.MuxCreateComment(t, mux, event, tt.expectedCommentSubstr)
 
-			err := v.CreateStatus(ctx, nil, event, &info.PacOpts{
-				Settings: &settings.Settings{
-					ApplicationName: "HELLO APP",
-				},
-			}, tt.status)
+			err := v.CreateStatus(ctx, event, tt.status)
 			assert.NilError(t, err)
 		})
 	}

--- a/pkg/provider/bitbucketserver/bitbucketserver_test.go
+++ b/pkg/provider/bitbucketserver/bitbucketserver_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	bbv1 "github.com/gfleury/go-bitbucket-v1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
@@ -177,10 +178,19 @@ func TestCreateStatus(t *testing.T) {
 			event := bbtest.MakeEvent(nil)
 			event.EventType = "pull_request"
 			event.Provider.Token = "token"
-			v := Provider{Client: client, pullRequestNumber: pullRequestNumber, projectKey: event.Organization}
+			v := &Provider{
+				Client:            client,
+				pullRequestNumber: pullRequestNumber,
+				projectKey:        event.Organization,
+				run: &params.Run{
+					Info: info.Info{
+						Pac: &tt.pacOpts,
+					},
+				},
+			}
 			bbtest.MuxCreateAndTestCommitStatus(t, mux, event, tt.expectedDescSubstr, tt.status)
 			bbtest.MuxCreateComment(t, mux, event, tt.expectedCommentSubstr, pullRequestNumber)
-			err := v.CreateStatus(ctx, nil, event, &tt.pacOpts, tt.status)
+			err := v.CreateStatus(ctx, event, tt.status)
 			if tt.wantErrSubstr != "" {
 				assert.ErrorContains(t, err, tt.wantErrSubstr)
 				return

--- a/pkg/provider/gitea/acl.go
+++ b/pkg/provider/gitea/acl.go
@@ -178,7 +178,7 @@ func (v *Provider) aclCheckAll(ctx context.Context, rev *info.Event) (bool, erro
 	return v.IsAllowedOwnersFile(ctx, rev)
 }
 
-// IsAllowedOwners get the owner file from main branch and check if we have
+// IsAllowedOwnersFile get the owner file from main branch and check if we have
 // explicitly allowed the user in there.
 func (v *Provider) IsAllowedOwnersFile(ctx context.Context, rev *info.Event) (bool, error) {
 	// If we have a prow OWNERS file in the defaultBranch (ie: master) then

--- a/pkg/provider/gitea/gitea.go
+++ b/pkg/provider/gitea/gitea.go
@@ -15,7 +15,6 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
-	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	"go.uber.org/zap"
 )
 
@@ -52,7 +51,7 @@ type Provider struct {
 }
 
 // GetTaskURI TODO: Implement ME
-func (v *Provider) GetTaskURI(_ context.Context, _ *params.Run, _ *info.Event, _ string) (bool, string, error) {
+func (v *Provider) GetTaskURI(_ context.Context, _ *info.Event, _ string) (bool, string, error) {
 	return false, "", nil
 }
 
@@ -105,9 +104,7 @@ func (v *Provider) SetClient(_ context.Context, run *params.Run, runevent *info.
 	return nil
 }
 
-func (v *Provider) CreateStatus(_ context.Context, _ versioned.Interface, event *info.Event, pacOpts *info.PacOpts,
-	statusOpts provider.StatusOpts,
-) error {
+func (v *Provider) CreateStatus(_ context.Context, event *info.Event, statusOpts provider.StatusOpts) error {
 	if v.Client == nil {
 		return fmt.Errorf("cannot set status on gitea no token or url set")
 	}
@@ -140,9 +137,9 @@ func (v *Provider) CreateStatus(_ context.Context, _ versioned.Interface, event 
 		onPr = fmt.Sprintf("/%s", statusOpts.PipelineRunName)
 	}
 	// gitea show weirdly the <br>
-	statusOpts.Summary = fmt.Sprintf("%s%s %s", pacOpts.ApplicationName, onPr, statusOpts.Summary)
+	statusOpts.Summary = fmt.Sprintf("%s%s %s", v.run.Info.Pac.ApplicationName, onPr, statusOpts.Summary)
 
-	return v.createStatusCommit(event, pacOpts, statusOpts)
+	return v.createStatusCommit(event, v.run.Info.Pac, statusOpts)
 }
 
 func (v *Provider) createStatusCommit(event *info.Event, pacopts *info.PacOpts, status provider.StatusOpts) error {
@@ -320,6 +317,6 @@ func (v *Provider) GetFiles(_ context.Context, _ *info.Event) ([]string, error) 
 	return []string{}, fmt.Errorf("GetFiles is not supported on Gitea")
 }
 
-func (v *Provider) CreateToken(_ context.Context, _ []string, _ *params.Run, _ *info.Event) (string, error) {
+func (v *Provider) CreateToken(_ context.Context, _ []string, _ *info.Event) (string, error) {
 	return "", nil
 }

--- a/pkg/provider/gitea/structs/hook.go
+++ b/pkg/provider/gitea/structs/hook.go
@@ -12,7 +12,7 @@ import (
 )
 
 // ErrInvalidReceiveHook FIXME
-var ErrInvalidReceiveHook = errors.New("Invalid JSON payload received over webhook")
+var ErrInvalidReceiveHook = errors.New("invalid JSON payload received over webhook")
 
 // Hook a hook is a web hook when one repository changed
 type Hook struct {
@@ -165,7 +165,7 @@ func ParseCreateHook(raw []byte) (*CreatePayload, error) {
 // PusherType define the type to push
 type PusherType string
 
-// describe all the PusherTypes
+// PusherTypeUser is the type of pusher
 const (
 	PusherTypeUser PusherType = "user"
 )

--- a/pkg/provider/github/acl.go
+++ b/pkg/provider/github/acl.go
@@ -46,7 +46,7 @@ func (v *Provider) CheckPolicyAllowing(ctx context.Context, event *info.Event, a
 	return false, fmt.Sprintf("user: %s is not a member of any of the allowed teams: %v", event.Sender, allowedTeams)
 }
 
-// IsAllowedOwners get the owner file from main branch and check if we have
+// IsAllowedOwnersFile gets the owner file from main branch and check if we have
 // explicitly allowed the user in there.
 func (v *Provider) IsAllowedOwnersFile(ctx context.Context, event *info.Event) (bool, error) {
 	ownerContent, err := v.getFileFromDefaultBranch(ctx, "OWNERS", event)

--- a/pkg/provider/github/github_test.go
+++ b/pkg/provider/github/github_test.go
@@ -82,7 +82,7 @@ func TestGetTaskURI(t *testing.T) {
 			mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/git/blobs/%s", "owner", "repo", sha), func(rw http.ResponseWriter, r *http.Request) {
 				fmt.Fprintf(rw, `{"content": "%s"}`, content)
 			})
-			allowed, content, err := provider.GetTaskURI(ctx, nil, event, tt.uri)
+			allowed, content, err := provider.GetTaskURI(ctx, event, tt.uri)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetTaskURI() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -989,7 +989,8 @@ func TestCreateToken(t *testing.T) {
 	}
 
 	provider := &Provider{Client: fakeclient}
-	_, err := provider.CreateToken(ctx, urlData, run, info)
+	provider.Run = run
+	_, err := provider.CreateToken(ctx, urlData, info)
 	if len(provider.RepositoryIDs) != 2 {
 		assert.Error(t, fmt.Errorf("found repositoryIDs are %d which is less than expected", len(provider.RepositoryIDs)),
 			"expected repositoryIDs are 2")

--- a/pkg/provider/github/parse_payload.go
+++ b/pkg/provider/github/parse_payload.go
@@ -137,6 +137,9 @@ func getInstallationIDFromPayload(payload string) int64 {
 // exfiltrate the token, it would fail since the jwt token generation will fail, so we are safe here.
 // a bit too far fetched but i don't see any way we can exploit this.
 func (v *Provider) ParsePayload(ctx context.Context, run *params.Run, request *http.Request, payload string) (*info.Event, error) {
+	// ParsePayload is really happening before SetClient so let's set this at first here.
+	// Only apply for GitHub provider since we do fancy token creation at payload parsing
+	v.Run = run
 	event := info.NewEvent()
 	// TODO: we should not have getenv in code only in main
 	systemNS := os.Getenv("SYSTEM_NAMESPACE")
@@ -187,7 +190,7 @@ func (v *Provider) ParsePayload(ctx context.Context, run *params.Run, request *h
 			}
 			v.Logger.Infof("Github token scope extended to %v keeping SecretGHAppRepoScoped to true", repoLists)
 		}
-		token, err := v.CreateToken(ctx, repoLists, run, processedEvent)
+		token, err := v.CreateToken(ctx, repoLists, processedEvent)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/provider/github/scope.go
+++ b/pkg/provider/github/scope.go
@@ -77,7 +77,7 @@ func ScopeTokenToListOfRepos(ctx context.Context, vcx provider.Interface, repo *
 		}
 		// adding the repo info from which event came so that repositoryID will be added while scoping the token
 		repoListToScopeToken = append(repoListToScopeToken, repoInfoFromWhichEventCame[1]+"/"+repoInfoFromWhichEventCame[2])
-		token, err = vcx.CreateToken(ctx, repoListToScopeToken, run, event)
+		token, err = vcx.CreateToken(ctx, repoListToScopeToken, event)
 		if err != nil {
 			return "", fmt.Errorf("failed to scope token to repositories with error : %w", err)
 		}

--- a/pkg/provider/github/scope_test.go
+++ b/pkg/provider/github/scope_test.go
@@ -236,6 +236,7 @@ func TestScopeTokenToListOfRipos(t *testing.T) {
 			gvcs := &Provider{
 				Logger: logger,
 				Client: fakeghclient,
+				Run:    run,
 			}
 
 			extraRepoInstallIds := map[string]string{"owner/repo": "789", "owner1/repo1": "10112", "owner2/repo2": "112233"}

--- a/pkg/provider/gitlab/acl.go
+++ b/pkg/provider/gitlab/acl.go
@@ -9,7 +9,7 @@ import (
 	"github.com/xanzy/go-gitlab"
 )
 
-// IsAllowedOwners get the owner file from main branch and check if we have
+// IsAllowedOwnersFile get the owner file from main branch and check if we have
 // explicitly allowed the user in there.
 func (v *Provider) IsAllowedOwnersFile(_ context.Context, event *info.Event) (bool, error) {
 	ownerContent, _ := v.getObject("OWNERS", event.DefaultBranch, v.targetProjectID)

--- a/pkg/provider/gitlab/gitlab_test.go
+++ b/pkg/provider/gitlab/gitlab_test.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	thelp "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/gitlab/test"
 	"github.com/xanzy/go-gitlab"
@@ -155,6 +155,7 @@ func TestCreateStatus(t *testing.T) {
 			ctx, _ := rtesting.SetupFakeContext(t)
 			v := &Provider{
 				targetProjectID: tt.fields.targetProjectID,
+				run:             params.New(),
 			}
 			if tt.args.event == nil {
 				tt.args.event = info.NewEvent()
@@ -168,8 +169,7 @@ func TestCreateStatus(t *testing.T) {
 				thelp.MuxNotePost(t, mux, v.targetProjectID, tt.args.event.PullRequestNumber, tt.args.postStr)
 			}
 
-			pacOpts := &info.PacOpts{Settings: &settings.Settings{ApplicationName: "Test me"}}
-			if err := v.CreateStatus(ctx, nil, tt.args.event, pacOpts, tt.args.statusOpts); (err != nil) != tt.wantErr {
+			if err := v.CreateStatus(ctx, tt.args.event, tt.args.statusOpts); (err != nil) != tt.wantErr {
 				t.Errorf("CreateStatus() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/pkg/provider/interface.go
+++ b/pkg/provider/interface.go
@@ -9,7 +9,6 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
-	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	"go.uber.org/zap"
 )
 
@@ -32,15 +31,15 @@ type Interface interface {
 	ParsePayload(context.Context, *params.Run, *http.Request, string) (*info.Event, error)
 	IsAllowed(context.Context, *info.Event) (bool, error)
 	IsAllowedOwnersFile(context.Context, *info.Event) (bool, error)
-	CreateStatus(context.Context, versioned.Interface, *info.Event, *info.PacOpts, StatusOpts) error
+	CreateStatus(context.Context, *info.Event, StatusOpts) error
 	GetTektonDir(context.Context, *info.Event, string, string) (string, error)      // ctx, event, path, provenance
 	GetFileInsideRepo(context.Context, *info.Event, string, string) (string, error) // ctx, event, path, branch
 	SetClient(context.Context, *params.Run, *info.Event, *v1alpha1.Repository, *events.EventEmitter) error
 	GetCommitInfo(context.Context, *info.Event) error
 	GetConfig() *info.ProviderConfig
 	GetFiles(context.Context, *info.Event) ([]string, error)
-	GetTaskURI(ctx context.Context, params *params.Run, event *info.Event, uri string) (bool, string, error)
-	CreateToken(context.Context, []string, *params.Run, *info.Event) (string, error)
+	GetTaskURI(context.Context, *info.Event, string) (bool, string, error)
+	CreateToken(context.Context, []string, *info.Event) (string, error)
 	CheckPolicyAllowing(context.Context, *info.Event, []string) (bool, string)
 }
 

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -22,7 +22,7 @@ const (
 )
 
 const (
-	ProviderGitHubApp = "GitHubApp"
+	GitHubApp = "GitHubApp"
 )
 
 func Valid(value string, validValues []string) bool {

--- a/pkg/reconciler/controller.go
+++ b/pkg/reconciler/controller.go
@@ -22,7 +22,7 @@ import (
 )
 
 func NewController() func(context.Context, configmap.Watcher) *controller.Impl {
-	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+	return func(ctx context.Context, _ configmap.Watcher) *controller.Impl {
 		log := logging.FromContext(ctx)
 		run := params.New()
 		err := run.Clients.NewClients(ctx, &run.Info)

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -220,7 +220,7 @@ func (r *Reconciler) updatePipelineRunToInProgress(ctx context.Context, logger *
 		OriginalPipelineRunName: pr.GetAnnotations()[keys.OriginalPRName],
 	}
 
-	if err := createStatusWithRetry(ctx, logger, r.run.Clients.Tekton, p, event, r.run.Info.Pac, status); err != nil {
+	if err := createStatusWithRetry(ctx, logger, p, event, status); err != nil {
 		// if failed to report status for running state, let the pipelineRun continue,
 		// pipelineRun is already started so we will try again once it completes
 		logger.Errorf("failed to report status to running on provider continuing! error: %v", err)

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -47,7 +47,7 @@ var (
 func testSetupGHReplies(t *testing.T, mux *http.ServeMux, runevent *info.Event, checkrunID, finalStatus string) {
 	t.Helper()
 	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/check-runs/%s", runevent.Organization, runevent.Repository, checkrunID),
-		func(w http.ResponseWriter, r *http.Request) {
+		func(_ http.ResponseWriter, r *http.Request) {
 			body, _ := io.ReadAll(r.Body)
 			created := github.CreateCheckRunOptions{}
 			err := json.Unmarshal(body, &created)

--- a/pkg/reconciler/status.go
+++ b/pkg/reconciler/status.go
@@ -17,7 +17,6 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/secrets"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/sort"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
-	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
@@ -152,15 +151,15 @@ func (r *Reconciler) postFinalStatus(ctx context.Context, logger *zap.SugaredLog
 		OriginalPipelineRunName: pr.GetAnnotations()[apipac.OriginalPRName],
 	}
 
-	err = createStatusWithRetry(ctx, logger, r.run.Clients.Tekton, vcx, event, r.run.Info.Pac, status)
+	err = createStatusWithRetry(ctx, logger, vcx, event, status)
 	logger.Infof("pipelinerun %s has a status of '%s'", pr.Name, status.Conclusion)
 	return pr, err
 }
 
-func createStatusWithRetry(ctx context.Context, logger *zap.SugaredLogger, tekton versioned.Interface, vcx provider.Interface, event *info.Event, opts *info.PacOpts, status provider.StatusOpts) error {
+func createStatusWithRetry(ctx context.Context, logger *zap.SugaredLogger, vcx provider.Interface, event *info.Event, status provider.StatusOpts) error {
 	var finalError error
 	for _, backoff := range backoffSchedule {
-		err := vcx.CreateStatus(ctx, tekton, event, opts, status)
+		err := vcx.CreateStatus(ctx, event, status)
 		if err == nil {
 			return nil
 		}

--- a/pkg/reconciler/status_test.go
+++ b/pkg/reconciler/status_test.go
@@ -26,7 +26,7 @@ func TestCreateStatusWithRetry(t *testing.T) {
 	fakelogger := zap.New(observer).Sugar()
 	vcx := tprovider.TestProviderImp{}
 
-	err := createStatusWithRetry(context.TODO(), fakelogger, nil, &vcx, nil, nil, provider.StatusOpts{})
+	err := createStatusWithRetry(context.TODO(), fakelogger, &vcx, nil, provider.StatusOpts{})
 	assert.NilError(t, err)
 }
 
@@ -36,7 +36,7 @@ func TestCreateStatusWithRetry_ErrorCase(t *testing.T) {
 	vcx := tprovider.TestProviderImp{}
 	vcx.CreateStatusErorring = true
 
-	err := createStatusWithRetry(context.TODO(), fakelogger, nil, &vcx, nil, nil, provider.StatusOpts{})
+	err := createStatusWithRetry(context.TODO(), fakelogger, &vcx, nil, provider.StatusOpts{})
 	assert.Error(t, err, "failed to report status: some provider error occurred while reporting status")
 }
 

--- a/pkg/test/provider/testwebvcs.go
+++ b/pkg/test/provider/testwebvcs.go
@@ -10,7 +10,6 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
-	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	"go.uber.org/zap"
 )
 
@@ -72,11 +71,11 @@ func (v *TestProviderImp) IsAllowed(_ context.Context, _ *info.Event) (bool, err
 	return false, nil
 }
 
-func (v *TestProviderImp) GetTaskURI(_ context.Context, _ *params.Run, _ *info.Event, _ string) (bool, string, error) {
+func (v *TestProviderImp) GetTaskURI(_ context.Context, _ *info.Event, _ string) (bool, string, error) {
 	return v.WantProviderRemoteTask, "", nil
 }
 
-func (v *TestProviderImp) CreateStatus(_ context.Context, _ versioned.Interface, _ *info.Event, _ *info.PacOpts, _ provider.StatusOpts) error {
+func (v *TestProviderImp) CreateStatus(_ context.Context, _ *info.Event, _ provider.StatusOpts) error {
 	if v.CreateStatusErorring {
 		return fmt.Errorf("some provider error occurred while reporting status")
 	}
@@ -98,6 +97,6 @@ func (v *TestProviderImp) GetFiles(_ context.Context, _ *info.Event) ([]string, 
 	return []string{}, nil
 }
 
-func (v *TestProviderImp) CreateToken(_ context.Context, _ []string, _ *params.Run, _ *info.Event) (string, error) {
+func (v *TestProviderImp) CreateToken(_ context.Context, _ []string, _ *info.Event) (string, error) {
 	return "", nil
 }

--- a/test/pkg/gitea/scm.go
+++ b/test/pkg/gitea/scm.go
@@ -198,7 +198,7 @@ func CreateGiteaUser(giteaClient *gitea.Client, username, password string) (*git
 	return newuser, nil
 }
 
-// func CreateGiteaUserSecondCnx(giteaClient *gitea.Client, apiURL, username, password string) (pgitea.Provider, *gitea.User, error) {
+// CreateGiteaUserSecondCnx creates a new user and a new provider for this user
 func CreateGiteaUserSecondCnx(topts *TestOpts, username, password string) (pgitea.Provider, *gitea.User, error) {
 	newuser, err := CreateGiteaUser(topts.GiteaCNX.Client, username, password)
 	if err != nil {

--- a/test/pkg/scm/scm.go
+++ b/test/pkg/scm/scm.go
@@ -106,7 +106,7 @@ func PushFilesToRefGit(t *testing.T, opts *Opts, entries map[string]string) {
 	}
 }
 
-// Make a clone url with username and password
+// MakeGitCloneURL will make a clone url with username and password
 func MakeGitCloneURL(targetURL, userName, password string) (string, error) {
 	// parse hostname of giteaURL
 	parsedURL, err := url.Parse(targetURL)


### PR DESCRIPTION
# Changes

* Refactor provider Interface
  Remove unused params from some of the methods in the provider interface.
  Except for methods that happen before SetClient is done we have all the
  client already set in there and we don't need to set this twice.

  Fix some linting on function comment, unused params and random others

* Add codespell to lint-md


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 A good commit message is important for other reviewers to understand the context of your change. Please refer to [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for more details how to write beautiful commit messages. We rather have the commit message in the PR body and the commit message instead of an external website.
- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
