### PR TITLE
Make sure we get the oldest repository

### DIFF
--- a/pkg/matcher/repo_runinfo_matcher.go
+++ b/pkg/matcher/repo_runinfo_matcher.go
@@ -7,17 +7,18 @@ import (
 	apipac "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/sort"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func MatchEventURLRepo(ctx context.Context, cs *params.Run, event *info.Event, ns string) (*apipac.Repository, error) {
 	repositories, err := cs.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(ns).List(
 		ctx, metav1.ListOptions{})
+	sort.RepositorySortByCreationOldestTime(repositories.Items)
 	if err != nil {
 		return nil, err
 	}
-	for i := len(repositories.Items) - 1; i >= 0; i-- {
-		repo := repositories.Items[i]
+	for _, repo := range repositories.Items {
 		repo.Spec.URL = strings.TrimSuffix(repo.Spec.URL, "/")
 		if repo.Spec.URL == event.URL {
 			return &repo, nil

--- a/pkg/sort/repository.go
+++ b/pkg/sort/repository.go
@@ -1,0 +1,23 @@
+package sort
+
+import (
+	"sort"
+
+	pacv1alpha1 "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+)
+
+// From tekton cli prsort package.
+type repositorySortByCompletionTime []pacv1alpha1.Repository
+
+func (repositorys repositorySortByCompletionTime) Len() int { return len(repositorys) }
+func (repositorys repositorySortByCompletionTime) Swap(i, j int) {
+	repositorys[j], repositorys[i] = repositorys[i], repositorys[j]
+}
+
+func (repositorys repositorySortByCompletionTime) Less(i, j int) bool {
+	return repositorys[j].CreationTimestamp.After(repositorys[i].CreationTimestamp.Time)
+}
+
+func RepositorySortByCreationOldestTime(repositorys []pacv1alpha1.Repository) {
+	sort.Sort(repositorySortByCompletionTime(repositorys))
+}

--- a/pkg/sort/repository_test.go
+++ b/pkg/sort/repository_test.go
@@ -1,0 +1,41 @@
+package sort
+
+import (
+	"testing"
+	"time"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSortRepositories(t *testing.T) {
+	repositories := []v1alpha1.Repository{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: metav1.NewTime(metav1.Now().Add(-2 * time.Minute)),
+			},
+			Spec:   v1alpha1.RepositorySpec{URL: "https://middle/one"},
+			Status: []v1alpha1.RepositoryRunStatus{},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: metav1.NewTime(metav1.Now().Add(-3 * time.Minute)),
+			},
+			Spec:   v1alpha1.RepositorySpec{URL: "https://first/one"},
+			Status: []v1alpha1.RepositoryRunStatus{},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: metav1.NewTime(metav1.Now().Add(-1 * time.Minute)),
+			},
+			Spec:   v1alpha1.RepositorySpec{URL: "https://last/one"},
+			Status: []v1alpha1.RepositoryRunStatus{},
+		},
+	}
+
+	RepositorySortByCreationOldestTime(repositories)
+	assert.Equal(t, repositories[0].Spec.URL, "https://first/one", repositories[0].Spec.URL)
+	assert.Equal(t, repositories[1].Spec.URL, "https://middle/one", repositories[1].Spec.URL)
+	assert.Equal(t, repositories[2].Spec.URL, "https://last/one", repositories[1].Spec.URL)
+}


### PR DESCRIPTION
When we have multiple matches for the same repository, we need to make sure we only get the oldest one. This is important since we pac assumes the first one is the one that should be used, to avoid an hijacking scenario.

This should never happen in practice since we have our webhook that make sure we only have one repository per URL per cluster. If for whichever reasons the webhook is crashing or the admin has disabled it then at least we are covered

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
