### PR TITLE
Add support of pr explicit testing via /test

### DIFF
--- a/docs/content/docs/guide/running.md
+++ b/docs/content/docs/guide/running.md
@@ -114,14 +114,16 @@ entire suite of checks once again.
 
 ![github apps rerun check](/images/github-apps-rerun-checks.png)
 
-### GitOps command on pull or merge request
+## GitOps commands
 
-If you are targeting a push, pull or merge request you can use `GitOps` comment
-inside your pull request, to restart all or specific Pipelines.
+The GitOps commands are a way to trigger Pipelines-as-Code actions via comments
+on a `Pull Request` or comment on a `Push`ed commit.
 
-For example, you want to restart all your pipeline you can add a comment starting
-with `/retest` and all PipelineRun attached to that pull or merge request will be
-restarted :
+### GitOps commands on Pull Requests
+
+When you are on a Pull Request you may want to restart all your pipelineruns
+you can add a comment starting with `/retest` and all PipelineRuns attached to
+that pull request will be restarted :
 
 Example :
 
@@ -141,14 +143,11 @@ roses are red, violets are blue. pipeline are bound to flake by design.
 /test <pipelinerun-name>
 ```
 
-You can expose custom GitOps commands on `Pull Request` comment via the
-[on-comment]({{< relref "/docs/guide/authoringprs.md#matching-a-pipelinerun-on-a-regexp-in-a-comment" >}}) annotation.
+### GitOps commands on pushed commits
 
-### GitOps command on push request
-
-To trigger GitOps commands in response to a push request, you can include `GitOps`
-comments within your commit messages. These comments can be used to restart
-either all pipelines or specific ones. Here's how it works:
+If you want to trigger a GitOps command on a pushed commit, you can include the
+`GitOps` comments within your commit messages. These comments can be used to
+restart either all pipelines or specific ones. Here's how it works:
 
 For restarting all pipeline runs:
 
@@ -185,7 +184,7 @@ located, with the context of the **test** branch.
    3. `/retest <pipelinerun-name> branch:test`
    4. `/test <pipelinerun-name> branch:test`
 
-To add `GitOps` comments to a push request, follow these steps:
+To issue a `GitOps` comment on a pushed commit you can follow these steps:
 
 1. Go to your repository.
 2. Click on the **Commits** section.
@@ -196,12 +195,25 @@ To add `GitOps` comments to a push request, follow these steps:
 
 Please note that this feature is supported for the GitHub provider only.
 
-## Cancelling the PipelineRun
+### GitOps commands on non-matching PipelineRun
+
+The PipelineRun will be restarted regardless of the annotations if the comment
+`/test <pipelinerun-name>` or `/retest <pipelinerun-name>` is used . This let
+you have control of PipelineRuns that gets only triggered by a comment on the
+pull request.
+
+### Custom GitOps commands
+
+Using the [on-comment]({{< relref "/docs/guide/authoringprs.md#matching-a-pipelinerun-on-a-regexp-in-a-comment" >}}) annotation on your `PipelineRun` you can define custom GitOps commands that will be triggered by the comments on the pull request.
+
+See the [on-comment]({{< relref "/docs/guide/authoringprs.md#matching-a-pipelinerun-on-a-regexp-in-a-comment" >}}) guide for more information.
+
+## Cancelling a PipelineRun
 
 You can cancel a running PipelineRun by commenting on the PullRequest.
 
 For example if you want to cancel all your PipelinerRuns you can add a comment starting
-with `/cancel` and all PipelineRun attached to that pull or merge request will be cancelled.
+with `/cancel` and all PipelineRun attached to that pull request will be cancelled.
 
 Example :
 

--- a/pkg/pipelineascode/testdata/no-match/.tekton/matched1.yaml
+++ b/pkg/pipelineascode/testdata/no-match/.tekton/matched1.yaml
@@ -1,0 +1,10 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: pull_request-1
+  annotations:
+    pipelinesascode.tekton.dev/on-target-branch: "[main]"
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+spec:
+  pipelineRef:
+    name: pipeline1

--- a/pkg/pipelineascode/testdata/no-match/.tekton/matched2.yaml
+++ b/pkg/pipelineascode/testdata/no-match/.tekton/matched2.yaml
@@ -1,0 +1,10 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: pull_request-2
+  annotations:
+    pipelinesascode.tekton.dev/on-target-branch: "[main]"
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+spec:
+  pipelineRef:
+    name: pipeline1

--- a/pkg/pipelineascode/testdata/no-match/.tekton/nomatch.yaml
+++ b/pkg/pipelineascode/testdata/no-match/.tekton/nomatch.yaml
@@ -1,0 +1,7 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: no-match
+spec:
+  pipelineRef:
+    name: pipeline1

--- a/pkg/pipelineascode/testdata/no-match/.tekton/pipeline.yaml
+++ b/pkg/pipelineascode/testdata/no-match/.tekton/pipeline.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: pipeline1
+tasks:
+  - name: task-from-tektondir
+    taskRef:
+      name: task-from-tektondir

--- a/pkg/pipelineascode/testdata/no-match/.tekton/task.yaml
+++ b/pkg/pipelineascode/testdata/no-match/.tekton/task.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: task-from-tektondir
+spec:
+  steps:
+    - name: task-1
+      image: gcr.io/distroless/python3:nonroot
+      script: |
+        #!/usr/bin/python3
+        print("Hello task-from-tektondir")

--- a/test/gitlab_merge_request_test.go
+++ b/test/gitlab_merge_request_test.go
@@ -217,6 +217,65 @@ func TestGitlabOnComment(t *testing.T) {
 	assert.NilError(t, err)
 }
 
+func TestGitlabIssueGitopsComment(t *testing.T) {
+	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
+	ctx := context.Background()
+	runcnx, opts, glprovider, err := tgitlab.Setup(ctx)
+	assert.NilError(t, err)
+	ctx, err = cctx.GetControllerCtxInfo(ctx, runcnx)
+	assert.NilError(t, err)
+	runcnx.Clients.Log.Info("Testing Gitlabs test/retest comments")
+	projectinfo, resp, err := glprovider.Client.Projects.GetProject(opts.ProjectID, nil)
+	assert.NilError(t, err)
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
+	}
+
+	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, targetNS, nil)
+	assert.NilError(t, err)
+
+	entries, err := payload.GetEntries(map[string]string{
+		".tekton/no-match.yaml": "testdata/pipelinerun-nomatch.yaml",
+	}, targetNS, projectinfo.DefaultBranch,
+		triggertype.PullRequest.String(), map[string]string{})
+	assert.NilError(t, err)
+
+	targetRefName := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test")
+
+	gitCloneURL, err := scm.MakeGitCloneURL(projectinfo.WebURL, opts.UserName, opts.Password)
+	assert.NilError(t, err)
+	mrTitle := "TestMergeRequest - " + targetRefName
+	scmOpts := &scm.Opts{
+		GitURL:        gitCloneURL,
+		Log:           runcnx.Clients.Log,
+		WebURL:        projectinfo.WebURL,
+		TargetRefName: targetRefName,
+		BaseRefName:   projectinfo.DefaultBranch,
+		CommitTitle:   mrTitle,
+	}
+	scm.PushFilesToRefGit(t, scmOpts, entries)
+
+	runcnx.Clients.Log.Infof("Branch %s has been created and pushed with files", targetRefName)
+	mrID, err := tgitlab.CreateMR(glprovider.Client, opts.ProjectID, targetRefName, projectinfo.DefaultBranch, mrTitle)
+	assert.NilError(t, err)
+	runcnx.Clients.Log.Infof("MergeRequest %s/-/merge_requests/%d has been created", projectinfo.WebURL, mrID)
+	defer tgitlab.TearDown(ctx, t, runcnx, glprovider, mrID, targetRefName, targetNS, opts.ProjectID)
+
+	_, _, err = glprovider.Client.Notes.CreateMergeRequestNote(opts.ProjectID, mrID, &clientGitlab.CreateMergeRequestNoteOptions{
+		Body: clientGitlab.Ptr("/test no-match"),
+	})
+	assert.NilError(t, err)
+	runcnx.Clients.Log.Infof("Created gitops comment /test no-match to get the no-match tested")
+
+	sopt := twait.SuccessOpt{
+		Title:           mrTitle,
+		OnEvent:         opscomments.TestSingleCommentEventType.String(),
+		TargetNS:        targetNS,
+		NumberofPRMatch: 1,
+	}
+	twait.Succeeded(ctx, t, runcnx, opts, sopt)
+}
+
 // Local Variables:
 // compile-command: "go test -tags=e2e -v -run ^TestGitlabMergeRequest$"
 // End:

--- a/test/testdata/pipelinerun-nomatch.yaml
+++ b/test/testdata/pipelinerun-nomatch.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: "no-match"
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: task
+        displayName: "The Task name is Task"
+        taskSpec:
+          steps:
+            - name: task
+              image: registry.access.redhat.com/ubi9/ubi-micro
+              command: ["/bin/echo", "NO MATCH"]


### PR DESCRIPTION
# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Users now have the ability to explicitly start a PipelineRun using the /test <pipelinerun-name> comment, irrespective of whether the pipelinerun matches the annotations. This feature grants users explicit control over the execution of PipelineRuns for specific types of Pull Requests, allowing manual initiation instead of relying solely on events.

This enhancement is particularly useful for scenarios where users need fine-grained control over the testing process, such as for Pull Requests managed by users rather than events.

Add e2e for gitlab/github(ghe)/gitea, but supports bitbutcketcloud as well

See: https://issues.redhat.com/browse/SRVKP-3561

## Demo
https://github.com/openshift-pipelines/pipelines-as-code/assets/98980/54762174-da6b-4323-ba49-47a3c4b93be0



<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
