### PR TITLE
pass ghe url when creating prun on incoming event

### DIFF
--- a/pkg/adapter/sinker.go
+++ b/pkg/adapter/sinker.go
@@ -42,7 +42,13 @@ func (s *sinker) processEventPayload(ctx context.Context, request *http.Request)
 }
 
 func (s *sinker) processEvent(ctx context.Context, request *http.Request) error {
-	if s.event.EventType != "incoming" {
+	// TODO(chmouel): Add E2E Test for incoming test on GHE when #1518 is merged
+	if s.event.EventType == "incoming" {
+		if request.Header.Get("X-GitHub-Enterprise-Host") != "" {
+			s.event.Provider.URL = request.Header.Get("X-GitHub-Enterprise-Host")
+			s.event.GHEURL = request.Header.Get("X-GitHub-Enterprise-Host")
+		}
+	} else {
 		if err := s.processEventPayload(ctx, request); err != nil {
 			return err
 		}


### PR DESCRIPTION
We didn't pass the GHE URL in the annotations to the watcher when
creating a prun on incoming webhook requests and as a result the watcher
was not able to connect to the GHE instance properly.

We can't test GHE yet (until #1518  is merged) but i tested it manually on [ghe.pac.com](https://ghe.pipelinesascode.com/pac/chmoupac/runs/1714) and check-run is added properly now:

![image](https://github.com/openshift-pipelines/pipelines-as-code/assets/98980/bc5ec7a3-96ee-4ed8-96bc-5a10d201025c)

