### PR TITLE
SRVKP-4499: watcher panic with pending runs, concurrency not set

### DIFF
--- a/.tekton/generate-coverage-release.yaml
+++ b/.tekton/generate-coverage-release.yaml
@@ -83,8 +83,7 @@ spec:
                 ARCH=aarch64
                 git config --global --add safe.directory $(workspaces.source.path)
                 git fetch -a --tags
-                version=$(curl -s https://uploader.codecov.io/${ARCH}/latest| sed -n '/full_version/ { s/.*full_version...//;s/".*//;p; }')
-                curl -LOs https://uploader.codecov.io/${version}/${ARCH}/codecov
+                curl -LOs https://uploader.codecov.io/v0.7.3/aarch64/codecov
                 chmod +x ./codecov
                 ./codecov -C {{revision}} -v
             - name: upload-release

--- a/.tekton/go.yaml
+++ b/.tekton/go.yaml
@@ -89,12 +89,12 @@ spec:
               script: |
                 #!/usr/bin/env bash
                 set -eux
+                ARCH=aarch64
                 git config --global --add safe.directory $(workspaces.source.path)
                 git fetch -a --tags
-                version=$(curl -s https://uploader.codecov.io/aarch64/latest| sed -n '/full_version/ { s/.*full_version...//;s/".*//;p; }')
-                curl -LOs https://uploader.codecov.io/${version}/aarch64/codecov
+                curl -LOs https://uploader.codecov.io/v0.7.3/aarch64/codecov
                 chmod +x ./codecov
-                ./codecov -P $GITHUB_PULL_REQUEST_ID -C {{revision}}
+                ./codecov -P $GITHUB_PULL_REQUEST_ID -C {{revision}} -v
             - name: lint
               image: golangci/golangci-lint:latest
               workingDir: $(workspaces.source.path)


### PR DESCRIPTION

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

During Konflux startup an existing pipelinrun in a PAC managed namespace was set to Pending (that is a Tekton wide API that can be manipulated by other components besides PAC).

The repo did not have the concurrency limit checked.

This panic ensued and PAC watcher ended up in a crash back loop until @savitaashture and I deleted the pending pipeline runs:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1b1905b]
goroutine 41 [running]:
github.com/openshift-pipelines/pipelines-as-code/pkg/sync.(*QueueManager).getSemaphore(0xc0005c53c8, 0xc000a3e0a8)
/go/src/github.com/openshift-pipelines/pipelines-as-code/pkg/sync/queue_manager.go:55 +0x15b
github.com/openshift-pipelines/pipelines-as-code/pkg/sync.(*QueueManager).AddListToQueue(0xc0005c53c8, 0xc000a3e0a8, {0xc000fb42e0, 0x1, 0x0?})
/go/src/github.com/openshift-pipelines/pipelines-as-code/pkg/sync/queue_manager.go:83 +0xf6
github.com/openshift-pipelines/pipelines-as-code/pkg/reconciler.(*Reconciler).queuePipelineRun(0xc00062b680, {0x28aed30, 0xc000626a20}, 0xc000fb42c0?, 0xc00039cb40)
/go/src/github.com/openshift-pipelines/pipelines-as-code/pkg/reconciler/queue_pipelineruns.go:48 +0x245
github.com/openshift-pipelines/pipelines-as-code/pkg/reconciler.(*Reconciler).ReconcileKind(0xc00062b680, {0x28aed30, 0xc0016d5800}, 0xc00039cb40)
/go/src/github.com/openshift-pipelines/pipelines-as-code/pkg/reconciler/reconciler.go:93 +0x5bf
github.com/tektoncd/pipeline/pkg/client/injection/reconciler/pipeline/v1/pipelinerun.(*reconcilerImpl).Reconcile(0xc0006999a0, {0x28aed30, 0xc0016d57d0}, {0xc0018ae7e0, 0x2d})
/go/src/github.com/openshift-pipelines/pipelines-as-code/vendor/github.com/tektoncd/pipeline/pkg/client/injection/reconciler/pipeline/v1/pipelinerun/reconciler.go:236 +0x542
knative.dev/pkg/controller.(*Impl).processNextWorkItem(0xc0000b14a0)
/go/src/github.com/openshift-pipelines/pipelines-as-code/vendor/knative.dev/pkg/controller/controller.go:542 +0x4cd
knative.dev/pkg/controller.(*Impl).RunContext.func3()
/go/src/github.com/openshift-pipelines/pipelines-as-code/vendor/knative.dev/pkg/controller/controller.go:491 +0x68
created by knative.dev/pkg/controller.(*Impl).RunContext
/go/src/github.com/openshift-pipelines/pipelines-as-code/vendor/knative.dev/pkg/controller/controller.go:489 +0x354
```

I could not get the linters to work on my system. Will reach out to devs separately for that.  Apologies.

@savitaashture @chmouel @enarha @piyush-garg FYI / PTAL

# Submitter Checklist

- [/ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [x] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
