### PR TITLE
Fix tkn pac generate when no git remote url

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -40,24 +40,6 @@ func RunGit(dir string, args ...string) (string, error) {
 
 // GetGitInfo try to detect the current remote for this URL return the origin url transformed and the topdir.
 func GetGitInfo(dir string) *Info {
-	gitURL, err := RunGit(dir, "remote", "get-url", "origin")
-	if err != nil {
-		gitURL, err = RunGit(dir, "remote", "get-url", "upstream")
-		if err != nil {
-			return &Info{}
-		}
-	}
-	gitURL = strings.TrimSpace(gitURL)
-	gitURL = strings.TrimSuffix(gitURL, ".git")
-
-	// convert github and probably others ssh access format into https
-	// i think it only fails with bitbucket server
-	if strings.HasPrefix(gitURL, "git@") {
-		sp := strings.Split(gitURL, ":")
-		prefix := strings.ReplaceAll(sp[0], "git@", "https://")
-		gitURL = fmt.Sprintf("%s/%s", prefix, strings.Join(sp[1:], ":"))
-	}
-
 	brootdir, err := RunGit(dir, "rev-parse", "--show-toplevel")
 	if err != nil {
 		return &Info{}
@@ -71,6 +53,25 @@ func GetGitInfo(dir string) *Info {
 	headbranch, err := RunGit(dir, "rev-parse", "--abbrev-ref", "HEAD")
 	if err != nil {
 		return &Info{}
+	}
+
+	gitURL, err := RunGit(dir, "remote", "get-url", "origin")
+	if err != nil {
+		gitURL, err = RunGit(dir, "remote", "get-url", "upstream")
+		if err != nil {
+			// use top dir name as fallback
+			gitURL = brootdir
+		}
+	}
+	gitURL = strings.TrimSpace(gitURL)
+	gitURL = strings.TrimSuffix(gitURL, ".git")
+
+	// convert github and probably others ssh access format into https
+	// i think it only fails with bitbucket server
+	if strings.HasPrefix(gitURL, "git@") {
+		sp := strings.Split(gitURL, ":")
+		prefix := strings.ReplaceAll(sp[0], "git@", "https://")
+		gitURL = fmt.Sprintf("%s/%s", prefix, strings.Join(sp[1:], ":"))
 	}
 
 	return &Info{

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -3,6 +3,7 @@ package git
 import (
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -36,6 +37,10 @@ func TestGetGitInfo(t *testing.T) {
 			want: Info{
 				URL: "https://github.com/chmouel/demo",
 			},
+		},
+		{
+			name:         "Get git info no github url",
+			remoteTarget: "origin",
 		},
 		{
 			name:         "Get git info remove .git suffix",
@@ -94,14 +99,19 @@ func TestGetGitInfo(t *testing.T) {
 			_, err = RunGit(gitDir, "config", "--local", "user.name", "Mister Ze Foo")
 			assert.NilError(t, err)
 
-			_, err = RunGit(gitDir, "remote", "add", tt.remoteTarget, tt.gitURL)
-			assert.NilError(t, err)
+			if tt.gitURL != "" {
+				_, err = RunGit(gitDir, "remote", "add", tt.remoteTarget, tt.gitURL)
+				assert.NilError(t, err)
+			}
 			_, err = RunGit(gitDir, "commit", "--allow-empty", "-m", "Empty Commit")
 			assert.NilError(t, err)
 			if tt.want.Branch != "" {
 				_, _ = RunGit(gitDir, "checkout", "-b", tt.want.Branch)
 			}
 			gitinfo := GetGitInfo(gitDir)
+			if tt.gitURL == "" {
+				assert.Assert(t, strings.HasPrefix(gitinfo.URL, "/"))
+			}
 			if tt.want.URL != "" {
 				assert.Equal(t, gitinfo.URL, tt.want.URL)
 			}


### PR DESCRIPTION
when we don't have a git remote url (like for example the repository
hasn't been pushed yet) the generate name would come back as "." which
would fail on kube.

So instead use the current working directory as the gitURL so we get a
name for the pipelinerun name
