### PR TITLE
Print friendly error message on bad detected yaml

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -2,6 +2,8 @@ ignore: |
   /vendor
   .git
   test/testdata/failures/pipeline_bad_format.yaml
+  test/testdata/failures/bad-yaml.yaml
+  *badyaml.yaml
   .github/workflows/*
 
 rules:

--- a/docs/content/docs/guide/resolver.md
+++ b/docs/content/docs/guide/resolver.md
@@ -4,16 +4,30 @@ weight: 2
 ---
 # Pipelines-as-Code resolver
 
-Pipelines-as-Code resolver ensures the PipelineRun you are running does not
-conflicts with others.
+The Pipelines-as-Code resolver ensures that the PipelineRun you are running
+doesn't conflict with others.
 
-If `Pipelines-as-Code` sees a PipelineRun with a reference to a `Task` or to a
-`Pipeline` in any YAML file located in the `.tekton/` directory it will
-automatically try to *resolves* it (see below) as a single PipelineRun with an
-embedded `PipelineSpec` to a `PipelineRun`.
+Pipelines-as-Code parses any files ending with a `.yaml` or `.yml` suffix in
+the `.tekton` directory and subdirectory at the root of your repository. It
+will automatically attempt to detect any [Tekton](https://tekton.dev) resources
+like `Pipeline`, `PipelineRun`, `Task`.
+
+When detecting a [PipelineRun](https://tekton.dev/docs/pipelines/pipelineruns/) it will try to *resolve*
+it as a single PipelineRun with an embedded PipelineSpec of the referenced
+[Task](https://tekton.dev/docs/pipelines/tasks/) or
+[Pipeline](https://tekton.dev/docs/pipelines/pipelines/). This embedding
+ensures that all dependencies required for execution are contained within a
+single PipelineRun at the time of execution on the cluster.
+
+{{< hint info >}}
+The `Pipelines-as-Code` resolver is a different concept than the [Tekton resolver](https://tekton.dev/docs/pipelines/resolution-getting-started/), both are compatible and you can have the Tekton resolver within Pipelines-as-Code PipelineRun.
+{{< /hint >}}
+
+In any case of errors in any YAML files, parsing will halt, and errors will be
+reported on both the Git provider interface and the event's Namespace stream.
 
 The resolver will then transform the Pipeline `Name` field to a `GenerateName`
-based on the Pipeline name as well.
+based on the Pipeline name to ensure each PipelineRun is unique.
 
 If you want to split your Pipeline and PipelineRun, you can store  the files in the
 `.tekton/` directory or its subdirectories. `Pipeline` and `Task` can as well be

--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -150,6 +150,13 @@ func (p *PacRun) getPipelineRunsFromRepo(ctx context.Context, repo *v1alpha1.Rep
 		provenance = repo.Spec.Settings.PipelineRunProvenance
 	}
 	rawTemplates, err := p.vcx.GetTektonDir(ctx, p.event, tektonDir, provenance)
+	if err != nil && strings.Contains(err.Error(), "error unmarshalling yaml file") {
+		// make the error a bit more friendly for users who don't know what marshalling or intricacies of the yaml parser works
+		errmsg := err.Error()
+		errmsg = strings.ReplaceAll(errmsg, " error converting YAML to JSON: yaml:", "")
+		errmsg = strings.ReplaceAll(errmsg, "unmarshalling", "while parsing the")
+		return nil, fmt.Errorf(errmsg)
+	}
 	if err != nil || rawTemplates == "" {
 		msg := fmt.Sprintf("cannot locate templates in %s/ directory for this repository in %s", tektonDir, p.event.HeadBranch)
 		if err != nil {

--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -54,9 +54,9 @@ func (p *PacRun) Run(ctx context.Context) error {
 			Text:       fmt.Sprintf("There was an issue validating the commit: %q", err),
 			DetailsURL: p.run.Clients.ConsoleUI.URL(),
 		})
-		p.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "RepositoryCreateStatus", fmt.Sprintf("There was an error while processing the payload: %s", err))
+		p.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "RepositoryCreateStatus", fmt.Sprintf("an error occurred: %s", err))
 		if createStatusErr != nil {
-			p.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "RepositoryCreateStatus", fmt.Sprintf("Cannot create status: %s: %s", err, createStatusErr))
+			p.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "RepositoryCreateStatus", fmt.Sprintf("cannot create status: %s: %s", err, createStatusErr))
 		}
 	}
 	if len(matchedPRs) == 0 {

--- a/pkg/pipelineascode/testdata/bad_yaml/.tekton/badyaml.yaml
+++ b/pkg/pipelineascode/testdata/bad_yaml/.tekton/badyaml.yaml
@@ -1,0 +1,3 @@
+foo:
+    bar:
+   xlxlxl

--- a/pkg/provider/bitbucketcloud/bitbucket.go
+++ b/pkg/provider/bitbucketcloud/bitbucket.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketcloud/types"
 	"go.uber.org/zap"
+	"gopkg.in/yaml.v2"
 )
 
 var _ provider.Interface = (*Provider)(nil)
@@ -255,6 +256,10 @@ func (v *Provider) concatAllYamlFiles(objects []bitbucket.RepositoryFile, event 
 			data, err := v.getBlob(event, revision, value.Path)
 			if err != nil {
 				return "", err
+			}
+			var i any
+			if err := yaml.Unmarshal([]byte(data), &i); err != nil {
+				return "", fmt.Errorf("error unmarshalling yaml file %s: %w", value.Path, err)
 			}
 
 			if allTemplates != "" && !strings.HasPrefix(data, "---") {

--- a/pkg/provider/gitea/gitea.go
+++ b/pkg/provider/gitea/gitea.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	"go.uber.org/zap"
+	"gopkg.in/yaml.v2"
 )
 
 const (
@@ -250,6 +251,11 @@ func (v *Provider) concatAllYamlFiles(objects []gitea.GitEntry, event *info.Even
 			data, err := v.getObject(value.SHA, event)
 			if err != nil {
 				return "", err
+			}
+			// validate yaml
+			var i any
+			if err := yaml.Unmarshal(data, &i); err != nil {
+				return "", fmt.Errorf("error unmarshalling yaml file %s: %w", value.Path, err)
 			}
 			if allTemplates != "" && !strings.HasPrefix(string(data), "---") {
 				allTemplates += "---"

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	"go.uber.org/zap"
 	"golang.org/x/oauth2"
+	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -402,6 +403,11 @@ func (v *Provider) concatAllYamlFiles(ctx context.Context, objects []*github.Tre
 			data, err := v.getObject(ctx, value.GetSHA(), runevent)
 			if err != nil {
 				return "", err
+			}
+			// validate yaml
+			var i any
+			if err := yaml.Unmarshal(data, &i); err != nil {
+				return "", fmt.Errorf("error unmarshalling yaml file %s: %w", value.GetPath(), err)
 			}
 			if allTemplates != "" && !strings.HasPrefix(string(data), "---") {
 				allTemplates += "---"

--- a/pkg/provider/github/testdata/tree/badyaml/.tekton/badyaml.yaml
+++ b/pkg/provider/github/testdata/tree/badyaml/.tekton/badyaml.yaml
@@ -1,0 +1,3 @@
+foo:
+    bar:
+   xlxlxl

--- a/test/github_pullrequest_test.go
+++ b/test/github_pullrequest_test.go
@@ -5,10 +5,16 @@ package test
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/google/go-github/v56/github"
 	tgithub "github.com/openshift-pipelines/pipelines-as-code/test/pkg/github"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/golden"
 )
 
 func TestGithubPullRequest(t *testing.T) {
@@ -85,6 +91,46 @@ func TestGithubPullRequestWebhook(t *testing.T) {
 	}
 	g.RunPullRequest(ctx, t)
 	defer g.TearDown(ctx, t)
+}
+
+func TestGithubPullRequestSecondBadYaml(t *testing.T) {
+	ctx := context.Background()
+	g := &tgithub.PRTest{
+		Label:            "Github Rerequest",
+		YamlFiles:        []string{"testdata/failures/bad-yaml.yaml"},
+		SecondController: true,
+		NoStatusCheck:    true,
+	}
+	g.RunPullRequest(ctx, t)
+	defer g.TearDown(ctx, t)
+
+	opt := github.ListOptions{}
+	res := &github.ListCheckRunsResults{}
+	resp := &github.Response{}
+	var err error
+	counter := 0
+	for {
+		res, resp, err = g.Provider.Client.Checks.ListCheckRunsForRef(ctx, g.Options.Organization, g.Options.Repo, g.SHA, &github.ListCheckRunsOptions{
+			AppID:       g.Provider.ApplicationID,
+			ListOptions: opt,
+		})
+		assert.NilError(t, err)
+		assert.Equal(t, resp.StatusCode, 200)
+		if len(res.CheckRuns) > 0 {
+			break
+		}
+		g.Cnx.Clients.Log.Infof("Waiting for the check run to be created")
+		if counter > 10 {
+			t.Errorf("Check run not created after 10 tries")
+			break
+		}
+		time.Sleep(5 * time.Second)
+	}
+	assert.Equal(t, len(res.CheckRuns), 1)
+	assert.Equal(t, res.CheckRuns[0].GetOutput().GetTitle(), "Failed")
+	// may be fragile if we change the application name, but life goes on if it fails and we fix the name if that happen
+	assert.Equal(t, res.CheckRuns[0].GetOutput().GetSummary(), "Pipelines as Code GHE has <b>failed</b>.")
+	golden.Assert(t, res.CheckRuns[0].GetOutput().GetText(), strings.ReplaceAll(fmt.Sprintf("%s.golden", t.Name()), "/", "-"))
 }
 
 // Local Variables:

--- a/test/testdata/TestGithubPullRequestSecondBadYaml.golden
+++ b/test/testdata/TestGithubPullRequestSecondBadYaml.golden
@@ -1,0 +1,1 @@
+There was an issue validating the commit: "error while parsing the yaml file bad-yaml.yaml: line 3: could not find expected ':'"

--- a/test/testdata/failures/bad-yaml.yaml
+++ b/test/testdata/failures/bad-yaml.yaml
@@ -1,0 +1,3 @@
+foo: aaa 1
+1
+bar: - aaaa


### PR DESCRIPTION
We now print a more friendly error message when we detect a bad yaml by showing the errors on the git provider interface and the namespace events stream.

support github/bitbucket/gitlab/gitea

this is how it looks like:

![image](https://github.com/openshift-pipelines/pipelines-as-code/assets/98980/bac9faaf-6ab8-4fc5-906b-6d86a9c9c09a)

jira: https://issues.redhat.com/browse/SRVKP-4109

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
