### PR TITLE
Improve get changed files

### DIFF
--- a/docs/content/docs/guide/authoringprs.md
+++ b/docs/content/docs/guide/authoringprs.md
@@ -204,7 +204,7 @@ This example will match modified files with the name of test.go:
 
 ```yaml
     pipelinesascode.tekton.dev/on-cel-expression: |
-      files.modified.exists(x, x.matches('test.go'))   
+      files.modified.exists(x, x.matches('test.go'))
 ```
 
 ### Matching PipelineRun on event title

--- a/pkg/cel/cel.go
+++ b/pkg/cel/cel.go
@@ -35,7 +35,7 @@ func celEvaluate(expr string, env *cel.Env, data map[string]interface{}) (ref.Va
 
 // CelValue evaluates a CEL expression with the given body, headers and
 // / pacParams, it will output a Cel value or an error if selectedjm.
-func CelValue(query string, body any, headers, pacParams map[string]string) (ref.Val, error) {
+func CelValue(query string, body any, headers, pacParams map[string]string, changedFiles map[string]interface{}) (ref.Val, error) {
 	// Marshal/Unmarshal the body to a map[string]interface{} so we can access it from the CEL
 	nbody, err := json.Marshal(body)
 	if err != nil {
@@ -53,11 +53,13 @@ func CelValue(query string, body any, headers, pacParams map[string]string) (ref
 			decls.NewVar("body", mapStrDyn),
 			decls.NewVar("headers", mapStrDyn),
 			decls.NewVar("pac", mapStrDyn),
+			decls.NewVar("files", mapStrDyn),
 		))
 	val, err := celEvaluate(query, celDec, map[string]any{
 		"body":    jsonMap,
 		"pac":     pacParams,
 		"headers": headers,
+		"files":   changedFiles,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/tknpac/resolve/resolve.go
+++ b/pkg/cmd/tknpac/resolve/resolve.go
@@ -203,7 +203,7 @@ func resolveFilenames(ctx context.Context, cs *params.Run, filenames []string, p
 	}
 
 	// TODO: flags
-	allTheYamls = templates.ReplacePlaceHoldersVariables(allTheYamls, params, nil, http.Header{})
+	allTheYamls = templates.ReplacePlaceHoldersVariables(allTheYamls, params, nil, http.Header{}, map[string]interface{}{})
 	// We use github here but since we don't do remotetask we would not care
 	providerintf := github.New()
 	event := info.NewEvent()

--- a/pkg/consoleui/custom.go
+++ b/pkg/consoleui/custom.go
@@ -42,7 +42,7 @@ func (o *CustomConsole) URL() string {
 // return the default URL if there it's not become a proper url or that it has
 // some of the templates like {{}} left.
 func (o *CustomConsole) generateURL(urlTmpl string, dict map[string]string) string {
-	newurl := templates.ReplacePlaceHoldersVariables(urlTmpl, dict, nil, nil)
+	newurl := templates.ReplacePlaceHoldersVariables(urlTmpl, dict, nil, nil, map[string]interface{}{})
 	// trim new line because yaml parser adds new line at the end of the string
 	newurl = strings.TrimSpace(strings.TrimSuffix(newurl, "\n"))
 	if _, err := url.ParseRequestURI(newurl); err != nil {

--- a/pkg/customparams/standard.go
+++ b/pkg/customparams/standard.go
@@ -1,30 +1,52 @@
 package customparams
 
 import (
+	"context"
+	"fmt"
 	"strings"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
+	"go.uber.org/zap"
 )
 
+func (p *CustomParams) getChangedFiles(ctx context.Context) provider.ChangedFiles {
+	if p.vcx == nil {
+		return provider.ChangedFiles{}
+	}
+	changedFiles, err := p.vcx.GetFiles(ctx, p.event)
+	if err != nil {
+		p.eventEmitter.EmitMessage(p.repo, zap.ErrorLevel, "ParamsError", fmt.Sprintf("error getting changed files: %s", err.Error()))
+	}
+	return changedFiles
+}
+
 // makeStandardParamsFromEvent will create a map of standard params out of the event.
-func (p *CustomParams) makeStandardParamsFromEvent() map[string]string {
+func (p *CustomParams) makeStandardParamsFromEvent(ctx context.Context) (map[string]string, map[string]interface{}) {
 	repoURL := p.event.URL
 	// On bitbucket server you are have a special url for checking it out, they
 	// seemed to fix it in 2.0 but i guess we have to live with this until then.
 	if p.event.CloneURL != "" {
 		repoURL = p.event.CloneURL
 	}
+	changedFiles := p.getChangedFiles(ctx)
 
 	return map[string]string{
-		"revision":         p.event.SHA,
-		"repo_url":         repoURL,
-		"repo_owner":       strings.ToLower(p.event.Organization),
-		"repo_name":        strings.ToLower(p.event.Repository),
-		"target_branch":    formatting.SanitizeBranch(p.event.BaseBranch),
-		"source_branch":    formatting.SanitizeBranch(p.event.HeadBranch),
-		"source_url":       p.event.HeadURL,
-		"sender":           strings.ToLower(p.event.Sender),
-		"target_namespace": p.repo.GetNamespace(),
-		"event_type":       p.event.EventType,
-	}
+			"revision":         p.event.SHA,
+			"repo_url":         repoURL,
+			"repo_owner":       strings.ToLower(p.event.Organization),
+			"repo_name":        strings.ToLower(p.event.Repository),
+			"target_branch":    formatting.SanitizeBranch(p.event.BaseBranch),
+			"source_branch":    formatting.SanitizeBranch(p.event.HeadBranch),
+			"source_url":       p.event.HeadURL,
+			"sender":           strings.ToLower(p.event.Sender),
+			"target_namespace": p.repo.GetNamespace(),
+			"event_type":       p.event.EventType,
+		}, map[string]interface{}{
+			"all":      changedFiles.All,
+			"added":    changedFiles.Added,
+			"deleted":  changedFiles.Deleted,
+			"modified": changedFiles.Modified,
+			"renamed":  changedFiles.Renamed,
+		}
 }

--- a/pkg/formatting/array.go
+++ b/pkg/formatting/array.go
@@ -1,0 +1,16 @@
+package formatting
+
+import "sort"
+
+func UniqueStringArray(slice []string) []string {
+	keys := make(map[string]bool)
+	list := []string{}
+	for _, entry := range slice {
+		if _, value := keys[entry]; !value {
+			keys[entry] = true
+			list = append(list, entry)
+		}
+	}
+	sort.Strings(list)
+	return list
+}

--- a/pkg/formatting/array_test.go
+++ b/pkg/formatting/array_test.go
@@ -1,0 +1,40 @@
+package formatting
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestUniqueStringArray(t *testing.T) {
+	type args struct {
+		slice []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "no duplicates",
+			args: args{
+				slice: []string{"1", "2"},
+			},
+			want: []string{"1", "2"},
+		},
+
+		{
+			name: "with duplicates",
+			args: args{
+				slice: []string{"1", "2", "1", "2", "1", "2", "3", "2", "5", "5"},
+			},
+			want: []string{"1", "2", "3", "5"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := UniqueStringArray(tt.args.slice); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("UniqueStringArray() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/matcher/annotation_matcher_test.go
+++ b/pkg/matcher/annotation_matcher_test.go
@@ -37,10 +37,16 @@ import (
 const pipelineTargetNSName = "pipeline-target-ns"
 
 type annotationTestArgs struct {
-	fileChanged []string
-	pruns       []*tektonv1.PipelineRun
-	runevent    info.Event
-	data        testclient.Data
+	fileChanged []struct {
+		FileName    string
+		Status      string
+		NewFile     bool
+		RenamedFile bool
+		DeletedFile bool
+	}
+	pruns    []*tektonv1.PipelineRun
+	runevent info.Event
+	data     testclient.Data
 }
 
 type annotationTest struct {
@@ -68,6 +74,45 @@ func makePipelineRunTargetNS(event, targetNS string) *tektonv1.PipelineRun {
 
 func TestMatchPipelinerunAnnotationAndRepositories(t *testing.T) {
 	cw := clockwork.NewFakeClock()
+
+	filesChanged := []struct {
+		FileName    string
+		Status      string
+		NewFile     bool
+		RenamedFile bool
+		DeletedFile bool
+	}{
+		{
+			FileName:    "src/added.go",
+			Status:      "added",
+			NewFile:     true,
+			RenamedFile: false,
+			DeletedFile: false,
+		},
+		{
+			FileName:    "src/modified.go",
+			Status:      "modified",
+			NewFile:     false,
+			RenamedFile: false,
+			DeletedFile: false,
+		},
+		{
+			FileName:    "src/removed.go",
+			Status:      "removed",
+			NewFile:     false,
+			RenamedFile: false,
+			DeletedFile: true,
+		},
+
+		{
+			FileName:    "src/renamed.go",
+			Status:      "renamed",
+			NewFile:     false,
+			RenamedFile: true,
+			DeletedFile: false,
+		},
+	}
+
 	tests := []annotationTest{
 		{
 			name:       "match a repository with target NS",
@@ -208,7 +253,21 @@ func TestMatchPipelinerunAnnotationAndRepositories(t *testing.T) {
 			name:       "cel/match path by glob",
 			wantPRName: pipelineTargetNSName,
 			args: annotationTestArgs{
-				fileChanged: []string{".tekton/pull_request.yaml"},
+				fileChanged: []struct {
+					FileName    string
+					Status      string
+					NewFile     bool
+					RenamedFile bool
+					DeletedFile bool
+				}{
+					{
+						FileName:    ".tekton/pull_request.yaml",
+						Status:      "added",
+						NewFile:     true,
+						RenamedFile: false,
+						DeletedFile: false,
+					},
+				},
 				pruns: []*tektonv1.PipelineRun{
 					{
 						ObjectMeta: metav1.ObjectMeta{
@@ -362,8 +421,20 @@ func TestMatchPipelinerunAnnotationAndRepositories(t *testing.T) {
 			name:    "cel/no match path by glob",
 			wantErr: true,
 			args: annotationTestArgs{
-				fileChanged: []string{
-					".tekton/foo.json",
+				fileChanged: []struct {
+					FileName    string
+					Status      string
+					NewFile     bool
+					RenamedFile bool
+					DeletedFile bool
+				}{
+					{
+						FileName:    ".tekton/foo.json",
+						Status:      "added",
+						NewFile:     true,
+						RenamedFile: false,
+						DeletedFile: false,
+					},
 				},
 				pruns: []*tektonv1.PipelineRun{
 					{
@@ -404,8 +475,20 @@ func TestMatchPipelinerunAnnotationAndRepositories(t *testing.T) {
 			name:       "cel/match by direct path",
 			wantPRName: pipelineTargetNSName,
 			args: annotationTestArgs{
-				fileChanged: []string{
-					".tekton/pull_request.yaml",
+				fileChanged: []struct {
+					FileName    string
+					Status      string
+					NewFile     bool
+					RenamedFile bool
+					DeletedFile bool
+				}{
+					{
+						FileName:    ".tekton/pull_request.yaml",
+						Status:      "added",
+						NewFile:     true,
+						RenamedFile: false,
+						DeletedFile: false,
+					},
 				},
 				pruns: []*tektonv1.PipelineRun{
 					{
@@ -707,7 +790,21 @@ func TestMatchPipelinerunAnnotationAndRepositories(t *testing.T) {
 			name:       "cel/match path by glob along with push event and target_branch info",
 			wantPRName: pipelineTargetNSName,
 			args: annotationTestArgs{
-				fileChanged: []string{".tekton/push.yaml"},
+				fileChanged: []struct {
+					FileName    string
+					Status      string
+					NewFile     bool
+					RenamedFile bool
+					DeletedFile bool
+				}{
+					{
+						FileName:    ".tekton/push.yaml",
+						Status:      "added",
+						NewFile:     true,
+						RenamedFile: false,
+						DeletedFile: false,
+					},
+				},
 				pruns: []*tektonv1.PipelineRun{
 					{
 						ObjectMeta: metav1.ObjectMeta{
@@ -742,6 +839,126 @@ func TestMatchPipelinerunAnnotationAndRepositories(t *testing.T) {
 				},
 			},
 		},
+
+		{
+			name:    "cel match on all changed files",
+			wantErr: false,
+			args: annotationTestArgs{
+				fileChanged: filesChanged,
+				pruns: []*tektonv1.PipelineRun{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: pipelineTargetNSName,
+							Annotations: map[string]string{
+								keys.OnCelExpression: "files.all.exists(x, x.matches(\"added.go\"))",
+							},
+						},
+					},
+				},
+				runevent: info.Event{
+					URL:               targetURL,
+					TriggerTarget:     "pull_request",
+					EventType:         "pull_request",
+					BaseBranch:        mainBranch,
+					HeadBranch:        "unittests",
+					PullRequestNumber: 1000,
+					PullRequestTitle:  "[DOWNSTREAM] don't test me cause i'm famous",
+					Organization:      "mylittle",
+					Repository:        "pony",
+				},
+				data: testclient.Data{
+					Repositories: []*v1alpha1.Repository{
+						testnewrepo.NewRepo(
+							testnewrepo.RepoTestcreationOpts{
+								Name:             "test-good",
+								URL:              targetURL,
+								InstallNamespace: targetNamespace,
+							},
+						),
+					},
+				},
+			},
+		},
+
+		{
+			name:    "cel NOT match on all changed files",
+			wantErr: true,
+			args: annotationTestArgs{
+				fileChanged: filesChanged,
+				pruns: []*tektonv1.PipelineRun{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: pipelineTargetNSName,
+							Annotations: map[string]string{
+								keys.OnCelExpression: "files.all.exists(x, x.matches(\"notmatch.go\"))",
+							},
+						},
+					},
+				},
+				runevent: info.Event{
+					URL:               targetURL,
+					TriggerTarget:     "pull_request",
+					EventType:         "pull_request",
+					BaseBranch:        mainBranch,
+					HeadBranch:        "unittests",
+					PullRequestNumber: 1000,
+					PullRequestTitle:  "[DOWNSTREAM] don't test me cause i'm famous",
+					Organization:      "mylittle",
+					Repository:        "pony",
+				},
+				data: testclient.Data{
+					Repositories: []*v1alpha1.Repository{
+						testnewrepo.NewRepo(
+							testnewrepo.RepoTestcreationOpts{
+								Name:             "test-good",
+								URL:              targetURL,
+								InstallNamespace: targetNamespace,
+							},
+						),
+					},
+				},
+			},
+		},
+
+		{
+			name:    "cel match on added, modified, deleted and renamed  files",
+			wantErr: false,
+			args: annotationTestArgs{
+				fileChanged: filesChanged,
+				pruns: []*tektonv1.PipelineRun{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: pipelineTargetNSName,
+							Annotations: map[string]string{
+								keys.OnCelExpression: "files.added.exists(x, x.matches(\"added.go\")) && files.deleted.exists(x, x.matches(\"removed.go\")) && files.modified.exists(x, x.matches(\"modified.go\")) && files.renamed.exists(x, x.matches(\"renamed.go\"))",
+							},
+						},
+					},
+				},
+				runevent: info.Event{
+					URL:               targetURL,
+					TriggerTarget:     "pull_request",
+					EventType:         "pull_request",
+					BaseBranch:        mainBranch,
+					HeadBranch:        "unittests",
+					PullRequestNumber: 1000,
+					PullRequestTitle:  "[DOWNSTREAM] don't test me cause i'm famous",
+					Organization:      "mylittle",
+					Repository:        "pony",
+				},
+				data: testclient.Data{
+					Repositories: []*v1alpha1.Repository{
+						testnewrepo.NewRepo(
+							testnewrepo.RepoTestcreationOpts{
+								Name:             "test-good",
+								URL:              targetURL,
+								InstallNamespace: targetNamespace,
+							},
+						),
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -759,7 +976,10 @@ func TestMatchPipelinerunAnnotationAndRepositories(t *testing.T) {
 			if len(tt.args.fileChanged) > 0 {
 				commitFiles := []*github.CommitFile{}
 				for _, v := range tt.args.fileChanged {
-					commitFiles = append(commitFiles, &github.CommitFile{Filename: github.String(v)})
+					commitFiles = append(commitFiles, &github.CommitFile{
+						Filename: github.String(v.FileName),
+						Status:   github.String(v.Status),
+					})
 				}
 				if tt.args.runevent.TriggerTarget == "push" {
 					mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/commits/%s",
@@ -803,7 +1023,12 @@ func TestMatchPipelinerunAnnotationAndRepositories(t *testing.T) {
 				pushFileChanges := []*gitlab.Diff{}
 				if tt.args.runevent.TriggerTarget == "push" {
 					for _, v := range tt.args.fileChanged {
-						pushFileChanges = append(pushFileChanges, &gitlab.Diff{NewPath: v})
+						pushFileChanges = append(pushFileChanges, &gitlab.Diff{
+							NewPath:     v.FileName,
+							RenamedFile: v.RenamedFile,
+							DeletedFile: v.DeletedFile,
+							NewFile:     v.NewFile,
+						})
 					}
 					glMux.HandleFunc(fmt.Sprintf("/projects/0/repository/commits/%s/diff",
 						tt.args.runevent.SHA), func(rw http.ResponseWriter, _ *http.Request) {
@@ -813,7 +1038,12 @@ func TestMatchPipelinerunAnnotationAndRepositories(t *testing.T) {
 					})
 				} else {
 					for _, v := range tt.args.fileChanged {
-						commitFiles.Changes = append(commitFiles.Changes, &gitlab.MergeRequestDiff{NewPath: v})
+						commitFiles.Changes = append(commitFiles.Changes, &gitlab.MergeRequestDiff{
+							NewPath:     v.FileName,
+							RenamedFile: v.RenamedFile,
+							DeletedFile: v.DeletedFile,
+							NewFile:     v.NewFile,
+						})
 					}
 					url := fmt.Sprintf("/projects/0/merge_requests/%d/changes", tt.args.runevent.PullRequestNumber)
 					glMux.HandleFunc(url, func(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -278,7 +278,7 @@ func changeSecret(prs []*tektonv1.PipelineRun) error {
 		name := secrets.GenerateBasicAuthSecretName()
 		processed := templates.ReplacePlaceHoldersVariables(string(b), map[string]string{
 			"git_auth_secret": name,
-		}, nil, nil)
+		}, nil, nil, map[string]interface{}{})
 
 		var np *tektonv1.PipelineRun
 		err = json.Unmarshal([]byte(processed), &np)

--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -67,8 +67,8 @@ func (p *PacRun) Run(ctx context.Context) error {
 	}
 
 	// set params for the console driver, only used for the custom console ones
-	cp := customparams.NewCustomParams(p.event, repo, p.run, p.k8int, p.eventEmitter)
-	maptemplate, err := cp.GetParams(ctx)
+	cp := customparams.NewCustomParams(p.event, repo, p.run, p.k8int, p.eventEmitter, p.vcx)
+	maptemplate, _, err := cp.GetParams(ctx)
 	if err != nil {
 		p.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "ParamsError",
 			fmt.Sprintf("error processing repository CR custom params: %s", err.Error()))

--- a/pkg/pipelineascode/template.go
+++ b/pkg/pipelineascode/template.go
@@ -14,8 +14,8 @@ import (
 // makeTemplate will process all templates replacing the value from the event and from the
 // params as set on Repo CR.
 func (p *PacRun) makeTemplate(ctx context.Context, repo *v1alpha1.Repository, template string) string {
-	cp := customparams.NewCustomParams(p.event, repo, p.run, p.k8int, p.eventEmitter)
-	maptemplate, err := cp.GetParams(ctx)
+	cp := customparams.NewCustomParams(p.event, repo, p.run, p.k8int, p.eventEmitter, p.vcx)
+	maptemplate, changedFiles, err := cp.GetParams(ctx)
 	if err != nil {
 		p.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "ParamsError",
 			fmt.Sprintf("error processing repository CR custom params: %s", err.Error()))
@@ -32,5 +32,5 @@ func (p *PacRun) makeTemplate(ctx context.Context, repo *v1alpha1.Repository, te
 		headers = p.event.Request.Header
 	}
 
-	return templates.ReplacePlaceHoldersVariables(template, maptemplate, p.event.Event, headers)
+	return templates.ReplacePlaceHoldersVariables(template, maptemplate, p.event.Event, headers, changedFiles)
 }

--- a/pkg/provider/bitbucketcloud/bitbucket.go
+++ b/pkg/provider/bitbucketcloud/bitbucket.go
@@ -277,8 +277,8 @@ func (v *Provider) getBlob(runevent *info.Event, ref, path string) (string, erro
 	return blob.String(), nil
 }
 
-func (v *Provider) GetFiles(_ context.Context, _ *info.Event) ([]string, error) {
-	return []string{}, nil
+func (v *Provider) GetFiles(_ context.Context, _ *info.Event) (provider.ChangedFiles, error) {
+	return provider.ChangedFiles{}, nil
 }
 
 func (v *Provider) CreateToken(_ context.Context, _ []string, _ *info.Event) (string, error) {

--- a/pkg/provider/bitbucketserver/bitbucketserver.go
+++ b/pkg/provider/bitbucketserver/bitbucketserver.go
@@ -272,8 +272,8 @@ func (v *Provider) GetConfig() *info.ProviderConfig {
 	}
 }
 
-func (v *Provider) GetFiles(_ context.Context, _ *info.Event) ([]string, error) {
-	return []string{}, nil
+func (v *Provider) GetFiles(_ context.Context, _ *info.Event) (provider.ChangedFiles, error) {
+	return provider.ChangedFiles{}, nil
 }
 
 func (v *Provider) CreateToken(_ context.Context, _ []string, _ *info.Event) (string, error) {

--- a/pkg/provider/gitea/gitea_test.go
+++ b/pkg/provider/gitea/gitea_test.go
@@ -1,0 +1,145 @@
+package gitea
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
+	tgitea "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/gitea/test"
+	"go.uber.org/zap"
+	zapobserver "go.uber.org/zap/zaptest/observer"
+	rtesting "knative.dev/pkg/reconciler/testing"
+)
+
+func TestProvider_GetFiles(t *testing.T) {
+	type args struct {
+		runevent *info.Event
+	}
+	tests := []struct {
+		name         string
+		args         args
+		changedFiles string
+		want         provider.ChangedFiles
+		wantErr      bool
+	}{
+		{
+			name: "pull_request",
+			args: args{
+				runevent: &info.Event{
+					Organization:      "myorg",
+					Repository:        "myrepo",
+					PullRequestNumber: 1,
+					TriggerTarget:     "pull_request",
+				},
+			},
+			want: provider.ChangedFiles{
+				All: []string{
+					"added.txt",
+					"deleted.txt",
+					"modified.txt",
+					"renamed.txt",
+				},
+				Added: []string{
+					"added.txt",
+				},
+				Deleted:  []string{"deleted.txt"},
+				Modified: []string{"modified.txt"},
+				Renamed:  []string{"renamed.txt"},
+			},
+			changedFiles: `[{"filename":"added.txt","status":"added"},{"filename":"deleted.txt","status":"deleted"},{"filename":"modified.txt","status":"changed"},{"filename":"renamed.txt","status":"renamed"}]`,
+		},
+		{
+			name: "push",
+			args: args{
+				runevent: &info.Event{
+					Organization:      "myorg",
+					Repository:        "myrepo",
+					PullRequestNumber: -1,
+					TriggerTarget:     "push",
+					Request: &info.Request{
+						Payload: []byte(`{"ref":"refs/heads/main","commits":[{"added":["added.txt"],"removed":["deleted.txt"],"modified":["modified.txt"]},{"added":[".tekton/pullrequest.yaml",".tekton/push.yaml"],"removed":[],"modified":[]}]}`),
+					},
+				},
+			},
+			want: provider.ChangedFiles{
+				All: []string{
+					".tekton/pullrequest.yaml",
+					".tekton/push.yaml",
+					"added.txt",
+					"deleted.txt",
+					"modified.txt",
+				},
+				Added: []string{
+					".tekton/pullrequest.yaml",
+					".tekton/push.yaml",
+					"added.txt",
+				},
+				Deleted:  []string{"deleted.txt"},
+				Modified: []string{"modified.txt"},
+				// Renamed:  []string{"renamed.txt"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeclient, mux, teardown := tgitea.Setup(t)
+			defer teardown()
+
+			mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/pulls/%d/files", tt.args.runevent.Organization, tt.args.runevent.Repository, tt.args.runevent.PullRequestNumber), func(rw http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(rw, tt.changedFiles)
+			})
+			ctx, _ := rtesting.SetupFakeContext(t)
+			observer, _ := zapobserver.New(zap.InfoLevel)
+			logger := zap.New(observer).Sugar()
+			repo := &v1alpha1.Repository{Spec: v1alpha1.RepositorySpec{
+				Settings: &v1alpha1.Settings{},
+			}}
+			gprovider := Provider{
+				Client: fakeclient,
+				repo:   repo,
+				Logger: logger,
+			}
+
+			got, err := gprovider.GetFiles(ctx, tt.args.runevent)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Provider.GetFiles() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			sort.Strings(got.All)
+			sort.Strings(tt.want.All)
+
+			sort.Strings(got.Added)
+			sort.Strings(tt.want.Added)
+
+			sort.Strings(got.Deleted)
+			sort.Strings(tt.want.Deleted)
+
+			sort.Strings(got.Modified)
+			sort.Strings(tt.want.Modified)
+
+			sort.Strings(got.Renamed)
+			sort.Strings(tt.want.Renamed)
+			if !reflect.DeepEqual(got.All, tt.want.All) {
+				t.Errorf("Provider.GetFiles() All = %v, want %v", got.All, tt.want.All)
+			}
+			if !reflect.DeepEqual(got.Added, tt.want.Added) {
+				t.Errorf("Provider.GetFiles() Added = %v, want %v", got.Added, tt.want.Added)
+			}
+			if !reflect.DeepEqual(got.Deleted, tt.want.Deleted) {
+				t.Errorf("Provider.GetFiles() Deleted = %v, want %v", got.Deleted, tt.want.Deleted)
+			}
+			if !reflect.DeepEqual(got.Modified, tt.want.Modified) {
+				t.Errorf("Provider.GetFiles() Modified = %v, want %v", got.Modified, tt.want.Modified)
+			}
+			if !reflect.DeepEqual(got.Renamed, tt.want.Renamed) {
+				t.Errorf("Provider.GetFiles() Renamed = %v, want %v", got.Renamed, tt.want.Renamed)
+			}
+		})
+	}
+}

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -441,38 +441,62 @@ func (v *Provider) getPullRequest(ctx context.Context, runevent *info.Event) (*i
 }
 
 // GetFiles get a files from pull request.
-func (v *Provider) GetFiles(ctx context.Context, runevent *info.Event) ([]string, error) {
+func (v *Provider) GetFiles(ctx context.Context, runevent *info.Event) (provider.ChangedFiles, error) {
 	if runevent.TriggerTarget == "pull_request" {
 		opt := &github.ListOptions{PerPage: v.paginedNumber}
-		result := []string{}
+		changedFiles := provider.ChangedFiles{}
 		for {
 			repoCommit, resp, err := v.Client.PullRequests.ListFiles(ctx, runevent.Organization, runevent.Repository, runevent.PullRequestNumber, opt)
 			if err != nil {
-				return []string{}, err
+				return provider.ChangedFiles{}, err
 			}
 			for j := range repoCommit {
-				result = append(result, *repoCommit[j].Filename)
+				changedFiles.All = append(changedFiles.All, *repoCommit[j].Filename)
+				if *repoCommit[j].Status == "added" {
+					changedFiles.Added = append(changedFiles.Added, *repoCommit[j].Filename)
+				}
+				if *repoCommit[j].Status == "removed" {
+					changedFiles.Deleted = append(changedFiles.Deleted, *repoCommit[j].Filename)
+				}
+				if *repoCommit[j].Status == "modified" {
+					changedFiles.Modified = append(changedFiles.Modified, *repoCommit[j].Filename)
+				}
+				if *repoCommit[j].Status == "renamed" {
+					changedFiles.Renamed = append(changedFiles.Renamed, *repoCommit[j].Filename)
+				}
 			}
 			if resp.NextPage == 0 {
 				break
 			}
 			opt.Page = resp.NextPage
 		}
-		return result, nil
+		return changedFiles, nil
 	}
 
 	if runevent.TriggerTarget == "push" {
-		result := []string{}
+		changedFiles := provider.ChangedFiles{}
 		rC, _, err := v.Client.Repositories.GetCommit(ctx, runevent.Organization, runevent.Repository, runevent.SHA, &github.ListOptions{})
 		if err != nil {
-			return []string{}, err
+			return provider.ChangedFiles{}, err
 		}
 		for i := range rC.Files {
-			result = append(result, *rC.Files[i].Filename)
+			changedFiles.All = append(changedFiles.All, *rC.Files[i].Filename)
+			if *rC.Files[i].Status == "added" {
+				changedFiles.Added = append(changedFiles.Added, *rC.Files[i].Filename)
+			}
+			if *rC.Files[i].Status == "removed" {
+				changedFiles.Deleted = append(changedFiles.Deleted, *rC.Files[i].Filename)
+			}
+			if *rC.Files[i].Status == "modified" {
+				changedFiles.Modified = append(changedFiles.Modified, *rC.Files[i].Filename)
+			}
+			if *rC.Files[i].Status == "renamed" {
+				changedFiles.Renamed = append(changedFiles.Renamed, *rC.Files[i].Filename)
+			}
 		}
-		return result, nil
+		return changedFiles, nil
 	}
-	return []string{}, nil
+	return provider.ChangedFiles{}, nil
 }
 
 // getObject Get an object from a repository.

--- a/pkg/provider/github/github_test.go
+++ b/pkg/provider/github/github_test.go
@@ -656,10 +656,14 @@ func TestValidate(t *testing.T) {
 
 func TestGetFiles(t *testing.T) {
 	tests := []struct {
-		name        string
-		event       *info.Event
-		commitFiles []*github.CommitFile
-		commit      *github.RepositoryCommit
+		name                   string
+		event                  *info.Event
+		commitFiles            []*github.CommitFile
+		commit                 *github.RepositoryCommit
+		wantAddedFilesCount    int
+		wantDeletedFilesCount  int
+		wantModifiedFilesCount int
+		wantRenamedFilesCount  int
 	}{
 		{
 			name: "pull-request",
@@ -671,11 +675,23 @@ func TestGetFiles(t *testing.T) {
 			},
 			commitFiles: []*github.CommitFile{
 				{
-					Filename: ptr.String("first.yaml"),
+					Filename: ptr.String("modified.yaml"),
+					Status:   ptr.String("modified"),
 				}, {
-					Filename: ptr.String("second.doc"),
+					Filename: ptr.String("added.doc"),
+					Status:   ptr.String("added"),
+				}, {
+					Filename: ptr.String("removed.yaml"),
+					Status:   ptr.String("removed"),
+				}, {
+					Filename: ptr.String("renamed.doc"),
+					Status:   ptr.String("renamed"),
 				},
 			},
+			wantAddedFilesCount:    1,
+			wantDeletedFilesCount:  1,
+			wantModifiedFilesCount: 1,
+			wantRenamedFilesCount:  1,
 		},
 		{
 			name: "push",
@@ -688,23 +704,59 @@ func TestGetFiles(t *testing.T) {
 			commit: &github.RepositoryCommit{
 				Files: []*github.CommitFile{
 					{
-						Filename: ptr.String("first.yaml"),
+						Filename: ptr.String("modified.yaml"),
+						Status:   ptr.String("modified"),
 					}, {
-						Filename: ptr.String("second.doc"),
+						Filename: ptr.String("added.doc"),
+						Status:   ptr.String("added"),
+					}, {
+						Filename: ptr.String("removed.yaml"),
+						Status:   ptr.String("removed"),
+					}, {
+						Filename: ptr.String("renamed.doc"),
+						Status:   ptr.String("renamed"),
 					},
 				},
 			},
+			wantAddedFilesCount:    1,
+			wantDeletedFilesCount:  1,
+			wantModifiedFilesCount: 1,
+			wantRenamedFilesCount:  1,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeclient, mux, _, teardown := ghtesthelper.SetupGH()
 			defer teardown()
-			commitFiles := []*github.CommitFile{
+			prCommitFiles := []*github.CommitFile{
 				{
-					Filename: ptr.String("first.yaml"),
+					Filename: ptr.String("modified.yaml"),
+					Status:   ptr.String("modified"),
 				}, {
-					Filename: ptr.String("second.doc"),
+					Filename: ptr.String("added.doc"),
+					Status:   ptr.String("added"),
+				}, {
+					Filename: ptr.String("removed.yaml"),
+					Status:   ptr.String("removed"),
+				}, {
+					Filename: ptr.String("renamed.doc"),
+					Status:   ptr.String("renamed"),
+				},
+			}
+
+			pushCommitFiles := []*github.CommitFile{
+				{
+					Filename: ptr.String("modified.yaml"),
+					Status:   ptr.String("modified"),
+				}, {
+					Filename: ptr.String("added.doc"),
+					Status:   ptr.String("added"),
+				}, {
+					Filename: ptr.String("removed.yaml"),
+					Status:   ptr.String("removed"),
+				}, {
+					Filename: ptr.String("renamed.doc"),
+					Status:   ptr.String("renamed"),
 				},
 			}
 			if tt.event.TriggerTarget == "pull_request" {
@@ -714,7 +766,7 @@ func TestGetFiles(t *testing.T) {
 						rw.Header().Add("Link", fmt.Sprintf("<https://api.github.com/repos/%s/%s/pulls/%d/files?page=2>; rel=\"next\"", tt.event.Organization, tt.event.Repository, tt.event.PullRequestNumber))
 						fmt.Fprint(rw, "[]")
 					} else {
-						b, _ := json.Marshal(commitFiles)
+						b, _ := json.Marshal(prCommitFiles)
 						fmt.Fprint(rw, string(b))
 					}
 				})
@@ -723,7 +775,7 @@ func TestGetFiles(t *testing.T) {
 				mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/commits/%s",
 					tt.event.Organization, tt.event.Repository, tt.event.SHA), func(rw http.ResponseWriter, r *http.Request) {
 					c := &github.RepositoryCommit{
-						Files: commitFiles,
+						Files: pushCommitFiles,
 					}
 					b, _ := json.Marshal(c)
 					fmt.Fprint(rw, string(b))
@@ -735,16 +787,21 @@ func TestGetFiles(t *testing.T) {
 				Client:        fakeclient,
 				paginedNumber: 1,
 			}
-			fileData, err := provider.GetFiles(ctx, tt.event)
+			changedFiles, err := provider.GetFiles(ctx, tt.event)
 			assert.NilError(t, err, nil)
+			assert.Equal(t, tt.wantAddedFilesCount, len(changedFiles.Added))
+			assert.Equal(t, tt.wantDeletedFilesCount, len(changedFiles.Deleted))
+			assert.Equal(t, tt.wantModifiedFilesCount, len(changedFiles.Modified))
+			assert.Equal(t, tt.wantRenamedFilesCount, len(changedFiles.Renamed))
+
 			if tt.event.TriggerTarget == "pull_request" {
-				for i := range fileData {
-					assert.Equal(t, *tt.commitFiles[i].Filename, fileData[i])
+				for i := range changedFiles.All {
+					assert.Equal(t, *tt.commitFiles[i].Filename, changedFiles.All[i])
 				}
 			}
 			if tt.event.TriggerTarget == "push" {
-				for i := range fileData {
-					assert.Equal(t, *tt.commit.Files[i].Filename, fileData[i])
+				for i := range changedFiles.All {
+					assert.Equal(t, *tt.commit.Files[i].Filename, changedFiles.All[i])
 				}
 			}
 		})

--- a/pkg/provider/github/repository.go
+++ b/pkg/provider/github/repository.go
@@ -109,5 +109,5 @@ func generateNamespaceName(nsTemplate string, gitEvent *github.RepositoryEvent) 
 		"repo_owner": repoOwner,
 		"repo_name":  repoName,
 	}
-	return templates.ReplacePlaceHoldersVariables(nsTemplate, maptemplate, nil, http.Header{}), nil
+	return templates.ReplacePlaceHoldersVariables(nsTemplate, maptemplate, nil, http.Header{}, map[string]interface{}{}), nil
 }

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -306,37 +306,61 @@ func (v *Provider) GetCommitInfo(_ context.Context, runevent *info.Event) error 
 	return nil
 }
 
-func (v *Provider) GetFiles(_ context.Context, runevent *info.Event) ([]string, error) {
+func (v *Provider) GetFiles(_ context.Context, runevent *info.Event) (provider.ChangedFiles, error) {
 	if v.Client == nil {
-		return []string{}, fmt.Errorf("no gitlab client has been initialized, " +
+		return provider.ChangedFiles{}, fmt.Errorf("no gitlab client has been initialized, " +
 			"exiting... (hint: did you forget setting a secret on your repo?)")
 	}
 	if runevent.TriggerTarget == "pull_request" {
 		//nolint: staticcheck
 		mrchanges, _, err := v.Client.MergeRequests.GetMergeRequestChanges(v.sourceProjectID, runevent.PullRequestNumber, &gitlab.GetMergeRequestChangesOptions{})
 		if err != nil {
-			return []string{}, err
+			return provider.ChangedFiles{}, err
 		}
 
-		result := []string{}
+		changedFiles := provider.ChangedFiles{}
 		for _, change := range mrchanges.Changes {
-			result = append(result, change.NewPath)
+			changedFiles.All = append(changedFiles.All, change.NewPath)
+			if change.NewFile {
+				changedFiles.Added = append(changedFiles.Added, change.NewPath)
+			}
+			if change.DeletedFile {
+				changedFiles.Deleted = append(changedFiles.Deleted, change.NewPath)
+			}
+			if !change.RenamedFile && !change.DeletedFile && !change.NewFile {
+				changedFiles.Modified = append(changedFiles.Modified, change.NewPath)
+			}
+			if change.RenamedFile {
+				changedFiles.Renamed = append(changedFiles.Renamed, change.NewPath)
+			}
 		}
-		return result, nil
+		return changedFiles, nil
 	}
 
 	if runevent.TriggerTarget == "push" {
 		pushChanges, _, err := v.Client.Commits.GetCommitDiff(v.sourceProjectID, runevent.SHA, &gitlab.GetCommitDiffOptions{})
 		if err != nil {
-			return []string{}, err
+			return provider.ChangedFiles{}, err
 		}
-		result := []string{}
+		changedFiles := provider.ChangedFiles{}
 		for _, change := range pushChanges {
-			result = append(result, change.NewPath)
+			changedFiles.All = append(changedFiles.All, change.NewPath)
+			if change.NewFile {
+				changedFiles.Added = append(changedFiles.Added, change.NewPath)
+			}
+			if change.DeletedFile {
+				changedFiles.Deleted = append(changedFiles.Deleted, change.NewPath)
+			}
+			if !change.RenamedFile && !change.DeletedFile && !change.NewFile {
+				changedFiles.Modified = append(changedFiles.Modified, change.NewPath)
+			}
+			if change.RenamedFile {
+				changedFiles.Renamed = append(changedFiles.Renamed, change.NewPath)
+			}
 		}
-		return result, nil
+		return changedFiles, nil
 	}
-	return []string{}, nil
+	return provider.ChangedFiles{}, nil
 }
 
 func (v *Provider) CreateToken(_ context.Context, _ []string, _ *info.Event) (string, error) {

--- a/pkg/provider/interface.go
+++ b/pkg/provider/interface.go
@@ -37,10 +37,18 @@ type Interface interface {
 	SetClient(context.Context, *params.Run, *info.Event, *v1alpha1.Repository, *events.EventEmitter) error
 	GetCommitInfo(context.Context, *info.Event) error
 	GetConfig() *info.ProviderConfig
-	GetFiles(context.Context, *info.Event) ([]string, error)
-	GetTaskURI(context.Context, *info.Event, string) (bool, string, error)
+	GetFiles(context.Context, *info.Event) (ChangedFiles, error)
+	GetTaskURI(ctx context.Context, event *info.Event, uri string) (bool, string, error)
 	CreateToken(context.Context, []string, *info.Event) (string, error)
 	CheckPolicyAllowing(context.Context, *info.Event, []string) (bool, string)
 }
 
 const DefaultProviderAPIUser = "git"
+
+type ChangedFiles struct {
+	All      []string
+	Added    []string
+	Deleted  []string
+	Modified []string
+	Renamed  []string
+}

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -109,8 +109,8 @@ func (r *Reconciler) reportFinalStatus(ctx context.Context, logger *zap.SugaredL
 		return nil, fmt.Errorf("reportFinalStatus: %w", err)
 	}
 
-	cp := customparams.NewCustomParams(event, repo, r.run, r.kinteract, r.eventEmitter)
-	maptemplate, err := cp.GetParams(ctx)
+	cp := customparams.NewCustomParams(event, repo, r.run, r.kinteract, r.eventEmitter, nil)
+	maptemplate, _, err := cp.GetParams(ctx)
 	if err != nil {
 		r.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "ParamsError",
 			fmt.Sprintf("error processing repository CR custom params: %s", err.Error()))

--- a/pkg/templates/templating.go
+++ b/pkg/templates/templating.go
@@ -22,18 +22,18 @@ var (
 )
 
 // ReplacePlaceHoldersVariables Replace those {{var}} placeholders to the runinfo variable.
-func ReplacePlaceHoldersVariables(template string, dico map[string]string, rawEvent any, headers http.Header) string {
+func ReplacePlaceHoldersVariables(template string, dico map[string]string, rawEvent any, headers http.Header, changedFiles map[string]interface{}) string {
 	return keys.ParamsRe.ReplaceAllStringFunc(template, func(s string) string {
 		parts := keys.ParamsRe.FindStringSubmatch(s)
 		key := strings.TrimSpace(parts[1])
-		if strings.HasPrefix(key, "body") || strings.HasPrefix(key, "headers") {
+		if strings.HasPrefix(key, "body") || strings.HasPrefix(key, "headers") || strings.HasPrefix(key, "files") {
 			if rawEvent != nil && headers != nil {
 				// convert headers to map[string]string
 				headerMap := make(map[string]string)
 				for k, v := range headers {
 					headerMap[k] = v[0]
 				}
-				val, err := customparams.CelValue(key, rawEvent, headerMap, map[string]string{})
+				val, err := customparams.CelValue(key, rawEvent, headerMap, map[string]string{}, changedFiles)
 				if err != nil {
 					return s
 				}

--- a/pkg/templates/templating_test.go
+++ b/pkg/templates/templating_test.go
@@ -9,12 +9,13 @@ import (
 
 func TestReplacePlaceHoldersVariables(t *testing.T) {
 	tests := []struct {
-		name     string
-		template string
-		expected string
-		dicto    map[string]string
-		headers  http.Header
-		rawEvent any
+		name         string
+		template     string
+		expected     string
+		dicto        map[string]string
+		headers      http.Header
+		changedFiles map[string]interface{}
+		rawEvent     any
 	}{
 		{
 			name:     "Test Replace standard",
@@ -24,41 +25,56 @@ func TestReplacePlaceHoldersVariables(t *testing.T) {
 				"revision": "master",
 				"url":      "https://chmouel.com",
 			},
+			changedFiles: map[string]interface{}{},
 		},
 		{
-			name:     "Test Replace with CEL body",
-			template: `hello: {{ body.hello }}`,
-			expected: `hello: world`,
-			dicto:    map[string]string{},
-			headers:  http.Header{},
+			name:         "Test Replace with CEL body",
+			template:     `hello: {{ body.hello }}`,
+			expected:     `hello: world`,
+			dicto:        map[string]string{},
+			changedFiles: map[string]interface{}{},
+			headers:      http.Header{},
 			rawEvent: map[string]string{
 				"hello": "world",
 			},
 		},
 		{
-			name:     "Test Replace with CEL body expression",
-			template: `Is this {{ body.hello == 'world' }}`,
-			expected: `Is this true`,
-			dicto:    map[string]string{},
-			headers:  http.Header{},
+			name:         "Test Replace with CEL body expression",
+			template:     `Is this {{ body.hello == 'world' }}`,
+			expected:     `Is this true`,
+			dicto:        map[string]string{},
+			changedFiles: map[string]interface{}{},
+			headers:      http.Header{},
 			rawEvent: map[string]string{
 				"hello": "world",
 			},
 		},
 		{
-			name:     "Test Replace with headers",
-			template: `header: {{ headers["X-Hello"] }}`,
-			expected: `header: World`,
-			dicto:    map[string]string{},
+			name:         "Test Replace with headers",
+			template:     `header: {{ headers["X-Hello"] }}`,
+			expected:     `header: World`,
+			dicto:        map[string]string{},
+			changedFiles: map[string]interface{}{},
 			headers: http.Header{
 				"X-Hello": []string{"World"},
 			},
 			rawEvent: map[string]string{},
 		},
+		{
+			name:     "Changed files - changed",
+			template: `changed: {{ files.all[0] }}`,
+			expected: `changed: changed.txt`,
+			dicto:    map[string]string{},
+			changedFiles: map[string]interface{}{
+				"all": []string{"changed.txt"},
+			},
+			headers:  http.Header{},
+			rawEvent: map[string]string{},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ReplacePlaceHoldersVariables(tt.template, tt.dicto, tt.rawEvent, tt.headers)
+			got := ReplacePlaceHoldersVariables(tt.template, tt.dicto, tt.rawEvent, tt.headers, tt.changedFiles)
 			if d := cmp.Diff(got, tt.expected); d != "" {
 				t.Fatalf("-got, +want: %v", d)
 			}

--- a/pkg/test/provider/testwebvcs.go
+++ b/pkg/test/provider/testwebvcs.go
@@ -24,6 +24,11 @@ type TestProviderImp struct {
 	WantProviderRemoteTask bool
 	PolicyDisallowing      bool
 	AllowedInOwnersFile    bool
+	WantAllChangedFiles    []string
+	WantAddedFiles         []string
+	WantDeletedFiles       []string
+	WantModifiedFiles      []string
+	WantRenamedFiles       []string
 }
 
 func (v *TestProviderImp) CheckPolicyAllowing(_ context.Context, _ *info.Event, _ []string) (bool, string) {
@@ -93,8 +98,17 @@ func (v *TestProviderImp) GetFileInsideRepo(_ context.Context, _ *info.Event, fi
 	return "", fmt.Errorf("could not find %s in tests", file)
 }
 
-func (v *TestProviderImp) GetFiles(_ context.Context, _ *info.Event) ([]string, error) {
-	return []string{}, nil
+func (v *TestProviderImp) GetFiles(_ context.Context, _ *info.Event) (provider.ChangedFiles, error) {
+	if v == nil {
+		return provider.ChangedFiles{}, nil
+	}
+	return provider.ChangedFiles{
+		All:      v.WantAllChangedFiles,
+		Added:    v.WantAddedFiles,
+		Deleted:  v.WantDeletedFiles,
+		Modified: v.WantModifiedFiles,
+		Renamed:  v.WantRenamedFiles,
+	}, nil
 }
 
 func (v *TestProviderImp) CreateToken(_ context.Context, _ []string, _ *info.Event) (string, error) {

--- a/test/pkg/gitea/scm.go
+++ b/test/pkg/gitea/scm.go
@@ -153,6 +153,16 @@ func CreateGiteaRepo(giteaClient *gitea.Client, user, name, hookURL string, onOr
 	return repo, err
 }
 
+func GetGiteaRepo(giteaClient *gitea.Client, user, name string, _ *zap.SugaredLogger) (*gitea.Repository, error) {
+	var repo *gitea.Repository
+	var err error
+	repo, _, err = giteaClient.GetRepo(user, name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get repo: %w", err)
+	}
+	return repo, err
+}
+
 func CreateTeam(topts *TestOpts, orgName, teamName string) (*gitea.Team, error) {
 	team, _, err := topts.GiteaCNX.Client.CreateTeam(orgName, gitea.CreateTeamOption{
 		Permission: gitea.AccessModeWrite,

--- a/test/pkg/scm/scm.go
+++ b/test/pkg/scm/scm.go
@@ -33,6 +33,40 @@ type FileChange struct {
 	NewContent string
 }
 
+// gitPushPullRetry tries to push the files to the repo, if it fails it will try to rebase and push again.
+func gitPushPullRetry(t *testing.T, opts *Opts, path string) {
+	// use a loop to try multiple times in case of error
+	var err error
+	count := 0
+	for {
+		pushForce := "--no-force"
+		if opts.PushForce {
+			pushForce = "-f"
+		}
+		if _, err = git.RunGit(path, "push", "origin", pushForce, opts.TargetRefName); err == nil {
+			opts.Log.Infof("Pushed files to repo %s branch %s", opts.WebURL, opts.TargetRefName)
+			// trying to avoid the multiple events at the time of creation we have a sync
+			time.Sleep(5 * time.Second)
+			return
+		}
+		if strings.Contains(err.Error(), "non-fast-forward") {
+			_, err = git.RunGit(path, "fetch", "-a", "origin")
+			assert.NilError(t, err)
+			_, err := git.RunGit(path, "pull", "--rebase", "origin", opts.TargetRefName)
+			assert.NilError(t, err)
+			opts.Log.Infof("Rebased against branch %s", opts.TargetRefName)
+			continue
+		}
+		count++
+		if count > 5 {
+			t.Fatalf("Failed to push files to repo %s branch %s, %+v", opts.WebURL, opts.TargetRefName, err.Error())
+		}
+		opts.Log.Errorf("Failed to push files to repo %s branch %s, retrying in 5 seconds, err: %v", opts.WebURL, opts.TargetRefName, err)
+
+		time.Sleep(5 * time.Second)
+	}
+}
+
 func PushFilesToRefGit(t *testing.T, opts *Opts, entries map[string]string) {
 	tmpdir := fs.NewDir(t, t.Name())
 	defer (func() {
@@ -82,35 +116,8 @@ func PushFilesToRefGit(t *testing.T, opts *Opts, entries map[string]string) {
 		_, err = git.RunGit(path, "tag", "-f", filepath.Base(opts.TargetRefName))
 		assert.NilError(t, err)
 	}
-	// use a loop to try multiple times in case of error
-	count := 0
-	for {
-		pushForce := "--no-force"
-		if opts.PushForce {
-			pushForce = "-f"
-		}
-		if _, err = git.RunGit(path, "push", "origin", pushForce, opts.TargetRefName); err == nil {
-			opts.Log.Infof("Pushed files to repo %s branch %s", opts.WebURL, opts.TargetRefName)
-			// trying to avoid the multiple events at the time of creation we have a sync
-			time.Sleep(5 * time.Second)
-			return
-		}
-		if strings.Contains(err.Error(), "non-fast-forward") {
-			_, err = git.RunGit(path, "fetch", "-a", "origin")
-			assert.NilError(t, err)
-			_, err := git.RunGit(path, "pull", "--rebase", "origin", opts.TargetRefName)
-			assert.NilError(t, err)
-			opts.Log.Infof("Rebased against branch %s", opts.TargetRefName)
-			continue
-		}
-		count++
-		if count > 5 {
-			t.Fatalf("Failed to push files to repo %s branch %s, %+v", opts.WebURL, opts.TargetRefName, err.Error())
-		}
-		opts.Log.Errorf("Failed to push files to repo %s branch %s, retrying in 5 seconds, err: %v", opts.WebURL, opts.TargetRefName, err)
 
-		time.Sleep(5 * time.Second)
-	}
+	gitPushPullRetry(t, opts, path)
 }
 
 func ChangeFilesRefGit(t *testing.T, opts *Opts, fileChanges []FileChange) {
@@ -169,35 +176,7 @@ func ChangeFilesRefGit(t *testing.T, opts *Opts, fileChanges []FileChange) {
 		_, err = git.RunGit(path, "tag", "-f", filepath.Base(opts.TargetRefName))
 		assert.NilError(t, err)
 	}
-	// use a loop to try multiple times in case of error
-	count := 0
-	for {
-		pushForce := "--no-force"
-		if opts.PushForce {
-			pushForce = "-f"
-		}
-		if _, err = git.RunGit(path, "push", "origin", pushForce, opts.TargetRefName); err == nil {
-			opts.Log.Infof("Pushed files to repo %s branch %s", opts.WebURL, opts.TargetRefName)
-			// trying to avoid the multiple events at the time of creation we have a sync
-			time.Sleep(5 * time.Second)
-			return
-		}
-		if strings.Contains(err.Error(), "non-fast-forward") {
-			_, err = git.RunGit(path, "fetch", "-a", "origin")
-			assert.NilError(t, err)
-			_, err := git.RunGit(path, "pull", "--rebase", "origin", opts.TargetRefName)
-			assert.NilError(t, err)
-			opts.Log.Infof("Rebased against branch %s", opts.TargetRefName)
-			continue
-		}
-		count++
-		if count > 5 {
-			t.Fatalf("Failed to push files to repo %s branch %s, %+v", opts.WebURL, opts.TargetRefName, err.Error())
-		}
-		opts.Log.Errorf("Failed to push files to repo %s branch %s, retrying in 5 seconds, err: %v", opts.WebURL, opts.TargetRefName, err)
-
-		time.Sleep(5 * time.Second)
-	}
+	gitPushPullRetry(t, opts, path)
 }
 
 // MakeGitCloneURL will make a clone url with username and password.

--- a/test/testdata/changed_files_deleted
+++ b/test/testdata/changed_files_deleted
@@ -1,0 +1,1 @@
+deleted

--- a/test/testdata/changed_files_modified
+++ b/test/testdata/changed_files_modified
@@ -1,0 +1,1 @@
+modified

--- a/test/testdata/changed_files_renamed
+++ b/test/testdata/changed_files_renamed
@@ -1,0 +1,1 @@
+renamed

--- a/test/testdata/pipelinerun-changed-files-pullrequest.yaml
+++ b/test/testdata/pipelinerun-changed-files-pullrequest.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: "\\ .PipelineName //"
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      target_branch == "\\ .TargetBranch //" && 
+      event == "pull_request" && 
+      files.all.exists(x, x.matches('tekton/|deleted.txt'))
+spec:
+  # params:
+  #   - name: all_changed_files
+  #     value: "{{ files.all }}"
+  #   - name: added_files
+  #     value: "{{ files.added }}"
+  #   - name: deleted_files
+  #     value: "{{ files.deleted }}"
+  #   - name: modified_files
+  #     value: "{{ files.modified }}"
+  #   - name: renamed_files
+  #     value: "{{ files.renamed }}"
+  pipelineSpec:
+    # params:
+    #   - name: all_changed_files
+    #   - name: added_files
+    #   - name: deleted_files
+    #   - name: modified_files
+    #   - name: renamed_files
+    tasks:
+      - name: changed-files-pullrequest-params
+        taskSpec:
+          steps:
+            - name: test-changed-files-params-pull
+              image: registry.access.redhat.com/ubi9/ubi-micro
+              script: |
+                # reply Should be:
+                cat <<EOF
+                changed files...
+                files.all: {{ files.all }}
+                files.added: {{ files.added }}
+                files.deleted: {{ files.deleted }}
+                files.modified: {{ files.modified }}
+                files.renamed: {{ files.renamed }}
+                EOF

--- a/test/testdata/pipelinerun-changed-files-pullrequest.yaml
+++ b/test/testdata/pipelinerun-changed-files-pullrequest.yaml
@@ -6,8 +6,8 @@ metadata:
   annotations:
     pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
     pipelinesascode.tekton.dev/on-cel-expression: >-
-      target_branch == "\\ .TargetBranch //" && 
-      event == "pull_request" && 
+      target_branch == "\\ .TargetBranch //" &&
+      event == "pull_request" &&
       files.all.exists(x, x.matches('tekton/|deleted.txt'))
 spec:
   # params:

--- a/test/testdata/pipelinerun-changed-files-push.yaml
+++ b/test/testdata/pipelinerun-changed-files-push.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: "\\ .PipelineName //"
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      ( event == "push" &&  target_branch == "main" ) &&
+      ( files.all.exists(x, x.matches('.tekton/pullrequest.yaml')) || files.all.exists(x, x.matches('modified.txt')) )
+spec:
+  # params:
+  #   - name: all_changed_files
+  #     value: "{{ files.all }}"
+  #   - name: added_files
+  #     value: "{{ files.added }}"
+  #   - name: deleted_files
+  #     value: "{{ files.deleted }}"
+  #   - name: modified_files
+  #     value: "{{ files.modified }}"
+  #   - name: renamed_files
+  #     value: "{{ files.renamed }}"
+  pipelineSpec:
+    # params:
+    #   - name: all_changed_files
+    #   - name: added_files
+    #   - name: deleted_files
+    #   - name: modified_files
+    #   - name: renamed_files
+    tasks:
+      - name: changed-files-push-params
+        taskSpec:
+          steps:
+            - name: test-changed-files-params-push
+              image: registry.access.redhat.com/ubi9/ubi-micro
+              script: |
+                # reply Should be:
+                cat <<EOF
+                changed files...
+                files.all: {{ files.all }}
+                files.added: {{ files.added }}
+                files.deleted: {{ files.deleted }}
+                files.modified: {{ files.modified }}
+                files.renamed: {{ files.renamed }}
+
+                EOF


### PR DESCRIPTION
# Changes

This change will add support for separating the files by the change type i.e. added, modified, deleted and renamed for a giving source control event. This provides the ability to target only added files or only renamed files. Note that this change still supports all changed files in case specifics types of changes are not needed.

In addition, this change will also allow the changed file information to be passed down using templating variable file. See below for details

- `{{ files.all }}`
- `{{ files.added }}`
- `{{ files.deleted }}`
- `{{ files.modified }}`
- `{{ files.renamed }}`
