### PR TITLE
Add on-comment annotation to match PipelineRun from a git provider comment

### DIFF
--- a/docs/content/docs/guide/running.md
+++ b/docs/content/docs/guide/running.md
@@ -141,6 +141,9 @@ roses are red, violets are blue. pipeline are bound to flake by design.
 /test <pipelinerun-name>
 ```
 
+You can expose custom GitOps commands on `Pull Request` comment via the
+[on-comment]({{< relref "/docs/guide/authoringprs.md#matching-a-pipelinerun-on-a-regexp-in-a-comment" >}}) annotation.
+
 ### GitOps command on push request
 
 To trigger GitOps commands in response to a push request, you can include `GitOps`

--- a/hack/dev/kind/gitea/gitea-deployment.yaml
+++ b/hack/dev/kind/gitea/gitea-deployment.yaml
@@ -76,6 +76,7 @@ data:
     REVERSE_PROXY_TRUSTED_PROXIES = *
     INTERNAL_TOKEN                = eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYmYiOjE2NTI3MTU2MTR9.oOW1-fGDSz0X2mrThNUwpw8uioEnwh1GcgAbZsHuQ4g
     PASSWORD_HASH_ALGO            = pbkdf2
+    MIN_PASSWORD_LENGTH           = 3
 
     [service]
     DISABLE_REGISTRATION              = false
@@ -157,7 +158,11 @@ spec:
             - name: GITEA_URL
               value: VAR_GITEA_URL
           command:
-            ["bash", "-xvec", "rm -rf /home/gitea/conf;cp -av /configmap /home/gitea/conf;rungitea"]
+            [
+              "bash",
+              "-xvec",
+              "rm -rf /home/gitea/conf;cp -av /configmap /home/gitea/conf;rungitea",
+            ]
           ports:
             - containerPort: 3000
           volumeMounts:

--- a/pkg/apis/pipelinesascode/keys/keys.go
+++ b/pkg/apis/pipelinesascode/keys/keys.go
@@ -47,6 +47,7 @@ const (
 	GitAuthSecret   = pipelinesascode.GroupName + "/git-auth-secret"
 	CheckRunID      = pipelinesascode.GroupName + "/check-run-id"
 	OnEvent         = pipelinesascode.GroupName + "/on-event"
+	OnComment       = pipelinesascode.GroupName + "/on-comment"
 	OnTargetBranch  = pipelinesascode.GroupName + "/on-target-branch"
 	OnCelExpression = pipelinesascode.GroupName + "/on-cel-expression"
 	TargetNamespace = pipelinesascode.GroupName + "/target-namespace"

--- a/pkg/customparams/customparams_test.go
+++ b/pkg/customparams/customparams_test.go
@@ -151,6 +151,7 @@ func TestProcessTemplates(t *testing.T) {
 				"source_url":            "",
 				"target_branch":         "",
 				"target_namespace":      "",
+				"trigger_comment":       "",
 			},
 			repository: &v1alpha1.Repository{
 				Spec: v1alpha1.RepositorySpec{},

--- a/pkg/customparams/standard.go
+++ b/pkg/customparams/standard.go
@@ -43,6 +43,7 @@ func (p *CustomParams) makeStandardParamsFromEvent(ctx context.Context) (map[str
 			"sender":           strings.ToLower(p.event.Sender),
 			"target_namespace": p.repo.GetNamespace(),
 			"event_type":       p.event.EventType,
+			"trigger_comment":  p.event.TriggerComment,
 		}, map[string]interface{}{
 			"all":      changedFiles.All,
 			"added":    changedFiles.Added,

--- a/pkg/customparams/standard_test.go
+++ b/pkg/customparams/standard_test.go
@@ -13,15 +13,16 @@ import (
 
 func TestMakeStandardParamsFromEvent(t *testing.T) {
 	event := &info.Event{
-		SHA:          "1234567890",
-		Organization: "Org",
-		Repository:   "Repo",
-		BaseBranch:   "main",
-		HeadBranch:   "foo",
-		EventType:    "pull_request",
-		Sender:       "SENDER",
-		URL:          "https://paris.com",
-		HeadURL:      "https://india.com",
+		SHA:            "1234567890",
+		Organization:   "Org",
+		Repository:     "Repo",
+		BaseBranch:     "main",
+		HeadBranch:     "foo",
+		EventType:      "pull_request",
+		Sender:         "SENDER",
+		URL:            "https://paris.com",
+		HeadURL:        "https://india.com",
+		TriggerComment: "/test me",
 	}
 
 	result := map[string]string{
@@ -35,6 +36,7 @@ func TestMakeStandardParamsFromEvent(t *testing.T) {
 		"source_branch":    "foo",
 		"target_branch":    "main",
 		"target_namespace": "myns",
+		"trigger_comment":  "/test me",
 	}
 
 	repo := &v1alpha1.Repository{

--- a/pkg/matcher/testdata/TestBuildAvailableMatchingAnnotationErr-Test_with_one_PipelineRun_and_one_annotation.golden
+++ b/pkg/matcher/testdata/TestBuildAvailableMatchingAnnotationErr-Test_with_one_PipelineRun_and_one_annotation.golden
@@ -1,0 +1,1 @@
+cannot match the event to any pipelineruns in the .tekton/ directory, payload target event is pull_request with source branch feature and target branch main. available annotations of the PipelineRuns annotations in .tekton/ dir: [PipelineRun: test-pipeline, annotations: on-event: pull_request]

--- a/pkg/opscomments/comments.go
+++ b/pkg/opscomments/comments.go
@@ -30,6 +30,7 @@ var (
 	TestSingleCommentEventType   = EventType("test-comment")
 	RetestSingleCommentEventType = EventType("retest-comment")
 	RetestAllCommentEventType    = EventType("retest-all-comment")
+	OnCommentEventType           = EventType("on-comment")
 	CancelCommentSingleEventType = EventType("cancel-comment")
 	CancelCommentAllEventType    = EventType("cancel-all-comment")
 	OkToTestCommentEventType     = EventType("ok-to-test-comment")
@@ -75,6 +76,7 @@ func SetEventTypeAndTargetPR(event *info.Event, comment string) {
 		event.TargetCancelPipelineRun = GetPipelineRunFromCancelComment(comment)
 	}
 	event.EventType = commentType.String()
+	event.TriggerComment = comment
 }
 
 func IsOkToTestComment(comment string) bool {
@@ -92,7 +94,8 @@ func IsAnyOpsEventType(eventType string) bool {
 		eventType == RetestSingleCommentEventType.String() ||
 		eventType == CancelCommentSingleEventType.String() ||
 		eventType == CancelCommentAllEventType.String() ||
-		eventType == OkToTestCommentEventType.String()
+		eventType == OkToTestCommentEventType.String() ||
+		eventType == OnCommentEventType.String()
 }
 
 func GetPipelineRunFromTestComment(comment string) string {

--- a/pkg/opscomments/comments_test.go
+++ b/pkg/opscomments/comments_test.go
@@ -49,6 +49,11 @@ func TestIsAnyOpsEventType(t *testing.T) {
 			want:      true,
 		},
 		{
+			name:      "OnCommentEventType",
+			eventType: OnCommentEventType.String(),
+			want:      true,
+		},
+		{
 			name:      "NoOpsCommentEventType",
 			eventType: NoOpsCommentEventType.String(),
 			want:      false,

--- a/pkg/params/info/events.go
+++ b/pkg/params/info/events.go
@@ -28,18 +28,20 @@ type Event struct {
 	// Target PipelineRun, the target PipelineRun user request. Used in incoming webhook
 	TargetPipelineRun string
 
-	BaseBranch        string // branch against where we are making the PR
-	DefaultBranch     string // master/main branches to know where things like the OWNERS file is located.
-	HeadBranch        string // branch from where our SHA get tested
-	BaseURL           string // url against where we are making the PR
-	HeadURL           string // url from where our SHA get tested
-	SHA               string
-	Sender            string
-	URL               string // WEB url not the git URL, which would match to the repo.spec
-	SHAURL            string // pretty URL for web browsing for UIs (cli/web)
-	SHATitle          string // commit title for UIs
+	BaseBranch    string // branch against where we are making the PR
+	DefaultBranch string // master/main branches to know where things like the OWNERS file is located.
+	HeadBranch    string // branch from where our SHA get tested
+	BaseURL       string // url against where we are making the PR
+	HeadURL       string // url from where our SHA get tested
+	SHA           string
+	Sender        string
+	URL           string // WEB url not the git URL, which would match to the repo.spec
+	SHAURL        string // pretty URL for web browsing for UIs (cli/web)
+	SHATitle      string // commit title for UIs
+
 	PullRequestNumber int    // Pull or Merge Request number
 	PullRequestTitle  string // Title of the pull Request
+	TriggerComment    string // The comment triggering the pipelinerun when using on-comment annotation
 
 	// TODO: move forge specifics to each driver
 	// Github

--- a/pkg/params/triggertype/types.go
+++ b/pkg/params/triggertype/types.go
@@ -8,6 +8,30 @@ func (t Trigger) String() string {
 	return string(t)
 }
 
+func StringToType(s string) Trigger {
+	switch s {
+	case OkToTest.String():
+		return OkToTest
+	case Retest.String():
+		return Retest
+	case Push.String():
+		return Push
+	case PullRequest.String():
+		return PullRequest
+	case Cancel.String():
+		return Cancel
+	case CheckSuiteRerequested.String():
+		return CheckSuiteRerequested
+	case CheckRunRerequested.String():
+		return CheckRunRerequested
+	case Incoming.String():
+		return Incoming
+	case Comment.String():
+		return Comment
+	}
+	return ""
+}
+
 const (
 	OkToTest              Trigger = "ok-to-test"
 	Retest                Trigger = "retest"
@@ -17,4 +41,5 @@ const (
 	CheckSuiteRerequested Trigger = "check-suite-rerequested"
 	CheckRunRerequested   Trigger = "check-run-rerequested"
 	Incoming              Trigger = "incoming"
+	Comment               Trigger = "comment"
 )

--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -24,7 +24,7 @@ import (
 func (p *PacRun) matchRepoPR(ctx context.Context) ([]matcher.Match, *v1alpha1.Repository, error) {
 	repo, err := p.verifyRepoAndUser(ctx)
 	if err != nil {
-		return nil, repo, err
+		return nil, nil, err
 	}
 	if repo == nil {
 		return nil, nil, nil
@@ -120,8 +120,8 @@ is that what you want? make sure you use -n when generating the secret, eg: echo
 	// on push we don't need to check the policy since the user has pushed to the repo so it has access to it.
 	// on comment we skip it for now, we are going to check later on
 	if p.event.TriggerTarget != triggertype.Push && p.event.EventType != opscomments.NoOpsCommentEventType.String() {
-		if allowed, err := p.checkAccessOrErrror(ctx, repo, ""); !allowed {
-			return repo, err
+		if allowed, err := p.checkAccessOrErrror(ctx, repo, "via "+p.event.TriggerTarget.String()); !allowed {
+			return nil, err
 		}
 	}
 	return repo, nil

--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -10,6 +10,8 @@ import (
 	apipac "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/matcher"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/opscomments"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/github"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/resolve"
@@ -115,29 +117,11 @@ is that what you want? make sure you use -n when generating the secret, eg: echo
 	}
 
 	// Check if the submitter is allowed to run this.
-	if p.event.TriggerTarget != "push" {
-		allowed, err := p.vcx.IsAllowed(ctx, p.event)
-		if err != nil {
+	// on push we don't need to check the policy since the user has pushed to the repo so it has access to it.
+	// on comment we skip it for now, we are going to check later on
+	if p.event.TriggerTarget != triggertype.Push && p.event.EventType != opscomments.NoOpsCommentEventType.String() {
+		if allowed, err := p.checkAccessOrErrror(ctx, repo, ""); !allowed {
 			return repo, err
-		}
-		if !allowed {
-			msg := fmt.Sprintf("User %s is not allowed to run CI on this repo.", p.event.Sender)
-			if p.event.AccountID != "" {
-				msg = fmt.Sprintf("User: %s AccountID: %s is not allowed to run CI on this repo.", p.event.Sender, p.event.AccountID)
-			}
-			p.eventEmitter.EmitMessage(repo, zap.InfoLevel, "RepositoryPermissionDenied", msg)
-
-			status := provider.StatusOpts{
-				Status:     "queued",
-				Title:      "Pending approval",
-				Conclusion: "pending",
-				Text:       msg,
-				DetailsURL: p.event.URL,
-			}
-			if err := p.vcx.CreateStatus(ctx, p.event, status); err != nil {
-				return repo, fmt.Errorf("failed to run create status, user is not allowed to run: %w", err)
-			}
-			return nil, nil
 		}
 	}
 	return repo, nil
@@ -204,6 +188,14 @@ func (p *PacRun) getPipelineRunsFromRepo(ctx context.Context, repo *v1alpha1.Rep
 		// Don't fail when you don't have a match between pipeline and annotations
 		p.eventEmitter.EmitMessage(nil, zap.WarnLevel, "RepositoryNoMatch", err.Error())
 		return nil, nil
+	}
+
+	// if the event is a comment event, but we don't have any match from the keys.OnComment then do the ACL checks again
+	// we skipped previously so we can get the match from the event to the pipelineruns
+	if p.event.EventType == opscomments.NoOpsCommentEventType.String() || p.event.EventType == opscomments.OnCommentEventType.String() {
+		if allowed, err := p.checkAccessOrErrror(ctx, repo, "by gitops comment"); !allowed {
+			return nil, err
+		}
 	}
 
 	// if event type is incoming then filter out the pipelineruns related to incoming event
@@ -313,4 +305,30 @@ func (p *PacRun) checkNeedUpdate(tmpl string) (string, bool) {
 		return `!Update needed! you have a old basic auth secret name, you need to modify your pipelinerun and change the string "secret: pac-git-basic-auth-{{repo_owner}}-{{repo_name}}" to "secret: {{ git_auth_secret }}"`, true
 	}
 	return "", false
+}
+
+func (p *PacRun) checkAccessOrErrror(ctx context.Context, repo *v1alpha1.Repository, viamsg string) (bool, error) {
+	allowed, err := p.vcx.IsAllowed(ctx, p.event)
+	if err != nil {
+		return false, err
+	}
+	if allowed {
+		return true, nil
+	}
+	msg := fmt.Sprintf("User %s is not allowed to trigger CI %s on this repo.", p.event.Sender, viamsg)
+	if p.event.AccountID != "" {
+		msg = fmt.Sprintf("User: %s AccountID: %s is not allowed to trigger CI %s on this repo.", p.event.Sender, p.event.AccountID, viamsg)
+	}
+	p.eventEmitter.EmitMessage(repo, zap.InfoLevel, "RepositoryPermissionDenied", msg)
+	status := provider.StatusOpts{
+		Status:     "queued",
+		Title:      "Pending approval",
+		Conclusion: "pending",
+		Text:       msg,
+		DetailsURL: p.event.URL,
+	}
+	if err := p.vcx.CreateStatus(ctx, p.event, status); err != nil {
+		return false, fmt.Errorf("failed to run create status, user is not allowed to run the CI:: %w", err)
+	}
+	return false, nil
 }

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -42,7 +42,9 @@ func (p *Policy) checkAllowed(ctx context.Context, tType triggertype.Trigger) (R
 	// NOTE: This make /retest /ok-to-test /test bound to the same policy, which is fine from a security standpoint but maybe we want to refine this in the future.
 	case triggertype.OkToTest, triggertype.Retest:
 		sType = settings.Policy.OkToTest
-	case triggertype.PullRequest:
+	// apply the same policy for PullRequest and comment
+	// we don't support comments on PRs yet but if we do on the future we will need our own policy
+	case triggertype.PullRequest, triggertype.Comment:
 		sType = settings.Policy.PullRequest
 		// NOTE: not supported yet, will imp if it gets requested and reasonable to implement
 	case triggertype.Push, triggertype.Cancel, triggertype.CheckSuiteRerequested, triggertype.CheckRunRerequested, triggertype.Incoming:

--- a/pkg/provider/gitea/detect.go
+++ b/pkg/provider/gitea/detect.go
@@ -70,7 +70,7 @@ func detectTriggerTypeFromPayload(ghEventType string, eventInt any) (triggertype
 				return triggertype.Cancel, ""
 			}
 			// this ignores the comment if it is not a PAC gitops comment and not return an error
-			return "", ""
+			return triggertype.Comment, ""
 		}
 		return "", "skip: not a PAC gitops comment"
 	}

--- a/pkg/provider/gitea/detect_test.go
+++ b/pkg/provider/gitea/detect_test.go
@@ -139,7 +139,7 @@ func TestProviderDetect(t *testing.T) {
 			processEvent: true,
 		},
 		{
-			name: "bad/issue comment",
+			name: "good/random issue comment",
 			args: args{
 				req: &http.Request{
 					Header: http.Header{
@@ -149,7 +149,7 @@ func TestProviderDetect(t *testing.T) {
 				payload: `{"action": "created", "comment":{"body": "YOYO/ok-to-test"}, "issue":{"pull_request": {"merged": false}, "state": "open"}}`,
 			},
 			isGitea:      true,
-			processEvent: false,
+			processEvent: true,
 		},
 		{
 			name: "bad/event not supported",

--- a/pkg/provider/gitea/gitea.go
+++ b/pkg/provider/gitea/gitea.go
@@ -170,15 +170,16 @@ func (v *Provider) createStatusCommit(event *info.Event, pacopts *info.PacOpts, 
 	if _, _, err := v.Client.CreateStatus(event.Organization, event.Repository, event.SHA, gStatus); err != nil {
 		return err
 	}
-	if event.EventType == triggertype.OkToTest.String() || event.EventType == triggertype.Retest.String() ||
-		event.EventType == triggertype.Cancel.String() {
-		event.EventType = triggertype.PullRequest.String()
+	eventType := event.EventType
+	if eventType == triggertype.OkToTest.String() || eventType == triggertype.Retest.String() ||
+		eventType == triggertype.Cancel.String() {
+		eventType = triggertype.PullRequest.String()
 	}
-	if opscomments.IsAnyOpsEventType(event.EventType) {
-		event.EventType = triggertype.PullRequest.String()
+	if opscomments.IsAnyOpsEventType(eventType) {
+		eventType = triggertype.PullRequest.String()
 	}
 
-	if status.Text != "" && (event.EventType == triggertype.PullRequest.String() || event.TriggerTarget == triggertype.PullRequest) {
+	if status.Text != "" && (eventType == triggertype.PullRequest.String() || event.TriggerTarget == triggertype.PullRequest) {
 		status.Text = strings.ReplaceAll(strings.TrimSpace(status.Text), "<br>", "\n")
 		_, _, err := v.Client.CreateIssueComment(event.Organization, event.Repository,
 			int64(event.PullRequestNumber), gitea.CreateIssueCommentOption{

--- a/pkg/provider/github/detect.go
+++ b/pkg/provider/github/detect.go
@@ -77,7 +77,7 @@ func detectTriggerTypeFromPayload(ghEventType string, eventInt any) (triggertype
 				return triggertype.Cancel, ""
 			}
 		}
-		return "", "comment: not a PAC gitops pull request comment"
+		return triggertype.Comment, ""
 	case *github.CheckSuiteEvent:
 		if event.GetAction() == "rerequested" && event.GetCheckSuite() != nil {
 			return triggertype.CheckSuiteRerequested, ""

--- a/pkg/provider/github/detect_test.go
+++ b/pkg/provider/github/detect_test.go
@@ -93,7 +93,7 @@ func TestProvider_Detect(t *testing.T) {
 			},
 			eventType:  "issue_comment",
 			isGH:       true,
-			processReq: false,
+			processReq: true,
 		},
 		{
 			name: "issue comment Event with no valid comment",
@@ -112,7 +112,7 @@ func TestProvider_Detect(t *testing.T) {
 			},
 			eventType:  "issue_comment",
 			isGH:       true,
-			processReq: false,
+			processReq: true,
 		},
 		{
 			name: "issue comment Event with ok-to-test comment",

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -300,7 +300,7 @@ func (v *Provider) GetTektonDir(ctx context.Context, runevent *info.Event, path,
 		revision = runevent.DefaultBranch
 		v.Logger.Infof("Using PipelineRun definition from default_branch: %s", runevent.DefaultBranch)
 	} else {
-		v.Logger.Infof("Using PipelineRun definition from source pull request SHA: %s", runevent.SHA)
+		v.Logger.Infof("Using PipelineRun definition from source pull request %s/%s#%d SHA on %s", runevent.Organization, runevent.Repository, runevent.PullRequestNumber, runevent.SHA)
 	}
 
 	rootobjects, _, err := v.Client.Git.GetTree(ctx, runevent.Organization, runevent.Repository, revision, false)

--- a/pkg/provider/github/github_test.go
+++ b/pkg/provider/github/github_test.go
@@ -242,7 +242,7 @@ func TestGetTektonDir(t *testing.T) {
 			},
 			expectedString:       "PipelineRun",
 			treepath:             "testdata/tree/simple",
-			filterMessageSnippet: "Using PipelineRun definition from source pull request SHA",
+			filterMessageSnippet: "Using PipelineRun definition from source pull request tekton/cat#0",
 		},
 		{
 			name: "test provenance default_branch ",

--- a/pkg/provider/gitlab/detect.go
+++ b/pkg/provider/gitlab/detect.go
@@ -51,17 +51,9 @@ func (v *Provider) Detect(req *http.Request, payload string, logger *zap.Sugared
 		return setLoggerAndProceed(true, "", nil)
 	case *gitlab.MergeCommentEvent:
 		if gitEvent.MergeRequest.State == "opened" {
-			if provider.IsTestRetestComment(gitEvent.ObjectAttributes.Note) {
-				return setLoggerAndProceed(true, "", nil)
-			}
-			if provider.IsOkToTestComment(gitEvent.ObjectAttributes.Note) {
-				return setLoggerAndProceed(true, "", nil)
-			}
-			if provider.IsCancelComment(gitEvent.ObjectAttributes.Note) {
-				return setLoggerAndProceed(true, "", nil)
-			}
+			return setLoggerAndProceed(true, "", nil)
 		}
-		return setLoggerAndProceed(false, "not a gitops style merge comment event", nil)
+		return setLoggerAndProceed(false, "comments on closed merge requests is not supported", nil)
 	default:
 		return setLoggerAndProceed(false, "", fmt.Errorf("gitlab: event \"%s\" is not supported", event))
 	}

--- a/pkg/provider/gitlab/detect_test.go
+++ b/pkg/provider/gitlab/detect_test.go
@@ -57,6 +57,13 @@ func TestProvider_Detect(t *testing.T) {
 			processReq: true,
 		},
 		{
+			name:       "bad/mergeRequest closed Event",
+			event:      sample.MREventAsJSON("closed", ""),
+			eventType:  gitlab.EventTypeMergeRequest,
+			isGL:       true,
+			processReq: false,
+		},
+		{
 			name:       "good/mergeRequest update Event with commit",
 			event:      sample.MREventAsJSON("update", `"oldrev": "123"`),
 			eventType:  gitlab.EventTypeMergeRequest,
@@ -71,11 +78,11 @@ func TestProvider_Detect(t *testing.T) {
 			processReq: false,
 		},
 		{
-			name:       "bad/note event with no valid comment",
+			name:       "good/note event",
 			event:      sample.NoteEventAsJSON("abc"),
 			eventType:  gitlab.EventTypeNote,
 			isGL:       true,
-			processReq: false,
+			processReq: true,
 		},
 		{
 			name:       "bad/note Event with ok-to-test comment",
@@ -85,11 +92,11 @@ func TestProvider_Detect(t *testing.T) {
 			processReq: true,
 		},
 		{
-			name:       "bad/issue comment Event with ok-to-test and some string",
+			name:       "good/issue comment Event with ok-to-test and some string",
 			event:      sample.NoteEventAsJSON("abc /ok-to-test"),
 			eventType:  gitlab.EventTypeNote,
 			isGL:       true,
-			processReq: false,
+			processReq: true,
 		},
 		{
 			name:       "good/issue comment Event with retest",

--- a/pkg/provider/gitlab/parse_payload.go
+++ b/pkg/provider/gitlab/parse_payload.go
@@ -59,6 +59,7 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 		processedEvent.TriggerTarget = triggertype.PullRequest
 		processedEvent.SourceProjectID = gitEvent.ObjectAttributes.SourceProjectID
 		processedEvent.TargetProjectID = gitEvent.Project.ID
+		processedEvent.EventType = strings.ReplaceAll(event, " Hook", "")
 	case *gitlab.TagEvent:
 		lastCommitIdx := len(gitEvent.Commits) - 1
 		processedEvent.Sender = gitEvent.UserUsername
@@ -79,6 +80,7 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 		v.userID = gitEvent.UserID
 		processedEvent.SourceProjectID = gitEvent.ProjectID
 		processedEvent.TargetProjectID = gitEvent.ProjectID
+		processedEvent.EventType = strings.ReplaceAll(event, " Hook", "")
 	case *gitlab.PushEvent:
 		if len(gitEvent.Commits) == 0 {
 			return nil, fmt.Errorf("no commits attached to this push event")
@@ -102,6 +104,7 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 		v.userID = gitEvent.UserID
 		processedEvent.SourceProjectID = gitEvent.ProjectID
 		processedEvent.TargetProjectID = gitEvent.ProjectID
+		processedEvent.EventType = strings.ReplaceAll(event, " Hook", "")
 	case *gitlab.MergeCommentEvent:
 		processedEvent.Sender = gitEvent.User.Username
 		processedEvent.DefaultBranch = gitEvent.Project.DefaultBranch
@@ -116,7 +119,6 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 		processedEvent.HeadURL = gitEvent.MergeRequest.Source.WebURL
 
 		opscomments.SetEventTypeAndTargetPR(processedEvent, gitEvent.ObjectAttributes.Note)
-
 		v.pathWithNamespace = gitEvent.Project.PathWithNamespace
 		processedEvent.Organization, processedEvent.Repository = getOrgRepo(v.pathWithNamespace)
 		processedEvent.TriggerTarget = triggertype.PullRequest

--- a/pkg/reconciler/event.go
+++ b/pkg/reconciler/event.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketcloud"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketserver"
@@ -63,6 +64,7 @@ func buildEventFromPipelineRun(pr *tektonv1.PipelineRun) *info.Event {
 	event.Organization = repo
 	event.Repository = org
 	event.EventType = prAnno[keys.EventType]
+	event.TriggerTarget = triggertype.StringToType(prAnno[keys.EventType])
 	event.BaseBranch = prAnno[keys.Branch]
 	event.SHA = prAnno[keys.SHA]
 

--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -113,8 +113,9 @@ func TestGiteaPullRequestPrivateRepository(t *testing.T) {
 	}
 	ctx, f := tgitea.TestPR(t, topts)
 	defer f()
-	assert.NilError(t, twait.RegexpMatchingInControllerLog(ctx, topts.ParamsRun, *regexp.MustCompile(
-		".*fetched git-clone task"), 10, "controller"))
+	reg := regexp.MustCompile(".*fetched git-clone task")
+	err := twait.RegexpMatchingInControllerLog(ctx, topts.ParamsRun, *reg, 10, "controller", github.Int64(20))
+	assert.NilError(t, err)
 	tgitea.WaitForSecretDeletion(t, topts, topts.TargetRefName)
 }
 
@@ -131,7 +132,7 @@ func TestGiteaBadYaml(t *testing.T) {
 	ctx, f := tgitea.TestPR(t, topts)
 	defer f()
 	assert.NilError(t, twait.RegexpMatchingInControllerLog(ctx, topts.ParamsRun, *regexp.MustCompile(
-		"pipelinerun.*has failed.*expected exactly one, got neither: spec.pipelineRef, spec.pipelineSpec"), 10, "controller"))
+		"pipelinerun.*has failed.*expected exactly one, got neither: spec.pipelineRef, spec.pipelineSpec"), 10, "controller", github.Int64(20)))
 }
 
 // don't test concurrency limit here, just parallel pipeline.
@@ -619,7 +620,7 @@ func TestGiteaBadLinkOfTask(t *testing.T) {
 	ctx, f := tgitea.TestPR(t, topts)
 	defer f()
 	errre := regexp.MustCompile("There was an error starting the PipelineRun")
-	assert.NilError(t, twait.RegexpMatchingInControllerLog(ctx, topts.ParamsRun, *errre, 10, "controller"))
+	assert.NilError(t, twait.RegexpMatchingInControllerLog(ctx, topts.ParamsRun, *errre, 10, "controller", github.Int64(20)))
 }
 
 // TestGiteaParamsOnRepoCR test gitea params on CR and its filters

--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -22,6 +22,7 @@ import (
 	tknpaclist "github.com/openshift-pipelines/pipelines-as-code/pkg/cmd/tknpac/list"
 	tknpacresolve "github.com/openshift-pipelines/pipelines-as-code/pkg/cmd/tknpac/resolve"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/git"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/opscomments"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
@@ -758,6 +759,58 @@ func TestGiteaClusterTasks(t *testing.T) {
 
 	topts.CheckForStatus = "success"
 	tgitea.WaitForStatus(t, topts, topts.TargetRefName, "", true)
+}
+
+// TestGiteaOnCommentAnnotation test custom annotations for gitops comment.
+func TestGiteaOnCommentAnnotation(t *testing.T) {
+	var err error
+	ctx := context.Background()
+	topts := &tgitea.TestOpts{
+		TargetRefName: names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test"),
+	}
+	triggerComment := "/hello-world"
+	topts.TargetNS = topts.TargetRefName
+	topts.ParamsRun, topts.Opts, topts.GiteaCNX, err = tgitea.Setup(ctx)
+	assert.NilError(t, err, fmt.Errorf("cannot do gitea setup: %w", err))
+	ctx, err = cctx.GetControllerCtxInfo(ctx, topts.ParamsRun)
+	assert.NilError(t, err)
+	assert.NilError(t, pacrepo.CreateNS(ctx, topts.TargetNS, topts.ParamsRun))
+	assert.NilError(t, secret.Create(ctx, topts.ParamsRun, map[string]string{"secret": "SHHHHHHH"}, topts.TargetNS, "pac-secret"))
+	topts.TargetEvent = triggertype.PullRequest.String()
+	topts.YAMLFiles = map[string]string{
+		".tekton/on-comment-match.yaml":   "testdata/pipelinerun-on-comment-annotation.yaml",
+		".tekton/pull-request-match.yaml": "testdata/pipelinerun.yaml",
+	}
+	_, f := tgitea.TestPR(t, topts)
+	defer f()
+	tgitea.WaitForStatus(t, topts, "heads/"+topts.TargetRefName, "", false)
+
+	tgitea.PostCommentOnPullRequest(t, topts, triggerComment)
+	// we have two status one for the pull request match and one on comment match from the comment sent
+	waitOpts := twait.Opts{
+		RepoName:        topts.TargetNS,
+		Namespace:       topts.TargetNS,
+		MinNumberStatus: 2,
+		PollTimeout:     twait.DefaultTimeout,
+	}
+	_, err = twait.UntilRepositoryUpdated(context.Background(), topts.ParamsRun.Clients, waitOpts)
+	assert.NilError(t, err)
+
+	tgitea.PostCommentOnPullRequest(t, topts, triggerComment)
+	waitOpts.MinNumberStatus = 3
+	// now we should have only 3 status, the last one is the on comment match from the comment sent
+	// but should not have matched the pull request ones
+	repo, err := twait.UntilRepositoryUpdated(context.Background(), topts.ParamsRun.Clients, waitOpts)
+	assert.NilError(t, err)
+	assert.Equal(t, len(repo.Status), waitOpts.MinNumberStatus, fmt.Sprintf("should have only %d status", waitOpts.MinNumberStatus))
+	assert.Equal(t, *repo.Status[len(repo.Status)-1].EventType, opscomments.OnCommentEventType.String(), "should have a on comment event type")
+
+	last := repo.Status[len(repo.Status)-1]
+	err = twait.RegexpMatchingInPodLog(context.Background(),
+		topts.ParamsRun,
+		topts.TargetNS,
+		fmt.Sprintf("tekton.dev/pipelineRun=%s", last.PipelineRunName), "step-task", *regexp.MustCompile(triggerComment), 2)
+	assert.NilError(t, err)
 }
 
 // Local Variables:

--- a/test/github_pullrequest_privaterepository_test.go
+++ b/test/github_pullrequest_privaterepository_test.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/google/go-github/v56/github"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/cctx"
 	tgithub "github.com/openshift-pipelines/pipelines-as-code/test/pkg/github"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
@@ -29,7 +30,7 @@ func TestGithubPullRequestGitClone(t *testing.T) {
 	ctx, err := cctx.GetControllerCtxInfo(ctx, g.Cnx)
 	assert.NilError(t, err)
 	assert.NilError(t, wait.RegexpMatchingInControllerLog(ctx, g.Cnx, *regexp.MustCompile(".*fetched git-clone task"),
-		10, "controller"), "Error while checking the logs of the pipelines-as-code controller pod")
+		10, "controller", github.Int64(20)), "Error while checking the logs of the pipelines-as-code controller pod")
 	defer g.TearDown(ctx, t)
 }
 

--- a/test/github_pullrequest_retest_test.go
+++ b/test/github_pullrequest_retest_test.go
@@ -18,7 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestGithubPullRequestRetest(t *testing.T) {
+func TestGithubSecondPullRequestRetest(t *testing.T) {
 	if os.Getenv("NIGHTLY_E2E_TEST") != "true" {
 		t.Skip("Skipping test since only enabled for nightly")
 	}

--- a/test/github_pullrequest_test_comment_test.go
+++ b/test/github_pullrequest_test_comment_test.go
@@ -98,4 +98,5 @@ func TestGithubSecondOnCommentAnnotation(t *testing.T) {
 		"step-task",
 		*regexp.MustCompile(triggerComment),
 		2)
+	assert.NilError(t, err)
 }

--- a/test/github_pullrequest_test_comment_test.go
+++ b/test/github_pullrequest_test_comment_test.go
@@ -5,15 +5,17 @@ package test
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/google/go-github/v56/github"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/opscomments"
 	tgithub "github.com/openshift-pipelines/pipelines-as-code/test/pkg/github"
 	twait "github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
 	"gotest.tools/v3/assert"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestGithubPullRequestTest(t *testing.T) {
@@ -44,11 +46,56 @@ func TestGithubPullRequestTest(t *testing.T) {
 		PollTimeout:     twait.DefaultTimeout,
 		TargetSHA:       g.SHA,
 	}
-	_, err = twait.UntilRepositoryUpdated(ctx, g.Cnx.Clients, waitOpts)
+	repo, err := twait.UntilRepositoryUpdated(ctx, g.Cnx.Clients, waitOpts)
 	assert.NilError(t, err)
-
 	g.Cnx.Clients.Log.Infof("Check if we have the repository set as succeeded")
-	repo, err := g.Cnx.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(g.TargetNamespace).Get(ctx, g.TargetNamespace, metav1.GetOptions{})
-	assert.NilError(t, err)
 	assert.Assert(t, repo.Status[len(repo.Status)-1].Conditions[0].Status == corev1.ConditionTrue)
+}
+
+func TestGithubSecondOnCommentAnnotation(t *testing.T) {
+	g := &tgithub.PRTest{
+		Label:            "Github test implicit comment",
+		YamlFiles:        []string{"testdata/pipelinerun-on-comment-annotation.yaml"},
+		SecondController: true,
+		NoStatusCheck:    true,
+	}
+	ctx := context.Background()
+	g.RunPullRequest(ctx, t)
+	defer g.TearDown(ctx, t)
+
+	triggerComment := "/hello-world"
+
+	g.Cnx.Clients.Log.Infof("Creating %s custom comment on PullRequest", triggerComment)
+	_, _, err := g.Provider.Client.Issues.CreateComment(ctx, g.Options.Organization, g.Options.Repo, g.PRNumber,
+		&github.IssueComment{Body: github.String(triggerComment)})
+	assert.NilError(t, err)
+	sopt := twait.SuccessOpt{
+		Title:           fmt.Sprintf("Testing %s with Github APPS integration on %s", g.Label, g.TargetNamespace),
+		OnEvent:         opscomments.OnCommentEventType.String(),
+		TargetNS:        g.TargetNamespace,
+		NumberofPRMatch: 1,
+	}
+	twait.Succeeded(ctx, t, g.Cnx, g.Options, sopt)
+
+	waitOpts := twait.Opts{
+		RepoName:        g.TargetNamespace,
+		Namespace:       g.TargetNamespace,
+		MinNumberStatus: 1,
+		PollTimeout:     twait.DefaultTimeout,
+		TargetSHA:       g.SHA,
+	}
+	repo, err := twait.UntilRepositoryUpdated(ctx, g.Cnx.Clients, waitOpts)
+	assert.NilError(t, err)
+	g.Cnx.Clients.Log.Infof("Check if we have the repository set as succeeded")
+	assert.Assert(t, repo.Status[len(repo.Status)-1].Conditions[0].Status == corev1.ConditionTrue)
+	lastPrName := repo.Status[len(repo.Status)-1].PipelineRunName
+
+	err = twait.RegexpMatchingInPodLog(
+		context.Background(),
+		g.Cnx,
+		g.TargetNamespace,
+		fmt.Sprintf("tekton.dev/pipelineRun=%s", lastPrName),
+		"step-task",
+		*regexp.MustCompile(triggerComment),
+		2)
 }

--- a/test/pkg/gitea/test.go
+++ b/test/pkg/gitea/test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"code.gitea.io/sdk/gitea"
+	"github.com/google/go-github/v56/github"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
@@ -496,8 +497,11 @@ func GetStandardParams(t *testing.T, topts *TestOpts, eventType string) (repoURL
 			t.Fatalf("pipelinerun has not finished, something is fishy")
 		}
 	}
-	out, err := tlogs.GetPodLog(context.Background(), topts.ParamsRun.Clients.Kube.CoreV1(), topts.TargetNS, fmt.Sprintf("tekton.dev/pipelineRun=%s",
-		prs.Items[0].Name), "step-test-standard-params-value")
+	out, err := tlogs.GetPodLog(context.Background(),
+		topts.ParamsRun.Clients.Kube.CoreV1(),
+		topts.TargetNS, fmt.Sprintf("tekton.dev/pipelineRun=%s",
+			prs.Items[0].Name), "step-test-standard-params-value",
+		github.Int64(10))
 	assert.NilError(t, err)
 	assert.Assert(t, out != "")
 	out = strings.TrimSpace(out)

--- a/test/pkg/logs/pod.go
+++ b/test/pkg/logs/pod.go
@@ -19,10 +19,10 @@ func GetControllerLog(ctx context.Context, kclient corev1i.CoreV1Interface, labe
 		return "", err
 	}
 
-	return GetPodLog(ctx, kclient, ns, labelselector, containerName)
+	return GetPodLog(ctx, kclient, ns, labelselector, containerName, github.Int64(10))
 }
 
-func GetPodLog(ctx context.Context, kclient corev1i.CoreV1Interface, ns, labelselector, containerName string) (string, error) {
+func GetPodLog(ctx context.Context, kclient corev1i.CoreV1Interface, ns, labelselector, containerName string, lines *int64) (string, error) {
 	nsO, err := kclient.Namespaces().Get(ctx, ns, metav1.GetOptions{})
 	if err != nil {
 		return "", err
@@ -39,7 +39,7 @@ func GetPodLog(ctx context.Context, kclient corev1i.CoreV1Interface, ns, labelse
 	// maybe one day there is going to be multiple controller containers and then we would need to handle it here
 	ios, err := kclient.Pods(nsO.GetName()).GetLogs(items.Items[0].GetName(), &v1.PodLogOptions{
 		Container: containerName,
-		TailLines: github.Int64(10),
+		TailLines: lines,
 	}).Stream(ctx)
 	if err != nil {
 		return "", err

--- a/test/testdata/pipelinerun-on-comment-annotation.yaml
+++ b/test/testdata/pipelinerun-on-comment-annotation.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: "on-comment"
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-comment: "^/hello-world"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: task
+        displayName: "The Task name is Task"
+        taskSpec:
+          steps:
+            - name: task
+              image: registry.access.redhat.com/ubi9/ubi-micro
+              script: |
+                echo "The comment is:"
+                cat <<EOF
+                {{ trigger_comment }}
+                EOF


### PR DESCRIPTION

We now support the `on-comment` annotation to match a PipelineRuns on
pull requests.

This is only supported on pull_requests and on GitHub, Gitea and GitLab
providers.


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
