### PR TITLE
Only act on events for newly created comments

### DIFF
--- a/pkg/provider/github/parse_payload.go
+++ b/pkg/provider/github/parse_payload.go
@@ -11,17 +11,18 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/bradleyfalzon/ghinstallation/v2"
+	ghinstallation "github.com/bradleyfalzon/ghinstallation/v2"
 	oGitHub "github.com/google/go-github/v57/github"
 	"github.com/google/go-github/v59/github"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/opscomments"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 )
 
 // GetAppIDAndPrivateKey retrieves the GitHub application ID and private key from a secret in the specified namespace.
@@ -237,6 +238,9 @@ func (v *Provider) processEvent(ctx context.Context, event *info.Event, eventInt
 	case *github.IssueCommentEvent:
 		if v.Client == nil {
 			return nil, fmt.Errorf("gitops style comments operation is only supported with github apps integration")
+		}
+		if gitEvent.GetAction() != "created" {
+			return nil, fmt.Errorf("only newly created comment is supported, received: %s", gitEvent.GetAction())
 		}
 		processedEvent, err = v.handleIssueCommentEvent(ctx, gitEvent)
 		if err != nil {

--- a/pkg/provider/github/parse_payload_test.go
+++ b/pkg/provider/github/parse_payload_test.go
@@ -10,6 +10,12 @@ import (
 	"testing"
 
 	"github.com/google/go-github/v59/github"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/env"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	rtesting "knative.dev/pkg/reconciler/testing"
+
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
@@ -17,11 +23,6 @@ import (
 	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
 	ghtesthelper "github.com/openshift-pipelines/pipelines-as-code/pkg/test/github"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/test/logger"
-	"gotest.tools/v3/assert"
-	"gotest.tools/v3/env"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	rtesting "knative.dev/pkg/reconciler/testing"
 )
 
 // script kiddies, don't get too excited, this has been randomly generated with random words.
@@ -149,7 +150,7 @@ func TestParsePayLoad(t *testing.T) {
 			eventType:          "issue_comment",
 			triggerTarget:      "pull_request",
 			githubClient:       true,
-			payloadEventStruct: github.IssueCommentEvent{Issue: &github.Issue{}},
+			payloadEventStruct: github.IssueCommentEvent{Action: github.String("created"), Issue: &github.Issue{}},
 			wantErrString:      "issue comment is not coming from a pull_request",
 		},
 		{
@@ -158,6 +159,7 @@ func TestParsePayLoad(t *testing.T) {
 			triggerTarget: "pull_request",
 			githubClient:  true,
 			payloadEventStruct: github.IssueCommentEvent{
+				Action: github.String("created"),
 				Issue: &github.Issue{
 					PullRequestLinks: &github.PullRequestLinks{
 						HTMLURL: github.String("/bad"),
@@ -234,11 +236,20 @@ func TestParsePayLoad(t *testing.T) {
 			shaRet: "headSHACheckSuite",
 		},
 		{
+			name:               "bad/issue_comment_not_from_created",
+			wantErrString:      "only newly created comment is supported, received: deleted",
+			payloadEventStruct: github.IssueCommentEvent{Action: github.String("deleted")},
+			eventType:          "issue_comment",
+			triggerTarget:      "pull_request",
+			githubClient:       true,
+		},
+		{
 			name:          "good/issue comment",
 			eventType:     "issue_comment",
 			triggerTarget: "pull_request",
 			githubClient:  true,
 			payloadEventStruct: github.IssueCommentEvent{
+				Action: github.String("created"),
 				Issue: &github.Issue{
 					PullRequestLinks: &github.PullRequestLinks{
 						HTMLURL: github.String("/666"),
@@ -275,6 +286,7 @@ func TestParsePayLoad(t *testing.T) {
 			triggerTarget: "pull_request",
 			githubClient:  true,
 			payloadEventStruct: github.IssueCommentEvent{
+				Action: github.String("created"),
 				Issue: &github.Issue{
 					PullRequestLinks: &github.PullRequestLinks{
 						HTMLURL: github.String("/777"),
@@ -295,6 +307,7 @@ func TestParsePayLoad(t *testing.T) {
 			triggerTarget: "pull_request",
 			githubClient:  true,
 			payloadEventStruct: github.IssueCommentEvent{
+				Action: github.String("created"),
 				Issue: &github.Issue{
 					PullRequestLinks: &github.PullRequestLinks{
 						HTMLURL: github.String("/999"),
@@ -314,6 +327,7 @@ func TestParsePayLoad(t *testing.T) {
 			triggerTarget: "pull_request",
 			githubClient:  true,
 			payloadEventStruct: github.IssueCommentEvent{
+				Action: github.String("created"),
 				Issue: &github.Issue{
 					PullRequestLinks: &github.PullRequestLinks{
 						HTMLURL: github.String("/888"),


### PR DESCRIPTION
When parsing issues comments, only do this on newly created comment not
for the other events.

This was an issue because when deleting a comment it would fire the
on-comment event and run a pipelinerun which is probably not what the
user wanted.

Fixes #1645

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
