### PR TITLE
Revise metrics emission to reflect data for both GitLab and Bitbucket

### DIFF
--- a/docs/content/docs/guide/repositorycrd.md
+++ b/docs/content/docs/guide/repositorycrd.md
@@ -274,7 +274,7 @@ and the scoping fails for the repository level configuration because the reposit
     namespace: test-repo
   spec:
     url: "https://github.com/linda/project"
-    setting
+    settings:
       github_app_token_scope_repos:
       - "owner5/project5"
   ```

--- a/docs/content/docs/install/metrics.md
+++ b/docs/content/docs/install/metrics.md
@@ -1,0 +1,15 @@
+---
+title: Running the PipelineRun
+weight: 4
+---
+
+# Metrics Overview
+
+The metrics for pipelines-as-code can be accessed through the `pipelines-as-code-watcher` service on port `9090`.
+
+pipelines-as-code supports various exporters, such as Prometheus, Google Stackdriver, and more.
+You can configure these exporters by referring to the [observability configuration](../config/config-observability.yaml).
+
+|  Name | Type    | Description                                         |
+| ---------- |---------|-----------------------------------------------------|
+| `pipelines_as_code_pipelinerun_count` | Counter | Number of pipelineruns created by pipelines-as-code |

--- a/pkg/reconciler/emit_metrics_test.go
+++ b/pkg/reconciler/emit_metrics_test.go
@@ -1,0 +1,71 @@
+package reconciler
+
+import (
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/metrics"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestEmitMetrics(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		wantErr     bool
+	}{
+		{
+			name: "provider is GitHub App",
+			annotations: map[string]string{
+				keys.GitProvider:    "github",
+				keys.EventType:      "pull_request",
+				keys.InstallationID: "123",
+			},
+			wantErr: false,
+		},
+		{
+			name: "provider is GitHub Webhook",
+			annotations: map[string]string{
+				keys.GitProvider: "github",
+				keys.EventType:   "pull_request",
+			},
+			wantErr: false,
+		},
+		{
+			name: "provider is GitLab",
+			annotations: map[string]string{
+				keys.GitProvider: "gitlab",
+				keys.EventType:   "push",
+			},
+			wantErr: false,
+		},
+		{
+			name: "unsupported provider",
+			annotations: map[string]string{
+				keys.GitProvider: "unsupported",
+				keys.EventType:   "push",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := metrics.NewRecorder()
+			assert.NilError(t, err)
+			r := &Reconciler{
+				metrics: m,
+			}
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: tt.annotations,
+				},
+			}
+			if err = r.emitMetrics(pr); (err != nil) != tt.wantErr {
+				t.Errorf("emitMetrics() error = %v, wantErr %v", err != nil, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The display of metrics in pipelines as code
now includes information for GitLab and Bitbucket.

![Screenshot from 2023-12-28 19-53-58](https://github.com/openshift-pipelines/pipelines-as-code/assets/9441662/04ed44ab-eab8-4c7f-a2ef-76ee50dcce71)

Signed-off-by: Savita Ashture <sashture@redhat.com>

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
