### PR TITLE
fix running incoming webhook on GHE

### DIFF
--- a/docs/content/docs/guide/incoming_webhook.md
+++ b/docs/content/docs/guide/incoming_webhook.md
@@ -147,6 +147,16 @@ curl -H "Content-Type: application/json" -X POST "https://control.pac.url/incomi
 
 The parameter value of `pull_request_number` will be set to `12345` when using the variable `{{pull_request_number}}` in your PipelineRun.
 
+### Using incoming webhook with GitHub Enterprise application
+
+When using a GitHub application over to a GitHub Enterprise, you will need to
+specify the `X-GitHub-Enterprise-Host` header when making the incoming webhook
+request. For example when using curl:
+
+```shell
+curl -H "X-GitHub-Enterprise-Host: github.example.com" -X POST "https://control.pac.url/incoming?repository=repo&branch=main&secret=very-secure-shared-secret&pipelinerun=target_pipelinerun"
+```
+
 ### Using incoming webhook with webhook based providers
 
 Webhook based providers (i.e: GitHub Webhook, GitLab, Bitbucket etc..) supports

--- a/pkg/provider/github/app/token.go
+++ b/pkg/provider/github/app/token.go
@@ -19,8 +19,8 @@ import (
 
 func GetAndUpdateInstallationID(ctx context.Context, req *http.Request, run *params.Run, repo *v1alpha1.Repository, gh *github.Provider, ns string) (string, string, int64, error) {
 	var (
-		enterpriseURL, token string
-		installationID       int64
+		enterpriseHost, token string
+		installationID        int64
 	)
 	jwtToken, err := GenerateJWT(ctx, ns, run)
 	if err != nil {
@@ -28,9 +28,10 @@ func GetAndUpdateInstallationID(ctx context.Context, req *http.Request, run *par
 	}
 
 	installationURL := *gh.APIURL + keys.InstallationURL
-	enterpriseURL = req.Header.Get("X-GitHub-Enterprise-Host")
-	if enterpriseURL != "" {
-		installationURL = enterpriseURL + keys.InstallationURL
+	enterpriseHost = req.Header.Get("X-GitHub-Enterprise-Host")
+	if enterpriseHost != "" {
+		// NOTE: Hopefully this works even when the ghe URL is on another host than the api URL
+		installationURL = "https://" + enterpriseHost + "/api/v3" + keys.InstallationURL
 	}
 
 	res, err := GetReponse(ctx, http.MethodGet, installationURL, jwtToken, run)
@@ -39,7 +40,7 @@ func GetAndUpdateInstallationID(ctx context.Context, req *http.Request, run *par
 	}
 
 	if res.StatusCode >= 300 {
-		return "", "", 0, fmt.Errorf("Non-OK HTTP status: %d", res.StatusCode)
+		return "", "", 0, fmt.Errorf("Non-OK HTTP status while getting installation URL: %s : %d", installationURL, res.StatusCode)
 	}
 
 	defer res.Body.Close()
@@ -61,7 +62,7 @@ func GetAndUpdateInstallationID(ctx context.Context, req *http.Request, run *par
 			return "", "", 0, fmt.Errorf("installation ID is nil")
 		}
 		if *installationData[i].ID != 0 {
-			token, err = gh.GetAppToken(ctx, run.Clients.Kube, enterpriseURL, *installationData[i].ID, ns)
+			token, err = gh.GetAppToken(ctx, run.Clients.Kube, enterpriseHost, *installationData[i].ID, ns)
 			if err != nil {
 				return "", "", 0, err
 			}
@@ -75,7 +76,7 @@ func GetAndUpdateInstallationID(ctx context.Context, req *http.Request, run *par
 			break
 		}
 	}
-	return enterpriseURL, token, installationID, nil
+	return enterpriseHost, token, installationID, nil
 }
 
 func listRepos(ctx context.Context, repo *v1alpha1.Repository, gh *github.Provider) (bool, error) {


### PR DESCRIPTION
We were not passing the installation URL properly to the endpoint when detecting the X-GitHub-Enterprise-Host header.

Clarify the documentation about this that the user need to pass a GHE Host header to work

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 A good commit message is important for other reviewers to understand the context of your change. Please refer to [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for more details how to write beautiful commit messages. We rather have the commit message in the PR body and the commit message instead of an external website.
- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
