### PR TITLE
Fix release pipeline for wrong version

### DIFF
--- a/.tekton/release-pipeline.yaml
+++ b/.tekton/release-pipeline.yaml
@@ -78,11 +78,11 @@ spec:
                 # it will keep v0.5.2, v0.6.2, v0.7.2
                 declare -A hashmap=()
                 for i in $(git tag -l | grep '^v' | sort -V); do
-                  version=${i//v/}
-                  if [[ ${version} =~ ^([0-9]+\.[0-9]+)\.[0-9]+$ ]]; then
+                  semanticVersion=${i//v/}
+                  if [[ ${semanticVersion} =~ ^([0-9]+\.[0-9]+)\.[0-9]+$ ]]; then
                     major_version=${BASH_REMATCH[1]}
                   fi
-                  hashmap["$major_version"]=$version
+                  hashmap["$major_version"]=$semanticVersion
                 done
                 output=$(for i in "${!hashmap[@]}"; do
                   echo v"${hashmap[$i]}"


### PR DESCRIPTION
During release, pipeline is pushing the branch as release-0.24.0 instead of release-v0.24.0 and similary same version is getting replaced in release yaml and also version file

This is to fix that behaviour. We are overiding the version variable in the for loop which is defined before the for loop containing the value of version getting released, and it is getting overwritten as the for loop is running in same shell. Declare a new name for the variable inside the for loop so that it does not override the original variable which is later getting used in script

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
