### PR TITLE
e2e: separate cancel and retest push GitOPS comments test

### DIFF
--- a/test/github_push_retest_test.go
+++ b/test/github_push_retest_test.go
@@ -15,10 +15,52 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestGithubSecondPushRequestGitOpsComments(t *testing.T) {
+func TestGithubPushRequestGitOpsCommentRetest(t *testing.T) {
 	ctx := context.Background()
 	g := &tgithub.PRTest{
-		Label:            "Github push request",
+		Label:     "Github GitOps push/retest request",
+		YamlFiles: []string{"testdata/pipelinerun-on-push.yaml", "testdata/pipelinerun.yaml"},
+	}
+	g.RunPushRequest(ctx, t)
+	defer g.TearDown(ctx, t)
+	comment := "/retest branch:" + g.TargetNamespace
+
+	pruns, err := g.Cnx.Clients.Tekton.TektonV1().PipelineRuns(g.TargetNamespace).List(ctx, metav1.ListOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, len(pruns.Items), 2)
+
+	g.Cnx.Clients.Log.Infof("%s on Push Request", comment)
+	_, _, err = g.Provider.Client.Repositories.CreateComment(ctx,
+		g.Options.Organization,
+		g.Options.Repo, g.SHA,
+		&github.RepositoryComment{Body: github.String(comment)})
+	assert.NilError(t, err)
+
+	waitOpts := twait.Opts{
+		RepoName:        g.TargetNamespace,
+		Namespace:       g.TargetNamespace,
+		MinNumberStatus: 4,
+		PollTimeout:     twait.DefaultTimeout,
+		TargetSHA:       g.SHA,
+	}
+	g.Cnx.Clients.Log.Info("Waiting for Repository to be updated")
+	_, err = twait.UntilRepositoryUpdated(ctx, g.Cnx.Clients, waitOpts)
+	assert.NilError(t, err)
+
+	g.Cnx.Clients.Log.Infof("Check if we have the repository set as succeeded")
+	repo, err := g.Cnx.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(g.TargetNamespace).Get(ctx, g.TargetNamespace, metav1.GetOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, repo.Status[len(repo.Status)-1].Conditions[0].Status, corev1.ConditionTrue)
+
+	pruns, err = g.Cnx.Clients.Tekton.TektonV1().PipelineRuns(g.TargetNamespace).List(ctx, metav1.ListOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, len(pruns.Items), 4)
+}
+
+func TestGithubPushRequestGitOpsCommentCancel(t *testing.T) {
+	ctx := context.Background()
+	g := &tgithub.PRTest{
+		Label:            "GitHub Gitops push/cancel request",
 		YamlFiles:        []string{"testdata/pipelinerun-on-push.yaml", "testdata/pipelinerun.yaml"},
 		SecondController: false,
 	}
@@ -29,63 +71,51 @@ func TestGithubSecondPushRequestGitOpsComments(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, len(pruns.Items), 2)
 
-	tests := []struct {
-		name, comment string
-		prNum         int
-	}{
-		{
-			name:    "Retest",
-			comment: "/retest branch:" + g.TargetNamespace,
-			prNum:   4,
-		},
-		{
-			name:    "Test and Cancel PipelineRun",
-			comment: "/cancel pipelinerun-on-push branch:" + g.TargetNamespace,
-			prNum:   5,
-		},
+	g.Cnx.Clients.Log.Info("/test pipelinerun-on-push on Push Request before canceling")
+	_, _, err = g.Provider.Client.Repositories.CreateComment(ctx,
+		g.Options.Organization,
+		g.Options.Repo, g.SHA,
+		&github.RepositoryComment{Body: github.String("/test pipelinerun-on-push branch:" + g.TargetNamespace)})
+	assert.NilError(t, err)
+	numberOfStatus := 3
+	waitOpts := twait.Opts{
+		RepoName:        g.TargetNamespace,
+		Namespace:       g.TargetNamespace,
+		MinNumberStatus: numberOfStatus,
+		PollTimeout:     twait.DefaultTimeout,
+		TargetSHA:       g.SHA,
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			waitOpts := twait.Opts{
-				RepoName:        g.TargetNamespace,
-				Namespace:       g.TargetNamespace,
-				MinNumberStatus: tt.prNum,
-				PollTimeout:     twait.DefaultTimeout,
-				TargetSHA:       g.SHA,
-			}
-			if tt.comment == "/cancel pipelinerun-on-push branch:"+g.TargetNamespace {
-				g.Cnx.Clients.Log.Info("/test pipelinerun-on-push on Push Request before canceling")
-				_, _, err = g.Provider.Client.Repositories.CreateComment(ctx,
-					g.Options.Organization,
-					g.Options.Repo, g.SHA,
-					&github.RepositoryComment{Body: github.String("/test pipelinerun-on-push branch:" + g.TargetNamespace)})
-				assert.NilError(t, err)
-				err = twait.UntilPipelineRunCreated(ctx, g.Cnx.Clients, waitOpts)
-				assert.NilError(t, err)
-			}
-			g.Cnx.Clients.Log.Infof("%s on Push Request", tt.comment)
-			_, _, err = g.Provider.Client.Repositories.CreateComment(ctx,
-				g.Options.Organization,
-				g.Options.Repo, g.SHA,
-				&github.RepositoryComment{Body: github.String(tt.comment)})
-			assert.NilError(t, err)
+	err = twait.UntilPipelineRunCreated(ctx, g.Cnx.Clients, waitOpts)
+	assert.NilError(t, err)
 
-			g.Cnx.Clients.Log.Info("Waiting for Repository to be updated")
-			_, err = twait.UntilRepositoryUpdated(ctx, g.Cnx.Clients, waitOpts)
-			assert.NilError(t, err)
+	comment := "/cancel pipelinerun-on-push branch:" + g.TargetNamespace
+	g.Cnx.Clients.Log.Infof("%s on Push Request", comment)
+	_, _, err = g.Provider.Client.Repositories.CreateComment(ctx,
+		g.Options.Organization,
+		g.Options.Repo, g.SHA,
+		&github.RepositoryComment{Body: github.String(comment)})
+	assert.NilError(t, err)
 
-			g.Cnx.Clients.Log.Infof("Check if we have the repository set as succeeded")
-			repo, err := g.Cnx.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(g.TargetNamespace).Get(ctx, g.TargetNamespace, metav1.GetOptions{})
-			assert.NilError(t, err)
-			if tt.comment == "/cancel pipelinerun-on-push branch:"+g.TargetNamespace {
-				assert.Equal(t, repo.Status[len(repo.Status)-1].Conditions[0].Status, corev1.ConditionFalse)
-			} else {
-				assert.Equal(t, repo.Status[len(repo.Status)-1].Conditions[0].Status, corev1.ConditionTrue)
-			}
-
-			pruns, err = g.Cnx.Clients.Tekton.TektonV1().PipelineRuns(g.TargetNamespace).List(ctx, metav1.ListOptions{})
-			assert.NilError(t, err)
-			assert.Equal(t, len(pruns.Items), tt.prNum)
-		})
+	g.Cnx.Clients.Log.Infof("Waiting for Repository to be updated still to %d since it has been canceled", numberOfStatus)
+	repo, _ := twait.UntilRepositoryUpdated(ctx, g.Cnx.Clients, waitOpts) // don't check for error, because canceled is not success and this will fail
+	cancelled := false
+	for _, c := range repo.Status {
+		if c.Conditions[0].Reason == "Cancelled" {
+			cancelled = true
+		}
 	}
+	assert.Assert(t, cancelled, "No cancelled status in repo Statuses run found")
+	assert.Equal(t, repo.Status[len(repo.Status)-1].Conditions[0].Status, corev1.ConditionFalse)
+
+	// make sure the number of items
+	pruns, err = g.Cnx.Clients.Tekton.TektonV1().PipelineRuns(g.TargetNamespace).List(ctx, metav1.ListOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, len(pruns.Items), numberOfStatus)
+	cancelled = false
+	for _, pr := range pruns.Items {
+		if pr.Status.Conditions[0].Reason == "Cancelled" {
+			cancelled = true
+		}
+	}
+	assert.Assert(t, cancelled, "No cancelled pipeline run found")
 }


### PR DESCRIPTION
We were mixing the retest and cancel GitOPS comments in the same test with one test function assuming the result of the previous one.  This is not a good practice and we should separate them to make it easy to debug and understand.

The tests was wrong as well, since we were checking for 3 success status in conditions but since we are canceling the pipeline we don't get success. So now checking properly the PipelineRun is cancelled properly.

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
