### PR TITLE
Refactoring before implementing on-comments PR

### DIFF
--- a/.github/workflows/kind-e2e-tests.yaml
+++ b/.github/workflows/kind-e2e-tests.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Install and run gosmee
         run: |
           go install -v github.com/chmouel/gosmee@main
-          nohup gosmee client --saveDir /tmp/gosmee-replay ${{ secrets.PYSMEE_URL }} http://${CONTROLLER_DOMAIN_URL} &
+          nohup gosmee client --saveDir /tmp/gosmee-replay ${{ secrets.PYSMEE_URL }} "http://${CONTROLLER_DOMAIN_URL}" &
 
       - name: Install ko
         run: curl -sfL https://github.com/google/ko/releases/download/v0.14.1/ko_0.14.1_Linux_x86_64.tar.gz -o-|tar xvzf - -C /usr/local/bin ko

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,10 +13,6 @@ repos:
       - id: check-vcs-permalinks
       - id: detect-private-key
         exclude: ".*_test.go"
-  - repo: https://github.com/koalaman/shellcheck-precommit
-    rev: v0.9.0
-    hooks:
-      - id: shellcheck
   - repo: https://github.com/jorisroovers/gitlint
     rev: v0.19.1
     hooks:
@@ -36,11 +32,10 @@ repos:
         types: [go]
         pass_filenames: false
       - id: lint
-        name: "Unit testing"
+        name: "Linting"
         entry: make
         args: ["lint"]
         language: system
-        types: [go]
         pass_filenames: false
       - id: check-generated
         name: "Check generated vendor and golden files"
@@ -49,4 +44,9 @@ repos:
         language: system
         types: [go]
         pass_filenames: false
+      - id: shellcheck
+        name: "Shellcheck"
+        entry: "shellcheck"
+        language: system
+        types: [shell]
 # TODO: add a lint-sh when we have the errors fix

--- a/cmd/pipelines-as-code-watcher/main.go
+++ b/cmd/pipelines-as-code-watcher/main.go
@@ -21,7 +21,7 @@ func main() {
 	}
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/live", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/live", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = fmt.Fprint(w, "ok")
 	})

--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -52,7 +52,7 @@ type Response struct {
 var _ adapter.Adapter = (*listener)(nil)
 
 func New(run *params.Run, k *kubeinteraction.Interaction) adapter.AdapterConstructor {
-	return func(ctx context.Context, processed adapter.EnvConfigAccessor, ceClient cloudevents.Client) adapter.Adapter {
+	return func(ctx context.Context, _ adapter.EnvConfigAccessor, _ cloudevents.Client) adapter.Adapter {
 		return &listener{
 			logger: logging.FromContext(ctx),
 			run:    run,

--- a/pkg/cli/webhook/bitbucket_cloud_test.go
+++ b/pkg/cli/webhook/bitbucket_cloud_test.go
@@ -93,13 +93,13 @@ func TestBBCreate(t *testing.T) {
 	io, _, _, _ := cli.IOTest()
 
 	// webhook created for repo pac/repo
-	mux.HandleFunc("/repositories/pac/repo/hooks", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repositories/pac/repo/hooks", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusCreated)
 		_, _ = fmt.Fprint(w, `{"type": "ok"}`)
 	})
 
 	// webhook failed for repo pac/invalid
-	mux.HandleFunc("/repositories/pac/invalid/hooks", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repositories/pac/invalid/hooks", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusForbidden)
 		_, _ = fmt.Fprint(w, `{"type": "error"}`)
 	})

--- a/pkg/cli/webhook/github.go
+++ b/pkg/cli/webhook/github.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli/prompt"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/random"
 	"golang.org/x/oauth2"
 )
@@ -133,7 +134,7 @@ func (gh *gitHubConfig) create(ctx context.Context) error {
 		Active: github.Bool(true),
 		Events: []string{
 			"issue_comment",
-			"pull_request",
+			triggertype.PullRequest.String(),
 			"push",
 		},
 		Config: map[string]interface{}{

--- a/pkg/cli/webhook/github_test.go
+++ b/pkg/cli/webhook/github_test.go
@@ -101,12 +101,12 @@ func TestCreate(t *testing.T) {
 	io, _, _, _ := cli.IOTest()
 
 	// webhook created for repo pac/valid
-	mux.HandleFunc("/repos/pac/valid/hooks", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/pac/valid/hooks", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusCreated)
 	})
 
 	// webhook failed for repo pac/invalid
-	mux.HandleFunc("/repos/pac/invalid/hooks", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/pac/invalid/hooks", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusForbidden)
 		_, _ = fmt.Fprint(w, `{"status": "forbidden"}`)
 	})

--- a/pkg/cli/webhook/gitlab_test.go
+++ b/pkg/cli/webhook/gitlab_test.go
@@ -91,13 +91,13 @@ func TestGLCreate(t *testing.T) {
 	io, _, _, _ := cli.IOTest()
 
 	// webhook created
-	mux.HandleFunc("/projects/11/hooks", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/projects/11/hooks", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusCreated)
 		_, _ = fmt.Fprint(w, `{"status": "ok"}`)
 	})
 
 	// webhook failed
-	mux.HandleFunc("/projects/13/hooks", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/projects/13/hooks", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusForbidden)
 		_, _ = fmt.Fprint(w, `{"status": "forbidden"}`)
 	})

--- a/pkg/cmd/tknpac/bootstrap/bootstrap.go
+++ b/pkg/cmd/tknpac/bootstrap/bootstrap.go
@@ -139,7 +139,7 @@ func Command(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
 		Use:   "bootstrap",
 		Long:  "Bootstrap Pipelines as Code",
 		Short: "Bootstrap Pipelines as Code.",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			opts.cliOpts = cli.NewCliOptions()
 			opts.ioStreams.SetColorEnabled(!opts.cliOpts.NoColoring)
@@ -193,7 +193,7 @@ func GithubApp(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
 		Use:   "github-app",
 		Long:  "A command helper to help you create the Pipelines as Code GitHub Application",
 		Short: "Create PAC GitHub Application",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			opts.cliOpts = cli.NewCliOptions()
 			opts.ioStreams.SetColorEnabled(!opts.cliOpts.NoColoring)

--- a/pkg/cmd/tknpac/bootstrap/github.go
+++ b/pkg/cmd/tknpac/bootstrap/github.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/go-github/scrape"
 	"github.com/google/go-github/v56/github"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 )
 
 // generateManifest generate manifest from the given options.
@@ -22,7 +23,7 @@ func generateManifest(opts *bootstrapOpts) ([]byte, error) {
 			"check_suite",
 			"issue_comment",
 			"commit_comment",
-			"pull_request",
+			triggertype.PullRequest.String(),
 			"push",
 		},
 		DefaultPermissions: &github.InstallationPermissions{

--- a/pkg/cmd/tknpac/create/repository.go
+++ b/pkg/cmd/tknpac/create/repository.go
@@ -51,7 +51,7 @@ func repositoryCommand(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command
 		Use:     "repository",
 		Aliases: []string{"repo"},
 		Short:   "Create a repository",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			createOpts.IoStreams = ioStreams
 			createOpts.cliOpts = cli.NewCliOptions()

--- a/pkg/cmd/tknpac/deleterepo/delete.go
+++ b/pkg/cmd/tknpac/deleterepo/delete.go
@@ -29,7 +29,7 @@ func repositoryCommand(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command
 		Short:   "Delete a Pipelines as Code Repository or multiple of them",
 		Long:    longHelp,
 		Aliases: []string{"repo"},
-		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		ValidArgsFunction: func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
 			return completion.BaseCompletion("repositories", args)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -60,7 +60,7 @@ func repositoryCommand(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command
 	cmd.Flags().StringP(
 		namespaceFlag, "n", "", "If present, the namespace scope for this CLI request")
 	_ = cmd.RegisterFlagCompletionFunc(namespaceFlag,
-		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
 			return completion.BaseCompletion(namespaceFlag, args)
 		},
 	)
@@ -70,7 +70,7 @@ func repositoryCommand(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command
 	cmd.Flags().StringVar(&repository, "repository", "", "The name of the repository to delete")
 
 	_ = cmd.RegisterFlagCompletionFunc(namespaceFlag,
-		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
 			return completion.BaseCompletion(namespaceFlag, args)
 		},
 	)

--- a/pkg/cmd/tknpac/describe/describe.go
+++ b/pkg/cmd/tknpac/describe/describe.go
@@ -79,7 +79,7 @@ func Root(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
 		Annotations: map[string]string{
 			"commandType": "main",
 		},
-		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		ValidArgsFunction: func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
 			return completion.BaseCompletion("repositories", args)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -130,7 +130,7 @@ func Root(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
 	cmd.Flags().StringP(
 		targetPRFlag, "t", "", "Show this PipelineRun information")
 	_ = cmd.RegisterFlagCompletionFunc(targetPRFlag,
-		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
 			return completion.BaseCompletion("pipelinerun", args)
 		},
 	)
@@ -138,7 +138,7 @@ func Root(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
 	cmd.Flags().StringP(
 		namespaceFlag, "n", "", "If present, the namespace scope for this CLI request")
 	_ = cmd.RegisterFlagCompletionFunc(namespaceFlag,
-		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
 			return completion.BaseCompletion(namespaceFlag, args)
 		},
 	)

--- a/pkg/cmd/tknpac/generate/generate.go
+++ b/pkg/cmd/tknpac/generate/generate.go
@@ -14,11 +14,12 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var eventTypes = map[string]string{"pull_request": "Pull Request", "push": "Push to a Branch or a Tag"}
+var eventTypes = map[string]string{triggertype.PullRequest.String(): "Pull Request", "push": "Push to a Branch or a Tag"}
 
 const (
 	gitCloneClusterTaskName = "git-clone"
@@ -162,7 +163,7 @@ func (o *Opts) branchOrTag() error {
 
 	o.Event.BaseBranch = mainBranch
 
-	if o.Event.EventType == "pull_request" {
+	if o.Event.EventType == triggertype.PullRequest.String() {
 		msg = "Enter the target GIT branch for the Pull Request (default: %s): "
 	} else if o.Event.EventType == "push" {
 		msg = "Enter a target GIT branch or a tag for the push (default: %s)"

--- a/pkg/cmd/tknpac/generate/generate.go
+++ b/pkg/cmd/tknpac/generate/generate.go
@@ -58,7 +58,7 @@ func Command(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
 		Use:     "generate",
 		Aliases: []string{"gen"},
 		Short:   "Generate PipelineRun",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			gopt.CLIOpts = cli.NewCliOptions()
 			gopt.IOStreams.SetColorEnabled(!gopt.CLIOpts.NoColoring)

--- a/pkg/cmd/tknpac/info/install.go
+++ b/pkg/cmd/tknpac/info/install.go
@@ -105,7 +105,7 @@ func installCommand(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "install",
 		Short: "Provides installation info for pipelines-as-code (admin only).",
-		RunE: func(cmd *cobra.Command, _ []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			if err := run.Clients.NewClients(ctx, &run.Info); err != nil {
 				return err

--- a/pkg/cmd/tknpac/list/list.go
+++ b/pkg/cmd/tknpac/list/list.go
@@ -42,7 +42,7 @@ func Root(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
 		Annotations: map[string]string{
 			"commandType": "main",
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			var err error
 			opts := cli.NewCliOptions()
 			opts.AllNameSpaces, err = cmd.Flags().GetBool(allNamespacesFlag)
@@ -84,7 +84,7 @@ func Root(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
 		namespaceFlag, "n", "", "If present, the namespace scope for this CLI request")
 
 	_ = cmd.RegisterFlagCompletionFunc(namespaceFlag,
-		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
 			return completion.BaseCompletion(namespaceFlag, args)
 		},
 	)

--- a/pkg/cmd/tknpac/logs/logs.go
+++ b/pkg/cmd/tknpac/logs/logs.go
@@ -135,7 +135,7 @@ func Command(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
 	cmd.Flags().StringP(
 		namespaceFlag, "n", "", "If present, the namespace scope for this CLI request")
 	_ = cmd.RegisterFlagCompletionFunc(namespaceFlag,
-		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
 			return completion.BaseCompletion(namespaceFlag, args)
 		},
 	)

--- a/pkg/cmd/tknpac/resolve/resolve.go
+++ b/pkg/cmd/tknpac/resolve/resolve.go
@@ -74,7 +74,7 @@ func Command(run *params.Run, streams *cli.IOStreams) *cobra.Command {
 		Use:   "resolve",
 		Long:  longhelp,
 		Short: "Resolve PipelineRun the same way its run on CI",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			ctx := context.Background()
 
 			errc := run.Clients.NewClients(ctx, &run.Info)
@@ -268,7 +268,7 @@ func listAllYamls(paths []string) []string {
 			ret = append(ret, path)
 			continue
 		}
-		err := filepath.Walk(path, func(fname string, fi os.FileInfo, err error) error {
+		err := filepath.Walk(path, func(fname string, _ os.FileInfo, _ error) error {
 			if filepath.Ext(fname) == ".yaml" {
 				ret = append(ret, fname)
 			}

--- a/pkg/cmd/tknpac/version/version.go
+++ b/pkg/cmd/tknpac/version/version.go
@@ -14,7 +14,7 @@ func Command(ioStreams *cli.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: fmt.Sprintf("Print %s pac version", settings.TknBinaryName),
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			fmt.Fprintln(ioStreams.Out, strings.TrimSpace(version.Version))
 		},
 		Annotations: map[string]string{

--- a/pkg/cmd/tknpac/webhook/add.go
+++ b/pkg/cmd/tknpac/webhook/add.go
@@ -56,7 +56,7 @@ func webhookAdd(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
 		namespaceFlag, "n", "", "If present, the namespace scope for this CLI request")
 
 	_ = cmd.RegisterFlagCompletionFunc(namespaceFlag,
-		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
 			return completion.BaseCompletion(namespaceFlag, args)
 		},
 	)

--- a/pkg/cmd/tknpac/webhook/update-token.go
+++ b/pkg/cmd/tknpac/webhook/update-token.go
@@ -45,7 +45,7 @@ func webhookUpdateToken(run *params.Run, ioStreams *cli.IOStreams) *cobra.Comman
 		Annotations: map[string]string{
 			"commandType": "main",
 		},
-		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		ValidArgsFunction: func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
 			return completion.BaseCompletion("repositories", args)
 		},
 	}
@@ -54,7 +54,7 @@ func webhookUpdateToken(run *params.Run, ioStreams *cli.IOStreams) *cobra.Comman
 		namespaceFlag, "n", "", "If present, the namespace scope for this CLI request")
 
 	_ = cmd.RegisterFlagCompletionFunc(namespaceFlag,
-		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
 			return completion.BaseCompletion(namespaceFlag, args)
 		},
 	)

--- a/pkg/matcher/annotation_matcher.go
+++ b/pkg/matcher/annotation_matcher.go
@@ -12,8 +12,8 @@ import (
 	apipac "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
-	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"go.uber.org/zap"
 )
@@ -88,10 +88,10 @@ func getAnnotationValues(annotation string) ([]string, error) {
 func getTargetBranch(prun *tektonv1.PipelineRun, logger *zap.SugaredLogger, event *info.Event) (bool, string, string, error) {
 	var targetEvent, targetBranch string
 	if key, ok := prun.GetObjectMeta().GetAnnotations()[keys.OnEvent]; ok {
-		targetEvents := []string{event.TriggerTarget}
-		if event.EventType == options.IncomingEvent {
+		targetEvents := []string{event.TriggerTarget.String()}
+		if event.EventType == triggertype.Incoming.String() {
 			// if we have a incoming event, we want to match pipelineruns on both incoming and push
-			targetEvents = []string{options.IncomingEvent, options.PushEvent}
+			targetEvents = []string{triggertype.Incoming.String(), triggertype.Push.String()}
 		}
 		matched, err := matchOnAnnotation(key, targetEvents, false)
 		targetEvent = key

--- a/pkg/matcher/annotation_matcher_test.go
+++ b/pkg/matcher/annotation_matcher_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	ghprovider "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/github"
 	glprovider "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/gitlab"
@@ -24,7 +25,6 @@ import (
 	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
 	ghtesthelper "github.com/openshift-pipelines/pipelines-as-code/pkg/test/github"
 	testnewrepo "github.com/openshift-pipelines/pipelines-as-code/pkg/test/repository"
-	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/xanzy/go-gitlab"
 	"go.uber.org/zap"
@@ -590,11 +590,11 @@ func TestMatchPipelinerunAnnotationAndRepositories(t *testing.T) {
 			name: "matching incoming webhook event on push target",
 			args: annotationTestArgs{
 				pruns: []*tektonv1.PipelineRun{
-					makePipelineRunTargetNS(options.PushEvent, ""),
+					makePipelineRunTargetNS(triggertype.Push.String(), ""),
 				},
 				runevent: info.Event{
 					URL:        targetURL,
-					EventType:  options.IncomingEvent,
+					EventType:  triggertype.Incoming.String(),
 					BaseBranch: mainBranch,
 				},
 				data: testclient.Data{
@@ -614,11 +614,11 @@ func TestMatchPipelinerunAnnotationAndRepositories(t *testing.T) {
 			name: "matching incoming webhook event on incoming target",
 			args: annotationTestArgs{
 				pruns: []*tektonv1.PipelineRun{
-					makePipelineRunTargetNS(options.IncomingEvent, ""),
+					makePipelineRunTargetNS(triggertype.Incoming.String(), ""),
 				},
 				runevent: info.Event{
 					URL:        targetURL,
-					EventType:  options.IncomingEvent,
+					EventType:  triggertype.Incoming.String(),
 					BaseBranch: mainBranch,
 				},
 				data: testclient.Data{

--- a/pkg/matcher/cel.go
+++ b/pkg/matcher/cel.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/changedfiles"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 )
 
@@ -25,7 +26,7 @@ const (
 
 func celEvaluate(ctx context.Context, expr string, event *info.Event, vcx provider.Interface) (ref.Val, error) {
 	eventTitle := event.PullRequestTitle
-	if event.TriggerTarget == "push" {
+	if event.TriggerTarget == triggertype.Push {
 		eventTitle = event.SHATitle
 		// For push event the target_branch & source_branch info coming from payload have refs/heads/
 		// but user may or mayn't provide refs/heads/ info while giving target_branch or source_branch in CEL expression
@@ -72,7 +73,7 @@ func celEvaluate(ctx context.Context, expr string, event *info.Event, vcx provid
 	}
 
 	data := map[string]interface{}{
-		"event":         event.TriggerTarget,
+		"event":         event.TriggerTarget.String(),
 		"event_title":   eventTitle,
 		"target_branch": event.BaseBranch,
 		"source_branch": event.HeadBranch,

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -53,7 +53,6 @@ func NewRecorder() (*Recorder, error) {
 			TagKeys:     []tag.Key{r.provider, r.eventType},
 		},
 	)
-
 	if err != nil {
 		r.initialized = false
 		return r, err

--- a/pkg/opscomments/comments.go
+++ b/pkg/opscomments/comments.go
@@ -1,0 +1,163 @@
+package opscomments
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+)
+
+var (
+	testAllRegex      = regexp.MustCompile(`(?m)^/test\s*$`)
+	retestAllRegex    = regexp.MustCompile(`(?m)^/retest\s*$`)
+	testSingleRegex   = regexp.MustCompile(`(?m)^/test[ \t]+\S+`)
+	retestSingleRegex = regexp.MustCompile(`(?m)^/retest[ \t]+\S+`)
+	oktotestRegex     = regexp.MustCompile(`(?m)^/ok-to-test\s*$`)
+	cancelAllRegex    = regexp.MustCompile(`(?m)^(/cancel)\s*$`)
+	cancelSingleRegex = regexp.MustCompile(`(?m)^(/cancel)[ \t]+\S+`)
+)
+
+type EventType string
+
+func (e EventType) String() string {
+	return string(e)
+}
+
+var (
+	NoOpsCommentEventType        = EventType("no-ops-comment")
+	TestAllCommentEventType      = EventType("test-all-comment")
+	TestSingleCommentEventType   = EventType("test-comment")
+	RetestSingleCommentEventType = EventType("retest-comment")
+	RetestAllCommentEventType    = EventType("retest-all-comment")
+	CancelCommentSingleEventType = EventType("cancel-comment")
+	CancelCommentAllEventType    = EventType("cancel-all-comment")
+	OkToTestCommentEventType     = EventType("ok-to-test-comment")
+)
+
+const (
+	testComment   = "/test"
+	retestComment = "/retest"
+	cancelComment = "/cancel"
+)
+
+func CommentEventType(comment string) EventType {
+	switch {
+	case retestAllRegex.MatchString(comment):
+		return RetestAllCommentEventType
+	case retestSingleRegex.MatchString(comment):
+		return RetestSingleCommentEventType
+	case testAllRegex.MatchString(comment):
+		return TestAllCommentEventType
+	case testSingleRegex.MatchString(comment):
+		return TestSingleCommentEventType
+	case oktotestRegex.MatchString(comment):
+		return OkToTestCommentEventType
+	case cancelAllRegex.MatchString(comment):
+		return CancelCommentAllEventType
+	case cancelSingleRegex.MatchString(comment):
+		return CancelCommentSingleEventType
+	default:
+		return NoOpsCommentEventType
+	}
+}
+
+// SetEventTypeAndTargetPR function will set the event type and target test pipeline run in an event.
+func SetEventTypeAndTargetPR(event *info.Event, comment string) {
+	commentType := CommentEventType(comment)
+	if commentType == RetestSingleCommentEventType || commentType == TestSingleCommentEventType {
+		event.TargetTestPipelineRun = GetPipelineRunFromTestComment(comment)
+	}
+	if commentType == CancelCommentAllEventType || commentType == CancelCommentSingleEventType {
+		event.CancelPipelineRuns = true
+	}
+	if commentType == CancelCommentSingleEventType {
+		event.TargetCancelPipelineRun = GetPipelineRunFromCancelComment(comment)
+	}
+	event.EventType = commentType.String()
+}
+
+func IsOkToTestComment(comment string) bool {
+	return oktotestRegex.MatchString(comment)
+}
+
+func IsCancelComment(comment string) bool {
+	return cancelAllRegex.MatchString(comment) || cancelSingleRegex.MatchString(comment)
+}
+
+func IsAnyOpsEventType(eventType string) bool {
+	return eventType == TestSingleCommentEventType.String() ||
+		eventType == TestAllCommentEventType.String() ||
+		eventType == RetestAllCommentEventType.String() ||
+		eventType == RetestSingleCommentEventType.String() ||
+		eventType == CancelCommentSingleEventType.String() ||
+		eventType == CancelCommentAllEventType.String() ||
+		eventType == OkToTestCommentEventType.String()
+}
+
+func GetPipelineRunFromTestComment(comment string) string {
+	if strings.Contains(comment, testComment) {
+		return getNameFromComment(testComment, comment)
+	}
+	return getNameFromComment(retestComment, comment)
+}
+
+func GetPipelineRunFromCancelComment(comment string) string {
+	return getNameFromComment(cancelComment, comment)
+}
+
+func getNameFromComment(typeOfComment, comment string) string {
+	splitTest := strings.Split(comment, typeOfComment)
+	if len(splitTest) < 2 {
+		return ""
+	}
+	// now get the first line
+	getFirstLine := strings.Split(splitTest[1], "\n")
+	// trim spaces
+	return strings.TrimSpace(getFirstLine[0])
+}
+
+func GetPipelineRunAndBranchNameFromTestComment(comment string) (string, string, error) {
+	if strings.Contains(comment, testComment) {
+		return getPipelineRunAndBranchNameFromComment(testComment, comment)
+	}
+	return getPipelineRunAndBranchNameFromComment(retestComment, comment)
+}
+
+func GetPipelineRunAndBranchNameFromCancelComment(comment string) (string, string, error) {
+	return getPipelineRunAndBranchNameFromComment(cancelComment, comment)
+}
+
+// getPipelineRunAndBranchNameFromComment function will take GitOps comment and split the comment
+// by /test, /retest or /cancel to return branch name and pipelinerun name.
+func getPipelineRunAndBranchNameFromComment(typeOfComment, comment string) (string, string, error) {
+	var prName, branchName string
+	splitTest := strings.Split(comment, typeOfComment)
+
+	// after the split get the second part of the typeOfComment (/test, /retest or /cancel)
+	// as second part can be branch name or pipelinerun name and branch name
+	// ex: /test branch:nightly, /test prname branch:nightly
+	if splitTest[1] != "" && strings.Contains(splitTest[1], ":") {
+		branchData := strings.Split(splitTest[1], ":")
+
+		// make sure no other word is supported other than branch word
+		if !strings.Contains(branchData[0], "branch") {
+			return prName, branchName, fmt.Errorf("the GitOps comment%s does not contain a branch word", branchData[0])
+		}
+		branchName = strings.Split(strings.TrimSpace(branchData[1]), " ")[0]
+
+		// if data after the split contains prname then fetch that
+		prData := strings.Split(strings.TrimSpace(branchData[0]), " ")
+		if len(prData) > 1 {
+			prName = strings.TrimSpace(prData[0])
+		}
+	} else {
+		// get the second part of the typeOfComment (/test, /retest or /cancel)
+		// as second part contains pipelinerun name
+		// ex: /test prname
+		getFirstLine := strings.Split(splitTest[1], "\n")
+		// trim spaces
+		prName = strings.TrimSpace(getFirstLine[0])
+	}
+	return prName, branchName, nil
+}

--- a/pkg/opscomments/comments_test.go
+++ b/pkg/opscomments/comments_test.go
@@ -145,7 +145,7 @@ func TestSetEventTypeTestPipelineRun(t *testing.T) {
 			wantTestPr: "prname",
 		},
 		{
-			name:       "no-ops-commenttest event type",
+			name:       "test single event type",
 			comment:    "/test prname",
 			wantType:   TestSingleCommentEventType.String(),
 			wantTestPr: "prname",

--- a/pkg/opscomments/comments_test.go
+++ b/pkg/opscomments/comments_test.go
@@ -1,0 +1,632 @@
+package opscomments
+
+import (
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"gotest.tools/v3/assert"
+)
+
+func TestIsAnyOpsEventType(t *testing.T) {
+	tests := []struct {
+		name      string
+		eventType string
+		want      bool
+	}{
+		{
+			name:      "TestSingleCommentEventType",
+			eventType: TestSingleCommentEventType.String(),
+			want:      true,
+		},
+		{
+			name:      "TestAllCommentEventType",
+			eventType: TestAllCommentEventType.String(),
+			want:      true,
+		},
+		{
+			name:      "RetestAllCommentEventType",
+			eventType: RetestAllCommentEventType.String(),
+			want:      true,
+		},
+		{
+			name:      "RetestSingleCommentEventType",
+			eventType: RetestSingleCommentEventType.String(),
+			want:      true,
+		},
+		{
+			name:      "CancelCommentSingleEventType",
+			eventType: CancelCommentSingleEventType.String(),
+			want:      true,
+		},
+		{
+			name:      "CancelCommentAllEventType",
+			eventType: CancelCommentAllEventType.String(),
+			want:      true,
+		},
+		{
+			name:      "OkToTestCommentEventType",
+			eventType: OkToTestCommentEventType.String(),
+			want:      true,
+		},
+		{
+			name:      "NoOpsCommentEventType",
+			eventType: NoOpsCommentEventType.String(),
+			want:      false,
+		},
+		{
+			name:      "Random string",
+			eventType: "random string",
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsAnyOpsEventType(tt.eventType)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCommentEventTypeTest(t *testing.T) {
+	tests := []struct {
+		name    string
+		comment string
+		want    EventType
+	}{
+		{
+			name:    "retest all",
+			comment: "/retest",
+			want:    RetestAllCommentEventType,
+		},
+		{
+			name:    "retest single",
+			comment: "/retest prname",
+			want:    RetestSingleCommentEventType,
+		},
+		{
+			name:    "test all",
+			comment: "/test",
+			want:    TestAllCommentEventType,
+		},
+		{
+			name:    "test single",
+			comment: "/test prname",
+			want:    TestSingleCommentEventType,
+		},
+		{
+			name:    "ok to test",
+			comment: "/ok-to-test",
+			want:    OkToTestCommentEventType,
+		},
+		{
+			name:    "no comment event type",
+			comment: "random comment",
+			want:    NoOpsCommentEventType,
+		},
+		{
+			name:    "cancel all",
+			comment: "/cancel",
+			want:    CancelCommentAllEventType,
+		},
+		{
+			name:    "cancel single",
+			comment: "/cancel prname",
+			want:    CancelCommentSingleEventType,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CommentEventType(tt.comment)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSetEventTypeTestPipelineRun(t *testing.T) {
+	tests := []struct {
+		name         string
+		comment      string
+		wantType     string
+		wantTestPr   string
+		wantCancelPr string
+		wantCancel   bool
+	}{
+		{
+			name:     "no event type",
+			comment:  "random comment",
+			wantType: NoOpsCommentEventType.String(),
+		},
+		{
+			name:       "retest single event type",
+			comment:    "/retest prname",
+			wantType:   RetestSingleCommentEventType.String(),
+			wantTestPr: "prname",
+		},
+		{
+			name:       "no-ops-commenttest event type",
+			comment:    "/test prname",
+			wantType:   TestSingleCommentEventType.String(),
+			wantTestPr: "prname",
+		},
+		{
+			name:         "cancel single pr",
+			comment:      "/cancel prname",
+			wantType:     CancelCommentSingleEventType.String(),
+			wantCancelPr: "prname",
+			wantCancel:   true,
+		},
+		{
+			name:       "cancel all pr",
+			comment:    "/cancel",
+			wantType:   CancelCommentAllEventType.String(),
+			wantCancel: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := &info.Event{}
+			SetEventTypeAndTargetPR(event, tt.comment)
+			assert.Equal(t, tt.wantType, event.EventType)
+			assert.Equal(t, tt.wantTestPr, event.TargetTestPipelineRun)
+		})
+	}
+}
+
+func TestIsOkToTestComment(t *testing.T) {
+	tests := []struct {
+		name    string
+		comment string
+		want    bool
+	}{
+		{
+			name:    "valid",
+			comment: "/ok-to-test",
+			want:    true,
+		},
+		{
+			name:    "valid with some string before",
+			comment: "/lgtm \n/ok-to-test",
+			want:    true,
+		},
+		{
+			name:    "valid with some string before and after",
+			comment: "hi, trigger the ci \n/ok-to-test \n then report the status back",
+			want:    true,
+		},
+		{
+			name:    "valid comments",
+			comment: "/lgtm \n/ok-to-test \n/approve",
+			want:    true,
+		},
+		{
+			name:    "invalid",
+			comment: "/ok",
+			want:    false,
+		},
+		{
+			name:    "invalid comment",
+			comment: "/ok-to-test abc",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsOkToTestComment(tt.comment)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCancelComment(t *testing.T) {
+	tests := []struct {
+		name    string
+		comment string
+		want    bool
+	}{
+		{
+			name:    "valid",
+			comment: "/cancel",
+			want:    true,
+		},
+		{
+			name:    "valid with some string before",
+			comment: "/lgtm \n/cancel",
+			want:    true,
+		},
+		{
+			name:    "valid with some string before and after",
+			comment: "hi, trigger the ci \n/cancel \n then report the status back",
+			want:    true,
+		},
+		{
+			name:    "valid comments",
+			comment: "/lgtm \n/cancel \n/approve",
+			want:    true,
+		},
+		{
+			name:    "invalid",
+			comment: "/ok",
+			want:    false,
+		},
+		{
+			name:    "invalid comment",
+			comment: "/ok-to-test abc",
+			want:    false,
+		},
+		{
+			name:    "cancel single pr",
+			comment: "/cancel abc",
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsCancelComment(tt.comment)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIsTestRetestComment(t *testing.T) {
+	tests := []struct {
+		name    string
+		comment string
+		want    EventType
+	}{
+		{
+			name:    "valid retest",
+			comment: "/retest",
+			want:    RetestAllCommentEventType,
+		},
+		{
+			name:    "valid test all",
+			comment: "/test",
+			want:    TestAllCommentEventType,
+		},
+		{
+			name:    "valid retest with some string before",
+			comment: "/lgtm \n/retest",
+			want:    RetestAllCommentEventType,
+		},
+		{
+			name:    "valid test with some string before",
+			comment: "/lgtm \n/test",
+			want:    TestAllCommentEventType,
+		},
+		{
+			name:    "retest with some string before and after",
+			comment: "hi, trigger the ci \n/retest \n then report the status back",
+			want:    RetestAllCommentEventType,
+		},
+		{
+			name:    "test valid with some string before and after",
+			comment: "hi, trigger the ci \n/test \n then report the status back",
+			want:    TestAllCommentEventType,
+		},
+		{
+			name:    "test valid with some string before and after",
+			comment: "hi, trigger the ci \n/test foobar\n then report the status back",
+			want:    TestSingleCommentEventType,
+		},
+		{
+			name:    "valid comments",
+			comment: "/lgtm \n/retest \n/approve",
+			want:    RetestAllCommentEventType,
+		},
+		{
+			name:    "retest trigger single pr",
+			comment: "/retest abc",
+			want:    RetestSingleCommentEventType,
+		},
+		{
+			name:    "test trigger single pr",
+			comment: "/test abc",
+			want:    TestSingleCommentEventType,
+		},
+		{
+			name:    "invalid",
+			comment: "test abc",
+			want:    NoOpsCommentEventType,
+		},
+		{
+			name:    "invalid",
+			comment: "/ok",
+			want:    NoOpsCommentEventType,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CommentEventType(tt.comment)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGetPipelineRunFromComment(t *testing.T) {
+	tests := []struct {
+		name    string
+		comment string
+		want    string
+	}{
+		{
+			name:    "test no pipelinerun",
+			comment: "/test",
+			want:    "",
+		},
+		{
+			name:    "retest no pipelinerun",
+			comment: "/retest",
+			want:    "",
+		},
+		{
+			name:    "test a pipeline",
+			comment: "/test abc-01-pr",
+			want:    "abc-01-pr",
+		},
+		{
+			name:    "string before test command",
+			comment: "abc \n /test abc-01-pr",
+			want:    "abc-01-pr",
+		},
+		{
+			name:    "string after test command",
+			comment: "/test abc-01-pr \n abc",
+			want:    "abc-01-pr",
+		},
+		{
+			name:    "string before and after test command",
+			comment: "before \n /test abc-01-pr \n after",
+			want:    "abc-01-pr",
+		},
+		{
+			name:    "retest a pipeline",
+			comment: "/retest abc-01-pr",
+			want:    "abc-01-pr",
+		},
+		{
+			name:    "string before retest command",
+			comment: "abc \n /retest abc-01-pr",
+			want:    "abc-01-pr",
+		},
+		{
+			name:    "string after retest command",
+			comment: "/retest abc-01-pr \n abc",
+			want:    "abc-01-pr",
+		},
+		{
+			name:    "string before and after retest command",
+			comment: "before \n /retest abc-01-pr \n after",
+			want:    "abc-01-pr",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetPipelineRunFromTestComment(tt.comment)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGetPipelineRunFromCancelComment(t *testing.T) {
+	tests := []struct {
+		name    string
+		comment string
+		want    string
+	}{
+		{
+			name:    "cancel all",
+			comment: "/cancel",
+			want:    "",
+		},
+		{
+			name:    "cancel a pipeline",
+			comment: "/cancel abc-01-pr",
+			want:    "abc-01-pr",
+		},
+		{
+			name:    "string before cancel command",
+			comment: "abc \n /cancel abc-01-pr",
+			want:    "abc-01-pr",
+		},
+		{
+			name:    "string after cancel command",
+			comment: "/cancel abc-01-pr \n abc",
+			want:    "abc-01-pr",
+		},
+		{
+			name:    "string before and after cancel command",
+			comment: "before \n /cancel abc-01-pr \n after",
+			want:    "abc-01-pr",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetPipelineRunFromCancelComment(tt.comment)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGetPipelineRunAndBranchNameFromTestComment(t *testing.T) {
+	tests := []struct {
+		name       string
+		comment    string
+		branchName string
+		prName     string
+		wantError  bool
+	}{
+		{
+			name:       "retest all on test branch",
+			comment:    "/retest branch:test",
+			branchName: "test",
+			wantError:  false,
+		},
+		{
+			name:       "test a pipeline on test branch",
+			comment:    "/test abc-01-pr branch:test",
+			prName:     "abc-01-pr",
+			branchName: "test",
+			wantError:  false,
+		},
+		{
+			name:       "string for test command before branch name test",
+			comment:    "/test abc-01-pr abc \n branch:test",
+			prName:     "abc-01-pr",
+			branchName: "test",
+			wantError:  false,
+		},
+		{
+			name:       "string for retest command after branch name test",
+			comment:    "/retest abc-01-pr branch:test \n abc",
+			prName:     "abc-01-pr",
+			branchName: "test",
+			wantError:  false,
+		},
+		{
+			name:       "string for test command before and after branch name test",
+			comment:    "/test abc-01-pr \n before branch:test \n after",
+			prName:     "abc-01-pr",
+			branchName: "test",
+			wantError:  false,
+		},
+		{
+			name:      "different word other than branch for retest command",
+			comment:   "/retest invalidname:nightly",
+			wantError: true,
+		},
+		{
+			name:      "test all",
+			comment:   "/test",
+			wantError: false,
+		},
+		{
+			name:      "test a pipeline",
+			comment:   "/test abc-01-pr",
+			prName:    "abc-01-pr",
+			wantError: false,
+		},
+		{
+			name:      "string before retest command",
+			comment:   "abc \n /retest abc-01-pr",
+			prName:    "abc-01-pr",
+			wantError: false,
+		},
+		{
+			name:      "string after retest command",
+			comment:   "/retest abc-01-pr \n abc",
+			prName:    "abc-01-pr",
+			wantError: false,
+		},
+		{
+			name:      "string before and after test command",
+			comment:   "before \n /test abc-01-pr \n after",
+			prName:    "abc-01-pr",
+			wantError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prName, branchName, err := GetPipelineRunAndBranchNameFromTestComment(tt.comment)
+			assert.Equal(t, tt.wantError, err != nil)
+			assert.Equal(t, tt.branchName, branchName)
+			assert.Equal(t, tt.prName, prName)
+		})
+	}
+}
+
+func TestGetPipelineRunAndBranchNameFromCancelComment(t *testing.T) {
+	tests := []struct {
+		name       string
+		comment    string
+		branchName string
+		prName     string
+		wantError  bool
+	}{
+		{
+			name:      "cancel all pipeline",
+			comment:   "/cancel",
+			wantError: false,
+		},
+		{
+			name:      "cancel a particular pipeline",
+			comment:   "/cancel abc-01-pr",
+			prName:    "abc-01-pr",
+			wantError: false,
+		},
+		{
+			name:      "add string before cancel command",
+			comment:   "abc \n /cancel abc-01-pr",
+			prName:    "abc-01-pr",
+			wantError: false,
+		},
+		{
+			name:      "add string after cancel command",
+			comment:   "/cancel abc-01-pr \n abc",
+			prName:    "abc-01-pr",
+			wantError: false,
+		},
+		{
+			name:      "add string before and after cancel command",
+			comment:   "before \n /cancel abc-01-pr \n after",
+			prName:    "abc-01-pr",
+			wantError: false,
+		},
+		{
+			name:       "cancel all on test branch",
+			comment:    "/cancel branch:test",
+			branchName: "test",
+			wantError:  false,
+		},
+		{
+			name:       "cancel a pipeline on test branch",
+			comment:    "/cancel abc-01-pr branch:test",
+			prName:     "abc-01-pr",
+			branchName: "test",
+			wantError:  false,
+		},
+		{
+			name:       "string for cancel command before branch name test",
+			comment:    "/cancel abc-01-pr abc \n branch:test",
+			prName:     "abc-01-pr",
+			branchName: "test",
+			wantError:  false,
+		},
+		{
+			name:       "string for cancel command after branch name test",
+			comment:    "/cancel abc-01-pr branch:test \n abc",
+			prName:     "abc-01-pr",
+			branchName: "test",
+			wantError:  false,
+		},
+		{
+			name:       "string for cancel command before and after branch name test",
+			comment:    "/cancel abc-01-pr \n before branch:test \n after",
+			prName:     "abc-01-pr",
+			branchName: "test",
+			wantError:  false,
+		},
+		{
+			name:      "different word other than branch for cancel command",
+			comment:   "/cancel invalidname:nightly",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prName, branchName, err := GetPipelineRunAndBranchNameFromCancelComment(tt.comment)
+			assert.Equal(t, tt.wantError, err != nil)
+			assert.Equal(t, tt.branchName, branchName)
+			assert.Equal(t, tt.prName, prName)
+		})
+	}
+}

--- a/pkg/params/info/events.go
+++ b/pkg/params/info/events.go
@@ -1,6 +1,10 @@
 package info
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
+)
 
 type Event struct {
 	State
@@ -19,9 +23,7 @@ type Event struct {
 	// TriggerTarget stable field across providers, ie: on Gitlab, Github and
 	// others it would be always be pull_request we can rely on to know if it's
 	// a push or a pull_request
-	// we need to merge this with the TriggerType type by doing a review of
-	// every instance using this and adapt it.
-	TriggerTarget string
+	TriggerTarget triggertype.Trigger
 
 	// Target PipelineRun, the target PipelineRun user request. Used in incoming webhook
 	TargetPipelineRun string
@@ -91,15 +93,3 @@ func NewEvent() *Event {
 		Request:  &Request{},
 	}
 }
-
-type TriggerType string
-
-const (
-	TriggerTypeOkToTest              TriggerType = "ok-to-test"
-	TriggerTypeRetest                TriggerType = "retest"
-	TriggerTypePush                  TriggerType = "push"
-	TriggerTypePullRequest           TriggerType = "pull_request"
-	TriggerTypeCancel                TriggerType = "cancel"
-	TriggerTypeCheckSuiteRerequested TriggerType = "check-suite-rerequested"
-	TriggerTypeCheckRunRerequested   TriggerType = "check-run-rerequested"
-)

--- a/pkg/params/triggertype/types.go
+++ b/pkg/params/triggertype/types.go
@@ -1,0 +1,20 @@
+package triggertype
+
+type (
+	Trigger string
+)
+
+func (t Trigger) String() string {
+	return string(t)
+}
+
+const (
+	OkToTest              Trigger = "ok-to-test"
+	Retest                Trigger = "retest"
+	Push                  Trigger = "push"
+	PullRequest           Trigger = "pull_request"
+	Cancel                Trigger = "cancel"
+	CheckSuiteRerequested Trigger = "check-suite-rerequested"
+	CheckRunRerequested   Trigger = "check-run-rerequested"
+	Incoming              Trigger = "incoming"
+)

--- a/pkg/pipelineascode/cancel_pipelineruns.go
+++ b/pkg/pipelineascode/cancel_pipelineruns.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,7 +30,7 @@ func (p *PacRun) cancelPipelineRuns(ctx context.Context, repo *v1alpha1.Reposito
 		keys.SHA:           formatting.CleanValueKubernetes(p.event.SHA),
 	})
 
-	if p.event.TriggerTarget == "pull_request" {
+	if p.event.TriggerTarget == triggertype.PullRequest {
 		labelSelector = getLabelSelector(map[string]string{
 			keys.PullRequest: strconv.Itoa(p.event.PullRequestNumber),
 		})

--- a/pkg/pipelineascode/pipelineascode_test.go
+++ b/pkg/pipelineascode/pipelineascode_test.go
@@ -44,7 +44,7 @@ const (
 )
 
 func replyString(mux *http.ServeMux, url, body string) {
-	mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(url, func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = fmt.Fprint(w, body)
 	})
 }
@@ -75,7 +75,7 @@ func testSetupCommonGhReplies(t *testing.T, mux *http.ServeMux, runevent info.Ev
 		jj)
 
 	if !noReplyOrgPublicMembers {
-		mux.HandleFunc("/orgs/"+runevent.Organization+"/members", func(rw http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("/orgs/"+runevent.Organization+"/members", func(rw http.ResponseWriter, _ *http.Request) {
 			_, _ = fmt.Fprintf(rw, `[{"login": "%s"}]`, runevent.Sender)
 		})
 	}
@@ -85,7 +85,7 @@ func testSetupCommonGhReplies(t *testing.T, mux *http.ServeMux, runevent info.Ev
 		`{"id": 26}`)
 
 	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/check-runs/26", runevent.Organization, runevent.Repository),
-		func(w http.ResponseWriter, r *http.Request) {
+		func(_ http.ResponseWriter, r *http.Request) {
 			body, _ := io.ReadAll(r.Body)
 			created := github.CreateCheckRunOptions{}
 			err := json.Unmarshal(body, &created)

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -7,6 +7,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/events"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	"go.uber.org/zap"
 )
@@ -27,7 +28,7 @@ type Policy struct {
 	EventEmitter *events.EventEmitter
 }
 
-func (p *Policy) checkAllowed(ctx context.Context, tType info.TriggerType) (Result, string) {
+func (p *Policy) checkAllowed(ctx context.Context, tType triggertype.Trigger) (Result, string) {
 	if p.Repository == nil {
 		return ResultNotSet, ""
 	}
@@ -39,12 +40,12 @@ func (p *Policy) checkAllowed(ctx context.Context, tType info.TriggerType) (Resu
 	var sType []string
 	switch tType {
 	// NOTE: This make /retest /ok-to-test /test bound to the same policy, which is fine from a security standpoint but maybe we want to refine this in the future.
-	case info.TriggerTypeOkToTest, info.TriggerTypeRetest:
+	case triggertype.OkToTest, triggertype.Retest:
 		sType = settings.Policy.OkToTest
-	case info.TriggerTypePullRequest:
+	case triggertype.PullRequest:
 		sType = settings.Policy.PullRequest
-	// NOTE: not supported yet, will imp if it gets requested and reasonable to implement
-	case info.TriggerTypePush, info.TriggerTypeCancel, info.TriggerTypeCheckSuiteRerequested, info.TriggerTypeCheckRunRerequested:
+		// NOTE: not supported yet, will imp if it gets requested and reasonable to implement
+	case triggertype.Push, triggertype.Cancel, triggertype.CheckSuiteRerequested, triggertype.CheckRunRerequested, triggertype.Incoming:
 		return ResultNotSet, ""
 	default:
 		return ResultNotSet, ""
@@ -76,7 +77,7 @@ func (p *Policy) checkAllowed(ctx context.Context, tType info.TriggerType) (Resu
 	return ResultDisallowed, fmt.Sprintf("policy check: %s, %s", string(tType), reason)
 }
 
-func (p *Policy) IsAllowed(ctx context.Context, tType info.TriggerType) (Result, string) {
+func (p *Policy) IsAllowed(ctx context.Context, tType triggertype.Trigger) (Result, string) {
 	var reason string
 	policyRes, reason := p.checkAllowed(ctx, tType)
 	switch policyRes {

--- a/pkg/policy/policy_test.go
+++ b/pkg/policy/policy_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/events"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
 	testprovider "github.com/openshift-pipelines/pipelines-as-code/pkg/test/provider"
 	"go.uber.org/zap"
@@ -36,7 +37,7 @@ func TestPolicy_IsAllowed(t *testing.T) {
 		event      *info.Event
 	}
 	type args struct {
-		tType info.TriggerType
+		tType triggertype.Trigger
 	}
 	tests := []struct {
 		name                 string
@@ -56,7 +57,7 @@ func TestPolicy_IsAllowed(t *testing.T) {
 				event:      nil,
 			},
 			args: args{
-				tType: info.TriggerTypePush,
+				tType: triggertype.Push,
 			},
 			want: ResultNotSet,
 		},
@@ -78,7 +79,7 @@ func TestPolicy_IsAllowed(t *testing.T) {
 				event:      nil,
 			},
 			args: args{
-				tType: info.TriggerTypePush,
+				tType: triggertype.Push,
 			},
 			want: ResultNotSet,
 		},
@@ -89,7 +90,7 @@ func TestPolicy_IsAllowed(t *testing.T) {
 				event:      info.NewEvent(),
 			},
 			args: args{
-				tType: info.TriggerTypePullRequest,
+				tType: triggertype.PullRequest,
 			},
 			vcsReplyAllowed: true,
 			want:            ResultAllowed,
@@ -101,7 +102,7 @@ func TestPolicy_IsAllowed(t *testing.T) {
 				event:      eventWithSender,
 			},
 			args: args{
-				tType: info.TriggerTypePullRequest,
+				tType: triggertype.PullRequest,
 			},
 			vcsReplyAllowed:     false,
 			allowedInOwnersFile: true,
@@ -117,7 +118,7 @@ func TestPolicy_IsAllowed(t *testing.T) {
 				event:      info.NewEvent(),
 			},
 			args: args{
-				tType: info.TriggerTypeOkToTest,
+				tType: triggertype.OkToTest,
 			},
 			vcsReplyAllowed: true,
 			want:            ResultAllowed,
@@ -129,7 +130,7 @@ func TestPolicy_IsAllowed(t *testing.T) {
 				event:      info.NewEvent(),
 			},
 			args: args{
-				tType: info.TriggerTypeRetest,
+				tType: triggertype.Retest,
 			},
 			vcsReplyAllowed: true,
 			want:            ResultAllowed,
@@ -142,7 +143,7 @@ func TestPolicy_IsAllowed(t *testing.T) {
 				event:      eventWithSender,
 			},
 			args: args{
-				tType: info.TriggerTypePullRequest,
+				tType: triggertype.PullRequest,
 			},
 			want: ResultDisallowed,
 		},
@@ -153,7 +154,7 @@ func TestPolicy_IsAllowed(t *testing.T) {
 				event:      info.NewEvent(),
 			},
 			args: args{
-				tType: info.TriggerTypePullRequest,
+				tType: triggertype.PullRequest,
 			},
 			want:                 ResultDisallowed,
 			wantErr:              true,
@@ -166,7 +167,7 @@ func TestPolicy_IsAllowed(t *testing.T) {
 				event:      info.NewEvent(),
 			},
 			args: args{
-				tType: info.TriggerTypeOkToTest,
+				tType: triggertype.OkToTest,
 			},
 			want:                 ResultDisallowed,
 			wantErr:              true,
@@ -179,7 +180,7 @@ func TestPolicy_IsAllowed(t *testing.T) {
 				event:      info.NewEvent(),
 			},
 			args: args{
-				tType: info.TriggerTypeRetest,
+				tType: triggertype.Retest,
 			},
 			want:                 ResultDisallowed,
 			wantErr:              true,
@@ -193,7 +194,7 @@ func TestPolicy_IsAllowed(t *testing.T) {
 				event:      info.NewEvent(),
 			},
 			args: args{
-				tType: info.TriggerTypePullRequest,
+				tType: triggertype.PullRequest,
 			},
 			vcsReplyAllowed:      false,
 			allowedInOwnersFile:  false,

--- a/pkg/provider/bitbucketcloud/bitbucket.go
+++ b/pkg/provider/bitbucketcloud/bitbucket.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/events"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketcloud/types"
 	"go.uber.org/zap"
@@ -107,7 +108,7 @@ func (v *Provider) CreateStatus(_ context.Context, event *info.Event, statusopts
 		return err
 	}
 	if statusopts.Conclusion != "STOPPED" && statusopts.Status == "completed" &&
-		statusopts.Text != "" && event.EventType == "pull_request" {
+		statusopts.Text != "" && event.EventType == triggertype.PullRequest.String() {
 		onPr := ""
 		if statusopts.OriginalPipelineRunName != "" {
 			onPr = "/" + statusopts.OriginalPipelineRunName

--- a/pkg/provider/bitbucketcloud/parse_payload_test.go
+++ b/pkg/provider/bitbucketcloud/parse_payload_test.go
@@ -181,7 +181,7 @@ func TestParsePayload(t *testing.T) {
 		},
 		{
 			name:              "test comment",
-			expectedEventType: opscomments.TestCommentEventType.String(),
+			expectedEventType: opscomments.TestAllCommentEventType.String(),
 			payloadEvent:      bbcloudtest.MakePREvent("account", "sender", "sha", "/test"),
 			eventType:         "pullrequest:comment_created",
 			expectedAccountID: "account",

--- a/pkg/provider/bitbucketcloud/test/bbcloudtest.go
+++ b/pkg/provider/bitbucketcloud/test/bbcloudtest.go
@@ -61,7 +61,7 @@ func MuxComments(t *testing.T, mux *http.ServeMux, event *info.Event, comments [
 	assert.Assert(t, ok)
 	prID := fmt.Sprintf("%d", pr.PullRequest.ID)
 	mux.HandleFunc("/repositories/"+event.Organization+"/"+event.Repository+"/pullrequests/"+prID+"/comments/",
-		func(rw http.ResponseWriter, r *http.Request) {
+		func(rw http.ResponseWriter, _ *http.Request) {
 			members := &types.Comments{
 				Values: comments,
 			}
@@ -74,7 +74,7 @@ func MuxComments(t *testing.T, mux *http.ServeMux, event *info.Event, comments [
 func MuxOrgMember(t *testing.T, mux *http.ServeMux, event *info.Event, members []types.Member) {
 	t.Helper()
 	mux.HandleFunc("/workspaces/"+event.Organization+"/members",
-		func(rw http.ResponseWriter, r *http.Request) {
+		func(rw http.ResponseWriter, _ *http.Request) {
 			members := &types.Members{
 				Values: members,
 			}
@@ -110,7 +110,7 @@ func MuxListDirFiles(t *testing.T, mux *http.ServeMux, event *info.Event, dirs m
 
 	for key, value := range dirs {
 		urlp := "/repositories/" + event.Organization + "/" + event.Repository + "/src/" + sha + "/" + key + "/"
-		mux.HandleFunc(urlp, func(rw http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc(urlp, func(rw http.ResponseWriter, _ *http.Request) {
 			dircontents := map[string][]bitbucket.RepositoryFile{
 				"values": value,
 			}
@@ -125,7 +125,7 @@ func MuxCommits(t *testing.T, mux *http.ServeMux, event *info.Event, commits []t
 	t.Helper()
 
 	path := fmt.Sprintf("/repositories/%s/%s/commits/%s", event.Organization, event.Repository, event.SHA)
-	mux.HandleFunc(path, func(rw http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(path, func(rw http.ResponseWriter, _ *http.Request) {
 		dircontents := map[string][]types.Commit{
 			"values": commits,
 		}
@@ -138,7 +138,7 @@ func MuxRepoInfo(t *testing.T, mux *http.ServeMux, event *info.Event, repo *bitb
 	t.Helper()
 
 	path := fmt.Sprintf("/repositories/%s/%s", event.Organization, event.Repository)
-	mux.HandleFunc(path, func(rw http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(path, func(rw http.ResponseWriter, _ *http.Request) {
 		b, _ := json.Marshal(repo)
 		fmt.Fprint(rw, string(b))
 	})

--- a/pkg/provider/bitbucketserver/bitbucketserver.go
+++ b/pkg/provider/bitbucketserver/bitbucketserver.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/events"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	"go.uber.org/zap"
 )
@@ -120,7 +121,7 @@ func (v *Provider) CreateStatus(_ context.Context, event *info.Event, statusOpts
 	}
 
 	if statusOpts.Conclusion == "SUCCESSFUL" && statusOpts.Status == "completed" &&
-		statusOpts.Text != "" && event.EventType == "pull_request" && v.pullRequestNumber > 0 {
+		statusOpts.Text != "" && event.EventType == triggertype.PullRequest.String() && v.pullRequestNumber > 0 {
 		_, err := v.Client.DefaultApi.CreatePullRequestComment(
 			v.projectKey, event.Repository, v.pullRequestNumber,
 			bbcomment, []string{"application/json"})

--- a/pkg/provider/bitbucketserver/test/test.go
+++ b/pkg/provider/bitbucketserver/test/test.go
@@ -139,7 +139,7 @@ func MuxDirContent(t *testing.T, mux *http.ServeMux, event *info.Event, testDir,
 func MuxCommitInfo(t *testing.T, mux *http.ServeMux, event *info.Event, commit bbv1.Commit) {
 	path := fmt.Sprintf("/projects/%s/repos/%s/commits/%s", event.Organization, event.Repository, event.SHA)
 
-	mux.HandleFunc(path, func(rw http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(path, func(rw http.ResponseWriter, _ *http.Request) {
 		b, err := json.Marshal(commit)
 		assert.NilError(t, err)
 		fmt.Fprint(rw, string(b))
@@ -148,7 +148,7 @@ func MuxCommitInfo(t *testing.T, mux *http.ServeMux, event *info.Event, commit b
 
 func MuxDefaultBranch(t *testing.T, mux *http.ServeMux, event *info.Event, defaultBranch, latestCommit string) {
 	path := fmt.Sprintf("/projects/%s/repos/%s/branches/default", event.Organization, event.Repository)
-	mux.HandleFunc(path, func(rw http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(path, func(rw http.ResponseWriter, _ *http.Request) {
 		resp := &bbv1.Branch{
 			LatestCommit: latestCommit,
 			DisplayID:    defaultBranch,
@@ -223,7 +223,7 @@ func MuxCreateAndTestCommitStatus(t *testing.T, mux *http.ServeMux, event *info.
 
 func MuxProjectMemberShip(t *testing.T, mux *http.ServeMux, event *info.Event, userperms []*bbv1.UserPermission) {
 	path := fmt.Sprintf("/projects/%s/permissions/users", event.Organization)
-	mux.HandleFunc(path, func(rw http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(path, func(rw http.ResponseWriter, _ *http.Request) {
 		if userperms == nil {
 			fmt.Fprintf(rw, "{\"values\": []}")
 		}
@@ -239,7 +239,7 @@ func MuxProjectMemberShip(t *testing.T, mux *http.ServeMux, event *info.Event, u
 
 func MuxRepoMemberShip(t *testing.T, mux *http.ServeMux, event *info.Event, userperms []*bbv1.UserPermission) {
 	path := fmt.Sprintf("/projects/%s/repos/%s/permissions/users", event.Organization, event.Repository)
-	mux.HandleFunc(path, func(rw http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(path, func(rw http.ResponseWriter, _ *http.Request) {
 		if userperms == nil {
 			fmt.Fprintf(rw, "{\"values\": []}")
 		}
@@ -254,7 +254,7 @@ func MuxRepoMemberShip(t *testing.T, mux *http.ServeMux, event *info.Event, user
 
 func MuxPullRequestActivities(t *testing.T, mux *http.ServeMux, event *info.Event, prNumber int, activities []*bbv1.Activity) {
 	path := fmt.Sprintf("/projects/%s/repos/%s/pull-requests/%d/activities", event.Organization, event.Repository, prNumber)
-	mux.HandleFunc(path, func(rw http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(path, func(rw http.ResponseWriter, _ *http.Request) {
 		resp := map[string]interface{}{
 			"values": activities,
 		}

--- a/pkg/provider/gitea/acl_test.go
+++ b/pkg/provider/gitea/acl_test.go
@@ -70,11 +70,11 @@ func TestCheckPolicyAllowing(t *testing.T) {
 				Sender:       "allowedUser",
 			}
 			if tt.listOrgReply != "" {
-				mux.HandleFunc(fmt.Sprintf("/orgs/%s/teams", event.Organization), func(rw http.ResponseWriter, r *http.Request) {
+				mux.HandleFunc(fmt.Sprintf("/orgs/%s/teams", event.Organization), func(rw http.ResponseWriter, _ *http.Request) {
 					fmt.Fprint(rw, tt.listOrgReply)
 				})
 			}
-			mux.HandleFunc(fmt.Sprintf("/teams/1/members/%s", event.Sender), func(rw http.ResponseWriter, r *http.Request) {
+			mux.HandleFunc(fmt.Sprintf("/teams/1/members/%s", event.Sender), func(rw http.ResponseWriter, _ *http.Request) {
 				fmt.Fprint(rw, tt.listTeamMemberships)
 			})
 			ctx, _ := rtesting.SetupFakeContext(t)
@@ -271,18 +271,16 @@ func TestOkToTestComment(t *testing.T) {
 			mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/issues/1/comments", tt.runevent.Organization,
 				tt.runevent.Repository),
 				func(rw http.ResponseWriter,
-					r *http.Request,
+					_ *http.Request,
 				) {
 					fmt.Fprint(rw, tt.commentsReply)
 				})
 			mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/issues/comments/1", tt.runevent.Organization,
 				tt.runevent.Repository),
-				func(rw http.ResponseWriter,
-					r *http.Request,
-				) {
+				func(rw http.ResponseWriter, _ *http.Request) {
 					fmt.Fprint(rw, tt.commentsReply)
 				})
-			mux.HandleFunc("/repos/owner/collaborators", func(rw http.ResponseWriter, r *http.Request) {
+			mux.HandleFunc("/repos/owner/collaborators", func(rw http.ResponseWriter, _ *http.Request) {
 				fmt.Fprint(rw, "[]")
 			})
 			ctx, _ := rtesting.SetupFakeContext(t)
@@ -372,7 +370,7 @@ func TestAclCheckAll(t *testing.T) {
 
 			if tt.allowedRules.collabo {
 				mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/collaborators/%s", tt.runevent.Organization,
-					tt.runevent.Repository, tt.runevent.Sender), func(rw http.ResponseWriter, r *http.Request) {
+					tt.runevent.Repository, tt.runevent.Sender), func(rw http.ResponseWriter, _ *http.Request) {
 					rw.WriteHeader(http.StatusNoContent)
 				})
 			}

--- a/pkg/provider/gitea/detect.go
+++ b/pkg/provider/gitea/detect.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	giteaStructs "code.gitea.io/gitea/modules/structs"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	"go.uber.org/zap"
 )
@@ -43,16 +43,16 @@ func (v *Provider) Detect(req *http.Request, payload string, logger *zap.Sugared
 
 // detectTriggerTypeFromPayload will detect the event type from the payload,
 // filtering out the events that are not supported.
-func detectTriggerTypeFromPayload(ghEventType string, eventInt any) (info.TriggerType, string) {
+func detectTriggerTypeFromPayload(ghEventType string, eventInt any) (triggertype.Trigger, string) {
 	switch event := eventInt.(type) {
 	case *giteaStructs.PushPayload:
 		if event.Pusher != nil {
-			return info.TriggerTypePush, ""
+			return triggertype.Push, ""
 		}
 		return "", "invalid payload: no pusher in event"
 	case *giteaStructs.PullRequestPayload:
 		if provider.Valid(string(event.Action), []string{"opened", "synchronize", "synchronized", "reopened"}) {
-			return info.TriggerTypePullRequest, ""
+			return triggertype.PullRequest, ""
 		}
 		return "", fmt.Sprintf("pull_request: unsupported action \"%s\"", event.Action)
 
@@ -61,13 +61,13 @@ func detectTriggerTypeFromPayload(ghEventType string, eventInt any) (info.Trigge
 			event.Issue.PullRequest != nil &&
 			event.Issue.State == "open" {
 			if provider.IsTestRetestComment(event.Comment.Body) {
-				return info.TriggerTypeRetest, ""
+				return triggertype.Retest, ""
 			}
 			if provider.IsOkToTestComment(event.Comment.Body) {
-				return info.TriggerTypeOkToTest, ""
+				return triggertype.OkToTest, ""
 			}
 			if provider.IsCancelComment(event.Comment.Body) {
-				return info.TriggerTypeCancel, ""
+				return triggertype.Cancel, ""
 			}
 			// this ignores the comment if it is not a PAC gitops comment and not return an error
 			return "", ""

--- a/pkg/provider/gitea/gitea.go
+++ b/pkg/provider/gitea/gitea.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/changedfiles"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/events"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/opscomments"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
@@ -168,8 +169,15 @@ func (v *Provider) createStatusCommit(event *info.Event, pacopts *info.PacOpts, 
 	if _, _, err := v.Client.CreateStatus(event.Organization, event.Repository, event.SHA, gStatus); err != nil {
 		return err
 	}
+	if event.EventType == triggertype.OkToTest.String() || event.EventType == triggertype.Retest.String() ||
+		event.EventType == triggertype.Cancel.String() {
+		event.EventType = triggertype.PullRequest.String()
+	}
+	if opscomments.IsAnyOpsEventType(event.EventType) {
+		event.EventType = triggertype.PullRequest.String()
+	}
 
-	if status.Text != "" && event.EventType == triggertype.PullRequest.String() {
+	if status.Text != "" && (event.EventType == triggertype.PullRequest.String() || event.TriggerTarget == triggertype.PullRequest) {
 		status.Text = strings.ReplaceAll(strings.TrimSpace(status.Text), "<br>", "\n")
 		_, _, err := v.Client.CreateIssueComment(event.Organization, event.Repository,
 			int64(event.PullRequestNumber), gitea.CreateIssueCommentOption{

--- a/pkg/provider/gitea/parse_payload.go
+++ b/pkg/provider/gitea/parse_payload.go
@@ -7,10 +7,10 @@ import (
 	"net/http"
 
 	giteaStructs "code.gitea.io/gitea/modules/structs"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/opscomments"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 )
 
 func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.Request,
@@ -78,15 +78,7 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 		processedEvent.Repository = gitEvent.Repository.Name
 		processedEvent.Sender = gitEvent.Sender.UserName
 		processedEvent.TriggerTarget = triggertype.PullRequest
-		processedEvent.EventType = triggertype.PullRequest.String()
-
-		if provider.IsTestRetestComment(gitEvent.Comment.Body) {
-			processedEvent.TargetTestPipelineRun = provider.GetPipelineRunFromTestComment(gitEvent.Comment.Body)
-		}
-		if provider.IsCancelComment(gitEvent.Comment.Body) {
-			processedEvent.CancelPipelineRuns = true
-			processedEvent.TargetCancelPipelineRun = provider.GetPipelineRunFromCancelComment(gitEvent.Comment.Body)
-		}
+		opscomments.SetEventTypeAndTargetPR(processedEvent, gitEvent.Comment.Body)
 		processedEvent.PullRequestNumber, err = convertPullRequestURLtoNumber(gitEvent.Issue.URL)
 		if err != nil {
 			return nil, err

--- a/pkg/provider/gitea/parse_payload.go
+++ b/pkg/provider/gitea/parse_payload.go
@@ -9,6 +9,7 @@ import (
 	giteaStructs "code.gitea.io/gitea/modules/structs"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 )
 
@@ -47,8 +48,8 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 		processedEvent.PullRequestTitle = gitEvent.PullRequest.Title
 		processedEvent.Organization = gitEvent.Repository.Owner.UserName
 		processedEvent.Repository = gitEvent.Repository.Name
-		processedEvent.TriggerTarget = "pull_request"
-		processedEvent.EventType = "pull_request"
+		processedEvent.TriggerTarget = triggertype.PullRequest
+		processedEvent.EventType = triggertype.PullRequest.String()
 	case *giteaStructs.PushPayload:
 		processedEvent = info.NewEvent()
 		processedEvent.SHA = gitEvent.HeadCommit.ID
@@ -76,8 +77,8 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 		processedEvent.Organization = gitEvent.Repository.Owner.UserName
 		processedEvent.Repository = gitEvent.Repository.Name
 		processedEvent.Sender = gitEvent.Sender.UserName
-		processedEvent.TriggerTarget = "pull_request"
-		processedEvent.EventType = "pull_request"
+		processedEvent.TriggerTarget = triggertype.PullRequest
+		processedEvent.EventType = triggertype.PullRequest.String()
 
 		if provider.IsTestRetestComment(gitEvent.Comment.Body) {
 			processedEvent.TargetTestPipelineRun = provider.GetPipelineRunFromTestComment(gitEvent.Comment.Body)

--- a/pkg/provider/gitea/test/setup.go
+++ b/pkg/provider/gitea/test/setup.go
@@ -28,7 +28,7 @@ func Setup(t *testing.T) (*gitea.Client, *http.ServeMux, func()) {
 		fmt.Fprintln(os.Stderr, "\tDid you accidentally use an absolute endpoint URL rather than relative?")
 		http.Error(w, "Client.BaseURL path prefix is not preserved in the request URL.", http.StatusInternalServerError)
 	})
-	mux.HandleFunc("/version", func(w http.ResponseWriter, req *http.Request) {
+	mux.HandleFunc("/version", func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprintf(w, `{"version": "%s"}`, giteaMinVersion)
 	})
 	//

--- a/pkg/provider/github/acl_test.go
+++ b/pkg/provider/github/acl_test.go
@@ -299,7 +299,7 @@ func TestOkToTestComment(t *testing.T) {
 			tt.runevent.TriggerTarget = "ok-to-test-comment"
 			fakeclient, mux, _, teardown := ghtesthelper.SetupGH()
 			defer teardown()
-			mux.HandleFunc("/repos/owner/issues/comments/0", func(rw http.ResponseWriter, r *http.Request) {
+			mux.HandleFunc("/repos/owner/issues/comments/0", func(rw http.ResponseWriter, _ *http.Request) {
 				fmt.Fprint(rw, tt.commentsReply)
 			})
 			mux.HandleFunc("/repos/owner/issues/1/comments", func(rw http.ResponseWriter, r *http.Request) {
@@ -311,7 +311,7 @@ func TestOkToTestComment(t *testing.T) {
 					fmt.Fprint(rw, tt.commentsReply)
 				}
 			})
-			mux.HandleFunc("/repos/owner/collaborators", func(rw http.ResponseWriter, r *http.Request) {
+			mux.HandleFunc("/repos/owner/collaborators", func(rw http.ResponseWriter, _ *http.Request) {
 				fmt.Fprint(rw, "[]")
 			})
 			ctx, _ := rtesting.SetupFakeContext(t)
@@ -368,33 +368,33 @@ func TestAclCheckAll(t *testing.T) {
 		}
 	})
 
-	mux.HandleFunc("/orgs/"+orgdenied+"/members", func(rw http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/"+orgdenied+"/members", func(rw http.ResponseWriter, _ *http.Request) {
 		fmt.Fprint(rw, `[]`)
 	})
 
-	mux.HandleFunc("/repos/"+orgdenied+"/collaborators", func(rw http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/"+orgdenied+"/collaborators", func(rw http.ResponseWriter, _ *http.Request) {
 		fmt.Fprint(rw, `[]`)
 	})
 
-	mux.HandleFunc("/orgs/"+errit+"/members", func(rw http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/"+errit+"/members", func(rw http.ResponseWriter, _ *http.Request) {
 		fmt.Fprint(rw, `x1x`)
 	})
 
-	mux.HandleFunc("/orgs/"+repoOwnerFileAllowed+"/members", func(rw http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/"+repoOwnerFileAllowed+"/members", func(rw http.ResponseWriter, _ *http.Request) {
 		fmt.Fprint(rw, `[]`)
 	})
-	mux.HandleFunc("/repos/"+repoOwnerFileAllowed+"/collaborators", func(rw http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/"+repoOwnerFileAllowed+"/collaborators", func(rw http.ResponseWriter, _ *http.Request) {
 		fmt.Fprint(rw, `[]`)
 	})
-	mux.HandleFunc("/repos/"+repoOwnerFileAllowed+"/contents/OWNERS", func(rw http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/"+repoOwnerFileAllowed+"/contents/OWNERS", func(rw http.ResponseWriter, _ *http.Request) {
 		fmt.Fprint(rw, `{"name": "OWNERS", "path": "OWNERS", "sha": "ownerssha"}`)
 	})
 
-	mux.HandleFunc("/repos/"+repoOwnerFileAllowed+"/git/blobs/ownerssha", func(rw http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/"+repoOwnerFileAllowed+"/git/blobs/ownerssha", func(rw http.ResponseWriter, _ *http.Request) {
 		fmt.Fprintf(rw, `{"content": "%s"}`, base64.RawStdEncoding.EncodeToString([]byte("approvers:\n  - approved\n")))
 	})
 
-	mux.HandleFunc(fmt.Sprintf("/repos/%v/%v/collaborators/%v", collabOwner, collabRepo, collaborator), func(rw http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(fmt.Sprintf("/repos/%v/%v/collaborators/%v", collabOwner, collabRepo, collaborator), func(rw http.ResponseWriter, _ *http.Request) {
 		rw.WriteHeader(http.StatusNoContent)
 	})
 
@@ -582,7 +582,7 @@ func TestIfPullRequestIsForSameRepoWithoutFork(t *testing.T) {
 			defer teardown()
 			ctx, _ := rtesting.SetupFakeContext(t)
 			mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/pulls/%d",
-				tt.event.Organization, tt.event.Repository, tt.pullRequestNumber), func(rw http.ResponseWriter, r *http.Request) {
+				tt.event.Organization, tt.event.Repository, tt.pullRequestNumber), func(rw http.ResponseWriter, _ *http.Request) {
 				b, _ := json.Marshal(tt.pullRequest)
 				fmt.Fprint(rw, string(b))
 			})

--- a/pkg/provider/github/app/token_test.go
+++ b/pkg/provider/github/app/token_test.go
@@ -239,7 +239,7 @@ func Test_GetAndUpdateInstallationID(t *testing.T) {
 
 	t.Setenv("PAC_GIT_PROVIDER_TOKEN_APIURL", serverURL+"/api/v3")
 
-	mux.HandleFunc("/installation/repositories", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/installation/repositories", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Authorization", "Bearer 12345")
 		w.Header().Set("Accept", "application/vnd.github+json")
 		_, _ = fmt.Fprint(w, `{"total_count": 1,"repositories": [{"id":1,"html_url": "https://matched/by/incoming"},{"id":2,"html_url": "https://anotherrepo/that/would/failit"}]}`)
@@ -262,11 +262,11 @@ func Test_ListRepos(t *testing.T) {
 	fakeclient, mux, _, teardown := ghtesthelper.SetupGH()
 	defer teardown()
 
-	mux.HandleFunc("user/installations/1/repositories/2", func(rw http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("user/installations/1/repositories/2", func(rw http.ResponseWriter, _ *http.Request) {
 		fmt.Fprint(rw)
 	})
 
-	mux.HandleFunc("/installation/repositories", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/installation/repositories", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Authorization", "Bearer 12345")
 		w.Header().Set("Accept", "application/vnd.github+json")
 		_, _ = fmt.Fprint(w, `{"total_count": 1,"repositories": [{"id":1,"html_url": "https://matched/by/incoming"}]}`)

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -433,7 +433,9 @@ func (v *Provider) getPullRequest(ctx context.Context, runevent *info.Event) (*i
 	runevent.BaseBranch = pr.GetBase().GetRef()
 	runevent.HeadURL = pr.GetHead().GetRepo().GetHTMLURL()
 	runevent.BaseURL = pr.GetBase().GetRepo().GetHTMLURL()
-	runevent.EventType = triggertype.PullRequest.String()
+	if runevent.EventType == "" {
+		runevent.EventType = triggertype.PullRequest.String()
+	}
 
 	v.RepositoryIDs = []int64{
 		pr.GetBase().GetRepo().GetID(),

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/events"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	"go.uber.org/zap"
 	"golang.org/x/oauth2"
@@ -432,7 +433,7 @@ func (v *Provider) getPullRequest(ctx context.Context, runevent *info.Event) (*i
 	runevent.BaseBranch = pr.GetBase().GetRef()
 	runevent.HeadURL = pr.GetHead().GetRepo().GetHTMLURL()
 	runevent.BaseURL = pr.GetBase().GetRepo().GetHTMLURL()
-	runevent.EventType = "pull_request"
+	runevent.EventType = triggertype.PullRequest.String()
 
 	v.RepositoryIDs = []int64{
 		pr.GetBase().GetRepo().GetID(),
@@ -442,7 +443,7 @@ func (v *Provider) getPullRequest(ctx context.Context, runevent *info.Event) (*i
 
 // GetFiles get a files from pull request.
 func (v *Provider) GetFiles(ctx context.Context, runevent *info.Event) (changedfiles.ChangedFiles, error) {
-	if runevent.TriggerTarget == "pull_request" {
+	if runevent.TriggerTarget == triggertype.PullRequest {
 		opt := &github.ListOptions{PerPage: v.paginedNumber}
 		changedFiles := changedfiles.ChangedFiles{}
 		for {

--- a/pkg/provider/github/github_test.go
+++ b/pkg/provider/github/github_test.go
@@ -76,10 +76,10 @@ func TestGetTaskURI(t *testing.T) {
 			event := info.NewEvent()
 			event.HeadBranch = "main"
 			event.URL = tt.eventURL
-			mux.HandleFunc("/repos/owner/repo/contents/file", func(rw http.ResponseWriter, r *http.Request) {
+			mux.HandleFunc("/repos/owner/repo/contents/file", func(rw http.ResponseWriter, _ *http.Request) {
 				fmt.Fprintf(rw, `{"sha": "%s"}`, sha)
 			})
-			mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/git/blobs/%s", "owner", "repo", sha), func(rw http.ResponseWriter, r *http.Request) {
+			mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/git/blobs/%s", "owner", "repo", sha), func(rw http.ResponseWriter, _ *http.Request) {
 				fmt.Fprintf(rw, `{"content": "%s"}`, content)
 			})
 			allowed, content, err := provider.GetTaskURI(ctx, event, tt.uri)
@@ -423,7 +423,7 @@ func TestCheckSenderOrgMembership(t *testing.T) {
 			gprovider := Provider{
 				Client: fakeclient,
 			}
-			mux.HandleFunc(fmt.Sprintf("/orgs/%s/members", tt.runevent.Organization), func(rw http.ResponseWriter, r *http.Request) {
+			mux.HandleFunc(fmt.Sprintf("/orgs/%s/members", tt.runevent.Organization), func(rw http.ResponseWriter, _ *http.Request) {
 				fmt.Fprint(rw, tt.apiReturn)
 			})
 
@@ -468,7 +468,7 @@ func TestGetStringPullRequestComment(t *testing.T) {
 			gprovider := Provider{
 				Client: fakeclient,
 			}
-			mux.HandleFunc(fmt.Sprintf("/repos/issues/%s/comments", filepath.Base(tt.runevent.URL)), func(rw http.ResponseWriter, r *http.Request) {
+			mux.HandleFunc(fmt.Sprintf("/repos/issues/%s/comments", filepath.Base(tt.runevent.URL)), func(rw http.ResponseWriter, _ *http.Request) {
 				fmt.Fprint(rw, tt.apiReturn)
 			})
 
@@ -526,7 +526,7 @@ func TestGithubGetCommitInfo(t *testing.T) {
 			fakeclient, mux, _, teardown := ghtesthelper.SetupGH()
 			defer teardown()
 			mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/git/commits/%s",
-				tt.event.Organization, tt.event.Repository, tt.event.SHA), func(rw http.ResponseWriter, r *http.Request) {
+				tt.event.Organization, tt.event.Repository, tt.event.SHA), func(rw http.ResponseWriter, _ *http.Request) {
 				if tt.apiReply != "" {
 					fmt.Fprintf(rw, tt.apiReply)
 					return
@@ -773,7 +773,7 @@ func TestGetFiles(t *testing.T) {
 			}
 			if tt.event.TriggerTarget == "push" {
 				mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/commits/%s",
-					tt.event.Organization, tt.event.Repository, tt.event.SHA), func(rw http.ResponseWriter, r *http.Request) {
+					tt.event.Organization, tt.event.Repository, tt.event.SHA), func(rw http.ResponseWriter, _ *http.Request) {
 					c := &github.RepositoryCommit{
 						Files: pushCommitFiles,
 					}
@@ -861,7 +861,7 @@ func TestProvider_checkWebhookSecretValidity(t *testing.T) {
 			logger, observer := logger.GetLogger()
 
 			if !tt.apiNotEnabled {
-				mux.HandleFunc("/rate_limit", func(rw http.ResponseWriter, r *http.Request) {
+				mux.HandleFunc("/rate_limit", func(rw http.ResponseWriter, _ *http.Request) {
 					s := &github.RateLimits{
 						SCIM: &github.Rate{
 							Remaining: tt.remaining,
@@ -940,7 +940,7 @@ func TestListRepos(t *testing.T) {
 	fakeclient, mux, _, teardown := ghtesthelper.SetupGH()
 	defer teardown()
 
-	mux.HandleFunc("user/installations/1/repositories/2", func(rw http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("user/installations/1/repositories/2", func(rw http.ResponseWriter, _ *http.Request) {
 		fmt.Fprint(rw)
 	})
 
@@ -1036,7 +1036,7 @@ func TestCreateToken(t *testing.T) {
 	fakeclient, mux, _, teardown := ghtesthelper.SetupGH()
 	defer teardown()
 
-	extraRepoInstallIds := map[string]string{"owner/project1": "789", "owner/project2": "10112"}
+	extraRepoInstallIDs := map[string]string{"owner/project1": "789", "owner/project2": "10112"}
 	urlData := []string{}
 	for _, r := range repos {
 		if r.Spec.Settings != nil {
@@ -1045,8 +1045,8 @@ func TestCreateToken(t *testing.T) {
 	}
 	for _, v := range urlData {
 		split := strings.Split(v, "/")
-		mux.HandleFunc(fmt.Sprintf("/repos/%s/%s", split[0], split[1]), func(w http.ResponseWriter, r *http.Request) {
-			sid := extraRepoInstallIds[fmt.Sprintf("%s/%s", split[0], split[1])]
+		mux.HandleFunc(fmt.Sprintf("/repos/%s/%s", split[0], split[1]), func(w http.ResponseWriter, _ *http.Request) {
+			sid := extraRepoInstallIDs[fmt.Sprintf("%s/%s", split[0], split[1])]
 			_, _ = fmt.Fprintf(w, `{"id": %s}`, sid)
 		})
 	}
@@ -1087,7 +1087,7 @@ func TestGetBranch(t *testing.T) {
 			defer teardown()
 
 			mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/branches/test1",
-				runEvent.Organization, runEvent.Repository), func(rw http.ResponseWriter, r *http.Request) {
+				runEvent.Organization, runEvent.Repository), func(rw http.ResponseWriter, _ *http.Request) {
 				_, err := fmt.Fprintf(rw, `{
 			"name": "test1",
 			"commit": {

--- a/pkg/provider/github/scope_test.go
+++ b/pkg/provider/github/scope_test.go
@@ -210,7 +210,7 @@ func TestScopeTokenToListOfRepos(t *testing.T) {
 
 			fakeghclient, mux, serverURL, teardown := ghtesthelper.SetupGH()
 			defer teardown()
-			mux.HandleFunc(fmt.Sprintf("/app/installations/%d/access_tokens", installationID), func(w http.ResponseWriter, r *http.Request) {
+			mux.HandleFunc(fmt.Sprintf("/app/installations/%d/access_tokens", installationID), func(w http.ResponseWriter, _ *http.Request) {
 				_, _ = fmt.Fprintf(w, `{"token": "%s"}`, tempToken)
 			})
 
@@ -232,11 +232,11 @@ func TestScopeTokenToListOfRepos(t *testing.T) {
 				Run:    run,
 			}
 
-			extraRepoInstallIds := map[string]string{"owner/repo": "789", "owner1/repo1": "10112", "owner2/repo2": "112233"}
-			for v := range extraRepoInstallIds {
+			extraRepoInstallIDs := map[string]string{"owner/repo": "789", "owner1/repo1": "10112", "owner2/repo2": "112233"}
+			for v := range extraRepoInstallIDs {
 				split := strings.Split(v, "/")
-				mux.HandleFunc(fmt.Sprintf("/repos/%s/%s", split[0], split[1]), func(w http.ResponseWriter, r *http.Request) {
-					sid := extraRepoInstallIds[fmt.Sprintf("%s/%s", split[0], split[1])]
+				mux.HandleFunc(fmt.Sprintf("/repos/%s/%s", split[0], split[1]), func(w http.ResponseWriter, _ *http.Request) {
+					sid := extraRepoInstallIDs[fmt.Sprintf("%s/%s", split[0], split[1])]
 					_, _ = fmt.Fprintf(w, `{"id": %s}`, sid)
 				})
 			}

--- a/pkg/provider/github/status.go
+++ b/pkg/provider/github/status.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
 	kstatus "github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction/status"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 )
@@ -307,7 +308,7 @@ func (v *Provider) createStatusCommit(ctx context.Context, runevent *info.Event,
 		runevent.Organization, runevent.Repository, runevent.SHA, ghstatus); err != nil {
 		return err
 	}
-	if (status.Status == "completed" || (status.Status == "queued" && status.Title == "Pending approval")) && status.Text != "" && runevent.EventType == "pull_request" {
+	if (status.Status == "completed" || (status.Status == "queued" && status.Title == "Pending approval")) && status.Text != "" && runevent.EventType == triggertype.PullRequest.String() {
 		_, _, err = v.Client.Issues.CreateComment(ctx, runevent.Organization, runevent.Repository,
 			runevent.PullRequestNumber,
 			&github.IssueComment{

--- a/pkg/provider/github/status_test.go
+++ b/pkg/provider/github/status_test.go
@@ -34,11 +34,11 @@ func TestGithubProviderCreateCheckRun(t *testing.T) {
 		Run:    params.New(),
 	}
 	defer teardown()
-	mux.HandleFunc("/repos/check/info/check-runs", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/check/info/check-runs", func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = fmt.Fprint(w, `{"id": 555}`)
 	})
 
-	mux.HandleFunc("/repos/check/info/check-runs/555", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/check/info/check-runs/555", func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = fmt.Fprint(w, `{"id": 555}`)
 	})
 
@@ -118,7 +118,7 @@ func TestGetExistingPendingApprovalCheckRunID(t *testing.T) {
 
 	chosenOne := "chosenOne"
 	chosenID := int64(55555)
-	mux.HandleFunc(fmt.Sprintf("/repos/%v/%v/commits/%v/check-runs", event.Organization, event.Repository, event.SHA), func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(fmt.Sprintf("/repos/%v/%v/commits/%v/check-runs", event.Organization, event.Repository, event.SHA), func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = fmt.Fprintf(w, `{
 			"total_count": 1,
 			"check_runs": [
@@ -297,7 +297,7 @@ func TestGithubProviderCreateStatus(t *testing.T) {
 			gcvs.Logger, _ = logger.GetLogger()
 			gcvs.Run = params.New()
 
-			mux.HandleFunc("/repos/check/run/statuses/sha", func(rw http.ResponseWriter, r *http.Request) {})
+			mux.HandleFunc("/repos/check/run/statuses/sha", func(_ http.ResponseWriter, _ *http.Request) {})
 			mux.HandleFunc(fmt.Sprintf("/repos/check/run/check-runs/%d", checkrunid), func(rw http.ResponseWriter, r *http.Request) {
 				bit, _ := io.ReadAll(r.Body)
 				checkRun := &github.CheckRun{}
@@ -322,7 +322,7 @@ func TestGithubProviderCreateStatus(t *testing.T) {
 			})
 			if tt.addExistingCheckruns {
 				tt.args.runevent.SHA = "sha"
-				mux.HandleFunc(fmt.Sprintf("/repos/%v/%v/commits/%v/check-runs", tt.args.runevent.Organization, tt.args.runevent.Repository, tt.args.runevent.SHA), func(w http.ResponseWriter, r *http.Request) {
+				mux.HandleFunc(fmt.Sprintf("/repos/%v/%v/commits/%v/check-runs", tt.args.runevent.Organization, tt.args.runevent.Repository, tt.args.runevent.SHA), func(w http.ResponseWriter, _ *http.Request) {
 					_, _ = fmt.Fprintf(w, `{
 						"total_count": 1,
 						"check_runs": [
@@ -444,13 +444,13 @@ func TestGithubProvidercreateStatusCommit(t *testing.T) {
 			fakeclient, mux, _, teardown := ghtesthelper.SetupGH()
 			defer teardown()
 			mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/statuses/%s",
-				tt.event.Organization, tt.event.Repository, tt.event.SHA), func(rw http.ResponseWriter, r *http.Request) {
+				tt.event.Organization, tt.event.Repository, tt.event.SHA), func(_ http.ResponseWriter, r *http.Request) {
 				body, _ := io.ReadAll(r.Body)
 				assert.Check(t, strings.Contains(string(body), fmt.Sprintf(`"state":"%s"`, tt.expectedConclusion)))
 			})
 			if tt.status.Status == "completed" {
 				mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/issues/%d/comments",
-					tt.event.Organization, tt.event.Repository, issuenumber), func(rw http.ResponseWriter, r *http.Request) {
+					tt.event.Organization, tt.event.Repository, issuenumber), func(_ http.ResponseWriter, r *http.Request) {
 					body, _ := io.ReadAll(r.Body)
 					assert.Equal(t, fmt.Sprintf(`{"body":"%s<br>%s"}`, tt.status.Summary, tt.status.Text)+"\n", string(body))
 				})
@@ -566,7 +566,7 @@ func TestProviderGetExistingCheckRunID(t *testing.T) {
 			v := &Provider{
 				Client: client,
 			}
-			mux.HandleFunc(fmt.Sprintf("/repos/%v/%v/commits/%v/check-runs", event.Organization, event.Repository, event.SHA), func(w http.ResponseWriter, r *http.Request) {
+			mux.HandleFunc(fmt.Sprintf("/repos/%v/%v/commits/%v/check-runs", event.Organization, event.Repository, event.SHA), func(w http.ResponseWriter, _ *http.Request) {
 				_, _ = fmt.Fprintf(w, tt.jsonret)
 			})
 

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/events"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	"github.com/xanzy/go-gitlab"
 	"go.uber.org/zap"
@@ -204,7 +205,7 @@ func (v *Provider) CreateStatus(_ context.Context, event *info.Event, statusOpts
 	_, _, _ = v.Client.Commits.SetCommitStatus(event.SourceProjectID, event.SHA, opt)
 
 	// only add a note when we are on a MR
-	if event.EventType == "pull_request" || event.EventType == "Merge_Request" || event.EventType == "Merge Request" {
+	if event.EventType == triggertype.PullRequest.String() || event.EventType == "Merge_Request" || event.EventType == "Merge Request" {
 		mopt := &gitlab.CreateMergeRequestNoteOptions{Body: gitlab.Ptr(body)}
 		_, _, err := v.Client.Notes.CreateMergeRequestNote(event.TargetProjectID, event.PullRequestNumber, mopt)
 		return err
@@ -312,7 +313,7 @@ func (v *Provider) GetFiles(_ context.Context, runevent *info.Event) (changedfil
 		return changedfiles.ChangedFiles{}, fmt.Errorf("no gitlab client has been initialized, " +
 			"exiting... (hint: did you forget setting a secret on your repo?)")
 	}
-	if runevent.TriggerTarget == "pull_request" {
+	if runevent.TriggerTarget == triggertype.PullRequest {
 		//nolint: staticcheck
 		mrchanges, _, err := v.Client.MergeRequests.GetMergeRequestChanges(v.sourceProjectID, runevent.PullRequestNumber, &gitlab.GetMergeRequestChangesOptions{})
 		if err != nil {

--- a/pkg/provider/gitlab/gitlab_test.go
+++ b/pkg/provider/gitlab/gitlab_test.go
@@ -545,7 +545,7 @@ func TestGetFiles(t *testing.T) {
 			}
 			if tt.event.TriggerTarget == "pull_request" {
 				mux.HandleFunc(fmt.Sprintf("/projects/0/merge_requests/%d/changes",
-					tt.event.PullRequestNumber), func(rw http.ResponseWriter, r *http.Request) {
+					tt.event.PullRequestNumber), func(rw http.ResponseWriter, _ *http.Request) {
 					jeez, err := json.Marshal(mergeFileChanges)
 					assert.NilError(t, err)
 					_, _ = rw.Write(jeez)
@@ -570,7 +570,7 @@ func TestGetFiles(t *testing.T) {
 			}
 			if tt.event.TriggerTarget == "push" {
 				mux.HandleFunc(fmt.Sprintf("/projects/0/repository/commits/%s/diff", tt.event.SHA),
-					func(rw http.ResponseWriter, r *http.Request) {
+					func(rw http.ResponseWriter, _ *http.Request) {
 						jeez, err := json.Marshal(pushFileChanges)
 						assert.NilError(t, err)
 						_, _ = rw.Write(jeez)

--- a/pkg/provider/gitlab/parse_payload.go
+++ b/pkg/provider/gitlab/parse_payload.go
@@ -7,10 +7,10 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/opscomments"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	"github.com/xanzy/go-gitlab"
 )
 
@@ -115,13 +115,8 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 		processedEvent.HeadBranch = gitEvent.MergeRequest.SourceBranch
 		processedEvent.BaseURL = gitEvent.MergeRequest.Target.WebURL
 		processedEvent.HeadURL = gitEvent.MergeRequest.Source.WebURL
-		// if it is a /test or /retest comment with pipelinerun name figure out the pipelineRun name
-		if provider.IsTestRetestComment(gitEvent.ObjectAttributes.Note) {
-			processedEvent.TargetTestPipelineRun = provider.GetPipelineRunFromTestComment(gitEvent.ObjectAttributes.Note)
-		}
-		if provider.IsCancelComment(gitEvent.ObjectAttributes.Note) {
-			processedEvent.TargetCancelPipelineRun = provider.GetPipelineRunFromCancelComment(gitEvent.ObjectAttributes.Note)
-		}
+
+		opscomments.SetEventTypeAndTargetPR(processedEvent, gitEvent.ObjectAttributes.Note)
 
 		v.pathWithNamespace = gitEvent.Project.PathWithNamespace
 		processedEvent.Organization, processedEvent.Repository = getOrgRepo(v.pathWithNamespace)

--- a/pkg/provider/gitlab/parse_payload.go
+++ b/pkg/provider/gitlab/parse_payload.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	"github.com/xanzy/go-gitlab"
 )
@@ -53,7 +54,7 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 
 		v.pathWithNamespace = gitEvent.ObjectAttributes.Target.PathWithNamespace
 		processedEvent.Organization, processedEvent.Repository = getOrgRepo(v.pathWithNamespace)
-		processedEvent.TriggerTarget = "pull_request"
+		processedEvent.TriggerTarget = triggertype.PullRequest
 		processedEvent.SourceProjectID = gitEvent.ObjectAttributes.SourceProjectID
 		processedEvent.TargetProjectID = gitEvent.Project.ID
 	case *gitlab.TagEvent:
@@ -124,7 +125,7 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 
 		v.pathWithNamespace = gitEvent.Project.PathWithNamespace
 		processedEvent.Organization, processedEvent.Repository = getOrgRepo(v.pathWithNamespace)
-		processedEvent.TriggerTarget = "pull_request"
+		processedEvent.TriggerTarget = triggertype.PullRequest
 
 		processedEvent.PullRequestNumber = gitEvent.MergeRequest.IID
 		v.targetProjectID = gitEvent.MergeRequest.TargetProjectID

--- a/pkg/provider/gitlab/test/test.go
+++ b/pkg/provider/gitlab/test/test.go
@@ -54,7 +54,7 @@ func MuxNotePost(t *testing.T, mux *http.ServeMux, projectNumber, mrID int, catc
 
 func MuxAllowUserID(mux *http.ServeMux, projectID, userID int) {
 	path := fmt.Sprintf("/projects/%d/members/all/%d", projectID, userID)
-	mux.HandleFunc(path, func(rw http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(path, func(rw http.ResponseWriter, _ *http.Request) {
 		fmt.Fprintf(rw, `{"id": %d}`, userID)
 	})
 }
@@ -96,7 +96,7 @@ func MuxDiscussionsNote(mux *http.ServeMux, pid, mrID int, author string, author
 }
 
 func MuxGetFile(mux *http.ServeMux, pid int, fname, content string) {
-	mux.HandleFunc(fmt.Sprintf("/projects/%d/repository/files/%s/raw", pid, fname), func(rw http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(fmt.Sprintf("/projects/%d/repository/files/%s/raw", pid, fname), func(rw http.ResponseWriter, _ *http.Request) {
 		fmt.Fprint(rw, content)
 	})
 }

--- a/pkg/reconciler/controller.go
+++ b/pkg/reconciler/controller.go
@@ -91,7 +91,7 @@ func checkStateAndEnqueue(impl *controller.Impl) func(obj interface{}) {
 }
 
 func ctrlOpts() func(impl *controller.Impl) controller.Options {
-	return func(impl *controller.Impl) controller.Options {
+	return func(_ *controller.Impl) controller.Options {
 		return controller.Options{
 			FinalizerName: pipelinesascode.GroupName,
 			PromoteFilterFunc: func(obj interface{}) bool {

--- a/pkg/test/github/github.go
+++ b/pkg/test/github/github.go
@@ -132,7 +132,7 @@ func SetupGitTree(t *testing.T, mux *http.ServeMux, dir string, event *info.Even
 		})
 	}
 	u := fmt.Sprintf("/repos/%v/%v/git/trees/%v", event.Organization, event.Repository, event.SHA)
-	mux.HandleFunc(u, func(rw http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(u, func(rw http.ResponseWriter, _ *http.Request) {
 		tree := &github.Tree{
 			SHA:     &event.SHA,
 			Entries: entries,

--- a/test/bitbucket_cloud_pullrequest_test.go
+++ b/test/bitbucket_cloud_pullrequest_test.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	tbb "github.com/openshift-pipelines/pipelines-as-code/test/pkg/bitbucketcloud"
-	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
 	"github.com/tektoncd/pipeline/pkg/names"
 	"gotest.tools/v3/assert"
@@ -35,7 +35,7 @@ func TestBitbucketCloudPullRequest(t *testing.T) {
 
 	sopt := wait.SuccessOpt{
 		TargetNS:        targetNS,
-		OnEvent:         options.PullRequestEvent,
+		OnEvent:         triggertype.PullRequest.String(),
 		NumberofPRMatch: 1,
 		SHA:             hash,
 		Title:           title,

--- a/test/gitea_access_control_test.go
+++ b/test/gitea_access_control_test.go
@@ -424,7 +424,8 @@ func TestGiteaPolicyAllowedOwnerFiles(t *testing.T) {
 		PollTimeout:     twait.DefaultTimeout,
 		TargetSHA:       npr.Head.Sha,
 	}
-	assert.NilError(t, twait.UntilRepositoryUpdated(context.Background(), topts.ParamsRun.Clients, waitOpts))
+	_, err = twait.UntilRepositoryUpdated(context.Background(), topts.ParamsRun.Clients, waitOpts)
+	assert.NilError(t, err)
 	time.Sleep(5 * time.Second) // “Evil does not sleep. It waits.” - Galadriel
 
 	prs, err := topts.ParamsRun.Clients.Tekton.TektonV1().PipelineRuns(topts.TargetNS).List(context.Background(), metav1.ListOptions{})

--- a/test/gitea_access_control_test.go
+++ b/test/gitea_access_control_test.go
@@ -12,10 +12,10 @@ import (
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/cctx"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/configmap"
 	tgitea "github.com/openshift-pipelines/pipelines-as-code/test/pkg/gitea"
-	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/scm"
 	twait "github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
@@ -41,7 +41,7 @@ func TestGiteaPolicyPullRequest(t *testing.T) {
 		OnOrg:                true,
 		SkipEventsCheck:      true,
 		CheckForNumberStatus: 2,
-		TargetEvent:          options.PullRequestEvent,
+		TargetEvent:          triggertype.PullRequest.String(),
 		Settings: &v1alpha1.Settings{
 			Policy: &v1alpha1.Policy{
 				PullRequest: []string{"pull_requester"},
@@ -102,7 +102,7 @@ func TestGiteaPolicyOkToTestRetest(t *testing.T) {
 	topts := &tgitea.TestOpts{
 		OnOrg:           true,
 		SkipEventsCheck: true,
-		TargetEvent:     options.PullRequestEvent,
+		TargetEvent:     triggertype.PullRequest.String(),
 		Settings: &v1alpha1.Settings{
 			Policy: &v1alpha1.Policy{
 				OkToTest: []string{"ok-to-test"},
@@ -170,7 +170,7 @@ func TestGiteaPolicyOkToTestRetest(t *testing.T) {
 // TestGiteaACLOrgAllowed tests that the policy check works when the user is part of an allowed org.
 func TestGiteaACLOrgAllowed(t *testing.T) {
 	topts := &tgitea.TestOpts{
-		TargetEvent: options.PullRequestEvent,
+		TargetEvent: triggertype.PullRequest.String(),
 		YAMLFiles: map[string]string{
 			".tekton/pr.yaml": "testdata/pipelinerun.yaml",
 		},
@@ -190,7 +190,7 @@ func TestGiteaACLOrgAllowed(t *testing.T) {
 // TestGiteaACLOrgPendingApproval tests when non authorized user sends a PR the status of CI shows as pending.
 func TestGiteaACLOrgPendingApproval(t *testing.T) {
 	topts := &tgitea.TestOpts{
-		TargetEvent: options.PullRequestEvent,
+		TargetEvent: triggertype.PullRequest.String(),
 		YAMLFiles: map[string]string{
 			".tekton/pr.yaml": "testdata/pipelinerun.yaml",
 		},
@@ -229,7 +229,7 @@ func TestGiteaACLCommentsAllowing(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			topts := &tgitea.TestOpts{
-				TargetEvent: options.PullRequestEvent,
+				TargetEvent: triggertype.PullRequest.String(),
 				YAMLFiles: map[string]string{
 					".tekton/pipelinerun-gitops.yaml": "testdata/pipelinerun-gitops.yaml",
 				},
@@ -268,7 +268,7 @@ func TestGiteaACLCommentsAllowingRememberOkToTestFalse(t *testing.T) {
 
 	ctx := context.Background()
 	topts := &tgitea.TestOpts{
-		TargetEvent: options.PullRequestEvent,
+		TargetEvent: triggertype.PullRequest.String(),
 		YAMLFiles: map[string]string{
 			".tekton/pr.yaml": "testdata/pipelinerun.yaml",
 		},
@@ -330,7 +330,7 @@ func TestGiteaACLCommentsAllowingRememberOkToTestFalse(t *testing.T) {
 func TestGiteaACLCommentsAllowingRememberOkToTestTrue(t *testing.T) {
 	ctx := context.Background()
 	topts := &tgitea.TestOpts{
-		TargetEvent: options.PullRequestEvent,
+		TargetEvent: triggertype.PullRequest.String(),
 		YAMLFiles: map[string]string{
 			".tekton/pr.yaml": "testdata/pipelinerun.yaml",
 		},
@@ -368,7 +368,7 @@ func TestGiteaPolicyAllowedOwnerFiles(t *testing.T) {
 	topts := &tgitea.TestOpts{
 		OnOrg:                 true,
 		NoPullRequestCreation: true,
-		TargetEvent:           options.PullRequestEvent,
+		TargetEvent:           triggertype.PullRequest.String(),
 		Settings: &v1alpha1.Settings{
 			Policy: &v1alpha1.Policy{
 				PullRequest: []string{"normal"},

--- a/test/gitea_params_test.go
+++ b/test/gitea_params_test.go
@@ -13,11 +13,11 @@ import (
 
 	"code.gitea.io/sdk/gitea"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/sort"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/cctx"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/configmap"
 	tgitea "github.com/openshift-pipelines/pipelines-as-code/test/pkg/gitea"
-	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
 	pacrepo "github.com/openshift-pipelines/pipelines-as-code/test/pkg/repository"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/scm"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/secret"
@@ -82,7 +82,7 @@ func TestGiteaParamsOnRepoCRWithCustomConsole(t *testing.T) {
 	topts := &tgitea.TestOpts{
 		CheckForStatus:  "success",
 		SkipEventsCheck: true,
-		TargetEvent:     options.PullRequestEvent,
+		TargetEvent:     triggertype.PullRequest.String(),
 		YAMLFiles: map[string]string{
 			".tekton/pr.yaml": "testdata/params.yaml",
 		},
@@ -123,7 +123,7 @@ func TestGiteaParamsOnRepoCR(t *testing.T) {
 	topts := &tgitea.TestOpts{
 		CheckForStatus:  "success",
 		SkipEventsCheck: true,
-		TargetEvent:     options.PullRequestEvent,
+		TargetEvent:     triggertype.PullRequest.String(),
 		YAMLFiles: map[string]string{
 			".tekton/pr.yaml": "testdata/params.yaml",
 		},

--- a/test/gitea_params_test.go
+++ b/test/gitea_params_test.go
@@ -249,7 +249,7 @@ my email is a true beauty and like groot, I AM pac`
 		PollTimeout:     twait.DefaultTimeout,
 		TargetSHA:       topts.PullRequest.Head.Sha,
 	}
-	err = twait.UntilRepositoryUpdated(context.Background(), topts.ParamsRun.Clients, waitOpts)
+	_, err = twait.UntilRepositoryUpdated(context.Background(), topts.ParamsRun.Clients, waitOpts)
 	assert.NilError(t, err)
 
 	time.Sleep(5 * time.Second)
@@ -338,7 +338,7 @@ func TestGiteaParamsChangedFilesCEL(t *testing.T) {
 		PollTimeout:     twait.DefaultTimeout,
 		TargetSHA:       topts.PullRequest.Head.Sha,
 	}
-	err = twait.UntilRepositoryUpdated(context.Background(), topts.ParamsRun.Clients, waitOpts)
+	_, err = twait.UntilRepositoryUpdated(context.Background(), topts.ParamsRun.Clients, waitOpts)
 	assert.NilError(t, err)
 	time.Sleep(5 * time.Second)
 
@@ -385,7 +385,7 @@ func TestGiteaParamsChangedFilesCEL(t *testing.T) {
 		PollTimeout:     twait.DefaultTimeout,
 		TargetSHA:       topts.PullRequest.Head.Sha,
 	}
-	err = twait.UntilRepositoryUpdated(context.Background(), topts.ParamsRun.Clients, waitOpts)
+	_, err = twait.UntilRepositoryUpdated(context.Background(), topts.ParamsRun.Clients, waitOpts)
 	assert.NilError(t, err)
 	time.Sleep(5 * time.Second)
 

--- a/test/gitea_results_annotation_test.go
+++ b/test/gitea_results_annotation_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	tgitea "github.com/openshift-pipelines/pipelines-as-code/test/pkg/gitea"
-	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
 	"gotest.tools/v3/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -20,7 +20,7 @@ import (
 func TestGiteaResultsAnnotations(t *testing.T) {
 	topts := &tgitea.TestOpts{
 		Regexp:      successRegexp,
-		TargetEvent: options.PullRequestEvent,
+		TargetEvent: triggertype.PullRequest.String(),
 		YAMLFiles: map[string]string{
 			".tekton/pipeline.yaml": "testdata/pipelinerun.yaml",
 		},

--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -295,7 +295,7 @@ func TestGiteaConfigMaxKeepRun(t *testing.T) {
 		PollTimeout:     twait.DefaultTimeout,
 		TargetSHA:       topts.PullRequest.Head.Sha,
 	}
-	err := twait.UntilRepositoryUpdated(context.Background(), topts.ParamsRun.Clients, waitOpts)
+	_, err := twait.UntilRepositoryUpdated(context.Background(), topts.ParamsRun.Clients, waitOpts)
 	assert.NilError(t, err)
 
 	time.Sleep(15 * time.Second) // “Evil does not sleep. It waits.” - Galadriel
@@ -511,7 +511,7 @@ func TestGiteaCancelRun(t *testing.T) {
 		PollTimeout:     twait.DefaultTimeout,
 		TargetSHA:       topts.PullRequest.Head.Sha,
 	}
-	err := twait.UntilRepositoryUpdated(context.Background(), topts.ParamsRun.Clients, waitOpts)
+	_, err := twait.UntilRepositoryUpdated(context.Background(), topts.ParamsRun.Clients, waitOpts)
 	assert.Error(t, err, "pipelinerun has failed")
 
 	tgitea.CheckIfPipelineRunsCancelled(t, topts)
@@ -694,7 +694,7 @@ func TestGiteaPushToTagGreedy(t *testing.T) {
 		MinNumberStatus: 0,
 		PollTimeout:     twait.DefaultTimeout,
 	}
-	err = twait.UntilRepositoryUpdated(context.Background(), topts.ParamsRun.Clients, waitOpts)
+	_, err = twait.UntilRepositoryUpdated(context.Background(), topts.ParamsRun.Clients, waitOpts)
 	assert.NilError(t, err)
 }
 
@@ -750,7 +750,7 @@ func TestGiteaClusterTasks(t *testing.T) {
 		PollTimeout:     twait.DefaultTimeout,
 		TargetSHA:       topts.PullRequest.Head.Sha,
 	}
-	err = twait.UntilRepositoryUpdated(context.Background(), topts.ParamsRun.Clients, waitOpts)
+	_, err = twait.UntilRepositoryUpdated(context.Background(), topts.ParamsRun.Clients, waitOpts)
 	assert.NilError(t, err)
 
 	topts.CheckForStatus = "success"

--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/cctx"
 	tknpactest "github.com/openshift-pipelines/pipelines-as-code/test/pkg/cli"
 	tgitea "github.com/openshift-pipelines/pipelines-as-code/test/pkg/gitea"
@@ -47,7 +48,7 @@ var successRegexp = regexp.MustCompile(`^Pipelines as Code CI.*has.*successfully
 func TestGiteaPullRequestTaskAnnotations(t *testing.T) {
 	topts := &tgitea.TestOpts{
 		Regexp:      successRegexp,
-		TargetEvent: options.PullRequestEvent,
+		TargetEvent: triggertype.PullRequest.String(),
 		YAMLFiles: map[string]string{
 			".tekton/pipeline.yaml":                        "testdata/pipeline_in_tektondir.yaml",
 			".other-tasks/task-referenced-internally.yaml": "testdata/task_referenced_internally.yaml",
@@ -66,7 +67,7 @@ func TestGiteaPullRequestTaskAnnotations(t *testing.T) {
 func TestGiteaUseDisplayName(t *testing.T) {
 	topts := &tgitea.TestOpts{
 		Regexp:      regexp.MustCompile(`.*The Task name is Task.*`),
-		TargetEvent: options.PullRequestEvent,
+		TargetEvent: triggertype.PullRequest.String(),
 		YAMLFiles: map[string]string{
 			".tekton/pr.yaml": "testdata/pipelinerun.yaml",
 		},
@@ -83,7 +84,7 @@ func TestGiteaUseDisplayName(t *testing.T) {
 func TestGiteaPullRequestPipelineAnnotations(t *testing.T) {
 	topts := &tgitea.TestOpts{
 		Regexp:      successRegexp,
-		TargetEvent: options.PullRequestEvent,
+		TargetEvent: triggertype.PullRequest.String(),
 		YAMLFiles: map[string]string{
 			".tekton/pr.yaml": "testdata/pipelinerun_remote_pipeline_annotations.yaml",
 		},
@@ -101,7 +102,7 @@ func TestGiteaPullRequestPipelineAnnotations(t *testing.T) {
 func TestGiteaPullRequestPrivateRepository(t *testing.T) {
 	topts := &tgitea.TestOpts{
 		Regexp:      successRegexp,
-		TargetEvent: options.PullRequestEvent,
+		TargetEvent: triggertype.PullRequest.String(),
 		YAMLFiles: map[string]string{
 			".tekton/pipeline.yaml": "testdata/pipelinerun_git_clone_private-gitea.yaml",
 		},
@@ -118,7 +119,7 @@ func TestGiteaPullRequestPrivateRepository(t *testing.T) {
 // it can only success if it matches it.
 func TestGiteaBadYaml(t *testing.T) {
 	topts := &tgitea.TestOpts{
-		TargetEvent:  options.PullRequestEvent,
+		TargetEvent:  triggertype.PullRequest.String(),
 		YAMLFiles:    map[string]string{".tekton/pr-bad-format.yaml": "testdata/failures/pipeline_bad_format.yaml"},
 		ExpectEvents: true,
 	}
@@ -138,7 +139,7 @@ func TestGiteaMultiplesParallelPipelines(t *testing.T) {
 	}
 	topts := &tgitea.TestOpts{
 		Regexp:               successRegexp,
-		TargetEvent:          options.PullRequestEvent,
+		TargetEvent:          triggertype.PullRequest.String(),
 		YAMLFiles:            yamlFiles,
 		CheckForStatus:       "success",
 		CheckForNumberStatus: maxParallel,
@@ -157,7 +158,7 @@ func TestGiteaConcurrencyExclusivenessMultiplePipelines(t *testing.T) {
 	}
 	topts := &tgitea.TestOpts{
 		Regexp:               successRegexp,
-		TargetEvent:          options.PullRequestEvent,
+		TargetEvent:          triggertype.PullRequest.String(),
 		YAMLFiles:            yamlFiles,
 		CheckForStatus:       "success",
 		CheckForNumberStatus: numPipelines,
@@ -172,7 +173,7 @@ func TestGiteaConcurrencyExclusivenessMultiplePipelines(t *testing.T) {
 func TestGiteaConcurrencyExclusivenessMultipleRuns(t *testing.T) {
 	numPipelines := 1
 	topts := &tgitea.TestOpts{
-		TargetEvent:          options.PullRequestEvent,
+		TargetEvent:          triggertype.PullRequest.String(),
 		YAMLFiles:            map[string]string{".tekton/pr.yaml": "testdata/pipelinerun.yaml"},
 		CheckForNumberStatus: numPipelines,
 		ConcurrencyLimit:     github.Int(1),
@@ -245,7 +246,7 @@ func TestGiteaConcurrencyExclusivenessMultipleRuns(t *testing.T) {
 func TestGiteaRetestAfterPush(t *testing.T) {
 	topts := &tgitea.TestOpts{
 		Regexp:      regexp.MustCompile(`.*has <b>failed</b>`),
-		TargetEvent: options.PullRequestEvent,
+		TargetEvent: triggertype.PullRequest.String(),
 		YAMLFiles: map[string]string{
 			".tekton/pr.yaml": "testdata/failures/pipelinerun-exit-1.yaml",
 		},
@@ -275,7 +276,7 @@ func TestGiteaRetestAfterPush(t *testing.T) {
 func TestGiteaConfigMaxKeepRun(t *testing.T) {
 	topts := &tgitea.TestOpts{
 		Regexp:      successRegexp,
-		TargetEvent: options.PullRequestEvent,
+		TargetEvent: triggertype.PullRequest.String(),
 		YAMLFiles: map[string]string{
 			".tekton/pr.yaml": "testdata/pipelinerun-max-keep-run-1.yaml",
 		},
@@ -491,7 +492,7 @@ func TestGiteaWithCLIGeneratePipeline(t *testing.T) {
 
 func TestGiteaCancelRun(t *testing.T) {
 	topts := &tgitea.TestOpts{
-		TargetEvent: options.PullRequestEvent,
+		TargetEvent: triggertype.PullRequest.String(),
 		YAMLFiles: map[string]string{
 			".tekton/pr.yaml": "testdata/pipelinerun_long_running.yaml",
 		},
@@ -519,7 +520,7 @@ func TestGiteaCancelRun(t *testing.T) {
 func TestGiteaConcurrencyOrderedExecution(t *testing.T) {
 	topts := &tgitea.TestOpts{
 		Regexp:      successRegexp,
-		TargetEvent: options.PullRequestEvent,
+		TargetEvent: triggertype.PullRequest.String(),
 		YAMLFiles: map[string]string{
 			".tekton/pr.yaml": "testdata/pipelineruns-ordered-execution.yaml",
 		},
@@ -543,7 +544,7 @@ func TestGiteaConcurrencyOrderedExecution(t *testing.T) {
 
 func TestGiteaErrorSnippet(t *testing.T) {
 	topts := &tgitea.TestOpts{
-		TargetEvent: options.PullRequestEvent,
+		TargetEvent: triggertype.PullRequest.String(),
 		YAMLFiles: map[string]string{
 			".tekton/pr.yaml": "testdata/pipelinerun-error-snippet.yaml",
 		},
@@ -570,7 +571,7 @@ func TestGiteaErrorSnippetWithSecret(t *testing.T) {
 	assert.NilError(t, err)
 	assert.NilError(t, pacrepo.CreateNS(ctx, topts.TargetNS, topts.ParamsRun))
 	assert.NilError(t, secret.Create(ctx, topts.ParamsRun, map[string]string{"secret": "SHHHHHHH"}, topts.TargetNS, "pac-secret"))
-	topts.TargetEvent = options.PullRequestEvent
+	topts.TargetEvent = triggertype.PullRequest.String()
 	topts.YAMLFiles = map[string]string{
 		".tekton/pr.yaml": "testdata/pipelinerun-error-snippet-with-secret.yaml",
 	}
@@ -587,7 +588,7 @@ func TestGiteaErrorSnippetWithSecret(t *testing.T) {
 func TestGiteaNotExistingClusterTask(t *testing.T) {
 	topts := &tgitea.TestOpts{
 		Regexp:      regexp.MustCompile(`.*clustertasks.tekton.dev "foo-bar" not found`),
-		TargetEvent: options.PullRequestEvent,
+		TargetEvent: triggertype.PullRequest.String(),
 		YAMLFiles: map[string]string{
 			".tekton/pr.yaml": "testdata/failures/not-existing-clustertask.yaml",
 		},
@@ -603,7 +604,7 @@ func TestGiteaNotExistingClusterTask(t *testing.T) {
 // and inside the pac controller.
 func TestGiteaBadLinkOfTask(t *testing.T) {
 	topts := &tgitea.TestOpts{
-		TargetEvent: options.PullRequestEvent,
+		TargetEvent: triggertype.PullRequest.String(),
 		YAMLFiles: map[string]string{
 			".tekton/pr.yaml": "testdata/failures/bad-runafter-task.yaml",
 		},
@@ -622,7 +623,7 @@ func TestGiteaBadLinkOfTask(t *testing.T) {
 func TestGiteaProvenance(t *testing.T) {
 	topts := &tgitea.TestOpts{
 		SkipEventsCheck:       true,
-		TargetEvent:           options.PullRequestEvent,
+		TargetEvent:           triggertype.PullRequest.String(),
 		Settings:              &v1alpha1.Settings{PipelineRunProvenance: "default_branch"},
 		NoPullRequestCreation: true,
 	}
@@ -663,7 +664,7 @@ func TestGiteaProvenance(t *testing.T) {
 func TestGiteaPushToTagGreedy(t *testing.T) {
 	topts := &tgitea.TestOpts{
 		SkipEventsCheck:       true,
-		TargetEvent:           options.PushEvent,
+		TargetEvent:           triggertype.Push.String(),
 		NoPullRequestCreation: true,
 	}
 	_, f := tgitea.TestPR(t, topts)

--- a/test/github_incoming_test.go
+++ b/test/github_incoming_test.go
@@ -109,7 +109,17 @@ func verifyIncomingWebhook(t *testing.T, randomedString string, entries map[stri
 	runcnx.Clients.Log.Infof("Kicked off on incoming URL: %s", url)
 	assert.Assert(t, httpResp.StatusCode >= 200 && httpResp.StatusCode < 300)
 	// to re enable after debugging...
-	defer tgithub.TearDown(ctx, t, runcnx, ghprovider, -1, targetRefName, randomedString, opts)
+	g := tgithub.PRTest{
+		Cnx:             runcnx,
+		Options:         opts,
+		Provider:        ghprovider,
+		TargetNamespace: randomedString,
+		TargetRefName:   targetRefName,
+		PRNumber:        -1,
+		SHA:             sha,
+		Logger:          runcnx.Clients.Log,
+	}
+	defer g.TearDown(ctx, t)
 
 	sopt := wait.SuccessOpt{
 		Title:           title,

--- a/test/github_incoming_test.go
+++ b/test/github_incoming_test.go
@@ -12,8 +12,8 @@ import (
 	"testing"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	tgithub "github.com/openshift-pipelines/pipelines-as-code/test/pkg/github"
-	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/secret"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
@@ -30,7 +30,7 @@ func TestGithubAppIncoming(t *testing.T) {
 
 	entries, err := payload.GetEntries(map[string]string{
 		".tekton/pipelinerun-incoming.yaml": "testdata/pipelinerun-incoming.yaml", ".tekton/pr.yaml": "testdata/pipelinerun.yaml",
-	}, randomedString, randomedString, options.IncomingEvent, map[string]string{})
+	}, randomedString, randomedString, triggertype.Incoming.String(), map[string]string{})
 	assert.NilError(t, err)
 
 	verifyIncomingWebhook(t, randomedString, entries)
@@ -44,7 +44,7 @@ func TestGithubAppIncomingForDifferentEvent(t *testing.T) {
 
 	entries, err := payload.GetEntries(map[string]string{
 		".tekton/pipelinerun-incoming.yaml": "testdata/pipelinerun-incoming-generatename.yaml", ".tekton/pr.yaml": "testdata/pipelinerun.yaml",
-	}, randomedString, randomedString, options.PullRequestEvent, map[string]string{})
+	}, randomedString, randomedString, triggertype.PullRequest.String(), map[string]string{})
 	assert.NilError(t, err)
 
 	verifyIncomingWebhook(t, randomedString, entries)
@@ -113,7 +113,7 @@ func verifyIncomingWebhook(t *testing.T, randomedString string, entries map[stri
 
 	sopt := wait.SuccessOpt{
 		Title:           title,
-		OnEvent:         options.IncomingEvent,
+		OnEvent:         triggertype.Incoming.String(),
 		TargetNS:        randomedString,
 		NumberofPRMatch: 1,
 		SHA:             "",

--- a/test/github_pullrequest_concurrency_test.go
+++ b/test/github_pullrequest_concurrency_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/google/go-github/v56/github"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	tgithub "github.com/openshift-pipelines/pipelines-as-code/test/pkg/github"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
@@ -63,7 +64,7 @@ func TestGithubPullRequestConcurrency(t *testing.T) {
 		yamlFiles[fmt.Sprintf(".tekton/prlongrunnning-%d.yaml", i)] = "testdata/pipelinerun_long_running.yaml"
 	}
 
-	entries, err := payload.GetEntries(yamlFiles, targetNS, options.MainBranch, options.PullRequestEvent, map[string]string{})
+	entries, err := payload.GetEntries(yamlFiles, targetNS, options.MainBranch, triggertype.PullRequest.String(), map[string]string{})
 	assert.NilError(t, err)
 
 	targetRefName := fmt.Sprintf("refs/heads/%s",

--- a/test/github_pullrequest_concurrency_test.go
+++ b/test/github_pullrequest_concurrency_test.go
@@ -78,7 +78,17 @@ func TestGithubPullRequestConcurrency(t *testing.T) {
 	prNumber, err := tgithub.PRCreate(ctx, runcnx, ghcnx, opts.Organization,
 		opts.Repo, targetRefName, repoinfo.GetDefaultBranch(), logmsg)
 	assert.NilError(t, err)
-	defer tgithub.TearDown(ctx, t, runcnx, ghcnx, prNumber, targetRefName, targetNS, opts)
+	g := tgithub.PRTest{
+		Cnx:             runcnx,
+		Options:         opts,
+		Provider:        ghcnx,
+		TargetNamespace: targetNS,
+		TargetRefName:   targetRefName,
+		PRNumber:        prNumber,
+		SHA:             sha,
+		Logger:          runcnx.Clients.Log,
+	}
+	defer g.TearDown(ctx, t)
 
 	runcnx.Clients.Log.Info("waiting to let controller process the event")
 	time.Sleep(5 * time.Second)

--- a/test/github_pullrequest_oktotest_test.go
+++ b/test/github_pullrequest_oktotest_test.go
@@ -26,22 +26,25 @@ func TestGithubPullRequestOkToTest(t *testing.T) {
 		t.Skip("Skipping test since only enabled for nightly")
 	}
 	ctx := context.TODO()
-	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, sha := tgithub.RunPullRequest(ctx, t,
-		"Github OkToTest comment", []string{"testdata/pipelinerun.yaml"}, false, false)
-	defer tgithub.TearDown(ctx, t, runcnx, ghcnx, prNumber, targetRefName, targetNS, opts)
+	g := &tgithub.PRTest{
+		Label:     "Github OkToTest comment",
+		YamlFiles: []string{"testdata/pipelinerun.yaml"},
+	}
+	g.RunPullRequest(ctx, t)
+	defer g.TearDown(ctx, t)
 
-	repoinfo, resp, err := ghcnx.Client.Repositories.Get(ctx, opts.Organization, opts.Repo)
+	repoinfo, resp, err := g.Provider.Client.Repositories.Get(ctx, g.Options.Organization, g.Options.Repo)
 	assert.NilError(t, err)
 	if resp != nil && resp.StatusCode == http.StatusNotFound {
-		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
+		t.Errorf("Repository %s not found in %s", g.Options.Organization, g.Options.Repo)
 	}
 
 	runevent := info.Event{
 		DefaultBranch: repoinfo.GetDefaultBranch(),
-		Organization:  opts.Organization,
-		Repository:    opts.Repo,
+		Organization:  g.Options.Organization,
+		Repository:    g.Options.Repo,
 		URL:           repoinfo.GetHTMLURL(),
-		Sender:        opts.Organization,
+		Sender:        g.Options.Organization,
 	}
 
 	installID, err := strconv.ParseInt(os.Getenv("TEST_GITHUB_REPO_INSTALLATION_ID"), 10, 64)
@@ -59,7 +62,7 @@ func TestGithubPullRequestOkToTest(t *testing.T) {
 			PullRequestLinks: &github.PullRequestLinks{
 				HTMLURL: github.String(fmt.Sprintf("%s/%s/pull/%d",
 					os.Getenv("TEST_GITHUB_API_URL"),
-					os.Getenv("TEST_GITHUB_REPO_OWNER"), prNumber)),
+					os.Getenv("TEST_GITHUB_REPO_OWNER"), g.PRNumber)),
 			},
 		},
 		Repo: &github.Repository{
@@ -74,7 +77,7 @@ func TestGithubPullRequestOkToTest(t *testing.T) {
 	}
 
 	err = payload.Send(ctx,
-		runcnx,
+		g.Cnx,
 		os.Getenv("TEST_EL_URL"),
 		os.Getenv("TEST_EL_WEBHOOK_SECRET"),
 		os.Getenv("TEST_GITHUB_API_URL"),
@@ -84,19 +87,19 @@ func TestGithubPullRequestOkToTest(t *testing.T) {
 	)
 	assert.NilError(t, err)
 
-	runcnx.Clients.Log.Infof("Wait for the second repository update to be updated")
+	g.Cnx.Clients.Log.Infof("Wait for the second repository update to be updated")
 	waitOpts := twait.Opts{
-		RepoName:        targetNS,
-		Namespace:       targetNS,
+		RepoName:        g.TargetNamespace,
+		Namespace:       g.TargetNamespace,
 		MinNumberStatus: 1,
 		PollTimeout:     twait.DefaultTimeout,
-		TargetSHA:       sha,
+		TargetSHA:       g.SHA,
 	}
-	err = twait.UntilRepositoryUpdated(ctx, runcnx.Clients, waitOpts)
+	_, err = twait.UntilRepositoryUpdated(ctx, g.Cnx.Clients, waitOpts)
 	assert.NilError(t, err)
 
-	runcnx.Clients.Log.Infof("Check if we have the repository set as succeeded")
-	repo, err := runcnx.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(targetNS).Get(ctx, targetNS, metav1.GetOptions{})
+	g.Cnx.Clients.Log.Infof("Check if we have the repository set as succeeded")
+	repo, err := g.Cnx.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(g.TargetNamespace).Get(ctx, g.TargetNamespace, metav1.GetOptions{})
 	assert.NilError(t, err)
 	assert.Assert(t, repo.Status[len(repo.Status)-1].Conditions[0].Status == corev1.ConditionTrue)
 }

--- a/test/github_pullrequest_privaterepository_test.go
+++ b/test/github_pullrequest_privaterepository_test.go
@@ -16,16 +16,23 @@ func TestGithubPullRequestGitClone(t *testing.T) {
 		t.Skip("Skipping test since only enabled for nightly")
 	}
 	ctx := context.Background()
-	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, _ := tgithub.RunPullRequest(ctx, t,
-		"Github Private Repo", []string{"testdata/pipelinerun_git_clone_private.yaml"}, false, false)
-	defer tgithub.TearDown(ctx, t, runcnx, ghcnx, prNumber, targetRefName, targetNS, opts)
+	g := &tgithub.PRTest{
+		Label:     "Github - Private Repo",
+		YamlFiles: []string{"testdata/pipelinerun_git_clone_private.yaml"},
+	}
+	g.RunPullRequest(ctx, t)
+	defer g.TearDown(ctx, t)
 }
 
 func TestGithubSecondPullRequestGitClone(t *testing.T) {
 	ctx := context.Background()
-	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, _ := tgithub.RunPullRequest(ctx, t,
-		"Github Private Repo", []string{"testdata/pipelinerun_git_clone_private.yaml"}, true, false)
-	defer tgithub.TearDown(ctx, t, runcnx, ghcnx, prNumber, targetRefName, targetNS, opts)
+	g := &tgithub.PRTest{
+		Label:            "Github GHE - Private Repo",
+		YamlFiles:        []string{"testdata/pipelinerun_git_clone_private.yaml"},
+		SecondController: true,
+	}
+	g.RunPullRequest(ctx, t)
+	defer g.TearDown(ctx, t)
 }
 
 func TestGithubPullRequestPrivateRepositoryOnWebhook(t *testing.T) {
@@ -33,9 +40,13 @@ func TestGithubPullRequestPrivateRepositoryOnWebhook(t *testing.T) {
 		t.Skip("Skipping test since only enabled for nightly")
 	}
 	ctx := context.Background()
-	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, _ := tgithub.RunPullRequest(ctx, t,
-		"Github Private Repo OnWebhook", []string{"testdata/pipelinerun_git_clone_private.yaml"}, false, true)
-	defer tgithub.TearDown(ctx, t, runcnx, ghcnx, prNumber, targetRefName, targetNS, opts)
+	g := &tgithub.PRTest{
+		Label:     "Github Rerequest",
+		YamlFiles: []string{"testdata/pipelinerun_git_clone_private.yaml"},
+		Webhook:   true,
+	}
+	g.RunPullRequest(ctx, t)
+	defer g.TearDown(ctx, t)
 }
 
 // Local Variables:

--- a/test/github_pullrequest_test.go
+++ b/test/github_pullrequest_test.go
@@ -13,17 +13,23 @@ import (
 
 func TestGithubPullRequest(t *testing.T) {
 	ctx := context.Background()
-	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, _ := tgithub.RunPullRequest(ctx, t, "Github PullRequest",
-		[]string{"testdata/pipelinerun.yaml"}, false, false)
-	defer tgithub.TearDown(ctx, t, runcnx, ghcnx, prNumber, targetRefName, targetNS, opts)
+	g := &tgithub.PRTest{
+		Label:     "Github PullRequest",
+		YamlFiles: []string{"testdata/pipelinerun.yaml"},
+	}
+	g.RunPullRequest(ctx, t)
+	defer g.TearDown(ctx, t)
 }
 
 func TestGithubPullRequestSecondController(t *testing.T) {
 	ctx := context.Background()
-	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, _ := tgithub.RunPullRequest(
-		ctx, t, "Github PullRequest", []string{"testdata/pipelinerun.yaml"}, true, false,
-	)
-	defer tgithub.TearDown(ctx, t, runcnx, ghcnx, prNumber, targetRefName, targetNS, opts)
+	g := &tgithub.PRTest{
+		Label:            "Github Rerequest",
+		YamlFiles:        []string{"testdata/pipelinerun.yaml"},
+		SecondController: true,
+	}
+	g.RunPullRequest(ctx, t)
+	defer g.TearDown(ctx, t)
 }
 
 func TestGithubPullRequestMultiples(t *testing.T) {
@@ -31,9 +37,12 @@ func TestGithubPullRequestMultiples(t *testing.T) {
 		t.Skip("Skipping test since only enabled for nightly")
 	}
 	ctx := context.Background()
-	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, _ := tgithub.RunPullRequest(ctx, t, "Github PullRequest",
-		[]string{"testdata/pipelinerun.yaml", "testdata/pipelinerun-clone.yaml"}, false, false)
-	defer tgithub.TearDown(ctx, t, runcnx, ghcnx, prNumber, targetRefName, targetNS, opts)
+	g := &tgithub.PRTest{
+		Label:     "Github multiple PullRequest",
+		YamlFiles: []string{"testdata/pipelinerun.yaml", "testdata/pipelinerun-clone.yaml"},
+	}
+	g.RunPullRequest(ctx, t)
+	defer g.TearDown(ctx, t)
 }
 
 func TestGithubPullRequestMatchOnCEL(t *testing.T) {
@@ -41,16 +50,22 @@ func TestGithubPullRequestMatchOnCEL(t *testing.T) {
 		t.Skip("Skipping test since only enabled for nightly")
 	}
 	ctx := context.Background()
-	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, _ := tgithub.RunPullRequest(ctx, t, "Github PullRequest",
-		[]string{"testdata/pipelinerun-cel-annotation.yaml"}, false, false)
-	defer tgithub.TearDown(ctx, t, runcnx, ghcnx, prNumber, targetRefName, targetNS, opts)
+	g := &tgithub.PRTest{
+		Label:     "Github CEL Match",
+		YamlFiles: []string{"testdata/pipelinerun-cel-annotation.yaml"},
+	}
+	g.RunPullRequest(ctx, t)
+	defer g.TearDown(ctx, t)
 }
 
 func TestGithubPullRequestCELMatchOnTitle(t *testing.T) {
 	ctx := context.Background()
-	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, _ := tgithub.RunPullRequest(ctx, t, "Github PullRequest",
-		[]string{"testdata/pipelinerun-cel-annotation-for-title-match.yaml"}, false, false)
-	defer tgithub.TearDown(ctx, t, runcnx, ghcnx, prNumber, targetRefName, targetNS, opts)
+	g := &tgithub.PRTest{
+		Label:     "Github CEL Match on Title",
+		YamlFiles: []string{"testdata/pipelinerun-cel-annotation-for-title-match.yaml"},
+	}
+	g.RunPullRequest(ctx, t)
+	defer g.TearDown(ctx, t)
 }
 
 func TestGithubPullRequestWebhook(t *testing.T) {
@@ -63,9 +78,13 @@ func TestGithubPullRequestWebhook(t *testing.T) {
 	}
 	ctx := context.Background()
 
-	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, _ := tgithub.RunPullRequest(ctx, t,
-		"Github PullRequest onWebhook", []string{"testdata/pipelinerun.yaml"}, false, true)
-	defer tgithub.TearDown(ctx, t, runcnx, ghcnx, prNumber, targetRefName, targetNS, opts)
+	g := &tgithub.PRTest{
+		Label:     "Github PullRequest onWebhook",
+		YamlFiles: []string{"testdata/pipelinerun.yaml"},
+		Webhook:   true,
+	}
+	g.RunPullRequest(ctx, t)
+	defer g.TearDown(ctx, t)
 }
 
 // Local Variables:

--- a/test/github_push_test.go
+++ b/test/github_push_test.go
@@ -5,6 +5,7 @@ package test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 
@@ -17,23 +18,34 @@ func TestGithubPush(t *testing.T) {
 	}
 	ctx := context.Background()
 	if os.Getenv("TEST_GITHUB_REPO_OWNER_WEBHOOK") == "" {
-		runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, _ := tgithub.RunPushRequest(ctx, t,
-			"Github Push Request Webhook", []string{"testdata/pipelinerun-on-push.yaml"}, false, true)
-		defer tgithub.TearDown(ctx, t, runcnx, ghcnx, prNumber, targetRefName, targetNS, opts)
+		g := &tgithub.PRTest{
+			Label:            "Github push request on Webhook",
+			YamlFiles:        []string{"testdata/pipelinerun-on-push.yaml"},
+			SecondController: false,
+			Webhook:          true,
+		}
+		g.RunPushRequest(ctx, t)
+		defer g.TearDown(ctx, t)
 	} else {
 		t.Skip("TEST_GITHUB_REPO_OWNER_WEBHOOK is not set")
 	}
-	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, _ := tgithub.RunPushRequest(ctx, t,
-		"Github Push Request Apps", []string{"testdata/pipelinerun-on-push.yaml"}, false, false)
-	defer tgithub.TearDown(ctx, t, runcnx, ghcnx, prNumber, targetRefName, targetNS, opts)
+	g := &tgithub.PRTest{
+		Label:     "Github apps push request",
+		YamlFiles: []string{"testdata/pipelinerun-on-push.yaml"},
+	}
+	g.RunPushRequest(ctx, t)
+	defer g.TearDown(ctx, t)
 }
 
 func TestGithubSecondPush(t *testing.T) {
 	ctx := context.Background()
-
-	runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, _ := tgithub.RunPushRequest(ctx, t,
-		"Github Push Request GHE Apps", []string{"testdata/pipelinerun-on-push.yaml"}, true, false)
-	defer tgithub.TearDown(ctx, t, runcnx, ghcnx, prNumber, targetRefName, targetNS, opts)
+	g := &tgithub.PRTest{
+		Label:            "Github push request",
+		YamlFiles:        []string{"testdata/pipelinerun-on-push.yaml"},
+		SecondController: true,
+	}
+	g.RunPushRequest(ctx, t)
+	defer g.TearDown(ctx, t)
 }
 
 func TestGithubPushRequestCELMatchOnTitle(t *testing.T) {
@@ -43,8 +55,12 @@ func TestGithubPushRequestCELMatchOnTitle(t *testing.T) {
 			t.Skip("TEST_GITHUB_REPO_OWNER_WEBHOOK is not set")
 			continue
 		}
-		runcnx, ghcnx, opts, targetNS, targetRefName, prNumber, _ := tgithub.RunPushRequest(ctx, t,
-			"Github Push Request", []string{"testdata/pipelinerun-cel-annotation-for-title-match.yaml"}, false, onWebhook)
-		defer tgithub.TearDown(ctx, t, runcnx, ghcnx, prNumber, targetRefName, targetNS, opts)
+		g := &tgithub.PRTest{
+			Label:     fmt.Sprintf("Github push request test CEL match on title onWebhook=%v", onWebhook),
+			YamlFiles: []string{"testdata/pipelinerun-cel-annotation-for-title-match.yaml"},
+			Webhook:   onWebhook,
+		}
+		g.RunPushRequest(ctx, t)
+		defer g.TearDown(ctx, t)
 	}
 }

--- a/test/github_scope_token_to_list_of_private_public_repos_test.go
+++ b/test/github_scope_token_to_list_of_private_public_repos_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	pacv1alpha1 "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/configmap"
 	tgithub "github.com/openshift-pipelines/pipelines-as-code/test/pkg/github"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
@@ -98,7 +99,7 @@ func verifyGHTokenScope(t *testing.T, remoteTaskURL, remoteTaskName string, data
 		".tekton/pr.yaml":                              "testdata/pipelinerun_remote_task_annotations.yaml",
 		".tekton/pipeline.yaml":                        "testdata/pipeline_in_tektondir.yaml",
 		".other-tasks/task-referenced-internally.yaml": "testdata/task_referenced_internally.yaml",
-	}, targetNS, options.MainBranch, options.PullRequestEvent, map[string]string{
+	}, targetNS, options.MainBranch, triggertype.PullRequest.String(), map[string]string{
 		"RemoteTaskURL":  remoteTaskURL,
 		"RemoteTaskName": remoteTaskName,
 	})
@@ -183,7 +184,7 @@ func verifyGHTokenScope(t *testing.T, remoteTaskURL, remoteTaskName string, data
 	pr, err := runcnx.Clients.Tekton.TektonV1().PipelineRuns(targetNS).Get(ctx, laststatus.PipelineRunName, metav1.GetOptions{})
 	assert.NilError(t, err)
 
-	assert.Equal(t, options.PullRequestEvent, pr.Annotations[keys.EventType])
+	assert.Equal(t, triggertype.PullRequest.String(), pr.Annotations[keys.EventType])
 	assert.Equal(t, repo.GetName(), pr.Annotations[keys.Repository])
 	assert.Equal(t, sha, pr.Annotations[keys.SHA])
 	assert.Equal(t, opts.Organization, pr.Annotations[keys.URLOrg])

--- a/test/github_scope_token_to_list_of_private_public_repos_test.go
+++ b/test/github_scope_token_to_list_of_private_public_repos_test.go
@@ -157,8 +157,17 @@ func verifyGHTokenScope(t *testing.T, remoteTaskURL, remoteTaskName string, data
 	title := "TestPullRequestRemoteAnnotations - " + targetRefName
 	number, err := tgithub.PRCreate(ctx, runcnx, ghcnx, opts.Organization, opts.Repo, targetRefName, repoinfo.GetDefaultBranch(), title)
 	assert.NilError(t, err)
-
-	defer tgithub.TearDown(ctx, t, runcnx, ghcnx, number, targetRefName, targetNS, opts)
+	g := tgithub.PRTest{
+		Cnx:             runcnx,
+		Options:         opts,
+		Provider:        ghcnx,
+		TargetNamespace: targetNS,
+		TargetRefName:   targetRefName,
+		PRNumber:        number,
+		SHA:             sha,
+		Logger:          runcnx.Clients.Log,
+	}
+	defer g.TearDown(ctx, t)
 
 	runcnx.Clients.Log.Infof("Waiting for Repository to be updated")
 	waitOpts := twait.Opts{
@@ -168,7 +177,7 @@ func verifyGHTokenScope(t *testing.T, remoteTaskURL, remoteTaskName string, data
 		PollTimeout:     twait.DefaultTimeout,
 		TargetSHA:       sha,
 	}
-	err = twait.UntilRepositoryUpdated(ctx, runcnx.Clients, waitOpts)
+	_, err = twait.UntilRepositoryUpdated(ctx, runcnx.Clients, waitOpts)
 	assert.NilError(t, err)
 
 	runcnx.Clients.Log.Infof("Check if we have the repository set as succeeded")

--- a/test/github_tkn_pac_cli_test.go
+++ b/test/github_tkn_pac_cli_test.go
@@ -15,6 +15,7 @@ import (
 	pacv1alpha1 "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	tknpacdesc "github.com/openshift-pipelines/pipelines-as-code/pkg/cmd/tknpac/describe"
 	tknpaclist "github.com/openshift-pipelines/pipelines-as-code/pkg/cmd/tknpac/list"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	cli2 "github.com/openshift-pipelines/pipelines-as-code/test/pkg/cli"
 	tgithub "github.com/openshift-pipelines/pipelines-as-code/test/pkg/github"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
@@ -53,7 +54,7 @@ spec:
             - name: task
               image: gcr.io/google-containers/busybox
               command: ["/bin/echo", "HELLOMOTO"]
-`, targetNS, options.MainBranch, options.PullRequestEvent),
+`, targetNS, options.MainBranch, triggertype.PullRequest.String()),
 	}
 
 	repoinfo, resp, err := ghprovider.Client.Repositories.Get(ctx, opts.Organization, opts.Repo)

--- a/test/github_tkn_pac_cli_test.go
+++ b/test/github_tkn_pac_cli_test.go
@@ -97,7 +97,17 @@ spec:
 	number, err := tgithub.PRCreate(ctx, runcnx, ghprovider, opts.Organization, opts.Repo, targetRefName, repoinfo.GetDefaultBranch(), title)
 	assert.NilError(t, err)
 
-	defer tgithub.TearDown(ctx, t, runcnx, ghprovider, number, targetRefName, targetNS, opts)
+	g := tgithub.PRTest{
+		Cnx:             runcnx,
+		Options:         opts,
+		Provider:        ghprovider,
+		TargetNamespace: targetNS,
+		TargetRefName:   targetRefName,
+		PRNumber:        number,
+		SHA:             sha,
+		Logger:          runcnx.Clients.Log,
+	}
+	defer g.TearDown(ctx, t)
 
 	runcnx.Clients.Log.Infof("Waiting for Repository to be updated")
 	waitOpts := twait.Opts{
@@ -107,7 +117,7 @@ spec:
 		PollTimeout:     twait.DefaultTimeout,
 		TargetSHA:       sha,
 	}
-	err = twait.UntilRepositoryUpdated(ctx, runcnx.Clients, waitOpts)
+	_, err = twait.UntilRepositoryUpdated(ctx, runcnx.Clients, waitOpts)
 	assert.NilError(t, err)
 
 	runcnx.Clients.Log.Infof("Check if we have the repository set as succeeded")

--- a/test/gitlab_incoming_webhook_test.go
+++ b/test/gitlab_incoming_webhook_test.go
@@ -11,9 +11,9 @@ import (
 	"testing"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/cctx"
 	tgitlab "github.com/openshift-pipelines/pipelines-as-code/test/pkg/gitlab"
-	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/scm"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/secret"
@@ -62,7 +62,7 @@ func TestGitlabIncomingWebhook(t *testing.T) {
 	entries, err := payload.GetEntries(map[string]string{
 		".tekton/pipelinerun-incoming.yaml": "testdata/pipelinerun-incoming.yaml",
 		".tekton/subdir/pr.yaml":            "testdata/pipelinerun-clone.yaml",
-	}, randomedString, randomedString, options.IncomingEvent, map[string]string{})
+	}, randomedString, randomedString, triggertype.Incoming.String(), map[string]string{})
 	assert.NilError(t, err)
 
 	title := "TestIncomingWebhook - " + randomedString
@@ -93,7 +93,7 @@ func TestGitlabIncomingWebhook(t *testing.T) {
 
 	sopt := wait.SuccessOpt{
 		Title:           title,
-		OnEvent:         options.IncomingEvent,
+		OnEvent:         triggertype.Incoming.String(),
 		TargetNS:        randomedString,
 		NumberofPRMatch: 1,
 		SHA:             "",

--- a/test/gitlab_merge_request_test.go
+++ b/test/gitlab_merge_request_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/cctx"
 	tgitlab "github.com/openshift-pipelines/pipelines-as-code/test/pkg/gitlab"
-	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/scm"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
@@ -43,7 +43,7 @@ func TestGitlabMergeRequest(t *testing.T) {
 		".tekton/pipelinerun.yaml":       "testdata/pipelinerun.yaml",
 		".tekton/pipelinerun-clone.yaml": "testdata/pipelinerun-clone.yaml",
 	}, targetNS, projectinfo.DefaultBranch,
-		options.PullRequestEvent, map[string]string{})
+		triggertype.PullRequest.String(), map[string]string{})
 	assert.NilError(t, err)
 
 	targetRefName := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test")
@@ -77,7 +77,7 @@ func TestGitlabMergeRequest(t *testing.T) {
 	entries, err = payload.GetEntries(map[string]string{
 		"hello-world.yaml": "testdata/pipelinerun.yaml",
 	}, targetNS, projectinfo.DefaultBranch,
-		options.PullRequestEvent, map[string]string{})
+		triggertype.PullRequest.String(), map[string]string{})
 	assert.NilError(t, err)
 	scmOpts.BaseRefName = targetRefName
 	scm.PushFilesToRefGit(t, scmOpts, entries)

--- a/test/pkg/bitbucketcloud/pr.go
+++ b/test/pkg/bitbucketcloud/pr.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ktrysmt/go-bitbucket"
 	"github.com/mitchellh/mapstructure"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketcloud"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketcloud/types"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
@@ -21,7 +22,7 @@ func MakePR(t *testing.T, bprovider bitbucketcloud.Provider, runcnx *params.Run,
 
 	entries, err := payload.GetEntries(
 		map[string]string{".tekton/pipelinerun.yaml": "testdata/pipelinerun.yaml"},
-		targetNS, options.MainBranch, options.PullRequestEvent, map[string]string{})
+		targetNS, options.MainBranch, triggertype.PullRequest.String(), map[string]string{})
 	assert.NilError(t, err)
 	tmpfile := fs.NewFile(t, "pipelinerun", fs.WithContent(entries[".tekton/pipelinerun.yaml"]))
 	defer tmpfile.Remove()

--- a/test/pkg/github/pr.go
+++ b/test/pkg/github/pr.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/go-github/v56/github"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	ghprovider "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/github"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
@@ -122,7 +123,7 @@ func RunPullRequest(ctx context.Context, t *testing.T, label string, yamlFiles [
 		yamlEntries[filepath.Join(".tekton", filepath.Base(v))] = v
 	}
 
-	entries, err := payload.GetEntries(yamlEntries, targetNS, options.MainBranch, options.PullRequestEvent,
+	entries, err := payload.GetEntries(yamlEntries, targetNS, options.MainBranch, triggertype.PullRequest.String(),
 		map[string]string{"TargetURL": repoinfo.GetHTMLURL(), "SourceURL": repoinfo.GetHTMLURL()})
 	assert.NilError(t, err)
 
@@ -139,7 +140,7 @@ func RunPullRequest(ctx context.Context, t *testing.T, label string, yamlFiles [
 
 	sopt := wait.SuccessOpt{
 		Title:           logmsg,
-		OnEvent:         options.PullRequestEvent,
+		OnEvent:         triggertype.PullRequest.String(),
 		TargetNS:        targetNS,
 		NumberofPRMatch: len(yamlFiles),
 		SHA:             sha,
@@ -187,7 +188,7 @@ func RunPushRequest(ctx context.Context, t *testing.T, label string, yamlFiles [
 
 	sopt := wait.SuccessOpt{
 		Title:           logmsg,
-		OnEvent:         options.PushEvent,
+		OnEvent:         triggertype.Push.String(),
 		TargetNS:        targetNS,
 		NumberofPRMatch: len(yamlFiles),
 		SHA:             sha,

--- a/test/pkg/github/setup.go
+++ b/test/pkg/github/setup.go
@@ -6,16 +6,12 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"testing"
 
-	ghlib "github.com/google/go-github/v56/github"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/github"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/cctx"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
-	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/repository"
-	"gotest.tools/v3/assert"
 )
 
 func Setup(ctx context.Context, onSecondController, viaDirectWebhook bool) (context.Context, *params.Run, options.E2E, *github.Provider, error) {
@@ -117,25 +113,4 @@ func Setup(ctx context.Context, onSecondController, viaDirectWebhook bool) (cont
 	}
 
 	return ctx, run, e2eoptions, gprovider, nil
-}
-
-func TearDown(ctx context.Context, t *testing.T, runcnx *params.Run, ghprovider *github.Provider, prNumber int, ref, targetNS string, opts options.E2E) {
-	if os.Getenv("TEST_NOCLEANUP") == "true" {
-		runcnx.Clients.Log.Infof("Not cleaning up and closing PR since TEST_NOCLEANUP is set")
-		return
-	}
-	runcnx.Clients.Log.Infof("Closing PR %d", prNumber)
-	if prNumber != -1 {
-		state := "closed"
-		_, _, err := ghprovider.Client.PullRequests.Edit(ctx,
-			opts.Organization, opts.Repo, prNumber,
-			&ghlib.PullRequest{State: &state})
-		if err != nil {
-			t.Fatal(err)
-		}
-	}
-	repository.NSTearDown(ctx, t, runcnx, targetNS)
-	runcnx.Clients.Log.Infof("Deleting Ref %s", ref)
-	_, err := ghprovider.Client.Git.DeleteRef(ctx, opts.Organization, opts.Repo, ref)
-	assert.NilError(t, err)
 }

--- a/test/pkg/options/options.go
+++ b/test/pkg/options/options.go
@@ -11,10 +11,7 @@ type E2E struct {
 }
 
 var (
-	MainBranch       = "main"
-	PullRequestEvent = "pull_request"
-	PushEvent        = "push"
-	IncomingEvent    = "incoming"
-	RemoteTaskURL    = "https://raw.githubusercontent.com/openshift-pipelines/pipelines-as-code/main/pkg/pipelineascode/testdata/pull_request/.tekton/task.yaml"
-	RemoteTaskName   = "task-from-tektondir"
+	MainBranch     = "main"
+	RemoteTaskURL  = "https://raw.githubusercontent.com/openshift-pipelines/pipelines-as-code/main/pkg/pipelineascode/testdata/pull_request/.tekton/task.yaml"
+	RemoteTaskName = "task-from-tektondir"
 )

--- a/test/pkg/wait/wait.go
+++ b/test/pkg/wait/wait.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
+	pacv1alpha1 "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
 	corev1 "k8s.io/api/core/v1"
@@ -36,14 +37,14 @@ func UntilMinPRAppeared(ctx context.Context, clients clients.Clients, opts Opts,
 	})
 }
 
-func UntilRepositoryUpdated(ctx context.Context, clients clients.Clients, opts Opts) error {
+func UntilRepositoryUpdated(ctx context.Context, clients clients.Clients, opts Opts) (*pacv1alpha1.Repository, error) {
 	ctx, cancel := context.WithTimeout(ctx, opts.PollTimeout)
 	defer cancel()
-	return kubeinteraction.PollImmediateWithContext(ctx, opts.PollTimeout, func() (bool, error) {
+	var repo *pacv1alpha1.Repository
+	return repo, kubeinteraction.PollImmediateWithContext(ctx, opts.PollTimeout, func() (bool, error) {
 		clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(opts.Namespace)
-		r, err := clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(opts.Namespace).Get(ctx, opts.RepoName,
-			metav1.GetOptions{})
-		if err != nil {
+		var err error
+		if repo, err = clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(opts.Namespace).Get(ctx, opts.RepoName, metav1.GetOptions{}); err != nil {
 			return true, err
 		}
 
@@ -60,9 +61,9 @@ func UntilRepositoryUpdated(ctx context.Context, clients clients.Clients, opts O
 			}
 		}
 
-		clients.Log.Infof("Still waiting for repository status to be updated: %d/%d", len(r.Status), opts.MinNumberStatus)
+		clients.Log.Infof("Still waiting for repository status to be updated: %d/%d", len(repo.Status), opts.MinNumberStatus)
 		time.Sleep(2 * time.Second)
-		return len(r.Status) >= opts.MinNumberStatus, nil
+		return len(repo.Status) >= opts.MinNumberStatus, nil
 	})
 }
 


### PR DESCRIPTION
refactor the code to use the TriggerType type instead of options which
was all over the place

Move all comments logic to a separate package
    
There is still plenty to be done but trying to do it step by step as this code is quite complex and need to be tested properly.
    

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com># Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
