### PR TITLE
Cleanup by removing labels from pipelinerun

### DIFF
--- a/pkg/cmd/tknpac/describe/describe.go
+++ b/pkg/cmd/tknpac/describe/describe.go
@@ -195,7 +195,7 @@ func describe(ctx context.Context, cs *params.Run, clock clockwork.Clock, opts *
 			runTimeObj = append(runTimeObj, &events.Items[i])
 		}
 
-		// we do twice the prun list, but since it's behind a flag and not the default behavior, it's ok (i guess)
+		// we do twice the prun list, but since it's behind a flag and not the default behavior, it's ok (I guess)
 		label := keys.Repository + "=" + repository.Name
 		prs, err := cs.Clients.Tekton.TektonV1().PipelineRuns(repository.Namespace).List(ctx, metav1.ListOptions{
 			LabelSelector: label,

--- a/pkg/cmd/tknpac/describe/describe_test.go
+++ b/pkg/cmd/tknpac/describe/describe_test.go
@@ -52,10 +52,11 @@ func TestDescribe(t *testing.T) {
 				currentNamespace: ns,
 				opts:             &describeOpts{},
 				pruns: []*tektonv1.PipelineRun{
-					tektontest.MakePRCompletion(cw, "running", ns, running, nil, map[string]string{
+					tektontest.MakePRCompletion(cw, "running", ns, running, map[string]string{
+						keys.Branch:    "tartanpion",
+						keys.EventType: "papayolo",
+					}, map[string]string{
 						keys.Repository: "test-run",
-						keys.Branch:     "tartanpion",
-						keys.EventType:  "papayolo",
 					}, 30),
 				},
 				statuses: []v1alpha1.RepositoryRunStatus{
@@ -89,9 +90,10 @@ func TestDescribe(t *testing.T) {
 				currentNamespace: ns,
 				opts:             &describeOpts{},
 				pruns: []*tektonv1.PipelineRun{
-					tektontest.MakePRCompletion(cw, "running", ns, running, nil, map[string]string{
+					tektontest.MakePRCompletion(cw, "running", ns, running, map[string]string{
+						keys.Branch: "tartanpion",
+					}, map[string]string{
 						keys.Repository: "test-run",
-						keys.Branch:     "tartanpion",
 					}, 30),
 				},
 				statuses: []v1alpha1.RepositoryRunStatus{},
@@ -105,13 +107,15 @@ func TestDescribe(t *testing.T) {
 				currentNamespace: ns,
 				opts:             &describeOpts{TargetPipelineRun: "running2"},
 				pruns: []*tektonv1.PipelineRun{
-					tektontest.MakePRCompletion(cw, "running", ns, running, nil, map[string]string{
+					tektontest.MakePRCompletion(cw, "running", ns, running, map[string]string{
+						keys.Branch: "tartanpion",
+					}, map[string]string{
 						keys.Repository: "test-run",
-						keys.Branch:     "tartanpion",
 					}, 30),
-					tektontest.MakePRCompletion(cw, "running2", ns, running, nil, map[string]string{
+					tektontest.MakePRCompletion(cw, "running2", ns, running, map[string]string{
+						keys.Branch: "vavaroom",
+					}, map[string]string{
 						keys.Repository: "test-run",
-						keys.Branch:     "vavaroom",
 					}, 30),
 				},
 				statuses: []v1alpha1.RepositoryRunStatus{},
@@ -125,13 +129,15 @@ func TestDescribe(t *testing.T) {
 				currentNamespace: ns,
 				opts:             &describeOpts{},
 				pruns: []*tektonv1.PipelineRun{
-					tektontest.MakePRCompletion(cw, "running", ns, running, nil, map[string]string{
+					tektontest.MakePRCompletion(cw, "running", ns, running, map[string]string{
+						keys.Branch: "tartanpion",
+					}, map[string]string{
 						keys.Repository: "test-run",
-						keys.Branch:     "tartanpion",
 					}, 30),
-					tektontest.MakePRCompletion(cw, "running2", ns, running, nil, map[string]string{
+					tektontest.MakePRCompletion(cw, "running2", ns, running, map[string]string{
+						keys.Branch: "vavaroom",
+					}, map[string]string{
 						keys.Repository: "test-run",
-						keys.Branch:     "vavaroom",
 					}, 30),
 				},
 				statuses: []v1alpha1.RepositoryRunStatus{},

--- a/pkg/kubeinteraction/labels.go
+++ b/pkg/kubeinteraction/labels.go
@@ -25,11 +25,11 @@ func AddLabelsAndAnnotations(ctx context.Context, event *info.Event, pipelineRun
 	if event == nil {
 		return fmt.Errorf("event should not be nil")
 	}
-	// Add labels on the soon to be created pipelinerun so UI/CLI can easily
+	// Add labels on the soon-to-be created pipelinerun so UI/CLI can easily
 	// query them.
 	paramsinfo := info.GetInfo(ctx, info.GetCurrentControllerName(ctx))
 	labels := map[string]string{
-		// These keys are used in LabelSelector query so we are keeping in Labels as it is.
+		// These keys are used in LabelSelector query, so we are keeping in Labels as it is.
 		// But adding same keys to Annotations so UI/CLI can fetch the actual value instead of modified value
 		"app.kubernetes.io/managed-by": pipelinesascode.GroupName,
 		"app.kubernetes.io/version":    formatting.CleanValueKubernetes(version.Version),
@@ -39,12 +39,6 @@ func AddLabelsAndAnnotations(ctx context.Context, event *info.Event, pipelineRun
 		keys.Repository:                formatting.CleanValueKubernetes(repo.GetName()),
 		keys.State:                     StateStarted,
 		keys.EventType:                 formatting.CleanValueKubernetes(event.EventType),
-
-		// We are deprecating these below keys from labels and adding it to Annotations
-		// In PAC v0.20.x releases we will remove these keys from Labels
-		keys.Sender:      formatting.CleanValueKubernetes(event.Sender),
-		keys.Branch:      formatting.CleanValueKubernetes(event.BaseBranch),
-		keys.GitProvider: providerinfo.Name,
 	}
 
 	annotations := map[string]string{

--- a/pkg/reconciler/event_test.go
+++ b/pkg/reconciler/event_test.go
@@ -44,7 +44,6 @@ func TestBuildEventFromPipelineRun(t *testing.T) {
 						keys.URLRepository: "repo",
 						keys.SHA:           "sha",
 						keys.EventType:     "push",
-						keys.Branch:        "branch",
 						keys.State:         kubeinteraction.StateStarted,
 						keys.PullRequest:   "1234",
 					},


### PR DESCRIPTION
In the v0.18.x PAC release, labels such as
git-provider, sender, and branch have been deprecated.

This change involves completely removing the
git-provider, sender, and branch labels,
which constitutes a breaking change.

Fixes: https://issues.redhat.com/browse/SRVKP-2995

Signed-off-by: Savita Ashture <sashture@redhat.com>

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
