### PR TITLE
gitlab: Fix posting prun status on gitops comments

### DIFF
--- a/.tekton/go.yaml
+++ b/.tekton/go.yaml
@@ -114,8 +114,8 @@ spec:
                 chmod +x ./codecov
                 ./codecov -P $GITHUB_PULL_REQUEST_ID -C {{revision}}
             - name: lint
-              # golangci-lint has not tagged their image for 1.40.0 yet so using latest for now until we can pin it
-              image: mirror.gcr.io/golangci/golangci-lint:latest
+              # pin for v0.24.x release newest fails without bunch of changes we don't want to backport
+              image: golangci/golangci-lint:v1.55
               workingDir: $(workspaces.source.path)
               env:
                 - name: GOCACHE

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -204,7 +204,7 @@ func (v *Provider) CreateStatus(_ context.Context, event *info.Event, statusOpts
 	_, _, _ = v.Client.Commits.SetCommitStatus(event.SourceProjectID, event.SHA, opt)
 
 	// only add a note when we are on a MR
-	if event.EventType == "pull_request" || event.EventType == "Merge_Request" || event.EventType == "Merge Request" {
+	if event.EventType == "pull_request" || event.EventType == "Merge_Request" || event.EventType == "Merge Request" || event.EventType == "Note" {
 		mopt := &gitlab.CreateMergeRequestNoteOptions{Body: gitlab.Ptr(body)}
 		_, _, err := v.Client.Notes.CreateMergeRequestNote(event.TargetProjectID, event.PullRequestNumber, mopt)
 		return err

--- a/pkg/provider/gitlab/gitlab_test.go
+++ b/pkg/provider/gitlab/gitlab_test.go
@@ -135,6 +135,20 @@ func TestCreateStatus(t *testing.T) {
 			},
 		},
 		{
+			name:       "gitops comments completed",
+			wantClient: true,
+			wantErr:    false,
+			args: args{
+				statusOpts: provider.StatusOpts{
+					Conclusion: "completed",
+				},
+				event: &info.Event{
+					TriggerTarget: "Note",
+				},
+				postStr: "has completed",
+			},
+		},
+		{
 			name:       "completed with a details url",
 			wantClient: true,
 			wantErr:    false,

--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -42,7 +42,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var successRegexp = regexp.MustCompile(`^Pipelines as Code CI.*has.*successfully`)
+// successRegexp will match a success text paac comment,sometime it includes html tags so we need to consider that.
+var successRegexp = regexp.MustCompile(`.*Pipelines as Code CI.*has.*successfully.*validated your commit.*`)
 
 func TestGiteaPullRequestTaskAnnotations(t *testing.T) {
 	topts := &tgitea.TestOpts{

--- a/test/gitlab_merge_request_test.go
+++ b/test/gitlab_merge_request_test.go
@@ -50,8 +50,10 @@ func TestGitlabMergeRequest(t *testing.T) {
 
 	gitCloneURL, err := scm.MakeGitCloneURL(projectinfo.WebURL, opts.UserName, opts.Password)
 	assert.NilError(t, err)
+	commitTitle := "Committing files from test on " + targetRefName
 	scmOpts := &scm.Opts{
 		GitURL:        gitCloneURL,
+		CommitTitle:   commitTitle,
 		Log:           runcnx.Clients.Log,
 		WebURL:        projectinfo.WebURL,
 		TargetRefName: targetRefName,
@@ -97,6 +99,32 @@ func TestGitlabMergeRequest(t *testing.T) {
 	for i := 0; i < len(prsNew.Items); i++ {
 		assert.Equal(t, "Merge Request", prsNew.Items[i].Annotations[keys.EventType])
 	}
+
+	runcnx.Clients.Log.Infof("Sending /retest comment on MergeRequest %s/-/merge_requests/%d", projectinfo.WebURL, mrID)
+	_, _, err = glprovider.Client.Notes.CreateMergeRequestNote(opts.ProjectID, mrID, &clientGitlab.CreateMergeRequestNoteOptions{
+		Body: clientGitlab.Ptr("/retest"),
+	})
+	assert.NilError(t, err)
+	sopt = wait.SuccessOpt{
+		Title:           commitTitle,
+		OnEvent:         "Note",
+		TargetNS:        targetNS,
+		NumberofPRMatch: 5, // this is the max we get in repos status
+		SHA:             "",
+	}
+	runcnx.Clients.Log.Info("Checking that PAC has posted successful comments for all PR that has been tested")
+	wait.Succeeded(ctx, t, runcnx, opts, sopt)
+
+	notes, _, err := glprovider.Client.Notes.ListMergeRequestNotes(opts.ProjectID, mrID, nil)
+	assert.NilError(t, err)
+	successCommentsPost := 0
+	for _, n := range notes {
+		if successRegexp.MatchString(n.Body) {
+			successCommentsPost++
+		}
+	}
+	// we get 2 PRS initially, 2 prs from the push update and 2 prs from the /retest == 6
+	assert.Equal(t, 6, successCommentsPost)
 }
 
 // Local Variables:

--- a/test/pkg/wait/check.go
+++ b/test/pkg/wait/check.go
@@ -3,6 +3,7 @@ package wait
 import (
 	"context"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -52,7 +53,7 @@ func Succeeded(ctx context.Context, t *testing.T, runcnx *params.Run, opts optio
 		assert.Equal(t, sopt.SHA, *laststatus.SHA)
 		assert.Equal(t, sopt.SHA, filepath.Base(*laststatus.SHAURL))
 	}
-	assert.Equal(t, sopt.Title, *laststatus.Title)
+	assert.Equal(t, sopt.Title, strings.TrimSpace(*laststatus.Title))
 	assert.Assert(t, *laststatus.LogURL != "")
 
 	pr, err := runcnx.Clients.Tekton.TektonV1().PipelineRuns(sopt.TargetNS).Get(ctx, laststatus.PipelineRunName, v1.GetOptions{})
@@ -71,7 +72,7 @@ func Succeeded(ctx context.Context, t *testing.T, runcnx *params.Run, opts optio
 		assert.Equal(t, sopt.SHA, pr.Annotations[keys.SHA])
 		assert.Equal(t, sopt.SHA, filepath.Base(pr.Annotations[keys.ShaURL]))
 	}
-	assert.Equal(t, sopt.Title, pr.Annotations[keys.ShaTitle])
+	assert.Equal(t, sopt.Title, strings.TrimSpace(pr.Annotations[keys.ShaTitle]))
 
 	runcnx.Clients.Log.Infof("Success, number of status %d has been matched", sopt.NumberofPRMatch)
 }


### PR DESCRIPTION
we were not posting the status on gitops comments, this is because we were not catching the Note events as defined by the gitlab provider.

better functional tests to check the actual comments has been posted properly on gitops comments for gitea.

This is for the release-v0.24.x branch since we have generics function for this in the main branch.

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
