### PR TITLE
Addressing the event title matching issue

### DIFF
--- a/pkg/provider/github/parse_payload.go
+++ b/pkg/provider/github/parse_payload.go
@@ -270,6 +270,7 @@ func (v *Provider) processEvent(ctx context.Context, event *info.Event, eventInt
 		processedEvent.Sender = gitEvent.GetPullRequest().GetUser().GetLogin()
 		processedEvent.EventType = event.EventType
 		processedEvent.PullRequestNumber = gitEvent.GetPullRequest().GetNumber()
+		processedEvent.PullRequestTitle = gitEvent.GetPullRequest().GetTitle()
 		// getting the repository ids of the base and head of the pull request
 		// to scope the token to
 		v.RepositoryIDs = []int64{

--- a/pkg/provider/github/parse_payload_test.go
+++ b/pkg/provider/github/parse_payload_test.go
@@ -65,6 +65,7 @@ var samplePRevent = github.PullRequestEvent{
 		User: &github.User{
 			Login: github.String("user"),
 		},
+		Title: github.String("my first PR"),
 	},
 	Repo: sampleRepo,
 }
@@ -577,6 +578,9 @@ func TestParsePayLoad(t *testing.T) {
 			assert.NilError(t, err)
 			assert.Assert(t, ret != nil)
 			assert.Equal(t, tt.shaRet, ret.SHA)
+			if tt.eventType == "pull_request" {
+				assert.Equal(t, "my first PR", ret.PullRequestTitle)
+			}
 			if tt.eventType == "commit_comment" {
 				assert.Equal(t, tt.wantedBranchName, ret.HeadBranch)
 				assert.Equal(t, tt.wantedBranchName, ret.BaseBranch)

--- a/test/github_pullrequest_test.go
+++ b/test/github_pullrequest_test.go
@@ -38,6 +38,13 @@ func TestGithubPullRequestMatchOnCEL(t *testing.T) {
 	defer tgithub.TearDown(ctx, t, runcnx, ghcnx, prNumber, targetRefName, targetNS, opts)
 }
 
+func TestGithubPullRequestCELMatchOnTitle(t *testing.T) {
+	ctx := context.Background()
+	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, _ := tgithub.RunPullRequest(ctx, t, "Github PullRequest",
+		[]string{"testdata/pipelinerun-cel-annotation-for-title-match.yaml"}, false)
+	defer tgithub.TearDown(ctx, t, runcnx, ghcnx, prNumber, targetRefName, targetNS, opts)
+}
+
 func TestGithubPullRequestWebhook(t *testing.T) {
 	if os.Getenv("NIGHTLY_E2E_TEST") != "true" {
 		t.Skip("Skipping test since only enabled for nightly")

--- a/test/github_push_test.go
+++ b/test/github_push_test.go
@@ -26,3 +26,16 @@ func TestGithubPush(t *testing.T) {
 		defer tgithub.TearDown(ctx, t, runcnx, ghcnx, prNumber, targetRefName, targetNS, opts)
 	}
 }
+
+func TestGithubPushRequestCELMatchOnTitle(t *testing.T) {
+	ctx := context.Background()
+	for _, onWebhook := range []bool{false, true} {
+		if onWebhook && os.Getenv("TEST_GITHUB_REPO_OWNER_WEBHOOK") == "" {
+			t.Skip("TEST_GITHUB_REPO_OWNER_WEBHOOK is not set")
+			continue
+		}
+		runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, _ := tgithub.RunPushRequest(ctx, t,
+			"Github Push Request", []string{"testdata/pipelinerun-cel-annotation-for-title-match.yaml"}, onWebhook)
+		defer tgithub.TearDown(ctx, t, runcnx, ghcnx, prNumber, targetRefName, targetNS, opts)
+	}
+}

--- a/test/testdata/pipelinerun-cel-annotation-for-title-match.yaml
+++ b/test/testdata/pipelinerun-cel-annotation-for-title-match.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: "\\ .PipelineName //"
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "\\ .TargetEvent //" && event_title.startsWith("Testing Github")
+spec:
+  pipelineSpec:
+    tasks:
+      - name: task
+        taskSpec:
+          steps:
+            - name: task
+              image: registry.access.redhat.com/ubi9/ubi-micro
+              command: ["/bin/echo", "HELLOMOTO"]


### PR DESCRIPTION
When event_title.startsWith() is used
for pull_request, the CEL expressions
do not behave as anticipated due to the
lack of handling for pull_request events.

Signed-off-by: Savita Ashture <sashture@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 A good commit message is important for other reviewers to understand the context of your change. Please refer to [How to Write a Git Commit Message](https://cbea.ms/git-commit/) for more details how to write beautiful commit messages. We rather have the commit message in the PR body and the commit message instead of an external website.
- [ ] ♽ Run `make test` before submitting a PR (ie: with [pre-commit](https://pipelinesascode.com/dev/tools), no need to waste CPU cycle on CI. (or even better install [pre-commit](https://pre-commit.com/) and do `pre-commit install` in the root of this repo).
- [ ] ✨ We heavily rely on linters to get our code clean and consistent, please ensure that you have run `make lint` before submitting a PR. The [markdownlint](https://github.com/DavidAnson/markdownlint) error can get usually fixed by running `make fix-markdownlint` (make sure it's installed first)
- [ ] 📖 If you are adding a user facing feature or make a change of the behavior, please verify that you have documented it
- [ ] 🧪 100% coverage is not a target but most of the time we would rather have a unit test if you make a code change.
- [ ] 🎁 If that's something that is possible to do please ensure to check if we can add a e2e test.
- [ ] 🔎 If there is a flakiness in the CI tests then don't *necessary* ignore it, better get the flakyness fixed before merging or if that's not possible there is a good reason to bypass it. (token rate limitation may be a good reason to skip).
