### PR TITLE
Filter some of the noises from the logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This getting started video will guide you thought the `tkn-pac bootstrap` flow u
 
 [![Getting started to Pipelines-as-Code](https://img.youtube.com/vi/cNOqPgpRXQY/0.jpg)](https://www.youtube.com/watch?v=cNOqPgpRXQY)
 
-For more details on the different installation method please follow [this document](docs/install.md) for installing Pipelines-as-Code on OpenShift.
+For more details on the different installation method please follow [this document](https://pipelinesascode.com/docs/install/overview/) for installing Pipelines-as-Code on OpenShift.
 
 ## Getting Started
 

--- a/docs/content/dev/_index.md
+++ b/docs/content/dev/_index.md
@@ -248,7 +248,7 @@ need to go to this URL:
 
 ## Documentation when we are doing the Release Process
 
-- See here [release-process](./release-process.md)
+- See here [release-process]({{< relref "/dev/release-process.md" >}})
 
 ## How to update all dependencies in Pipelines-as-Code
 

--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -206,9 +206,9 @@ func (l listener) processRes(processEvent bool, provider provider.Interface, log
 	}
 
 	if skipReason != "" {
-		logger.Infof("skipping event: %s", skipReason)
+		logger.Debugf("skipping non supported event: %s", skipReason)
 	}
-	return nil, logger, fmt.Errorf("skipping event")
+	return nil, logger, fmt.Errorf("skipping non supported event")
 }
 
 func (l listener) detectProvider(req *http.Request, reqBody string) (provider.Interface, *zap.SugaredLogger, error) {

--- a/pkg/matcher/annotation_matcher_test.go
+++ b/pkg/matcher/annotation_matcher_test.go
@@ -1964,3 +1964,46 @@ func TestGetTargetBranch(t *testing.T) {
 		})
 	}
 }
+
+func TestGetName(t *testing.T) {
+	tests := []struct {
+		name     string
+		prun     *tektonv1.PipelineRun
+		expected string
+	}{
+		{
+			name: "Test with name",
+			prun: &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pipeline",
+				},
+			},
+			expected: "test-pipeline",
+		},
+		{
+			name: "Test with generateName",
+			prun: &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-pipeline-",
+				},
+			},
+			expected: "test-pipeline-",
+		},
+		{
+			name: "Test with generateName and name",
+			prun: &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:         "test-pipeline",
+					GenerateName: "generate-pipeline-",
+				},
+			},
+			expected: "generate-pipeline-",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name := getName(tt.prun)
+			assert.Equal(t, tt.expected, name)
+		})
+	}
+}


### PR DESCRIPTION
By changing the log level of some of the logs from Info or Warn to Debug

admin can always configure the debug level to show if they want, https://pipelinesascode.com/docs/install/settings/#logging-configuration

some docs links issues fix as well

Fixes #1658 



# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
