### PR TITLE
Add private URL example to GitLab URL

### DIFF
--- a/.vale/styles/PaaC/GitLab.yml
+++ b/.vale/styles/PaaC/GitLab.yml
@@ -1,0 +1,7 @@
+extends: substitution
+message: Use '%s' instead of '%s'
+level: error
+scope: text
+nonword: false
+swap:
+  "Gitlab": GitLab

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Pipelines-as-Code features:
 
 - `tkn-pac` plug-in for Tekton CLI for managing pipelines-as-code repositories and bootstrapping.
 
-- Gitlab, Bitbucket Server, Bitbucket Cloud and GitHub through Webhook support.
+- GitLab, Bitbucket Server, Bitbucket Cloud and GitHub through Webhook support.
 
 ## Installation Guide
 
@@ -101,7 +101,7 @@ Note that even if installing with GitHub application is the preferred installati
 supports other methods :
 
 - GitHub direct Webhook
-- Gitlab public and private instances.
+- GitLab public and private instances.
 - Bitbucket Cloud
 - Bitbucket Server
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -10,7 +10,7 @@ An opinionated CI based on OpenShift Pipelines / Tekton.
 
 Pipelines as code is a project allowing you to define your CI/CD using
 [Tekton](https://tekton.dev) PipelineRuns and Tasks in a file located in your
-source control management (SCM) system, such as GitHub or Gitlab. This file is
+source control management (SCM) system, such as GitHub or GitLab. This file is
 then used to automatically create a pipeline for a Pull Request or a Push to a
 branch.
 
@@ -45,7 +45,7 @@ tracking using a Git workflow.
 
 - Git events Filtering and support for separate pipelines for each event
 
-- Gitlab, Bitbucket Server, Bitbucket Cloud and GitHub Webhook support.
+- GitLab, Bitbucket Server, Bitbucket Cloud and GitHub Webhook support.
 
 - `tkn-pac` plug-in for Tekton CLI for managing pipelines-as-code repositories and bootstrapping.
 

--- a/docs/content/dev/release-process.md
+++ b/docs/content/dev/release-process.md
@@ -28,7 +28,7 @@ git tag v1.2.3
 
 * After a while (gorelease takes sometime) If everything is fine you should
   have the new version set as pre-release in
-  github.com/openshift-pipelines/pipelines-as-code/releases
+  <https://github.com/openshift-pipelines/pipelines-as-code/releases>
 
 * Edit the release like the other releases has been done with a snippet of the highlight of the release.
 

--- a/docs/content/docs/guide/cli.md
+++ b/docs/content/docs/guide/cli.md
@@ -319,7 +319,7 @@ There is no clean-up of the secret after the run.
 
 {{< details "tkn pac webhook add" >}}
 
-### Configure and create webhook secret for GitHub, Gitlab and Bitbucket Cloud provider
+### Configure and create webhook secret for GitHub, GitLab and Bitbucket Cloud provider
 
 `tkn-pac webhook add [-n namespace]`: Allows you to add new webhook secret for a given provider and update the value of the new webhook secret in the existing `Secret` object used to interact with Pipelines-as-Code
 

--- a/docs/content/docs/guide/incoming_webhook.md
+++ b/docs/content/docs/guide/incoming_webhook.md
@@ -149,7 +149,7 @@ The parameter value of `pull_request_number` will be set to `12345` when using t
 
 ### Using incoming webhook with webhook based providers
 
-Webhook based providers (i.e: GitHub Webhook, Gitlab, Bitbucket etc..) supports
+Webhook based providers (i.e: GitHub Webhook, GitLab, Bitbucket etc..) supports
 incoming webhook, using the token provided in the git_provider section.
 
 Here is an example of a Repository CRD matching the target branch main with a GitHub webhook provider:

--- a/docs/content/docs/install/gitlab.md
+++ b/docs/content/docs/install/gitlab.md
@@ -1,11 +1,11 @@
 ---
-title: Gitlab
+title: GitLab
 weight: 13
 ---
 
-# Use Pipelines-as-Code with Gitlab Webhook
+# Use Pipelines-as-Code with GitLab Webhook
 
-Pipelines-As-Code supports on [Gitlab](https://www.gitlab.com) through a webhook.
+Pipelines-As-Code supports on [GitLab](https://www.gitlab.com) through a webhook.
 
 Follow the pipelines-as-code [installation](/docs/install/installation) according to your Kubernetes cluster.
 
@@ -64,7 +64,7 @@ $ tkn pac create repo
 
 ### Create a `Repository` and configure webhook manually
 
-* From the left navigation pane of your Gitlab repository, go to **settings** -->
+* From the left navigation pane of your GitLab repository, go to **settings** -->
   **Webhooks** tab.
 
 * Go to your project and click on *Settings* and *"Webhooks"* from the sidebar on the left.
@@ -119,6 +119,7 @@ $ tkn pac create repo
   spec:
     url: "https://gitlab.com/group/project"
     git_provider:
+      # url: "https://gitlab.example.com/ # Set this if you are using a private GitLab instance
       secret:
         name: "gitlab-webhook-config"
         # Set this if you have a different key in your secret
@@ -151,7 +152,7 @@ Below is the sample format for `tkn pac webhook add`
 $ tkn pac webhook add -n project-pipelines
 
 ✓ Setting up GitLab Webhook for Repository https://gitlab.com/repositories/project
-? Please enter the project ID for the repository you want to be configured, 
+? Please enter the project ID for the repository you want to be configured,
   project ID refers to an unique ID (e.g. 34405323) shown at the top of your GitLab project : 17103
 👀 I have detected a controller url: https://pipelines-as-code-controller-openshift-pipelines.apps.awscl2.aws.ospqa.com
 ? Do you want me to use it? Yes
@@ -169,7 +170,7 @@ $ tkn pac webhook add -n project-pipelines
 
 There are two ways to update the provider token for the existing `Repository`:
 
-### Update using tkn pac cli
+### Update using tkn pac CLI
 
 * Use the [`tkn pac webhook update-token`](/docs/guide/cli) command which
   will update provider token for the existing Repository CR.
@@ -197,6 +198,7 @@ You can find the secret name in the `Repository` CR.
   ```yaml
   spec:
     git_provider:
+      # url: "https://gitlab.example.com/ # Set this if you are using a private GitLab instance
       secret:
         name: "gitlab-webhook-config"
   ```

--- a/docs/content/docs/install/overview.md
+++ b/docs/content/docs/install/overview.md
@@ -34,6 +34,6 @@ preferences the preferred install method is the GitHub Application method.
 
 * [GitHub Application](/docs/install/github_apps).
 * [GitHub Webhook](/docs/install/github_webhook)
-* [Gitlab](/docs/install/gitlab)
+* [GitLab](/docs/install/gitlab)
 * [Bitbucket Server](/docs/install/bitbucket_server)
 * [Bitbucket Cloud](/docs/install/bitbucket_cloud)


### PR DESCRIPTION
Atm we do have in a note that private instances (i.e. self-hosted enterprise/private instances) of GitLab are not automatically detected.

However we could make it easier for the developers to grasp what do we mean, by adding said field (even in a commented out fashion) in the example

This commit add the url for example and as well make sure we use the word GitLab instead of gitlab by enforcing a rule with vale.

https://issues.redhat.com/browse/SRVKP-3735

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 A good commit message is important for other reviewers to understand the context of your change. Please refer to [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for more details how to write beautiful commit messages. We rather have the commit message in the PR body and the commit message instead of an external website.
- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
