### PR TITLE
Fix GH installation match verification

### DIFF
--- a/pkg/apis/pipelinesascode/keys/keys.go
+++ b/pkg/apis/pipelinesascode/keys/keys.go
@@ -55,9 +55,7 @@ const (
 	LogURL          = pipelinesascode.GroupName + "/log-url"
 	ExecutionOrder  = pipelinesascode.GroupName + "/execution-order"
 	// PublicGithubAPIURL default is "https://api.github.com" but it can be overridden by X-GitHub-Enterprise-Host header.
-	PublicGithubAPIURL = "https://api.github.com"
-	// InstallationURL gives us the Installation ID for the GitHub Application.
-	InstallationURL      = "/app/installations"
+	PublicGithubAPIURL   = "https://api.github.com"
 	GithubApplicationID  = "github-application-id"
 	GithubPrivateKey     = "github-private-key"
 	ResultsRecordSummary = "results.tekton.dev/recordSummaryAnnotations"

--- a/pkg/cmd/tknpac/info/install.go
+++ b/pkg/cmd/tknpac/info/install.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
+	"net/url"
 	"text/tabwriter"
 	"text/template"
 
@@ -31,7 +33,7 @@ type InstallInfo struct {
 var infoTemplate string
 
 func (g *InstallInfo) hookConfig(ctx context.Context) error {
-	resp, err := app.GetReponse(ctx, "GET", fmt.Sprintf("%s/app/hook/config", g.apiURL), g.jwtToken, g.run)
+	resp, err := GetResponse(ctx, "GET", fmt.Sprintf("%s/app/hook/config", g.apiURL), g.jwtToken, g.run)
 	if err != nil {
 		return err
 	}
@@ -45,7 +47,7 @@ func (g *InstallInfo) hookConfig(ctx context.Context) error {
 }
 
 func (g *InstallInfo) get(ctx context.Context) error {
-	resp, err := app.GetReponse(ctx, "GET", fmt.Sprintf("%s/app", g.apiURL), g.jwtToken, g.run)
+	resp, err := GetResponse(ctx, "GET", fmt.Sprintf("%s/app", g.apiURL), g.jwtToken, g.run)
 	if err != nil {
 		return err
 	}
@@ -120,4 +122,22 @@ func installCommand(run *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
 	// add params for enteprise github
 	cmd.PersistentFlags().StringVarP(&apiURL, "github-api-url", "", "https://api.github.com", "Github API URL")
 	return cmd
+}
+
+func GetResponse(ctx context.Context, method, urlData, jwtToken string, run *params.Run) (*http.Response, error) {
+	rawurl, err := url.Parse(urlData)
+	if err != nil {
+		return nil, err
+	}
+
+	newreq, err := http.NewRequestWithContext(ctx, method, rawurl.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	newreq.Header = map[string][]string{
+		"Accept":        {"application/vnd.github+json"},
+		"Authorization": {fmt.Sprintf("Bearer %s", jwtToken)},
+	}
+	res, err := run.Clients.HTTP.Do(newreq)
+	return res, err
 }

--- a/pkg/provider/github/acl.go
+++ b/pkg/provider/github/acl.go
@@ -18,7 +18,7 @@ import (
 func (v *Provider) CheckPolicyAllowing(ctx context.Context, event *info.Event, allowedTeams []string) (bool, string) {
 	for _, team := range allowedTeams {
 		// TODO: caching
-		opt := github.ListOptions{PerPage: v.paginedNumber}
+		opt := github.ListOptions{PerPage: v.PaginedNumber}
 		for {
 			members, resp, err := v.Client.Teams.ListTeamMembersBySlug(ctx, event.Organization, team, &github.TeamListTeamMembersOptions{ListOptions: opt})
 			if resp.StatusCode == http.StatusNotFound {
@@ -254,7 +254,7 @@ func (v *Provider) checkPullRequestForSameURL(ctx context.Context, runevent *inf
 // only get the one that the user sets as public 🤷.
 func (v *Provider) checkSenderOrgMembership(ctx context.Context, runevent *info.Event) (bool, error) {
 	opt := &github.ListMembersOptions{
-		ListOptions: github.ListOptions{PerPage: v.paginedNumber},
+		ListOptions: github.ListOptions{PerPage: v.PaginedNumber},
 	}
 
 	for {
@@ -310,7 +310,7 @@ func (v *Provider) GetStringPullRequestComment(ctx context.Context, runevent *in
 	}
 
 	opt := &github.IssueListCommentsOptions{
-		ListOptions: github.ListOptions{PerPage: v.paginedNumber},
+		ListOptions: github.ListOptions{PerPage: v.PaginedNumber},
 	}
 	for {
 		comments, resp, err := v.Client.Issues.ListComments(ctx, runevent.Organization, runevent.Repository,

--- a/pkg/provider/github/acl_test.go
+++ b/pkg/provider/github/acl_test.go
@@ -92,7 +92,7 @@ func TestCheckPolicyAllowing(t *testing.T) {
 				Client:        fakeclient,
 				repo:          repo,
 				Logger:        logger,
-				paginedNumber: 1,
+				PaginedNumber: 1,
 			}
 
 			gotAllowed, gotReason := gprovider.CheckPolicyAllowing(ctx, event, tt.allowedTeams)
@@ -329,7 +329,7 @@ func TestOkToTestComment(t *testing.T) {
 				Client:        fakeclient,
 				repo:          repo,
 				Logger:        logger,
-				paginedNumber: 1,
+				PaginedNumber: 1,
 				Run:           &params.Run{},
 				pacInfo:       pacopts,
 			}
@@ -405,7 +405,7 @@ func TestAclCheckAll(t *testing.T) {
 	gprovider := Provider{
 		Client:        fakeclient,
 		Logger:        logger,
-		paginedNumber: 1,
+		PaginedNumber: 1,
 	}
 
 	tests := []struct {

--- a/pkg/provider/github/app/token.go
+++ b/pkg/provider/github/app/token.go
@@ -2,19 +2,16 @@ package app
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
-	"net/url"
 	"time"
 
 	"github.com/golang-jwt/jwt/v4"
 	gt "github.com/google/go-github/v61/github"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/github"
+	"knative.dev/pkg/logging"
 )
 
 type Install struct {
@@ -50,31 +47,27 @@ func (ip *Install) GetAndUpdateInstallationID(ctx context.Context) (string, stri
 		return "", "", 0, err
 	}
 
-	installationURL := *ip.ghClient.APIURL + keys.InstallationURL
+	apiURL := *ip.ghClient.APIURL
 	enterpriseHost = ip.request.Header.Get("X-GitHub-Enterprise-Host")
 	if enterpriseHost != "" {
 		// NOTE: Hopefully this works even when the ghe URL is on another host than the api URL
-		installationURL = "https://" + enterpriseHost + "/api/v3" + keys.InstallationURL
+		apiURL = "https://" + enterpriseHost + "/api/v3"
 	}
 
-	res, err := GetReponse(ctx, http.MethodGet, installationURL, jwtToken, ip.run)
-	if err != nil {
-		return "", "", 0, err
-	}
-
-	if res.StatusCode >= 300 {
-		return "", "", 0, fmt.Errorf("Non-OK HTTP status while getting installation URL: %s : %d", installationURL, res.StatusCode)
-	}
-
-	defer res.Body.Close()
-	data, err := io.ReadAll(res.Body)
-	if err != nil {
-		return "", "", 0, err
-	}
-
-	installationData := []gt.Installation{}
-	if err = json.Unmarshal(data, &installationData); err != nil {
-		return "", "", 0, err
+	logger := logging.FromContext(ctx)
+	opt := &gt.ListOptions{PerPage: ip.ghClient.PaginedNumber}
+	client, _, _ := github.MakeClient(ctx, apiURL, jwtToken)
+	installationData := []*gt.Installation{}
+	for {
+		installationSet, resp, err := client.Apps.ListInstallations(ctx, opt)
+		if err != nil {
+			return "", "", 0, err
+		}
+		installationData = append(installationData, installationSet...)
+		if resp.NextPage == 0 {
+			break
+		}
+		opt.Page = resp.NextPage
 	}
 
 	/* each installationID can have list of repository
@@ -86,11 +79,18 @@ func (ip *Install) GetAndUpdateInstallationID(ctx context.Context) (string, stri
 		}
 		if *installationData[i].ID != 0 {
 			token, err = ip.ghClient.GetAppToken(ctx, ip.run.Clients.Kube, enterpriseHost, *installationData[i].ID, ip.namespace)
+			// While looping on the list of installations, there could be cases where we can't
+			// obtain a token for installation. In a test I did for GitHub App with ~400
+			// installations, there were 3 failing consistently with:
+			// "could not refresh installation id XXX's token: received non 2xx response status "403 Forbidden".
+			// If there is a matching installation after the failure, we miss it. So instead of
+			// failing, we just log the error and continue. Token is "".
 			if err != nil {
-				return "", "", 0, err
+				logger.Warn(err)
+				continue
 			}
 		}
-		exist, err := ip.listRepos(ctx)
+		exist, err := ip.matchRepos(ctx)
 		if err != nil {
 			return "", "", 0, err
 		}
@@ -102,17 +102,16 @@ func (ip *Install) GetAndUpdateInstallationID(ctx context.Context) (string, stri
 	return enterpriseHost, token, installationID, nil
 }
 
-func (ip *Install) listRepos(ctx context.Context) (bool, error) {
-	if ip.repoList == nil {
-		var err error
-		ip.repoList, err = github.ListRepos(ctx, ip.ghClient)
-		if err != nil {
-			return false, err
-		}
+// matchRepos matching github repositories to its installation IDs
+func (ip *Install) matchRepos(ctx context.Context) (bool, error) {
+	installationRepoList, err := github.ListRepos(ctx, ip.ghClient)
+	if err != nil {
+		return false, err
 	}
-	for i := range ip.repoList {
+	ip.repoList = append(ip.repoList, installationRepoList...)
+	for i := range installationRepoList {
 		// If URL matches with repo spec url then we can break for loop
-		if ip.repoList[i] == ip.repo.Spec.URL {
+		if installationRepoList[i] == ip.repo.Spec.URL {
 			return true, nil
 		}
 	}
@@ -156,22 +155,4 @@ func (ip *Install) GenerateJWT(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("failed to sign private key: %w", err)
 	}
 	return tokenString, nil
-}
-
-func GetReponse(ctx context.Context, method, urlData, jwtToken string, run *params.Run) (*http.Response, error) {
-	rawurl, err := url.Parse(urlData)
-	if err != nil {
-		return nil, err
-	}
-
-	newreq, err := http.NewRequestWithContext(ctx, method, rawurl.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-	newreq.Header = map[string][]string{
-		"Accept":        {"application/vnd.github+json"},
-		"Authorization": {fmt.Sprintf("Bearer %s", jwtToken)},
-	}
-	res, err := run.Clients.HTTP.Do(newreq)
-	return res, err
 }

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -52,7 +52,7 @@ type Provider struct {
 	RepositoryIDs []int64
 	repo          *v1alpha1.Repository
 	eventEmitter  *events.EventEmitter
-	paginedNumber int
+	PaginedNumber int
 	skippedRun
 }
 
@@ -64,7 +64,7 @@ type skippedRun struct {
 func New() *Provider {
 	return &Provider{
 		APIURL:        github.String(keys.PublicGithubAPIURL),
-		paginedNumber: defaultPaginedNumber,
+		PaginedNumber: defaultPaginedNumber,
 		skippedRun: skippedRun{
 			mutex: &sync.Mutex{},
 		},
@@ -190,7 +190,7 @@ func (v *Provider) GetConfig() *info.ProviderConfig {
 	}
 }
 
-func makeClient(ctx context.Context, apiURL, token string) (*github.Client, string, *string) {
+func MakeClient(ctx context.Context, apiURL, token string) (*github.Client, string, *string) {
 	var client *github.Client
 	ts := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: token},
@@ -270,7 +270,7 @@ func (v *Provider) checkWebhookSecretValidity(ctx context.Context, cw clockwork.
 }
 
 func (v *Provider) SetClient(ctx context.Context, run *params.Run, event *info.Event, repo *v1alpha1.Repository, eventsEmitter *events.EventEmitter) error {
-	client, providerName, apiURL := makeClient(ctx, event.Provider.URL, event.Provider.Token)
+	client, providerName, apiURL := MakeClient(ctx, event.Provider.URL, event.Provider.Token)
 	v.providerName = providerName
 	v.Run = run
 	v.repo = repo
@@ -457,7 +457,7 @@ func (v *Provider) getPullRequest(ctx context.Context, runevent *info.Event) (*i
 // GetFiles get a files from pull request.
 func (v *Provider) GetFiles(ctx context.Context, runevent *info.Event) (changedfiles.ChangedFiles, error) {
 	if runevent.TriggerTarget == triggertype.PullRequest {
-		opt := &github.ListOptions{PerPage: v.paginedNumber}
+		opt := &github.ListOptions{PerPage: v.PaginedNumber}
 		changedFiles := changedfiles.ChangedFiles{}
 		for {
 			repoCommit, resp, err := v.Client.PullRequests.ListFiles(ctx, runevent.Organization, runevent.Repository, runevent.PullRequestNumber, opt)
@@ -534,7 +534,7 @@ func ListRepos(ctx context.Context, v *Provider) ([]string, error) {
 			"exiting... (hint: did you forget setting a secret on your repo?)")
 	}
 
-	opt := &github.ListOptions{PerPage: v.paginedNumber}
+	opt := &github.ListOptions{PerPage: v.PaginedNumber}
 	repoURLs := []string{}
 	for {
 		repoList, resp, err := v.Client.Apps.ListRepos(ctx, opt)

--- a/pkg/provider/github/github_test.go
+++ b/pkg/provider/github/github_test.go
@@ -802,7 +802,7 @@ func TestGetFiles(t *testing.T) {
 			ctx, _ := rtesting.SetupFakeContext(t)
 			provider := &Provider{
 				Client:        fakeclient,
-				paginedNumber: 1,
+				PaginedNumber: 1,
 			}
 			changedFiles, err := provider.GetFiles(ctx, tt.event)
 			assert.NilError(t, err, nil)
@@ -973,7 +973,7 @@ func TestListRepos(t *testing.T) {
 	})
 
 	ctx, _ := rtesting.SetupFakeContext(t)
-	provider := &Provider{Client: fakeclient, paginedNumber: 1}
+	provider := &Provider{Client: fakeclient, PaginedNumber: 1}
 	data, err := ListRepos(ctx, provider)
 	assert.NilError(t, err)
 	assert.Equal(t, data[0], "https://matched/by/incoming")

--- a/pkg/provider/github/status.go
+++ b/pkg/provider/github/status.go
@@ -45,7 +45,7 @@ func getCheckName(status provider.StatusOpts, pacopts *info.PacOpts) string {
 }
 
 func (v *Provider) getExistingCheckRunID(ctx context.Context, runevent *info.Event, status provider.StatusOpts) (*int64, error) {
-	opt := github.ListOptions{PerPage: v.paginedNumber}
+	opt := github.ListOptions{PerPage: v.PaginedNumber}
 	for {
 		res, resp, err := v.Client.Checks.ListCheckRunsForRef(ctx, runevent.Organization, runevent.Repository,
 			runevent.SHA, &github.ListCheckRunsOptions{

--- a/pkg/provider/github/status_test.go
+++ b/pkg/provider/github/status_test.go
@@ -105,7 +105,7 @@ func TestGetExistingCheckRunIDFromMultiple(t *testing.T) {
 
 	cnx := &Provider{
 		Client:        client,
-		paginedNumber: 1,
+		PaginedNumber: 1,
 	}
 	event := &info.Event{
 		Organization: "owner",


### PR DESCRIPTION
# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Fix pagignation for listing installation.
Fix caching of repoList property in Install.
Use the go-github ListInstallations method.
Includes a workaround for cases where we fail to obtain a token for installation. If the failure happens early in the loop, we miss the legitimate installation including the matching repo.

# Submitter Checklist

- [x] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
