### PR TITLE
Make sure to sort secrets by longest when hiding

### DIFF
--- a/docs/content/docs/guide/statuses.md
+++ b/docs/content/docs/guide/statuses.md
@@ -45,8 +45,11 @@ failed task.
 To prevent exposing secrets, Pipelines-as-Code analyze the PipelineRun and
 replace secret values with hidden characters. This is achieved by retrieving
 all secrets from the environment variables associated with tasks and steps, and
-searching for matches of these values in the output snippet. These matches are
-then replaced with a `"*****"` placeholder hiding these secrets.
+searching for matches of these values in the output snippet.
+
+These matches are first sorted by the longest and then replaced with a
+`"*****"` placeholder in the output snippet. This ensures that the output
+will not contain any leaked secrets.
 
 The hiding of the secret does not support concealing secrets from `workspaces`
 and

--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -202,6 +202,21 @@ func TestReplaceSecretsInText(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:   "replace secrets in text with same prefix",
+			text:   "I am the most beautifuller person in the world with the most beautiful friends",
+			result: "I am the most ***** person in the world with the most ***** friends",
+			values: []types.SecretValue{
+				{
+					Name:  "beautiful-secret",
+					Value: "beautiful",
+				},
+				{
+					Name:  "most-beautiful-secret",
+					Value: "beautifuller",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -209,4 +224,23 @@ func TestReplaceSecretsInText(t *testing.T) {
 			assert.Equal(t, ret, tt.result)
 		})
 	}
+}
+
+func TestSortByLongest(t *testing.T) {
+	values := []types.SecretValue{
+		{
+			Name:  "beautiful-secret",
+			Value: "beautiful",
+		},
+		{
+			Name:  "Even more beautiful",
+			Value: "beautifuller",
+		},
+		{
+			Name:  "Not that beautiful",
+			Value: "notpretty",
+		},
+	}
+	ret := sortSecretsByLongests(values)
+	assert.Equal(t, ret[0].Name, "Even more beautiful")
 }


### PR DESCRIPTION
When we hide secrets in the logs we need to make sure that we start from the longest one, otherwise if we have two secrets with the same prefix the shortest one may hide first and leak the end of the longest one. Since we are in a loop and text is replace the substitutions would not occurs.

https://issues.redhat.com/browse/SRVKP-3668

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 A good commit message is important for other reviewers to understand the context of your change. Please refer to [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for more details how to write beautiful commit messages. We rather have the commit message in the PR body and the commit message instead of an external website.
- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
