### PR TITLE
Fix matching proper PipelineRun with /test

### DIFF
--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -215,11 +215,14 @@ func (p *PacRun) getPipelineRunsFromRepo(ctx context.Context, repo *v1alpha1.Rep
 	}
 
 	// if /test command is used then filter out the pipelinerun
-	pipelineRuns = filterRunningPipelineRunOnTargetTest(p.event.TargetTestPipelineRun, pipelineRuns)
-	if pipelineRuns == nil {
-		msg := fmt.Sprintf("cannot find pipelinerun %s in this repository", p.event.TargetTestPipelineRun)
-		p.eventEmitter.EmitMessage(repo, zap.InfoLevel, "RepositoryCannotLocatePipelineRun", msg)
-		return nil, nil
+	if p.event.TargetTestPipelineRun != "" {
+		targetPR := filterRunningPipelineRunOnTargetTest(p.event.TargetTestPipelineRun, pipelineRuns)
+		if targetPR == nil {
+			msg := fmt.Sprintf("cannot find the targeted pipelinerun %s in this repository", p.event.TargetTestPipelineRun)
+			p.eventEmitter.EmitMessage(repo, zap.InfoLevel, "RepositoryCannotLocatePipelineRun", msg)
+			return nil, nil
+		}
+		pipelineRuns = []*tektonv1.PipelineRun{targetPR}
 	}
 
 	// finally resolve with fetching the remote tasks (if enabled)
@@ -253,11 +256,13 @@ func (p *PacRun) getPipelineRunsFromRepo(ctx context.Context, repo *v1alpha1.Rep
 	// if we are doing explicit /test command then we only want to run the one that has matched the /test
 	if p.event.TargetTestPipelineRun != "" {
 		p.eventEmitter.EmitMessage(repo, zap.InfoLevel, "RepositoryMatchedPipelineRun", fmt.Sprintf("explicit testing via /test of PipelineRun %s", p.event.TargetTestPipelineRun))
+		selectedPr := filterRunningPipelineRunOnTargetTest(p.event.TargetTestPipelineRun, pipelineRuns)
 		return []matcher.Match{{
-			PipelineRun: pipelineRuns[0],
+			PipelineRun: selectedPr,
 			Repo:        repo,
 		}}, nil
 	}
+
 	matchedPRs, err = matcher.MatchPipelinerunByAnnotation(ctx, p.logger, pipelineRuns, p.run, p.event, p.vcx)
 	if err != nil {
 		// Don't fail when you don't have a match between pipeline and annotations
@@ -268,14 +273,11 @@ func (p *PacRun) getPipelineRunsFromRepo(ctx context.Context, repo *v1alpha1.Rep
 	return matchedPRs, nil
 }
 
-func filterRunningPipelineRunOnTargetTest(testPipeline string, prs []*tektonv1.PipelineRun) []*tektonv1.PipelineRun {
-	if testPipeline == "" {
-		return prs
-	}
+func filterRunningPipelineRunOnTargetTest(testPipeline string, prs []*tektonv1.PipelineRun) *tektonv1.PipelineRun {
 	for _, pr := range prs {
 		if prName, ok := pr.GetAnnotations()[apipac.OriginalPRName]; ok {
 			if prName == testPipeline {
-				return []*tektonv1.PipelineRun{pr}
+				return pr
 			}
 		}
 	}

--- a/pkg/pipelineascode/match_test.go
+++ b/pkg/pipelineascode/match_test.go
@@ -77,9 +77,9 @@ func TestFilterRunningPipelineRunOnTargetTest(t *testing.T) {
 		},
 	}
 	ret := filterRunningPipelineRunOnTargetTest("", prs)
-	assert.Equal(t, prs[0].GetName(), ret[0].GetName())
+	assert.Assert(t, ret == nil)
 	ret = filterRunningPipelineRunOnTargetTest(testPipeline, prs)
-	assert.Equal(t, prs[0].GetName(), ret[0].GetName())
+	assert.Equal(t, prs[0].GetName(), ret.GetName())
 	prs = []*tektonv1.PipelineRun{}
 	ret = filterRunningPipelineRunOnTargetTest(testPipeline, prs)
 	assert.Assert(t, ret == nil)

--- a/pkg/resolve/remote.go
+++ b/pkg/resolve/remote.go
@@ -47,7 +47,7 @@ func getRemotes(ctx context.Context, rt *matcher.RemoteTasks, types TektonTypes)
 
 		for _, task := range remoteTasks {
 			if alreadySeen(remoteType.Tasks, task) {
-				rt.Logger.Infof("skipping duplicated task %s in annotations on pipelinerun %s", task.GetName(), pipelinerun.GetName())
+				rt.Logger.Debugf("skipping already fetched task %s in annotations on pipelinerun %s", task.GetName(), pipelinerun.GetName())
 				continue
 			}
 			remoteType.Tasks = append(remoteType.Tasks, task)

--- a/pkg/resolve/remote_test.go
+++ b/pkg/resolve/remote_test.go
@@ -218,10 +218,8 @@ func TestRemote(t *testing.T) {
 			expectedLogsSnippets: []string{
 				fmt.Sprintf("successfully fetched %s from remote https url", remoteTaskURL),
 				fmt.Sprintf("successfully fetched %s from remote https url", remoteTaskURL),
-				fmt.Sprintf("skipping duplicated task %s in annotations on pipelinerun %s", remoteTaskName, randomPipelineRunName),
 				fmt.Sprintf("successfully fetched %s from remote https url", remotePipelineURL),
 				fmt.Sprintf("successfully fetched %s from remote https url", remoteTaskURL),
-				fmt.Sprintf("skipping remote task %s from remote pipeline %s as already defined in pipelinerun", remoteTaskName, remotePipelineName),
 			},
 			expectedPipelinesFetch: 1,
 			expectedTaskFetch:      1,

--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -22,7 +22,6 @@ import (
 	tknpaclist "github.com/openshift-pipelines/pipelines-as-code/pkg/cmd/tknpac/list"
 	tknpacresolve "github.com/openshift-pipelines/pipelines-as-code/pkg/cmd/tknpac/resolve"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/git"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/opscomments"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
@@ -495,33 +494,6 @@ func TestGiteaWithCLIGeneratePipeline(t *testing.T) {
 	}
 }
 
-func TestGiteaCancelRun(t *testing.T) {
-	topts := &tgitea.TestOpts{
-		TargetEvent: triggertype.PullRequest.String(),
-		YAMLFiles: map[string]string{
-			".tekton/pr.yaml": "testdata/pipelinerun_long_running.yaml",
-		},
-		ExpectEvents: false,
-	}
-	_, f := tgitea.TestPR(t, topts)
-	defer f()
-	// let pipelineRun start and then cancel it
-	time.Sleep(time.Second * 2)
-	tgitea.PostCommentOnPullRequest(t, topts, "/cancel")
-
-	waitOpts := twait.Opts{
-		RepoName:        topts.TargetNS,
-		Namespace:       topts.TargetNS,
-		MinNumberStatus: 1,
-		PollTimeout:     twait.DefaultTimeout,
-		TargetSHA:       topts.PullRequest.Head.Sha,
-	}
-	_, err := twait.UntilRepositoryUpdated(context.Background(), topts.ParamsRun.Clients, waitOpts)
-	assert.Error(t, err, "pipelinerun has failed")
-
-	tgitea.CheckIfPipelineRunsCancelled(t, topts)
-}
-
 func TestGiteaConcurrencyOrderedExecution(t *testing.T) {
 	topts := &tgitea.TestOpts{
 		Regexp:      successRegexp,
@@ -760,134 +732,6 @@ func TestGiteaClusterTasks(t *testing.T) {
 
 	topts.CheckForStatus = "success"
 	tgitea.WaitForStatus(t, topts, topts.TargetRefName, "", true)
-}
-
-// TestGiteaOnCommentAnnotation test custom annotations for gitops comment.
-func TestGiteaOnCommentAnnotation(t *testing.T) {
-	var err error
-	ctx := context.Background()
-	topts := &tgitea.TestOpts{
-		TargetRefName: names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test"),
-	}
-	triggerComment := "/hello-world"
-	topts.TargetNS = topts.TargetRefName
-	topts.ParamsRun, topts.Opts, topts.GiteaCNX, err = tgitea.Setup(ctx)
-	assert.NilError(t, err, fmt.Errorf("cannot do gitea setup: %w", err))
-	ctx, err = cctx.GetControllerCtxInfo(ctx, topts.ParamsRun)
-	assert.NilError(t, err)
-	assert.NilError(t, pacrepo.CreateNS(ctx, topts.TargetNS, topts.ParamsRun))
-	assert.NilError(t, secret.Create(ctx, topts.ParamsRun, map[string]string{"secret": "SHHHHHHH"}, topts.TargetNS, "pac-secret"))
-	topts.TargetEvent = triggertype.PullRequest.String()
-	topts.YAMLFiles = map[string]string{
-		".tekton/on-comment-match.yaml":   "testdata/pipelinerun-on-comment-annotation.yaml",
-		".tekton/pull-request-match.yaml": "testdata/pipelinerun.yaml",
-	}
-	_, f := tgitea.TestPR(t, topts)
-	defer f()
-	tgitea.WaitForStatus(t, topts, "heads/"+topts.TargetRefName, "", false)
-
-	tgitea.PostCommentOnPullRequest(t, topts, triggerComment)
-	// we have two status one for the pull request match and one on comment match from the comment sent
-	waitOpts := twait.Opts{
-		RepoName:        topts.TargetNS,
-		Namespace:       topts.TargetNS,
-		MinNumberStatus: 2,
-		PollTimeout:     twait.DefaultTimeout,
-	}
-	_, err = twait.UntilRepositoryUpdated(context.Background(), topts.ParamsRun.Clients, waitOpts)
-	assert.NilError(t, err)
-
-	tgitea.PostCommentOnPullRequest(t, topts, triggerComment)
-	waitOpts.MinNumberStatus = 3
-	// now we should have only 3 status, the last one is the on comment match from the comment sent
-	// but should not have matched the pull request ones
-	repo, err := twait.UntilRepositoryUpdated(context.Background(), topts.ParamsRun.Clients, waitOpts)
-	assert.NilError(t, err)
-	assert.Equal(t, len(repo.Status), waitOpts.MinNumberStatus, fmt.Sprintf("should have only %d status", waitOpts.MinNumberStatus))
-	assert.Equal(t, *repo.Status[len(repo.Status)-1].EventType, opscomments.OnCommentEventType.String(), "should have a on comment event type")
-
-	last := repo.Status[len(repo.Status)-1]
-	err = twait.RegexpMatchingInPodLog(context.Background(),
-		topts.ParamsRun,
-		topts.TargetNS,
-		fmt.Sprintf("tekton.dev/pipelineRun=%s", last.PipelineRunName), "step-task", *regexp.MustCompile(triggerComment), 2)
-	assert.NilError(t, err)
-}
-
-// TestGiteaTestPipelineRunExplicitelyWithTestComment will test a pipelinerun
-// even if it hasn't matched when we are doing a /test comment.
-func TestGiteaTestPipelineRunExplicitelyWithTestComment(t *testing.T) {
-	var err error
-	ctx := context.Background()
-	topts := &tgitea.TestOpts{
-		TargetRefName: names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test"),
-	}
-	topts.TargetNS = topts.TargetRefName
-	topts.ParamsRun, topts.Opts, topts.GiteaCNX, err = tgitea.Setup(ctx)
-	assert.NilError(t, err, fmt.Errorf("cannot do gitea setup: %w", err))
-	ctx, err = cctx.GetControllerCtxInfo(ctx, topts.ParamsRun)
-	assert.NilError(t, err)
-	assert.NilError(t, pacrepo.CreateNS(ctx, topts.TargetNS, topts.ParamsRun))
-	assert.NilError(t, secret.Create(ctx, topts.ParamsRun, map[string]string{"secret": "SHHHHHHH"}, topts.TargetNS, "pac-secret"))
-	topts.TargetEvent = triggertype.PullRequest.String()
-	topts.YAMLFiles = map[string]string{
-		".tekton/pr.yaml": "testdata/pipelinerun-nomatch.yaml",
-	}
-	_, f := tgitea.TestPR(t, topts)
-	defer f()
-	tgitea.PostCommentOnPullRequest(t, topts, "/test no-match")
-	tgitea.WaitForStatus(t, topts, "heads/"+topts.TargetRefName, "", false)
-	waitOpts := twait.Opts{
-		RepoName:        topts.TargetNS,
-		Namespace:       topts.TargetNS,
-		MinNumberStatus: 1,
-		PollTimeout:     twait.DefaultTimeout,
-	}
-
-	repo, err := twait.UntilRepositoryUpdated(context.Background(), topts.ParamsRun.Clients, waitOpts)
-	assert.NilError(t, err)
-	assert.Equal(t, len(repo.Status), 1, "should have only 1 status")
-	assert.Equal(t, *repo.Status[0].EventType, opscomments.TestSingleCommentEventType.String(), "should have a test comment event in status")
-}
-
-func TestGiteaRetestAll(t *testing.T) {
-	var err error
-	ctx := context.Background()
-	topts := &tgitea.TestOpts{
-		TargetRefName: names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test"),
-	}
-	topts.TargetNS = topts.TargetRefName
-	topts.ParamsRun, topts.Opts, topts.GiteaCNX, err = tgitea.Setup(ctx)
-	assert.NilError(t, err, fmt.Errorf("cannot do gitea setup: %w", err))
-	ctx, err = cctx.GetControllerCtxInfo(ctx, topts.ParamsRun)
-	assert.NilError(t, err)
-	assert.NilError(t, pacrepo.CreateNS(ctx, topts.TargetNS, topts.ParamsRun))
-	assert.NilError(t, secret.Create(ctx, topts.ParamsRun, map[string]string{"secret": "SHHHHHHH"}, topts.TargetNS, "pac-secret"))
-	topts.TargetEvent = triggertype.PullRequest.String()
-	topts.YAMLFiles = map[string]string{
-		".tekton/pr.yaml":      "testdata/pipelinerun.yaml",
-		".tekton/nomatch.yaml": "testdata/pipelinerun-nomatch.yaml",
-	}
-	_, f := tgitea.TestPR(t, topts)
-	defer f()
-	tgitea.PostCommentOnPullRequest(t, topts, "/retest")
-	waitOpts := twait.Opts{
-		RepoName:        topts.TargetNS,
-		Namespace:       topts.TargetNS,
-		MinNumberStatus: 2,
-		PollTimeout:     twait.DefaultTimeout,
-	}
-
-	repo, err := twait.UntilRepositoryUpdated(context.Background(), topts.ParamsRun.Clients, waitOpts)
-	assert.NilError(t, err)
-	var rt bool
-	for _, status := range repo.Status {
-		if *status.EventType == opscomments.RetestAllCommentEventType.String() {
-			rt = true
-		}
-	}
-	assert.Assert(t, rt, "should have a retest all comment event in status")
-	assert.Equal(t, len(repo.Status), 2, "should have only 2 status")
 }
 
 // Local Variables:

--- a/test/gitops_commands_test.go
+++ b/test/gitops_commands_test.go
@@ -1,0 +1,179 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/opscomments"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/cctx"
+	tgitea "github.com/openshift-pipelines/pipelines-as-code/test/pkg/gitea"
+	pacrepo "github.com/openshift-pipelines/pipelines-as-code/test/pkg/repository"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/secret"
+	twait "github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
+	"github.com/tektoncd/pipeline/pkg/names"
+	"gotest.tools/v3/assert"
+)
+
+func TestGiteaCancelRun(t *testing.T) {
+	topts := &tgitea.TestOpts{
+		TargetEvent: triggertype.PullRequest.String(),
+		YAMLFiles: map[string]string{
+			".tekton/pr.yaml": "testdata/pipelinerun_long_running.yaml",
+		},
+		ExpectEvents: false,
+	}
+	_, f := tgitea.TestPR(t, topts)
+	defer f()
+	// let pipelineRun start and then cancel it
+	time.Sleep(time.Second * 2)
+	tgitea.PostCommentOnPullRequest(t, topts, "/cancel")
+
+	waitOpts := twait.Opts{
+		RepoName:        topts.TargetNS,
+		Namespace:       topts.TargetNS,
+		MinNumberStatus: 1,
+		PollTimeout:     twait.DefaultTimeout,
+		TargetSHA:       topts.PullRequest.Head.Sha,
+	}
+	_, err := twait.UntilRepositoryUpdated(context.Background(), topts.ParamsRun.Clients, waitOpts)
+	assert.Error(t, err, "pipelinerun has failed")
+
+	tgitea.CheckIfPipelineRunsCancelled(t, topts)
+}
+
+// TestGiteaOnCommentAnnotation test custom annotations for gitops comment.
+func TestGiteaOnCommentAnnotation(t *testing.T) {
+	var err error
+	ctx := context.Background()
+	topts := &tgitea.TestOpts{
+		TargetRefName: names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test"),
+	}
+	triggerComment := "/hello-world"
+	topts.TargetNS = topts.TargetRefName
+	topts.ParamsRun, topts.Opts, topts.GiteaCNX, err = tgitea.Setup(ctx)
+	assert.NilError(t, err, fmt.Errorf("cannot do gitea setup: %w", err))
+	ctx, err = cctx.GetControllerCtxInfo(ctx, topts.ParamsRun)
+	assert.NilError(t, err)
+	assert.NilError(t, pacrepo.CreateNS(ctx, topts.TargetNS, topts.ParamsRun))
+	assert.NilError(t, secret.Create(ctx, topts.ParamsRun, map[string]string{"secret": "SHHHHHHH"}, topts.TargetNS, "pac-secret"))
+	topts.TargetEvent = triggertype.PullRequest.String()
+	topts.YAMLFiles = map[string]string{
+		".tekton/on-comment-match.yaml":   "testdata/pipelinerun-on-comment-annotation.yaml",
+		".tekton/pull-request-match.yaml": "testdata/pipelinerun.yaml",
+	}
+	_, f := tgitea.TestPR(t, topts)
+	defer f()
+	tgitea.WaitForStatus(t, topts, "heads/"+topts.TargetRefName, "", false)
+
+	tgitea.PostCommentOnPullRequest(t, topts, triggerComment)
+	// we have two status one for the pull request match and one on comment match from the comment sent
+	waitOpts := twait.Opts{
+		RepoName:        topts.TargetNS,
+		Namespace:       topts.TargetNS,
+		MinNumberStatus: 2,
+		PollTimeout:     twait.DefaultTimeout,
+	}
+	_, err = twait.UntilRepositoryUpdated(context.Background(), topts.ParamsRun.Clients, waitOpts)
+	assert.NilError(t, err)
+
+	tgitea.PostCommentOnPullRequest(t, topts, triggerComment)
+	waitOpts.MinNumberStatus = 3
+	// now we should have only 3 status, the last one is the on comment match from the comment sent
+	// but should not have matched the pull request ones
+	repo, err := twait.UntilRepositoryUpdated(context.Background(), topts.ParamsRun.Clients, waitOpts)
+	assert.NilError(t, err)
+	assert.Equal(t, len(repo.Status), waitOpts.MinNumberStatus, fmt.Sprintf("should have only %d status", waitOpts.MinNumberStatus))
+	assert.Equal(t, *repo.Status[len(repo.Status)-1].EventType, opscomments.OnCommentEventType.String(), "should have a on comment event type")
+
+	last := repo.Status[len(repo.Status)-1]
+	err = twait.RegexpMatchingInPodLog(context.Background(),
+		topts.ParamsRun,
+		topts.TargetNS,
+		fmt.Sprintf("tekton.dev/pipelineRun=%s", last.PipelineRunName), "step-task", *regexp.MustCompile(triggerComment), 2)
+	assert.NilError(t, err)
+}
+
+// TestGiteaTestPipelineRunExplicitelyWithTestComment will test a pipelinerun
+// even if it hasn't matched when we are doing a /test comment.
+func TestGiteaTestPipelineRunExplicitelyWithTestComment(t *testing.T) {
+	var err error
+	ctx := context.Background()
+	topts := &tgitea.TestOpts{
+		TargetRefName: names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test"),
+	}
+	topts.TargetNS = topts.TargetRefName
+	topts.ParamsRun, topts.Opts, topts.GiteaCNX, err = tgitea.Setup(ctx)
+	assert.NilError(t, err, fmt.Errorf("cannot do gitea setup: %w", err))
+	ctx, err = cctx.GetControllerCtxInfo(ctx, topts.ParamsRun)
+	assert.NilError(t, err)
+	assert.NilError(t, pacrepo.CreateNS(ctx, topts.TargetNS, topts.ParamsRun))
+	assert.NilError(t, secret.Create(ctx, topts.ParamsRun, map[string]string{"secret": "SHHHHHHH"}, topts.TargetNS, "pac-secret"))
+	topts.TargetEvent = triggertype.PullRequest.String()
+	topts.YAMLFiles = map[string]string{
+		".tekton/2-pr.yaml":         "testdata/pipelinerun-nomatch.yaml",
+		".tekton/1-anotherone.yaml": "testdata/pipelinerun-on-comment-annotation.yaml",
+	}
+	_, f := tgitea.TestPR(t, topts)
+	defer f()
+	targetPrName := "no-match"
+	tgitea.PostCommentOnPullRequest(t, topts, "/test "+targetPrName)
+	tgitea.WaitForStatus(t, topts, "heads/"+topts.TargetRefName, "", false)
+	waitOpts := twait.Opts{
+		RepoName:        topts.TargetNS,
+		Namespace:       topts.TargetNS,
+		MinNumberStatus: 1,
+		PollTimeout:     twait.DefaultTimeout,
+	}
+
+	repo, err := twait.UntilRepositoryUpdated(context.Background(), topts.ParamsRun.Clients, waitOpts)
+	assert.NilError(t, err)
+	assert.Equal(t, len(repo.Status), 1, "should have only 1 status")
+	assert.Equal(t, *repo.Status[0].EventType, opscomments.TestSingleCommentEventType.String(), "should have a test comment event in status")
+	assert.Assert(t, strings.HasPrefix(repo.Status[0].PipelineRunName, targetPrName+"-"),
+		"we didn't target the proper pipelinerun, we tested: %s", repo.Status[0].PipelineRunName)
+}
+
+func TestGiteaRetestAll(t *testing.T) {
+	var err error
+	ctx := context.Background()
+	topts := &tgitea.TestOpts{
+		TargetRefName: names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test"),
+	}
+	topts.TargetNS = topts.TargetRefName
+	topts.ParamsRun, topts.Opts, topts.GiteaCNX, err = tgitea.Setup(ctx)
+	assert.NilError(t, err, fmt.Errorf("cannot do gitea setup: %w", err))
+	ctx, err = cctx.GetControllerCtxInfo(ctx, topts.ParamsRun)
+	assert.NilError(t, err)
+	assert.NilError(t, pacrepo.CreateNS(ctx, topts.TargetNS, topts.ParamsRun))
+	assert.NilError(t, secret.Create(ctx, topts.ParamsRun, map[string]string{"secret": "SHHHHHHH"}, topts.TargetNS, "pac-secret"))
+	topts.TargetEvent = triggertype.PullRequest.String()
+	topts.YAMLFiles = map[string]string{
+		".tekton/pr.yaml":      "testdata/pipelinerun.yaml",
+		".tekton/nomatch.yaml": "testdata/pipelinerun-nomatch.yaml",
+	}
+	_, f := tgitea.TestPR(t, topts)
+	defer f()
+	tgitea.PostCommentOnPullRequest(t, topts, "/retest")
+	waitOpts := twait.Opts{
+		RepoName:        topts.TargetNS,
+		Namespace:       topts.TargetNS,
+		MinNumberStatus: 2,
+		PollTimeout:     twait.DefaultTimeout,
+	}
+
+	repo, err := twait.UntilRepositoryUpdated(context.Background(), topts.ParamsRun.Clients, waitOpts)
+	assert.NilError(t, err)
+	var rt bool
+	for _, status := range repo.Status {
+		if *status.EventType == opscomments.RetestAllCommentEventType.String() {
+			rt = true
+		}
+	}
+	assert.Assert(t, rt, "should have a retest all comment event in status")
+	assert.Equal(t, len(repo.Status), 2, "should have only 2 status")
+}


### PR DESCRIPTION
 We were always getting the first one of the pipelinerun, i thought the
filtering was already done and it would always be only one PipelineRun
but we re-fetch everything on resolve.Resolve, so redoing the filtering
properly.

Improve e2e to make sure it handles this properly to explicit test the
proper PipelineRun.

Refactor a bit the gitea tests for GitOPS commands to be in its own file.
g# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
