### PR TITLE
Don't try to cleanup Pending PipelineRuns

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ LDFLAGS=
 OUTPUT_DIR=bin
 GO           = go
 TIMEOUT_UNIT = 20m
-TIMEOUT_E2E  = 30m
+TIMEOUT_E2E  = 45m
 GO_TEST_FLAGS +=
 SHELL := bash
 

--- a/docs/content/docs/guide/authoringprs.md
+++ b/docs/content/docs/guide/authoringprs.md
@@ -198,6 +198,11 @@ with `/merge-pr`
 
 You can then use the template variable `{{ trigger_comment }}` to get the
 actual comment and do some action based on for example the comment content.
+There is a restriction with the trigger_comment variable we modify it to
+replace the newline with a `\n` since the multi-line comment can cause a
+issue when replaced inside the yaml. It is up to you to replace it back to
+newline, for example with shell scripts you can use `echo -e` to expand the
+newline back.
 
 Note that the `on-comment` annotation will respect the `pull_request` [Policy]({{< relref "/docs/guide/policy" >}}) rule,
 so only users into the `pull_request` policy will be able to trigger the

--- a/docs/content/docs/guide/cleanups.md
+++ b/docs/content/docs/guide/cleanups.md
@@ -4,17 +4,23 @@ weight: 8
 ---
 # PipelineRuns Cleanups
 
-There can be many PipelineRuns into a user namespace and Pipelines-as-Code
-has the ability to only keep several PipelineRuns that matches an event.
+There can be many PipelineRuns into a user namespace and Pipelines-as-Code has
+the ability to only keep a certain amount of PipelineRuns and cleaning the old
+ones.
 
-For example if the PipelineRun has this annotation :
+When your PipelineRun has this annotation :
 
 ```yaml
 pipelinesascode.tekton.dev/max-keep-runs: "maxNumber"
 ```
 
-Pipelines-as-Code sees this and will start cleaning up right after it finishes a
-successful execution keeping only the maxNumber of PipelineRuns.
+Pipelines-as-Code sees this and will start cleaning up right after one of the
+PipelineRun finishes to a successful execution keeping only the last `maxNumber` of
+PipelineRuns.
 
-It will skip the `Running` PipelineRuns but will not skip the PipelineRuns with
-`Unknown` status.
+It will skip the `Running` or `Pending` PipelineRuns but will not skip the
+PipelineRuns with `Unknown` status.
+
+{{< hint info >}}
+The setting can be as well configured globally for a cluster via the [Pipelines-as-Code ConfigMap]({{< relref "/docs/install/settings.md" >}})
+{{< /hint >}}

--- a/pkg/customparams/standard.go
+++ b/pkg/customparams/standard.go
@@ -31,6 +31,7 @@ func (p *CustomParams) makeStandardParamsFromEvent(ctx context.Context) (map[str
 		repoURL = p.event.CloneURL
 	}
 	changedFiles := p.getChangedFiles(ctx)
+	triggerCommentAsSingleLine := strings.ReplaceAll(p.event.TriggerComment, "\n", "\\n")
 
 	return map[string]string{
 			"revision":         p.event.SHA,
@@ -43,7 +44,7 @@ func (p *CustomParams) makeStandardParamsFromEvent(ctx context.Context) (map[str
 			"sender":           strings.ToLower(p.event.Sender),
 			"target_namespace": p.repo.GetNamespace(),
 			"event_type":       p.event.EventType,
-			"trigger_comment":  p.event.TriggerComment,
+			"trigger_comment":  triggerCommentAsSingleLine,
 		}, map[string]interface{}{
 			"all":      changedFiles.All,
 			"added":    changedFiles.Added,

--- a/pkg/customparams/standard_test.go
+++ b/pkg/customparams/standard_test.go
@@ -22,7 +22,7 @@ func TestMakeStandardParamsFromEvent(t *testing.T) {
 		Sender:         "SENDER",
 		URL:            "https://paris.com",
 		HeadURL:        "https://india.com",
-		TriggerComment: "/test me",
+		TriggerComment: "/test me\nHelp me obiwan kenobi",
 	}
 
 	result := map[string]string{
@@ -36,7 +36,7 @@ func TestMakeStandardParamsFromEvent(t *testing.T) {
 		"source_branch":    "foo",
 		"target_branch":    "main",
 		"target_namespace": "myns",
-		"trigger_comment":  "/test me",
+		"trigger_comment":  "/test me\\nHelp me obiwan kenobi",
 	}
 
 	repo := &v1alpha1.Repository{

--- a/pkg/kubeinteraction/cleanups.go
+++ b/pkg/kubeinteraction/cleanups.go
@@ -31,8 +31,9 @@ func (k Interaction) CleanupPipelines(ctx context.Context, logger *zap.SugaredLo
 	}
 
 	for c, prun := range psort.PipelineRunSortByCompletionTime(pruns.Items) {
-		if prun.GetStatusCondition().GetCondition(apis.ConditionSucceeded).GetReason() == "Running" {
-			logger.Infof("skipping %s since currently running", prun.GetName())
+		prReason := prun.GetStatusCondition().GetCondition(apis.ConditionSucceeded).GetReason()
+		if prReason == tektonv1.PipelineRunReasonRunning.String() || prReason == tektonv1.PipelineRunReasonPending.String() {
+			logger.Infof("skipping cleaning PipelineRun %s since the conditions.reason is %s", prReason, prun.GetName())
 			continue
 		}
 

--- a/pkg/kubeinteraction/cleanups_test.go
+++ b/pkg/kubeinteraction/cleanups_test.go
@@ -84,6 +84,22 @@ func TestCleanupPipelines(t *testing.T) {
 			},
 		},
 		{
+			name: "cleanup-skip-pending",
+			args: args{
+				namespace:      ns,
+				repositoryName: cleanupRepoName,
+				maxKeep:        1,
+				kept:           1, // see my comment in code why only 1 is kept.
+				prunCurrent:    &tektonv1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Labels: cleanupLabels, Annotations: cleanupAnnotations}},
+				pruns: []*tektonv1.PipelineRun{
+					tektontest.MakePRCompletion(clock, "pipeline-pending", ns, tektonv1.PipelineRunReasonPending.String(), nil, cleanupLabels, 10),
+					tektontest.MakePRCompletion(clock, "pipeline-toclean", ns, tektonv1.PipelineRunReasonSuccessful.String(), nil, cleanupLabels, 30),
+					tektontest.MakePRCompletion(clock, "pipeline-tokeep", ns, tektonv1.PipelineRunReasonSuccessful.String(), nil, cleanupLabels, 20),
+				},
+				prunLatestInList: "pipeline-pending",
+			},
+		},
+		{
 			name: "cleanup with secrets",
 			args: args{
 				namespace:      ns,

--- a/pkg/resolve/resolve.go
+++ b/pkg/resolve/resolve.go
@@ -130,7 +130,7 @@ func ReadTektonTypes(ctx context.Context, log *zap.SugaredLogger, data string) (
 
 		obj, _, err := decoder.Decode([]byte(doc), nil, nil)
 		if err != nil {
-			log.Infof("Skipping document not looking like a kubernetes resources: %v", err)
+			log.Infof("skipping yaml document not looking like a kubernetes resources: %v", err)
 			continue
 		}
 		switch o := obj.(type) {
@@ -159,7 +159,7 @@ func ReadTektonTypes(ctx context.Context, log *zap.SugaredLogger, data string) (
 		case *tektonv1.Task:
 			types.Tasks = append(types.Tasks, o)
 		default:
-			log.Info("Skipping document not looking like a tekton resource we can Resolve.")
+			log.Info("skipping yaml document not looking like a tekton resource we can Resolve.")
 		}
 	}
 

--- a/pkg/resolve/resolve_test.go
+++ b/pkg/resolve/resolve_test.go
@@ -1,6 +1,7 @@
 package resolve
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"strings"
@@ -196,7 +197,7 @@ func TestNotTektonDocumentIgnore(t *testing.T) {
 	assert.NilError(t, err)
 	logs := log.TakeAll()
 	assert.Assert(t, len(logs) > 0)
-	assert.Assert(t, strings.HasPrefix(logs[0].Message, "Skipping"))
+	assert.Assert(t, strings.HasPrefix(logs[0].Message, "skipping yaml"), fmt.Sprintf("'%s'", logs[0].Message))
 	assert.Assert(t, resolved.Spec.PipelineSpec != nil)
 }
 
@@ -204,7 +205,7 @@ func TestNotKubernetesDocumentIgnore(t *testing.T) {
 	resolved, log, err := readTDfile(t, "not-a-kubernetes-yaml", false, true)
 	logs := log.TakeAll()
 	assert.Assert(t, len(logs) > 0)
-	assert.Assert(t, strings.HasPrefix(logs[0].Message, "Skipping"))
+	assert.Assert(t, strings.HasPrefix(logs[0].Message, "skipping yaml"), logs[0].Message)
 	assert.Assert(t, resolved.Spec.PipelineSpec != nil)
 	assert.NilError(t, err)
 	assert.Assert(t, resolved.Spec.PipelineSpec != nil)

--- a/test/testdata/pipelinerun_long_running_maxkeep_run.yaml
+++ b/test/testdata/pipelinerun_long_running_maxkeep_run.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: "\\ .PipelineName //"
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
+    pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
+    pipelinesascode.tekton.dev/max-keep-runs: "\\ .MaxKeepRun //"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: task
+        taskSpec:
+          steps:
+            - name: task
+              image: registry.access.redhat.com/ubi9/ubi-micro
+              script: |
+                echo "hello pipeline"
+                sleep 10
+                exit 0


### PR DESCRIPTION
When using max-keep-runs annotations with concurrency, the cleanups process on the watcher was trying to cleanup Pending PipelineRuns. This would cause the watcher to get stuck and not able to process its queue.

We now avoiding it the same way we do for Running PipelineRuns.

improved TestGithubSecondPullRequestConcurrencyMultiplePR to include max-keep-runs and /retest over concurrency

Fixes #1625 a bug on-comment feature related which caused the issue in this e2e but fixing it here to make it green..

Jira: https://issues.redhat.com/browse/SRVKP-4266

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
