### PR TITLE
Add e2e tests for incoming webhook on GHE/Webhook

### DIFF
--- a/hack/gh-workflow-ci.sh
+++ b/hack/gh-workflow-ci.sh
@@ -41,8 +41,10 @@ create_second_github_app_controller_on_ghe() {
 	./hack/second-controller.py \
 		--controller-image="ko" \
 		--smee-url="${test_github_second_smee_url}" \
+		--ingress-domain="paac-127-0-0-1.nip.io" \
 		--namespace="pipelines-as-code" \
-		ghe >/tmp/generated.yaml
+		ghe | tee /tmp/generated.yaml
+
 	ko apply -f /tmp/generated.yaml
 	kubectl delete secret -n pipelines-as-code ghe-secret || true
 	kubectl -n pipelines-as-code create secret generic ghe-secret \
@@ -92,6 +94,7 @@ run_e2e_tests() {
 	export TEST_GITHUB_TOKEN="${gh_apps_token}"
 
 	export TEST_GITHUB_SECOND_API_URL=ghe.pipelinesascode.com
+	export TEST_GITHUB_SECOND_EL_URL=http://ghe.paac-127-0-0-1.nip.io
 	export TEST_GITHUB_SECOND_REPO_OWNER_GITHUBAPP=pipelines-as-code/e2e
 	# TODO: webhook repo for second github
 	# export TEST_GITHUB_SECOND_REPO_OWNER_WEBHOOK=openshift-pipelines/pipelines-as-code-e2e-tests-webhook

--- a/hack/second-controller.py
+++ b/hack/second-controller.py
@@ -65,6 +65,12 @@ def parse_arguments():
     )
 
     parser.add_argument(
+        "--ingress-domain",
+        help="if set this will add an ingress to the generated controller",
+        default=os.environ.get("PAC_CONTROLLER_INGRESS_DOMAIN"),
+    )
+
+    parser.add_argument(
         "--secret",
         help="name of the secret to use for the controller, default label-secret",
         default=os.environ.get("PAC_CONTROLLER_SECRET"),
@@ -191,6 +197,34 @@ spec:
             ]
     """
     )
+
+if args.ingress_domain:
+    sys.stdout.write(
+        f"""
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {args.label}-controller
+  namespace: {args.namespace}
+  labels:
+    pipelines-as-code/route: {args.label}
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: "{args.label}.{args.ingress_domain}"
+    http:
+      paths:
+      - backend:
+          service:
+            name: "{args.label}-controller"
+            port:
+              number: 8080
+        path: /
+        pathType: Prefix
+"""
+    )
+
 
 if args.openshift_route:
     with open("config/openshift/10-routes.yaml", "r", encoding="utf-8") as f:

--- a/pkg/adapter/sinker.go
+++ b/pkg/adapter/sinker.go
@@ -42,7 +42,6 @@ func (s *sinker) processEventPayload(ctx context.Context, request *http.Request)
 }
 
 func (s *sinker) processEvent(ctx context.Context, request *http.Request) error {
-	// TODO(chmouel): Add E2E Test for incoming test on GHE when #1518 is merged
 	if s.event.EventType == "incoming" {
 		if request.Header.Get("X-GitHub-Enterprise-Host") != "" {
 			s.event.Provider.URL = request.Header.Get("X-GitHub-Enterprise-Host")

--- a/test/pkg/github/setup.go
+++ b/test/pkg/github/setup.go
@@ -20,6 +20,7 @@ func Setup(ctx context.Context, onSecondController, viaDirectWebhook bool) (cont
 	githubRepoOwnerGithubApp := os.Getenv("TEST_GITHUB_REPO_OWNER_GITHUBAPP")
 	githubRepoOwnerDirectWebhook := os.Getenv("TEST_GITHUB_REPO_OWNER_WEBHOOK")
 
+	// EL_URL mean CONTROLLER URL, it's called el_url because a long time ago pac was based on trigger
 	for _, value := range []string{
 		"EL_URL",
 		"GITHUB_API_URL",
@@ -36,11 +37,16 @@ func Setup(ctx context.Context, onSecondController, viaDirectWebhook bool) (cont
 			"TEST_GITHUB_SECOND_API_URL",
 			"TEST_GITHUB_SECOND_REPO_OWNER_GITHUBAPP",
 			"TEST_GITHUB_SECOND_TOKEN",
+			"TEST_GITHUB_SECOND_EL_URL",
 		} {
 			if env := os.Getenv(value); env == "" {
 				return ctx, nil, options.E2E{}, github.New(), fmt.Errorf("\"%s\" env variable is required for testing a second controller, cannot continue", value)
 			}
 		}
+	}
+	controllerURL := os.Getenv("TEST_EL_URL")
+	if controllerURL == "" {
+		return ctx, nil, options.E2E{}, github.New(), fmt.Errorf("TEST_EL_URL variable is required, cannot continue")
 	}
 
 	var split []string
@@ -61,6 +67,7 @@ func Setup(ctx context.Context, onSecondController, viaDirectWebhook bool) (cont
 		githubURL = os.Getenv("TEST_GITHUB_SECOND_API_URL")
 		githubRepoOwnerGithubApp = os.Getenv("TEST_GITHUB_SECOND_REPO_OWNER_GITHUBAPP")
 		githubToken = os.Getenv("TEST_GITHUB_SECOND_TOKEN")
+		controllerURL = os.Getenv("TEST_GITHUB_SECOND_EL_URL")
 		split = strings.Split(githubRepoOwnerGithubApp, "/")
 	}
 
@@ -69,12 +76,6 @@ func Setup(ctx context.Context, onSecondController, viaDirectWebhook bool) (cont
 		return ctx, nil, options.E2E{}, github.New(), err
 	}
 	run.Info.Controller = info.GetControllerInfoFromEnvOrDefault()
-
-	controllerURL := os.Getenv("TEST_EL_URL")
-	if controllerURL == "" {
-		return ctx, nil, options.E2E{}, github.New(), fmt.Errorf("TEST_EL_URL variable is required, cannot continue")
-	}
-
 	e2eoptions := options.E2E{Organization: split[0], Repo: split[1], DirectWebhook: viaDirectWebhook, ControllerURL: controllerURL}
 	gprovider := github.New()
 	event := info.NewEvent()


### PR DESCRIPTION
This was a TODO list waiting for some infra to be merged, now that it's avaialble we can add the e2e tests for the incoming webhook feature on GHE and when using Github provider as webhook

https://issues.redhat.com/browse/SRVKP-3929

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
