### PR TITLE
Fix metrics emission for GitHubApp Enterprise

### DIFF
--- a/pkg/reconciler/emit_metrics.go
+++ b/pkg/reconciler/emit_metrics.go
@@ -12,7 +12,7 @@ func (r *Reconciler) emitMetrics(pr *tektonv1.PipelineRun) error {
 	eventType := pr.GetAnnotations()[keys.EventType]
 
 	switch gitProvider {
-	case "github":
+	case "github", "github-enterprise":
 		if _, ok := pr.GetAnnotations()[keys.InstallationID]; ok {
 			gitProvider += "-app"
 		} else {

--- a/pkg/reconciler/emit_metrics_test.go
+++ b/pkg/reconciler/emit_metrics_test.go
@@ -26,6 +26,15 @@ func TestEmitMetrics(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "provider is GitHub Enterprise App",
+			annotations: map[string]string{
+				keys.GitProvider:    "github-enterprise",
+				keys.EventType:      "pull_request",
+				keys.InstallationID: "123",
+			},
+			wantErr: false,
+		},
+		{
 			name: "provider is GitHub Webhook",
 			annotations: map[string]string{
 				keys.GitProvider: "github",


### PR DESCRIPTION
# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Now PAC will emit metrics for
GitHub Enterprise App

![Screenshot from 2024-03-20 23-01-39](https://github.com/openshift-pipelines/pipelines-as-code/assets/9441662/6212d728-a860-4064-b866-97daacf2b0da)

Signed-off-by: Savita Ashture <sashture@redhat.com>

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
