### PR TITLE
github.provider.token, cache github.ListRepos call

### DIFF
--- a/pkg/adapter/incoming.go
+++ b/pkg/adapter/incoming.go
@@ -106,7 +106,8 @@ func (l *listener) detectIncoming(ctx context.Context, req *http.Request, payloa
 		gh := github.New()
 		gh.Run = l.run
 		ns := info.GetNS(ctx)
-		enterpriseURL, token, installationID, err := app.GetAndUpdateInstallationID(ctx, req, l.run, repo, gh, ns)
+		ip := app.NewInstallation(req, l.run, repo, gh, ns)
+		enterpriseURL, token, installationID, err := ip.GetAndUpdateInstallationID(ctx)
 		if err != nil {
 			return false, nil, err
 		}

--- a/pkg/cmd/tknpac/info/install.go
+++ b/pkg/cmd/tknpac/info/install.go
@@ -64,7 +64,8 @@ func install(ctx context.Context, run *params.Run, ios *cli.IOStreams, apiURL st
 		return err
 	}
 	info := &InstallInfo{run: run, apiURL: apiURL}
-	if jwtToken, err := app.GenerateJWT(ctx, targetNs, info.run); err == nil {
+	ip := app.NewInstallation(nil, run, nil, nil, targetNs)
+	if jwtToken, err := ip.GenerateJWT(ctx); err == nil {
 		info.jwtToken = jwtToken
 		if err := info.get(ctx); err != nil {
 			return err


### PR DESCRIPTION
we were calling:

```
repoList, err := github.ListRepos(ctx, gh)
```

each time on each isntallationData when this call can only be done once and be cached.

using a struct and refactor the code to use it.

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
