### PR TITLE
fix TestGithubPushRequestGitOpsCommentCancel

### DIFF
--- a/test/pkg/wait/logs.go
+++ b/test/pkg/wait/logs.go
@@ -22,7 +22,7 @@ func RegexpMatchingInControllerLog(ctx context.Context, clients *params.Run, reg
 	ns := info.GetNS(ctx)
 	clients.Clients.Log.Infof("looking for regexp %s in %s for label %s container %s", reg.String(), ns, labelselector, containerName)
 	for i := 0; i <= maxNumberOfLoop; i++ {
-		output, err := tlogs.GetPodLog(ctx, clients.Clients.Kube.CoreV1(), info.GetNS(ctx), labelselector, containerName, lines)
+		output, err := tlogs.GetPodLog(ctx, clients.Clients.Kube.CoreV1(), ns, labelselector, containerName, lines)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
when the pipelinerun goes to quick to finish it would not be able to
check if it's canceled, to avoid that flakyness we say it's okay when we
have found it in the controller log that the request has been sent over.
There is other test testing cancellation anyway

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
