### PR TITLE
Fix checkrun status issue

### DIFF
--- a/pkg/provider/github/status.go
+++ b/pkg/provider/github/status.go
@@ -92,7 +92,7 @@ func isFailedCheckrun(run *github.CheckRun) bool {
 	if run == nil || run.Output == nil {
 		return false
 	}
-	if run.Output.Title != nil && strings.Contains(*run.Output.Title, "Failed") &&
+	if run.Output.Title != nil && strings.Contains(*run.Output.Title, "pipelinerun start failure") &&
 		run.Output.Summary != nil &&
 		strings.Contains(*run.Output.Summary, "failed") {
 		return true
@@ -206,6 +206,8 @@ func (v *Provider) getOrUpdateCheckRunStatus(ctx context.Context, runevent *info
 	// when multiple pipelineruns fail. In such cases, generate only one checkrun ID,
 	// regardless of the number of failed pipelineruns.
 	if statusOpts.Title == "Failed" && statusOpts.PipelineRunName == "" {
+		// setting different title to handle multiple checkrun cases
+		statusOpts.Title = "pipelinerun start failure"
 		if statusOpts.InstanceCountForCheckRun >= 1 {
 			return nil
 		}

--- a/test/github_pullrequest_test.go
+++ b/test/github_pullrequest_test.go
@@ -129,7 +129,7 @@ func TestGithubPullRequestSecondBadYaml(t *testing.T) {
 		time.Sleep(5 * time.Second)
 	}
 	assert.Equal(t, len(res.CheckRuns), 1)
-	assert.Equal(t, res.CheckRuns[0].GetOutput().GetTitle(), "Failed")
+	assert.Equal(t, res.CheckRuns[0].GetOutput().GetTitle(), "pipelinerun start failure")
 	// may be fragile if we change the application name, but life goes on if it fails and we fix the name if that happen
 	assert.Equal(t, res.CheckRuns[0].GetOutput().GetSummary(), "Pipelines as Code GHE has <b>failed</b>.")
 	golden.Assert(t, res.CheckRuns[0].GetOutput().GetText(), strings.ReplaceAll(fmt.Sprintf("%s.golden", t.Name()), "/", "-"))


### PR DESCRIPTION
we encountered a bug related to status display
when resolving multiple checkrun issues as part of 1566. This was rectified by introducing a new
title specifix to multiple checkrun scenario.

Signed-off-by: Savita Ashture <sashture@redhat.com>

[Screencast from 2024-04-17 14-44-46.webm](https://github.com/openshift-pipelines/pipelines-as-code/assets/9441662/13775ddc-2b3c-4299-bf8c-9b170c5c2753)

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
