### PR TITLE
Updates sort package to latest

### DIFF
--- a/pkg/pipelineascode/concurrency.go
+++ b/pkg/pipelineascode/concurrency.go
@@ -43,9 +43,19 @@ func (c *ConcurrencyManager) GetExecutionOrder() (string, []*v1.PipelineRun) {
 		return "", nil
 	}
 
+	if len(c.pipelineRuns) == 0 {
+		return "", nil
+	}
+
 	runtimeObjs := []runtime.Object{}
 	for _, pr := range c.pipelineRuns {
-		runtimeObjs = append(runtimeObjs, pr)
+		if pr != nil && pr.Name != "" {
+			runtimeObjs = append(runtimeObjs, pr)
+		}
+	}
+
+	if len(runtimeObjs) == 0 {
+		return "", nil
 	}
 
 	// sort runs by name

--- a/pkg/pipelineascode/concurrency_test.go
+++ b/pkg/pipelineascode/concurrency_test.go
@@ -29,3 +29,18 @@ func TestExecutionOrder(t *testing.T) {
 	assert.Equal(t, order, "test/abc,test/def,test/mno,test/pqr")
 	assert.Equal(t, len(runs), 4)
 }
+
+func TestExecutionOrder_SinglePRun(t *testing.T) {
+	cm := NewConcurrencyManager()
+
+	testNs := "test"
+	abcPR := &tektonv1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: testNs}}
+	cm.Enable()
+
+	// add pipelineRuns in random order
+	cm.AddPipelineRun(abcPR)
+
+	order, runs := cm.GetExecutionOrder()
+	assert.Equal(t, order, "test/abc")
+	assert.Equal(t, len(runs), 1)
+}

--- a/pkg/sort/runtime_sort.go
+++ b/pkg/sort/runtime_sort.go
@@ -17,7 +17,7 @@ import (
 
 // The following code has been take from kubectl get command
 // instead of importing all the dependencies, copying only the required part
-// https://github.com/kubernetes/kubernetes/blob/8e48df135318026d5f8a972a96a2ff665889568a/staging/src/k8s.io/kubectl/pkg/cmd/get/sorter.go#L151
+// https://github.com/kubernetes/kubernetes/blob/20d0ab7ae808aaddb1556c3c38ca0607663c50ac/staging/src/k8s.io/kubectl/pkg/cmd/get/sorter.go#L150
 
 // RuntimeSort is an implementation of the golang sort interface that knows how to sort
 // lists of runtime.Object.
@@ -56,7 +56,7 @@ func isLess(i, j reflect.Value) (bool, error) {
 		return i.Float() < j.Float(), nil
 	case reflect.String:
 		return sortorder.NaturalLess(i.String(), j.String()), nil
-	case reflect.Ptr:
+	case reflect.Pointer:
 		return isLess(i.Elem(), j.Elem())
 	case reflect.Struct:
 		// sort metav1.Time
@@ -210,6 +210,8 @@ func (r *RuntimeSort) Less(i, j int) bool {
 }
 
 // OriginalPosition returns the starting (original) position of a particular index.
+// e.g. If OriginalPosition(0) returns 5 than the
+// item currently at position 0 was at position 5 in the original unsorted array.
 func (r *RuntimeSort) OriginalPosition(ix int) int {
 	if ix < 0 || ix > len(r.origPosition) {
 		return -1
@@ -227,5 +229,7 @@ func findJSONPathResults(parser *jsonpath.JSONPath, from runtime.Object) ([][]re
 // ByField sorts the runtime objects passed by the field.
 func ByField(field string, runTimeObj []runtime.Object) {
 	sorter := NewRuntimeSort(field, runTimeObj)
-	sort.Sort(sorter)
+	if len(runTimeObj) > 0 {
+		sort.Sort(sorter)
+	}
 }


### PR DESCRIPTION
# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

we use sort code from k8s repo, this updates the code to the latest master
https://github.com/kubernetes/kubernetes/blob/20d0ab7ae808aaddb1556c3c38ca0607663c50ac/staging/src/k8s.io/kubectl/pkg/cmd/get/sorter.go#L150
but keeps using integer.IntMin to continue using golang 1.20


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
