### PR TITLE
Only cleanups PRs after reconciliation

### DIFF
--- a/pkg/kubeinteraction/cleanups.go
+++ b/pkg/kubeinteraction/cleanups.go
@@ -20,8 +20,10 @@ func (k Interaction) CleanupPipelines(ctx context.Context, logger *zap.SugaredLo
 	}
 
 	// Select PR by repository and by its true pipelineRun name (not auto generated one)
-	labelSelector := fmt.Sprintf("%s=%s,%s=%s",
-		keys.Repository, formatting.CleanValueKubernetes(repo.GetName()), keys.OriginalPRName, formatting.CleanValueKubernetes(pr.GetLabels()[keys.OriginalPRName]))
+	labelSelector := fmt.Sprintf("%s=%s,%s=%s,%s=%s",
+		keys.Repository, formatting.CleanValueKubernetes(repo.GetName()), keys.OriginalPRName,
+		formatting.CleanValueKubernetes(pr.GetLabels()[keys.OriginalPRName]),
+		keys.State, StateCompleted)
 	logger.Infof("selecting pipelineruns by labels \"%s\" for deletion", labelSelector)
 
 	pruns, err := k.Run.Clients.Tekton.TektonV1().PipelineRuns(repo.GetNamespace()).List(ctx,

--- a/pkg/kubeinteraction/cleanups.go
+++ b/pkg/kubeinteraction/cleanups.go
@@ -33,7 +33,7 @@ func (k Interaction) CleanupPipelines(ctx context.Context, logger *zap.SugaredLo
 	for c, prun := range psort.PipelineRunSortByCompletionTime(pruns.Items) {
 		prReason := prun.GetStatusCondition().GetCondition(apis.ConditionSucceeded).GetReason()
 		if prReason == tektonv1.PipelineRunReasonRunning.String() || prReason == tektonv1.PipelineRunReasonPending.String() {
-			logger.Infof("skipping cleaning PipelineRun %s since the conditions.reason is %s", prReason, prun.GetName())
+			logger.Infof("skipping cleaning PipelineRun %s since the conditions.reason is %s", prun.GetName(), prReason)
 			continue
 		}
 

--- a/pkg/kubeinteraction/cleanups_test.go
+++ b/pkg/kubeinteraction/cleanups_test.go
@@ -27,6 +27,7 @@ func TestCleanupPipelines(t *testing.T) {
 	cleanupLabels := map[string]string{
 		keys.OriginalPRName: cleanupPRName,
 		keys.Repository:     cleanupRepoName,
+		keys.State:          StateCompleted,
 	}
 	// copy of cleanupLabels to be used in annotations
 	cleanupAnnotations := maps.Clone(cleanupLabels)

--- a/pkg/reconciler/cleanup_test.go
+++ b/pkg/reconciler/cleanup_test.go
@@ -30,6 +30,7 @@ func TestCleanupPipelineRuns(t *testing.T) {
 	cleanupLabels := map[string]string{
 		keys.OriginalPRName: cleanupPRName,
 		keys.Repository:     cleanupRepoName,
+		keys.State:          kubeinteraction.StateCompleted,
 	}
 
 	cleanupAnnotation := map[string]string{


### PR DESCRIPTION
I experienced some issues where the watcher was getting stuck when there
is a race between the deletion of the PR and the reconciliation.

The high load would make it slow to know which PR to get deleted, and
the reconciliation would be stuck trying to reconcile on a deleted PR.

Stress tested this over 150 concurrent PR of 3 PipelineRuns with a
concurrency of 1 and a max-keep-runs of 1 for each pipelinerun and the Q
processed properly until the end all PipelineRuns without getting stuck
(like it was before the change).# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
