### PR TITLE
Add support for fetching pipeline from hub

### DIFF
--- a/docs/content/dev/_index.md
+++ b/docs/content/dev/_index.md
@@ -277,4 +277,4 @@ need to have on your system:
 - [Jira Backlog](https://issues.redhat.com/browse/SRVKP-2144?jql=component%20%3D%20%22Pipeline%20as%20Code%22%20%20AND%20status%20!%3D%20Done)
 - [Bitbucket Server Rest API](https://docs.atlassian.com/bitbucket-server/rest/7.17.0/bitbucket-rest.html)
 - [GitHub API](https://docs.github.com/en/rest/reference)
-- [Gitlab API](https://docs.gitlab.com/ee/api/api_resources.html)
+- [GitLab API](https://docs.gitlab.com/ee/api/api_resources.html)

--- a/docs/content/docs/guide/customparams.md
+++ b/docs/content/docs/guide/customparams.md
@@ -106,5 +106,5 @@ and a pull request event.
 {{< hint info >}}
 
 - [GitHub Documentation for webhook events](https://docs.github.com/webhooks-and-events/webhooks/webhook-events-and-payloads?actionType=auto_merge_disabled#pull_request)
-- [Gitlab Documentation for webhook events](https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html)
+- [GitLab Documentation for webhook events](https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html)
 {{< /hint >}}

--- a/docs/content/docs/guide/resolver.md
+++ b/docs/content/docs/guide/resolver.md
@@ -63,7 +63,7 @@ or multiple tasks with an array :
 pipelinesascode.tekton.dev/task: "[git-clone, pylint]"
 ```
 
-### [Tekton Hub](https://hub.tekton.dev)
+### [Tekton Hub](https://hub.tekton.dev) Support for Tasks
 
 ```yaml
 pipelinesascode.tekton.dev/task: "git-clone"
@@ -102,7 +102,7 @@ this example :
 pipelinesascode.tekton.dev/task: "[git-clone:0.1]" # this will install git-clone 0.1 from tekton.hub
 ```
 
-#### Custom [Tekton Hub](https://github.com/tektoncd/hub/)
+#### Custom [Tekton Hub](https://github.com/tektoncd/hub/) Support for Tasks
 
 Additionally if the cluster administrator has [set-up](/docs/install/settings#tekton-hub-support) a custom Tekton Hub you
 are able to reference it from your template like this example:
@@ -177,7 +177,8 @@ If the object fetched cannot be parsed as a Tekton `Task` it will error out.
 
 Remote Pipeline can be referenced by annotation, allowing you to share a Pipeline across multiple repositories.
 
-Only one Pipeline is allowed on the `PipelineRun` annotation.
+Only one pipeline annotation(pipelinesascode.tekton.dev/pipeline) for remote pipeline is allowed on the `PipelineRun`. Also, the
+value of the annotation should have one pipeline. Annotations like `pipelinesascode.tekton.dev/pipeline-1` are not supported.
 
 An annotation to a remote pipeline looks like this, using a remote URL:
 
@@ -191,7 +192,32 @@ or from a relative path inside the repository:
 pipelinesascode.tekton.dev/pipeline: "./tasks/pipeline.yaml
 ```
 
-Fetching `Pipelines` from the [Tekton Hub](https://hub.tekton.dev) is not currently supported.
+### [Tekton Hub](https://hub.tekton.dev) Support for Pipelines
+
+```yaml
+pipelinesascode.tekton.dev/pipeline: "[buildpacks]"
+```
+
+The syntax above installs the
+[buildpacks](https://github.com/tektoncd/catalog/tree/main/pipeline/buildpacks) pipeline
+from the [tekton hub](https://hub.tekton.dev) repository querying for the latest
+version with the tekton hub API.
+
+If you want to have a specific version of the pipeline, you can add a colon `:` to
+the string and a version number, like in this example :
+
+```yaml
+pipelinesascode.tekton.dev/pipeline: "[buildpacks:0.1]" # this will install buildpacks 0.1 from tekton hub
+```
+
+#### Custom [Tekton Hub](https://github.com/tektoncd/hub/) Support for Pipelines
+
+Additionally if the cluster administrator has [set-up](/docs/install/settings#tekton-hub-support) a custom Tekton Hub you
+are able to reference it from your template like this example:
+
+```yaml
+pipelinesascode.tekton.dev/pipeline: "[anothercatalog://buildpacks:0.1]" # this will install buildpacks from the custom catalog configured by the cluster administrator as anothercatalog
+```
 
 ### Overriding tasks from a remote pipeline on a PipelineRun
 

--- a/docs/content/docs/install/operator_installation.md
+++ b/docs/content/docs/install/operator_installation.md
@@ -4,7 +4,7 @@ weight: 2.1
 ---
 # Installation Through Operator
 
-The easiest way to install Pipelines-as-Code on OpenShift is with the [Red Hat Openshift Pipelines Operator](https://docs.openshift.com/container-platform/latest/cicd/pipelines/installing-pipelines.html).
+The easiest way to install Pipelines-as-Code on OpenShift is with the [Red Hat OpenShift Pipelines Operator](https://docs.openshift.com/container-platform/latest/cicd/pipelines/installing-pipelines.html).
 
 On the OpenShift Pipelines Operator, the default namespace is `openshift-pipelines`.
 

--- a/pkg/hub/get_test.go
+++ b/pkg/hub/get_test.go
@@ -32,18 +32,20 @@ func TestGetTask(t *testing.T) {
 		})
 	tests := []struct {
 		name        string
-		task        string
+		resource    string
 		want        string
 		wantErr     bool
 		config      map[string]map[string]string
 		catalogName string
+		kind        string
 	}{
 		{
 			name:        "get-task-latest",
-			task:        "task1",
+			resource:    "task1",
 			want:        "This is Task1",
 			wantErr:     false,
 			catalogName: "default",
+			kind:        "task",
 			config: map[string]map[string]string{
 				fmt.Sprintf("%s/resource/%s/task/task1", testHubURL, testCatalogHubName): {
 					"body": `{"data":{"latestVersion": {"version": "0.2"}}}`,
@@ -57,10 +59,11 @@ func TestGetTask(t *testing.T) {
 		},
 		{
 			name:        "get-task-latest-custom",
-			task:        "task1",
+			resource:    "task1",
 			want:        "This is Task1",
 			wantErr:     false,
 			catalogName: "anotherHub",
+			kind:        "task",
 			config: map[string]map[string]string{
 				fmt.Sprintf("%s/resource/%s/task/task1", testHubURL, testCatalogHubName): {
 					"body": `{"data":{"latestVersion": {"version": "0.2"}}}`,
@@ -74,9 +77,10 @@ func TestGetTask(t *testing.T) {
 		},
 		{
 			name:        "get-latest-task-not-there",
-			task:        "task1",
+			resource:    "task1",
 			catalogName: "default",
 			wantErr:     true,
+			kind:        "task",
 			config: map[string]map[string]string{
 				fmt.Sprintf("%s/resource/%s/task/task1", testHubURL, testCatalogHubName): {
 					"code": "404",
@@ -85,9 +89,10 @@ func TestGetTask(t *testing.T) {
 		},
 		{
 			name:        "get-specific-task-not-there",
-			task:        "task1:1.1",
+			resource:    "task1:1.1",
 			wantErr:     true,
 			catalogName: "default",
+			kind:        "task",
 			config: map[string]map[string]string{
 				fmt.Sprintf("%s/resource/%s/task/task1/1.1", testHubURL, testCatalogHubName): {
 					"code": "404",
@@ -95,11 +100,26 @@ func TestGetTask(t *testing.T) {
 			},
 		},
 		{
+			name:        "get-specific-hub-not-there",
+			resource:    "task1:1.1",
+			wantErr:     true,
+			catalogName: "notexist",
+			kind:        "task",
+		},
+		{
+			name:        "get-specific-hub-not-there-with-latest",
+			resource:    "task1",
+			wantErr:     true,
+			catalogName: "notexist",
+			kind:        "task",
+		},
+		{
 			name:        "get-task-specific",
-			task:        "task2:1.1",
+			resource:    "task2:1.1",
 			want:        "This is Task2",
 			wantErr:     false,
 			catalogName: "default",
+			kind:        "task",
 			config: map[string]map[string]string{
 				fmt.Sprintf("%s/resource/%s/task/task2/1.1", testHubURL, testCatalogHubName): {
 					"body": `{}`,
@@ -107,6 +127,84 @@ func TestGetTask(t *testing.T) {
 				},
 				fmt.Sprintf("%s/resource/%s/task/task2/1.1/raw", testHubURL, testCatalogHubName): {
 					"body": "This is Task2",
+					"code": "200",
+				},
+			},
+		},
+		{
+			name:        "get-pipeline-latest",
+			resource:    "pipeline1",
+			want:        "This is Pipeline1",
+			wantErr:     false,
+			catalogName: "default",
+			kind:        "pipeline",
+			config: map[string]map[string]string{
+				fmt.Sprintf("%s/resource/%s/pipeline/pipeline1", testHubURL, testCatalogHubName): {
+					"body": `{"data":{"latestVersion": {"version": "0.2"}}}`,
+					"code": "200",
+				},
+				fmt.Sprintf("%s/resource/%s/pipeline/pipeline1/0.2/raw", testHubURL, testCatalogHubName): {
+					"body": "This is Pipeline1",
+					"code": "200",
+				},
+			},
+		},
+		{
+			name:        "get-pipeline-latest-custom",
+			resource:    "pipeline1",
+			want:        "This is Pipeline1",
+			wantErr:     false,
+			catalogName: "anotherHub",
+			kind:        "pipeline",
+			config: map[string]map[string]string{
+				fmt.Sprintf("%s/resource/%s/pipeline/pipeline1", testHubURL, testCatalogHubName): {
+					"body": `{"data":{"latestVersion": {"version": "0.2"}}}`,
+					"code": "200",
+				},
+				fmt.Sprintf("%s/resource/%s/pipeline/pipeline1/0.2/raw", testHubURL, testCatalogHubName): {
+					"body": "This is Pipeline1",
+					"code": "200",
+				},
+			},
+		},
+		{
+			name:        "get-latest-pipeline-not-there",
+			resource:    "pipeline1",
+			catalogName: "default",
+			wantErr:     true,
+			kind:        "pipeline",
+			config: map[string]map[string]string{
+				fmt.Sprintf("%s/resource/%s/pipeline/pipeline1", testHubURL, testCatalogHubName): {
+					"code": "404",
+				},
+			},
+		},
+		{
+			name:        "get-specific-pipeline-not-there",
+			resource:    "pipeline1:1.1",
+			wantErr:     true,
+			catalogName: "default",
+			kind:        "pipeline",
+			config: map[string]map[string]string{
+				fmt.Sprintf("%s/resource/%s/pipeline/pipeline1/1.1", testHubURL, testCatalogHubName): {
+					"code": "404",
+				},
+			},
+		},
+		{
+			name:        "get-pipeline-specific",
+			resource:    "pipeline2:1.1",
+			want:        "This is Pipeline2",
+			wantErr:     false,
+			catalogName: "default",
+			kind:        "pipeline",
+			config: map[string]map[string]string{
+				fmt.Sprintf("%s/resource/%s/pipeline/pipeline2/1.1", testHubURL, testCatalogHubName): {
+					"body": `{}`,
+					"code": "200",
+				},
+				fmt.Sprintf("%s/resource/%s/pipeline/pipeline2/1.1/raw", testHubURL, testCatalogHubName): {
+					"body": "This is Pipeline2",
 					"code": "200",
 				},
 			},
@@ -126,7 +224,7 @@ func TestGetTask(t *testing.T) {
 					},
 				}},
 			}
-			got, err := GetTask(ctx, cs, tt.catalogName, tt.task)
+			got, err := GetResource(ctx, cs, tt.catalogName, tt.resource, tt.kind)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetTask() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
This will add support for fetching pipeline from hub if specified with annotation pipelinesascode.tekton.dev/pipeline Users can specify only one annotation and also it can be used to specify the version of pipeline and also can be used with custom hub just same like task.

Add docs and unit tests, also this break if user has been previously using annotation like pipelinesascode.tekton.dev/pipeline-1 etc as these are not supported anymore.

# Submitter Checklist

- [x] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [x] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [x] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [x] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
