### PR TITLE
Resolve inconsistent status of a PipelineRun after a failure

### DIFF
--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -340,9 +340,9 @@ func (p *PacRun) checkAccessOrErrror(ctx context.Context, repo *v1alpha1.Reposit
 	}
 	p.eventEmitter.EmitMessage(repo, zap.InfoLevel, "RepositoryPermissionDenied", msg)
 	status := provider.StatusOpts{
-		Status:     "queued",
+		Status:     queuedStatus,
 		Title:      "Pending approval",
-		Conclusion: "pending",
+		Conclusion: pendingConclusion,
 		Text:       msg,
 		DetailsURL: p.event.URL,
 	}

--- a/pkg/provider/github/status.go
+++ b/pkg/provider/github/status.go
@@ -58,7 +58,7 @@ func (v *Provider) getExistingCheckRunID(ctx context.Context, runevent *info.Eve
 
 		for _, checkrun := range res.CheckRuns {
 			// if it is a Pending approval CheckRun then overwrite it
-			if isPendingApprovalCheckrun(checkrun) {
+			if isPendingApprovalCheckrun(checkrun) || isFailedCheckrun(checkrun) {
 				if v.canIUseCheckrunID(checkrun.ID) {
 					return checkrun.ID, nil
 				}
@@ -83,6 +83,18 @@ func isPendingApprovalCheckrun(run *github.CheckRun) bool {
 	if run.Output.Title != nil && strings.Contains(*run.Output.Title, "Pending") &&
 		run.Output.Summary != nil &&
 		strings.Contains(*run.Output.Summary, "is waiting for approval") {
+		return true
+	}
+	return false
+}
+
+func isFailedCheckrun(run *github.CheckRun) bool {
+	if run == nil || run.Output == nil {
+		return false
+	}
+	if run.Output.Title != nil && strings.Contains(*run.Output.Title, "Failed") &&
+		run.Output.Summary != nil &&
+		strings.Contains(*run.Output.Summary, "failed") {
 		return true
 	}
 	return false
@@ -183,12 +195,21 @@ func (v *Provider) getFailuresMessageAsAnnotations(ctx context.Context, pr *tekt
 }
 
 // getOrUpdateCheckRunStatus create a status via the checkRun API, which is only
-// available with Github apps tokens.
+// available with GitHub apps tokens.
 func (v *Provider) getOrUpdateCheckRunStatus(ctx context.Context, runevent *info.Event, statusOpts provider.StatusOpts) error {
 	var err error
 	var checkRunID *int64
 	var found bool
 	pacopts := v.pacInfo
+
+	// The purpose of this condition is to limit the generation of checkrun IDs
+	// when multiple pipelineruns fail. In such cases, generate only one checkrun ID,
+	// regardless of the number of failed pipelineruns.
+	if statusOpts.Title == "Failed" && statusOpts.PipelineRunName == "" {
+		if statusOpts.InstanceCountForCheckRun >= 1 {
+			return nil
+		}
+	}
 
 	// check if pipelineRun has the label with checkRun-id
 	if statusOpts.PipelineRun != nil {

--- a/pkg/provider/interface.go
+++ b/pkg/provider/interface.go
@@ -14,15 +14,16 @@ import (
 )
 
 type StatusOpts struct {
-	PipelineRun             *v1.PipelineRun
-	PipelineRunName         string
-	OriginalPipelineRunName string
-	Status                  string
-	Conclusion              string
-	Text                    string
-	DetailsURL              string
-	Summary                 string
-	Title                   string
+	PipelineRun              *v1.PipelineRun
+	PipelineRunName          string
+	OriginalPipelineRunName  string
+	Status                   string
+	Conclusion               string
+	Text                     string
+	DetailsURL               string
+	Summary                  string
+	Title                    string
+	InstanceCountForCheckRun int
 }
 
 type Interface interface {

--- a/pkg/reconciler/status.go
+++ b/pkg/reconciler/status.go
@@ -13,6 +13,7 @@ import (
 	kstatus "github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction/status"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/pipelineascode"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/secrets"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/sort"
@@ -142,7 +143,7 @@ func (r *Reconciler) postFinalStatus(ctx context.Context, logger *zap.SugaredLog
 	}
 
 	status := provider.StatusOpts{
-		Status:                  "completed",
+		Status:                  pipelineascode.CompletedStatus,
 		PipelineRun:             pr,
 		Conclusion:              formatting.PipelineRunStatus(pr),
 		Text:                    tmplStatusText,


### PR DESCRIPTION
In Pipelines as Code for some CI failures failed checkrun persist
like below
    
Pipelines a Code CI - Failed
 
on the GitHub status page.
 
These are the 2 scenarios
    
1. If there is a pull request on which the CI has failed checkrun,
    updating the PR results in the override of the failed check run.
    This is because a PR update generates a new commit SHA,
    leading to the creation of new check runs for the updated SHA.
    
2. If there is a pull request on which the CI has failed checkrun,
    if a user adds a `/test` or `/retest` comment on the same commit SHA
    without updating the PR, the failed check run will be retained.
    Alongside this, new check runs will be added for the existing SHA.
    
However, in both scenarios, a challenge arises when there
are multiple pipeline runs (**n** pipelineruns) in the .tekton
directory, resulting in the creation of
**n** check run IDs for each failed pipeline run.
    
With the proposed fix, Pipelines as Code now effectively
addresses this issue.
The solution ensures that, for failed pipeline runs,
the check run is appropriately overridden without
generating n check run IDs for each failed pipelinerun.

Fixes: https://issues.redhat.com/browse/SRVKP-3400 & https://issues.redhat.com/browse/SRVKP-3379


https://github.com/openshift-pipelines/pipelines-as-code/assets/9441662/ae8fd3bc-e607-4be6-8145-a08c46616be0



# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
