### PR TITLE
Report tekton yaml validation error to the user

### DIFF
--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -168,6 +168,13 @@ func (p *PacRun) getPipelineRunsFromRepo(ctx context.Context, repo *v1alpha1.Rep
 	if err != nil {
 		return nil, err
 	}
+
+	if types.ValidationErrors != nil {
+		for k, v := range types.ValidationErrors {
+			kv := fmt.Sprintf("prun: %s tekton validation error: %s", k, v)
+			p.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "PipelineRunValidationErrors", kv)
+		}
+	}
 	pipelineRuns := types.PipelineRuns
 	if len(pipelineRuns) == 0 {
 		msg := fmt.Sprintf("cannot locate templates in %s/ directory for this repository in %s", tektonDir, p.event.HeadBranch)

--- a/pkg/pipelineascode/testdata/invalid_tekton_yaml/.tekton/on-comment.yaml
+++ b/pkg/pipelineascode/testdata/invalid_tekton_yaml/.tekton/on-comment.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: bad-tekton-yaml
+  annotations:
+    pipelinesascode.tekton.dev/max-keep-runs: "2"
+    pipelinesascode.tekton.dev/task: ".tekton/remotetask.yaml"
+    pipelinesascode.tekton.dev/on-comment: "/make-me-a-sandwich"
+spec:
+  pipelineSpec:
+    tasks:
+      taskSpec:
+        steps:
+          - name: noop-task
+            image: registry.access.redhat.com/ubi9/ubi-micro
+            script: |
+              echo "make me a sandwich"

--- a/pkg/resolve/testdata/bad-tekton-yaml-generate-name.yaml
+++ b/pkg/resolve/testdata/bad-tekton-yaml-generate-name.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: bad-generate-name
+spec:
+  pipelineSpec:
+    tasks:
+      taskSpec:
+        steps:
+          - name: hello-moto
+            image: scratch

--- a/pkg/resolve/testdata/bad-tekton-yaml-name.yaml
+++ b/pkg/resolve/testdata/bad-tekton-yaml-name.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: bad-name
+spec:
+  pipelineSpec:
+    tasks:
+      taskSpec:
+        steps:
+          - name: hello-moto
+            image: scratch


### PR DESCRIPTION
The validation errors occurring in PipelineRuns as reported by the tekton controller within the .tekton directory are now reported directly in the event logs of the user namespaces along with the pipelinerun name where the error has occurred, this let a user troubleshoot the issue even if she or he doesn't have access to the controller log.

https://issues.redhat.com/browse/SRVKP-4318

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
