### PR TITLE
add golangci-lint errcheck warning

### DIFF
--- a/.errcheck.txt
+++ b/.errcheck.txt
@@ -1,7 +1,0 @@
-(*github.com/tektoncd/pipeline/vendor/go.uber.org/zap.SugaredLogger).Sync
-flag.Set
-logger.Sync
-fmt.Fprintf
-fmt.Fprintln
-(io.Closer).Close
-updateConfigMap

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,7 +15,14 @@ linters-settings:
     disabled-checks:
       - unlambda
   errcheck:
-    exclude: .errcheck.txt
+    exclude-functions:
+      - (*github.com/tektoncd/pipeline/vendor/go.uber.org/zap.SugaredLogger).Sync
+      - flag.Set
+      - logger.Sync
+      - fmt.Fprintf
+      - fmt.Fprintln
+      - (io.Closer).Close
+      - updateConfigMap
   gofumpt:
     extra-rules: true
 linters:

--- a/pkg/templates/templating.go
+++ b/pkg/templates/templating.go
@@ -21,7 +21,33 @@ var (
 	mapType    = reflect.TypeOf(&structpb.Struct{})
 )
 
-// ReplacePlaceHoldersVariables Replace those {{var}} placeholders to the runinfo variable.
+// ReplacePlaceHoldersVariables is a function that replaces placeholders in a
+// given string template with their corresponding values. The placeholders are
+// expected to be in the format `{{key}}`, where `key` is the identifier for a
+// value.
+//
+// The function first checks if the key in the placeholder has a prefix of
+// "body", "headers", or "files". If it does and both `rawEvent` and `headers`
+// are not nil, it attempts to retrieve the value for the key using the
+// `customparams.CelValue` function and returns the corresponding string
+// representation. If the key does not have any of the mentioned prefixes, the
+// function checks if the key exists in the `dico` map. If it does, the
+// function replaces the placeholder with the corresponding value from the
+// `dico` map.
+//
+// Parameters:
+//   - template (string): The input string that may contain placeholders in the
+//     format `{{key}}`.
+//   - dico (map[string]string): A dictionary mapping keys to their corresponding
+//     string values. If a placeholder's key is found in this dictionary, it will
+//     be replaced with the corresponding value.
+//   - rawEvent (any): The raw event data that may be used to retrieve values for
+//     placeholders with keys that have a prefix of "body", "headers", or "files".
+//   - headers (http.Header): The HTTP headers that may be used to retrieve
+//     values for placeholders with keys that have a prefix of "headers".
+//   - changedFiles (map[string]interface{}): A map of changed files that may be
+//     used to retrieve values for placeholders with keys that have a prefix of
+//     "files".
 func ReplacePlaceHoldersVariables(template string, dico map[string]string, rawEvent any, headers http.Header, changedFiles map[string]interface{}) string {
 	return keys.ParamsRe.ReplaceAllStringFunc(template, func(s string) string {
 		parts := keys.ParamsRe.FindStringSubmatch(s)


### PR DESCRIPTION
we were getting this warning:

```
WARN [config_reader] The configuration option `linters.errcheck.exclude`
is deprecated, please use `linters.errcheck.exclude-functions`.
```

so removing .errcheck.txt and adding the functions to the .golangci.yml

add a comment to the go code to explain what the function does and launch golangci-lint to make sure it's all good.

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
