### PR TITLE
Update test yaml with increased timeout

### DIFF
--- a/test/github_pullrequest_retest_test.go
+++ b/test/github_pullrequest_retest_test.go
@@ -51,6 +51,7 @@ func TestGithubPullRequestRetest(t *testing.T) {
 	assert.Equal(t, repo.Status[len(repo.Status)-1].Conditions[0].Status, corev1.ConditionTrue)
 }
 
+// TestGithubPullRequestGitOpsComments tests GitOps comments /test, /retest and /cancel commands.
 func TestGithubPullRequestGitOpsComments(t *testing.T) {
 	ctx := context.Background()
 	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, sha := tgithub.RunPullRequest(ctx, t,

--- a/test/testdata/pipelinerun-gitops.yaml
+++ b/test/testdata/pipelinerun-gitops.yaml
@@ -18,5 +18,5 @@ spec:
               image: registry.access.redhat.com/ubi9/ubi-micro
               script: |
                 echo "HELLOMOTO"
-                sleep 10
+                sleep 30
                 exit 0

--- a/test/testdata/pipelinerun-on-push.yaml
+++ b/test/testdata/pipelinerun-on-push.yaml
@@ -17,5 +17,5 @@ spec:
               image: registry.access.redhat.com/ubi9/ubi-micro
               script: |
                 echo "HELLOMOTO"
-                sleep 10
+                sleep 30
                 exit 0


### PR DESCRIPTION
Sometimes Pipelineruns are successfully completing before the cancellation is initiated. So increased sleep time to avoid such cases

sometimes tests are failing 
```
{"level":"info","ts":1700544847.5309966,"caller":"github/setup.go:120","msg":"Deleting Ref refs/heads/pac-e2e-push-6tflm"}
--- FAIL: TestGithubPushRequestGitOpsComments (51.91s)
    --- PASS: TestGithubPushRequestGitOpsComments/Retest (20.44s)
    --- FAIL: TestGithubPushRequestGitOpsComments/Test_and_Cancel_PipelineRun (5.88s)
```

Signed-off-by: Savita Ashture <sashture@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 A good commit message is important for other reviewers to understand the context of your change. Please refer to [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for more details how to write beautiful commit messages. We rather have the commit message in the PR body and the commit message instead of an external website.
- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
