### PR TITLE
try to fix documentation for cloudfare docs

### DIFF
--- a/docs/content/docs/guide/authoringprs.md
+++ b/docs/content/docs/guide/authoringprs.md
@@ -209,7 +209,7 @@ with `/merge-pr`
 
 When the PipelineRun that has been triggered with the `on-comment` annotation
 gets started the template variable `{{ trigger_comment }}` get set. See the
-documentation [here]({{< relref "/docs/guide/gitops_commands/#accessing-the-comment-triggering-the-pipelinerun" >}})
+documentation [here]({{< relref "/docs/guide/gitops_commands.md#accessing-the-comment-triggering-the-pipelinerun" >}})
 
 Note that the `on-comment` annotation will respect the `pull_request` [Policy]({{< relref "/docs/guide/policy" >}}) rule,
 so only users into the `pull_request` policy will be able to trigger the


### PR DESCRIPTION
it seems to fails on cloudfare with:

ERROR 2024/04/17 13:57:25 [en] REF_NOT_FOUND: Ref
"/docs/guide/gitops_commands/":
"/opt/buildhome/repo/docs/content/docs/guide/authoringprs.md:212:22":
page not REF_NOT_FOUND

not sure exactly the reason but  the fix make sense
