### PR TITLE
Add kind along with the tekton resource name

### DIFF
--- a/pkg/matcher/annotation_tasks_install.go
+++ b/pkg/matcher/annotation_tasks_install.go
@@ -159,7 +159,7 @@ func (rt RemoteTasks) getRemote(ctx context.Context, uri string, fromHub bool, k
 		if !ok {
 			return "", fmt.Errorf("could not get details for catalog name: %s", "default")
 		}
-		rt.Logger.Infof("successfully fetched %s from default configured catalog HUB on URL: %s", uri, catalogValue.URL)
+		rt.Logger.Infof("successfully fetched %s %s from default configured catalog HUB on URL: %s", uri, kind, catalogValue.URL)
 		return data, nil
 	}
 	return "", fmt.Errorf(`cannot find "%s" anywhere`, uri)

--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -109,8 +109,10 @@ func TestGiteaPullRequestPrivateRepository(t *testing.T) {
 		ExpectEvents:   false,
 		CheckForStatus: "success",
 	}
-	_, f := tgitea.TestPR(t, topts)
+	ctx, f := tgitea.TestPR(t, topts)
 	defer f()
+	assert.NilError(t, twait.RegexpMatchingInControllerLog(ctx, topts.ParamsRun, *regexp.MustCompile(
+		".*fetched git-clone task"), 10, "controller"))
 	tgitea.WaitForSecretDeletion(t, topts, topts.TargetRefName)
 }
 

--- a/test/github_pullrequest_privaterepository_test.go
+++ b/test/github_pullrequest_privaterepository_test.go
@@ -6,9 +6,13 @@ package test
 import (
 	"context"
 	"os"
+	"regexp"
 	"testing"
 
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/cctx"
 	tgithub "github.com/openshift-pipelines/pipelines-as-code/test/pkg/github"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
+	"gotest.tools/v3/assert"
 )
 
 func TestGithubPullRequestGitClone(t *testing.T) {
@@ -21,6 +25,11 @@ func TestGithubPullRequestGitClone(t *testing.T) {
 		YamlFiles: []string{"testdata/pipelinerun_git_clone_private.yaml"},
 	}
 	g.RunPullRequest(ctx, t)
+
+	ctx, err := cctx.GetControllerCtxInfo(ctx, g.Cnx)
+	assert.NilError(t, err)
+	assert.NilError(t, wait.RegexpMatchingInControllerLog(ctx, g.Cnx, *regexp.MustCompile(".*fetched git-clone task"),
+		10, "controller"), "Error while checking the logs of the pipelines-as-code controller pod")
 	defer g.TearDown(ctx, t)
 }
 

--- a/test/pkg/wait/logs.go
+++ b/test/pkg/wait/logs.go
@@ -27,7 +27,7 @@ func RegexpMatchingInControllerLog(ctx context.Context, clients *params.Run, reg
 		}
 
 		if reg.MatchString(output) {
-			clients.Clients.Log.Infof("matched regexp %s in %s:%s labelSelector/pod %s for regexp: %s", reg.String(), labelselector, containerName)
+			clients.Clients.Log.Infof("matched regexp %s in %s:%s labelSelector/pod", reg.String(), labelselector, containerName)
 			return nil
 		}
 		time.Sleep(5 * time.Second)


### PR DESCRIPTION
This change helps us to differentiate between
Tekton resources, especially when Pipeline and Task names coincide

Signed-off-by: Savita Ashture <sashture@redhat.com

**Before:**
```
{*****,"msg":"successfully fetched buildpacks from default configured catalog HUB on URL: https://api.hub.tekton.dev/v1"******}

{*****,"msg":"successfully fetched buildpacks from default configured catalog HUB on URL: https://api.hub.tekton.dev/v1"******"}

```

**After:**
```
{*****,"msg":"successfully fetched buildpacks task from default configured catalog HUB on URL: https://api.hub.tekton.dev/v1"******}

{*****,"msg":"successfully fetched buildpacks pipeline from default configured catalog HUB on URL: https://api.hub.tekton.dev/v1"******"}

```

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
