### PR TITLE
CI Fixes

### DIFF
--- a/pkg/changedfiles/changedfiles.go
+++ b/pkg/changedfiles/changedfiles.go
@@ -1,0 +1,29 @@
+package changedfiles
+
+type ChangedFiles struct {
+	All      []string
+	Added    []string
+	Deleted  []string
+	Modified []string
+	Renamed  []string
+}
+
+func removeDuplicates(s []string) []string {
+	holdit := make(map[string]bool)
+	var result []string
+	for _, str := range s {
+		if _, ok := holdit[str]; !ok {
+			holdit[str] = true
+			result = append(result, str)
+		}
+	}
+	return result
+}
+
+func (c *ChangedFiles) RemoveDuplicates() {
+	c.All = removeDuplicates(c.All)
+	c.Added = removeDuplicates(c.Added)
+	c.Deleted = removeDuplicates(c.Deleted)
+	c.Modified = removeDuplicates(c.Modified)
+	c.Renamed = removeDuplicates(c.Renamed)
+}

--- a/pkg/changedfiles/changedfiles_test.go
+++ b/pkg/changedfiles/changedfiles_test.go
@@ -1,0 +1,83 @@
+package changedfiles
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestRemoveDuplicates(t *testing.T) {
+	tests := []struct {
+		name     string
+		initial  []string
+		expected []string
+	}{
+		{
+			name:     "no duplicates",
+			initial:  []string{"a", "b", "c"},
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			name:     "with duplicates",
+			initial:  []string{"a", "b", "a", "c", "b"},
+			expected: []string{"a", "b", "c"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := removeDuplicates(tt.initial)
+			assert.DeepEqual(t, got, tt.expected)
+		})
+	}
+}
+
+func TestRemoveDuplicatesMethod(t *testing.T) {
+	tests := []struct {
+		name     string
+		initial  ChangedFiles
+		expected ChangedFiles
+	}{
+		{
+			name: "no duplicates",
+			initial: ChangedFiles{
+				All:      []string{"a", "b", "c"},
+				Added:    []string{"a", "b", "c"},
+				Deleted:  []string{"a", "b", "c"},
+				Modified: []string{"a", "b", "c"},
+				Renamed:  []string{"a", "b", "c"},
+			},
+			expected: ChangedFiles{
+				All:      []string{"a", "b", "c"},
+				Added:    []string{"a", "b", "c"},
+				Deleted:  []string{"a", "b", "c"},
+				Modified: []string{"a", "b", "c"},
+				Renamed:  []string{"a", "b", "c"},
+			},
+		},
+		{
+			name: "with duplicates",
+			initial: ChangedFiles{
+				All:      []string{"a", "b", "a", "c", "b"},
+				Added:    []string{"a", "b", "a", "c", "b"},
+				Deleted:  []string{"a", "b", "a", "c", "b"},
+				Modified: []string{"a", "b", "a", "c", "b"},
+				Renamed:  []string{"a", "b", "a", "c", "b"},
+			},
+			expected: ChangedFiles{
+				All:      []string{"a", "b", "c"},
+				Added:    []string{"a", "b", "c"},
+				Deleted:  []string{"a", "b", "c"},
+				Modified: []string{"a", "b", "c"},
+				Renamed:  []string{"a", "b", "c"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.initial.RemoveDuplicates()
+			assert.DeepEqual(t, tt.initial, tt.expected)
+		})
+	}
+}

--- a/pkg/customparams/standard.go
+++ b/pkg/customparams/standard.go
@@ -5,19 +5,20 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/changedfiles"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	"go.uber.org/zap"
 )
 
-func (p *CustomParams) getChangedFiles(ctx context.Context) provider.ChangedFiles {
+func (p *CustomParams) getChangedFiles(ctx context.Context) changedfiles.ChangedFiles {
 	if p.vcx == nil {
-		return provider.ChangedFiles{}
+		return changedfiles.ChangedFiles{}
 	}
 	changedFiles, err := p.vcx.GetFiles(ctx, p.event)
 	if err != nil {
 		p.eventEmitter.EmitMessage(p.repo, zap.ErrorLevel, "ParamsError", fmt.Sprintf("error getting changed files: %s", err.Error()))
 	}
+	changedFiles.RemoveDuplicates()
 	return changedFiles
 }
 

--- a/pkg/formatting/k8labels.go
+++ b/pkg/formatting/k8labels.go
@@ -1,17 +1,25 @@
 package formatting
 
-import "strings"
+import (
+	"strings"
+)
 
-// CleanValueKubernetes k8s do not like slash in labels value and on push we have the
-// full ref, we replace the "/" by "-". The tools probably need to be aware of
-// it when querying.
-//
-// valid label must be an empty string or consist of alphanumeric characters,
-// '-', '_' or '.', and must start and end with an alphanumeric character
-// (e.g. 'MyValue', or 'my_value', or '12345', regex used for validation is
-// '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?').
+// CleanValueKubernetes conform a string to kubernetes naming convention
+// see https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
+// rules are:
+// • contain at most 63 characters
+// • contain only lowercase alphanumeric characters or '-'
+// • start with an alphanumeric character
+// • end with an alphanumeric character.
 func CleanValueKubernetes(s string) string {
-	replasoeur := strings.NewReplacer("/", "-", " ", "_", "[", "__", "]", "__")
-	replaced := replasoeur.Replace(strings.TrimRight(s, " -_[]"))
+	if len(s) >= 63 {
+		// keep the last 62 characters
+		s = s[len(s)-62:]
+	}
+
+	replasoeur := strings.NewReplacer(":", "-", "/", "-", " ", "_", "[", "__", "]", "__")
+	s = strings.TrimRight(s, " -_[]")
+	s = strings.TrimLeft(s, " -_[]")
+	replaced := replasoeur.Replace(s)
 	return strings.TrimSpace(replaced)
 }

--- a/pkg/formatting/k8labels_test.go
+++ b/pkg/formatting/k8labels_test.go
@@ -1,6 +1,9 @@
 package formatting
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestK8LabelsCleanup(t *testing.T) {
 	tests := []struct {
@@ -15,8 +18,8 @@ func TestK8LabelsCleanup(t *testing.T) {
 		},
 		{
 			name: "keep dash",
-			str:  "foo-bar_hello",
-			want: "foo-bar_hello",
+			str:  "foo-bar-hello",
+			want: "foo-bar-hello",
 		},
 		{
 			name: "github bot name",
@@ -33,7 +36,29 @@ func TestK8LabelsCleanup(t *testing.T) {
 			str:  "foo\n",
 			want: "foo",
 		},
+
+		{
+			name: "secret name longer than 63 characters",
+			str:  strings.Repeat("a", 64),
+			want: strings.Repeat("a", 62),
+		},
+		{
+			name: "secret name ends with non-alphanumeric character",
+			str:  "secret-name-",
+			want: "secret-name",
+		},
+		{
+			name: "secret name starts with non-alphanumeric character",
+			str:  "-secret-name",
+			want: "secret-name",
+		},
+		{
+			name: "secret name contains non-alphanumeric characters keep underscore",
+			str:  "secret:name/with_underscores",
+			want: "secret-name-with_underscores",
+		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := CleanValueKubernetes(tt.str); got != tt.want {

--- a/pkg/matcher/cel.go
+++ b/pkg/matcher/cel.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/cel-go/checker/decls"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/changedfiles"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 )
@@ -61,7 +62,7 @@ func celEvaluate(ctx context.Context, expr string, event *info.Event, vcx provid
 	}
 
 	r := regexp.MustCompile(changedFilesTags)
-	changedFiles := provider.ChangedFiles{}
+	changedFiles := changedfiles.ChangedFiles{}
 
 	if r.MatchString(expr) {
 		changedFiles, err = vcx.GetFiles(ctx, event)

--- a/pkg/provider/bitbucketcloud/bitbucket.go
+++ b/pkg/provider/bitbucketcloud/bitbucket.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ktrysmt/go-bitbucket"
 	"github.com/mitchellh/mapstructure"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/changedfiles"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/events"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
@@ -277,8 +278,8 @@ func (v *Provider) getBlob(runevent *info.Event, ref, path string) (string, erro
 	return blob.String(), nil
 }
 
-func (v *Provider) GetFiles(_ context.Context, _ *info.Event) (provider.ChangedFiles, error) {
-	return provider.ChangedFiles{}, nil
+func (v *Provider) GetFiles(_ context.Context, _ *info.Event) (changedfiles.ChangedFiles, error) {
+	return changedfiles.ChangedFiles{}, nil
 }
 
 func (v *Provider) CreateToken(_ context.Context, _ []string, _ *info.Event) (string, error) {

--- a/pkg/provider/bitbucketserver/bitbucketserver.go
+++ b/pkg/provider/bitbucketserver/bitbucketserver.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/go-github/v56/github"
 	"github.com/mitchellh/mapstructure"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/changedfiles"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/events"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
@@ -272,8 +273,8 @@ func (v *Provider) GetConfig() *info.ProviderConfig {
 	}
 }
 
-func (v *Provider) GetFiles(_ context.Context, _ *info.Event) (provider.ChangedFiles, error) {
-	return provider.ChangedFiles{}, nil
+func (v *Provider) GetFiles(_ context.Context, _ *info.Event) (changedfiles.ChangedFiles, error) {
+	return changedfiles.ChangedFiles{}, nil
 }
 
 func (v *Provider) CreateToken(_ context.Context, _ []string, _ *info.Event) (string, error) {

--- a/pkg/provider/gitea/gitea_test.go
+++ b/pkg/provider/gitea/gitea_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/changedfiles"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	tgitea "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/gitea/test"
 	"go.uber.org/zap"
 	zapobserver "go.uber.org/zap/zaptest/observer"
@@ -24,7 +24,7 @@ func TestProvider_GetFiles(t *testing.T) {
 		name         string
 		args         args
 		changedFiles string
-		want         provider.ChangedFiles
+		want         changedfiles.ChangedFiles
 		wantErr      bool
 	}{
 		{
@@ -37,7 +37,7 @@ func TestProvider_GetFiles(t *testing.T) {
 					TriggerTarget:     "pull_request",
 				},
 			},
-			want: provider.ChangedFiles{
+			want: changedfiles.ChangedFiles{
 				All: []string{
 					"added.txt",
 					"deleted.txt",
@@ -66,7 +66,7 @@ func TestProvider_GetFiles(t *testing.T) {
 					},
 				},
 			},
-			want: provider.ChangedFiles{
+			want: changedfiles.ChangedFiles{
 				All: []string{
 					".tekton/pullrequest.yaml",
 					".tekton/push.yaml",

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/changedfiles"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/events"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
@@ -440,14 +441,14 @@ func (v *Provider) getPullRequest(ctx context.Context, runevent *info.Event) (*i
 }
 
 // GetFiles get a files from pull request.
-func (v *Provider) GetFiles(ctx context.Context, runevent *info.Event) (provider.ChangedFiles, error) {
+func (v *Provider) GetFiles(ctx context.Context, runevent *info.Event) (changedfiles.ChangedFiles, error) {
 	if runevent.TriggerTarget == "pull_request" {
 		opt := &github.ListOptions{PerPage: v.paginedNumber}
-		changedFiles := provider.ChangedFiles{}
+		changedFiles := changedfiles.ChangedFiles{}
 		for {
 			repoCommit, resp, err := v.Client.PullRequests.ListFiles(ctx, runevent.Organization, runevent.Repository, runevent.PullRequestNumber, opt)
 			if err != nil {
-				return provider.ChangedFiles{}, err
+				return changedfiles.ChangedFiles{}, err
 			}
 			for j := range repoCommit {
 				changedFiles.All = append(changedFiles.All, *repoCommit[j].Filename)
@@ -473,10 +474,10 @@ func (v *Provider) GetFiles(ctx context.Context, runevent *info.Event) (provider
 	}
 
 	if runevent.TriggerTarget == "push" {
-		changedFiles := provider.ChangedFiles{}
+		changedFiles := changedfiles.ChangedFiles{}
 		rC, _, err := v.Client.Repositories.GetCommit(ctx, runevent.Organization, runevent.Repository, runevent.SHA, &github.ListOptions{})
 		if err != nil {
-			return provider.ChangedFiles{}, err
+			return changedfiles.ChangedFiles{}, err
 		}
 		for i := range rC.Files {
 			changedFiles.All = append(changedFiles.All, *rC.Files[i].Filename)
@@ -495,7 +496,7 @@ func (v *Provider) GetFiles(ctx context.Context, runevent *info.Event) (provider
 		}
 		return changedFiles, nil
 	}
-	return provider.ChangedFiles{}, nil
+	return changedfiles.ChangedFiles{}, nil
 }
 
 // getObject Get an object from a repository.

--- a/pkg/provider/interface.go
+++ b/pkg/provider/interface.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/changedfiles"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/events"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
@@ -37,18 +38,10 @@ type Interface interface {
 	SetClient(context.Context, *params.Run, *info.Event, *v1alpha1.Repository, *events.EventEmitter) error
 	GetCommitInfo(context.Context, *info.Event) error
 	GetConfig() *info.ProviderConfig
-	GetFiles(context.Context, *info.Event) (ChangedFiles, error)
+	GetFiles(context.Context, *info.Event) (changedfiles.ChangedFiles, error)
 	GetTaskURI(ctx context.Context, event *info.Event, uri string) (bool, string, error)
 	CreateToken(context.Context, []string, *info.Event) (string, error)
 	CheckPolicyAllowing(context.Context, *info.Event, []string) (bool, string)
 }
 
 const DefaultProviderAPIUser = "git"
-
-type ChangedFiles struct {
-	All      []string
-	Added    []string
-	Deleted  []string
-	Modified []string
-	Renamed  []string
-}

--- a/pkg/test/provider/testwebvcs.go
+++ b/pkg/test/provider/testwebvcs.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/changedfiles"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/events"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
@@ -98,11 +99,11 @@ func (v *TestProviderImp) GetFileInsideRepo(_ context.Context, _ *info.Event, fi
 	return "", fmt.Errorf("could not find %s in tests", file)
 }
 
-func (v *TestProviderImp) GetFiles(_ context.Context, _ *info.Event) (provider.ChangedFiles, error) {
+func (v *TestProviderImp) GetFiles(_ context.Context, _ *info.Event) (changedfiles.ChangedFiles, error) {
 	if v == nil {
-		return provider.ChangedFiles{}, nil
+		return changedfiles.ChangedFiles{}, nil
 	}
-	return provider.ChangedFiles{
+	return changedfiles.ChangedFiles{
 		All:      v.WantAllChangedFiles,
 		Added:    v.WantAddedFiles,
 		Deleted:  v.WantDeletedFiles,

--- a/test/github_incoming_test.go
+++ b/test/github_incoming_test.go
@@ -87,14 +87,14 @@ func verifyIncomingWebhook(t *testing.T, randomedString string, entries map[stri
 	targetRefName := fmt.Sprintf("refs/heads/%s", randomedString)
 
 	title := "TestGithubAppIncoming - " + randomedString
-	sha, err := tgithub.PushFilesToRef(ctx, ghprovider.Client, title,
+	sha, vref, err := tgithub.PushFilesToRef(ctx, ghprovider.Client, title,
 		repoinfo.GetDefaultBranch(),
 		targetRefName,
 		opts.Organization,
 		opts.Repo,
 		entries)
 	assert.NilError(t, err)
-	runcnx.Clients.Log.Infof("Commit %s has been created and pushed to branch %s", sha, targetRefName)
+	runcnx.Clients.Log.Infof("Commit %s has been created and pushed to branch %s", sha, vref.GetURL())
 
 	url := fmt.Sprintf("%s/incoming?repository=%s&branch=%s&pipelinerun=%s&secret=%s", opts.ControllerURL,
 		randomedString, randomedString, "pipelinerun-incoming", incomingSecreteValue)

--- a/test/github_pullrequest_concurrency_test.go
+++ b/test/github_pullrequest_concurrency_test.go
@@ -69,10 +69,10 @@ func TestGithubPullRequestConcurrency(t *testing.T) {
 	targetRefName := fmt.Sprintf("refs/heads/%s",
 		names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test"))
 
-	sha, err := tgithub.PushFilesToRef(ctx, ghcnx.Client, logmsg, repoinfo.GetDefaultBranch(), targetRefName,
+	sha, vref, err := tgithub.PushFilesToRef(ctx, ghcnx.Client, logmsg, repoinfo.GetDefaultBranch(), targetRefName,
 		opts.Organization, opts.Repo, entries)
 	assert.NilError(t, err)
-	runcnx.Clients.Log.Infof("Commit %s has been created and pushed to %s", sha, targetRefName)
+	runcnx.Clients.Log.Infof("Commit %s has been created and pushed to %s", sha, vref.GetURL())
 
 	prNumber, err := tgithub.PRCreate(ctx, runcnx, ghcnx, opts.Organization,
 		opts.Repo, targetRefName, repoinfo.GetDefaultBranch(), logmsg)

--- a/test/github_scope_token_to_list_of_private_public_repos_test.go
+++ b/test/github_scope_token_to_list_of_private_public_repos_test.go
@@ -149,9 +149,9 @@ func verifyGHTokenScope(t *testing.T, remoteTaskURL, remoteTaskName string, data
 	targetRefName := fmt.Sprintf("refs/heads/%s",
 		names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test"))
 
-	sha, err := tgithub.PushFilesToRef(ctx, ghcnx.Client, "TestPullRequestRemoteAnnotations - "+targetRefName, repoinfo.GetDefaultBranch(), targetRefName, opts.Organization, opts.Repo, entries)
+	sha, vref, err := tgithub.PushFilesToRef(ctx, ghcnx.Client, "TestPullRequestRemoteAnnotations - "+targetRefName, repoinfo.GetDefaultBranch(), targetRefName, opts.Organization, opts.Repo, entries)
 	assert.NilError(t, err)
-	runcnx.Clients.Log.Infof("Commit %s has been created and pushed to %s", sha, targetRefName)
+	runcnx.Clients.Log.Infof("Commit %s has been created and pushed to %s", sha, vref.GetURL())
 
 	title := "TestPullRequestRemoteAnnotations - " + targetRefName
 	number, err := tgithub.PRCreate(ctx, runcnx, ghcnx, opts.Organization, opts.Repo, targetRefName, repoinfo.GetDefaultBranch(), title)

--- a/test/github_tkn_pac_cli_test.go
+++ b/test/github_tkn_pac_cli_test.go
@@ -88,9 +88,9 @@ spec:
 	targetRefName := fmt.Sprintf("refs/heads/%s",
 		names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test"))
 
-	sha, err := tgithub.PushFilesToRef(ctx, ghprovider.Client, "TestPacCli - "+targetRefName, repoinfo.GetDefaultBranch(), targetRefName, opts.Organization, opts.Repo, entries)
+	sha, vref, err := tgithub.PushFilesToRef(ctx, ghprovider.Client, "TestPacCli - "+targetRefName, repoinfo.GetDefaultBranch(), targetRefName, opts.Organization, opts.Repo, entries)
 	assert.NilError(t, err)
-	runcnx.Clients.Log.Infof("Commit %s has been created and pushed to %s", sha, targetRefName)
+	runcnx.Clients.Log.Infof("Commit %s has been created and pushed to %s", sha, vref.GetURL())
 
 	title := "TestPacCli - " + targetRefName
 	number, err := tgithub.PRCreate(ctx, runcnx, ghprovider, opts.Organization, opts.Repo, targetRefName, repoinfo.GetDefaultBranch(), title)

--- a/test/testdata/TestGiteaParamsChangedFilesCEL-changed-files-pullrequest-params-1.golden
+++ b/test/testdata/TestGiteaParamsChangedFilesCEL-changed-files-pullrequest-params-1.golden
@@ -1,0 +1,6 @@
+changed files...
+files.all: [".tekton/pullrequest.yaml", ".tekton/push.yaml", "deleted.txt", "modified.txt", "renamed.txt"]
+files.added: [".tekton/pullrequest.yaml", ".tekton/push.yaml", "deleted.txt", "modified.txt", "renamed.txt"]
+files.deleted: []
+files.modified: []
+files.renamed: []

--- a/test/testdata/TestGiteaParamsChangedFilesCEL-changed-files-pullrequest-params-2.golden
+++ b/test/testdata/TestGiteaParamsChangedFilesCEL-changed-files-pullrequest-params-2.golden
@@ -1,0 +1,6 @@
+changed files...
+files.all: ["deleted.txt", "hasbeenrenamed.txt", "modified.txt"]
+files.added: []
+files.deleted: ["deleted.txt"]
+files.modified: ["modified.txt"]
+files.renamed: ["hasbeenrenamed.txt"]

--- a/test/testdata/TestGiteaParamsChangedFilesCEL-changed-files-push-params-1.golden
+++ b/test/testdata/TestGiteaParamsChangedFilesCEL-changed-files-push-params-1.golden
@@ -1,0 +1,7 @@
+changed files...
+files.all: [".tekton/pullrequest.yaml", ".tekton/push.yaml", "deleted.txt", "modified.txt", "renamed.txt"]
+files.added: [".tekton/pullrequest.yaml", ".tekton/push.yaml", "deleted.txt", "modified.txt", "renamed.txt"]
+files.deleted: []
+files.modified: []
+files.renamed: []
+

--- a/test/testdata/TestGiteaParamsChangedFilesCEL-changed-files-push-params-2.golden
+++ b/test/testdata/TestGiteaParamsChangedFilesCEL-changed-files-push-params-2.golden
@@ -1,0 +1,7 @@
+changed files...
+files.all: ["hasbeenrenamed.txt", "modified.txt", "deleted.txt", "renamed.txt"]
+files.added: ["hasbeenrenamed.txt"]
+files.deleted: ["deleted.txt", "renamed.txt"]
+files.modified: ["modified.txt"]
+files.renamed: []
+

--- a/test/testdata/pipelinerun-cel-params-pullrequest.yaml
+++ b/test/testdata/pipelinerun-cel-params-pullrequest.yaml
@@ -38,5 +38,5 @@ spec:
                 # my email is a true beauty and like groot, I AM pac
                 cat <<EOF
                 Look mum I know that we are acting on a {{ headers['X-Gitea-Event-Type'] }}
-                my email is a {{ body.pull_request.user.email == 'pac@pac.com' }} beauty and like groot, I AM {{ body.pull_request.user.login }}
+                my email is a {{ body.pull_request.user.email.startsWith("pac@")  }} beauty and like groot, I AM {{ body.pull_request.user.login }}
                 EOF

--- a/test/testdata/pipelinerun-cel-params-push.yaml
+++ b/test/testdata/pipelinerun-cel-params-push.yaml
@@ -36,5 +36,5 @@ spec:
                 # my email is a true beauty and you can call me pacman
                 cat <<EOF
                 Look mum I know that we are acting on a {{ headers['X-Gitea-Event-Type'] }}
-                my email is a {{ body.sender.email == 'pac@pac.com' }} beauty and you can call me {{ body.sender.username }}man
+                my email is a {{ body.sender.email.startsWith('pac@') }} beauty and you can call me {{ body.sender.username }}man
                 EOF


### PR DESCRIPTION
When we are getting the changed files we didn't remove the duplicates
and they would show multiple time when getting the files changes out of
multiple commits modifying the same files.

Convert to use the e2e test to use golden to make it easy to see outputs
changed

Move to its own packages with unittests

Fixes #1570 while at it so we get e2e greens

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
