### PR TITLE
Remove detection of old basic auth secret

### DIFF
--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"regexp"
 	"strings"
 
 	apipac "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
@@ -294,16 +293,15 @@ func changeSecret(prs []*tektonv1.PipelineRun) error {
 	return nil
 }
 
-// checkNeedUpdate using regexp, try to match some pattern for some issue in PR
-// to let the user know they need to update. or otherwise we will fail.
-// checks are deprecated/removed to n+1 release of OSP.
-// each check should give a good error message on how to update.
-func (p *PacRun) checkNeedUpdate(tmpl string) (string, bool) {
-	// nolint: gosec
-	oldBasicAuthSecretName := `\W*secretName: "pac-git-basic-auth-{{repo_owner}}-{{repo_name}}"`
-	if matched, _ := regexp.MatchString(oldBasicAuthSecretName, tmpl); matched {
-		return `!Update needed! you have a old basic auth secret name, you need to modify your pipelinerun and change the string "secret: pac-git-basic-auth-{{repo_owner}}-{{repo_name}}" to "secret: {{ git_auth_secret }}"`, true
-	}
+// checkNeedUpdate checks if the template needs an update form the user, try to
+// match some patterns for some issues in a template to let the user know they need to
+// update.
+//
+// We otherwise fail with a descriptive error message to the user (check run
+// interface on as comment for other providers) on how to update.
+//
+// Checks are deprecated/removed to n+2 release of OSP.
+func (p *PacRun) checkNeedUpdate(_ string) (string, bool) {
 	return "", false
 }
 

--- a/pkg/pipelineascode/match_test.go
+++ b/pkg/pipelineascode/match_test.go
@@ -32,12 +32,6 @@ func TestPacRun_checkNeedUpdate(t *testing.T) {
 		needupdate           bool
 	}{
 		{
-			name:                 "old secrets",
-			tmpl:                 `secretName: "pac-git-basic-auth-{{repo_owner}}-{{repo_name}}"`,
-			upgradeMessageSubstr: "old basic auth secret name",
-			needupdate:           true,
-		},
-		{
 			name:       "no need",
 			tmpl:       ` secretName: "foo-bar-foo"`,
 			needupdate: false,


### PR DESCRIPTION
I have added that check in 42ff2920ea5bb7b6db37834314aa49bdf69b4011 (April 2022) when we migrated from one secret name to another.

We can safely remove it now but keep that function for future checks if needed when doing a similar migration.

Improve documentation for the developers on how to add new checks.

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
