### PR TITLE
Set timeout for http.Client

### DIFF
--- a/pkg/matcher/annotation_tasks_install.go
+++ b/pkg/matcher/annotation_tasks_install.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
 	"regexp"
 	"strings"
@@ -106,16 +104,10 @@ func (rt RemoteTasks) getRemote(ctx context.Context, uri string, fromHub bool) (
 
 	switch {
 	case strings.HasPrefix(uri, "https://"), strings.HasPrefix(uri, "http://"): // if it starts with http(s)://, it is a remote resource
-		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil)
-		res, err := rt.Run.Clients.HTTP.Do(req)
+		data, err := rt.Run.Clients.GetURL(ctx, uri)
 		if err != nil {
 			return "", err
 		}
-		if res.StatusCode != http.StatusOK {
-			return "", fmt.Errorf("cannot get remote resource: %s: %s", uri, res.Status)
-		}
-		data, _ := io.ReadAll(res.Body)
-		defer res.Body.Close()
 		rt.Logger.Infof("successfully fetched %s from remote https url", uri)
 		return string(data), nil
 	case fromHub && strings.Contains(uri, "://"): // if it contains ://, it is a remote custom catalog


### PR DESCRIPTION
Used a default of 100 seconds for the timeout.  This is the same value
as what c# uses by default. I didn't find any other good default.

Make annotation_tasks_install.go use the common function instead of
defining it's own.

Fixes #1514
# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 A good commit message is important for other reviewers to understand the context of your change. Please refer to [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for more details how to write beautiful commit messages. We rather have the commit message in the PR body and the commit message instead of an external website.
- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
