### PR TITLE
Update sort package to latest & adds nil check for PRun before sorting

### DIFF
--- a/docs/content/docs/install/bitbucket_cloud.md
+++ b/docs/content/docs/install/bitbucket_cloud.md
@@ -174,7 +174,7 @@ $ tkn pac webhook add -n repo-pipelines
 👀 I have detected a controller url: https://pipelines-as-code-controller-openshift-pipelines.apps.awscl2.aws.ospqa.com
 ? Do you want me to use it? Yes
 ✓ Webhook has been created on repository workspace/repo
-🔑 Secret workspace-repo has been updated with webhook secert in the repo-pipelines namespace.
+🔑 Secret workspace-repo has been updated with webhook secret in the repo-pipelines namespace.
 
 ```
 

--- a/docs/content/docs/install/github_webhook.md
+++ b/docs/content/docs/install/github_webhook.md
@@ -196,7 +196,7 @@ $ tkn pac webhook add -n repo-pipelines
 ? Do you want me to use it? Yes
 ? Please enter the secret to configure the webhook for payload validation (default: AeHdHTJVfAeH):  AeHdHTJVfAeH
 ✓ Webhook has been created on repository owner/repo
-🔑 Secret owner-repo has been updated with webhook secert in the repo-pipelines namespace.
+🔑 Secret owner-repo has been updated with webhook secret in the repo-pipelines namespace.
 
 ```
 

--- a/docs/content/docs/install/gitlab.md
+++ b/docs/content/docs/install/gitlab.md
@@ -157,7 +157,7 @@ $ tkn pac webhook add -n project-pipelines
 ? Do you want me to use it? Yes
 ? Please enter the secret to configure the webhook for payload validation (default: TXArbGNDHTXU):  TXArbGNDHTXU
 ✓ Webhook has been created on your repository
-🔑 Secret repositories-project has been updated with webhook secert in the project-pipelines namespace.
+🔑 Secret repositories-project has been updated with webhook secret in the project-pipelines namespace.
 
 ```
 

--- a/pkg/cli/webhook/secret.go
+++ b/pkg/cli/webhook/secret.go
@@ -40,7 +40,7 @@ func (w *Options) updateWebhookSecret(ctx context.Context, response *response) e
 		return err
 	}
 
-	fmt.Fprintf(w.IOStreams.Out, "🔑 Secret %s has been updated with webhook secert in the %s namespace.\n", w.SecretName, w.RepositoryNamespace)
+	fmt.Fprintf(w.IOStreams.Out, "🔑 Secret %s has been updated with webhook secret in the %s namespace.\n", w.SecretName, w.RepositoryNamespace)
 	return nil
 }
 

--- a/pkg/cli/webhook/testdata/TestWebHookSecret.golden
+++ b/pkg/cli/webhook/testdata/TestWebHookSecret.golden
@@ -1,3 +1,3 @@
 🔑 Webhook Secret test-repo has been created in the test-ns namespace.
 🔑 Repository CR test-repo has been updated with webhook secret in the test-ns namespace
-🔑 Secret test-secret has been updated with webhook secert in the test-ns namespace.
+🔑 Secret test-secret has been updated with webhook secret in the test-ns namespace.

--- a/pkg/cmd/tknpac/info/install.go
+++ b/pkg/cmd/tknpac/info/install.go
@@ -75,7 +75,7 @@ func install(ctx context.Context, run *params.Run, ios *cli.IOStreams, apiURL st
 	}
 	repos, err := run.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories("").List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return fmt.Errorf("cannot list alll repo on cluster, check your rights and that paac is installed: %w", err)
+		return fmt.Errorf("cannot list all repo on cluster, check your rights and that paac is installed: %w", err)
 	}
 	reposItems := &repos.Items
 	args := struct {

--- a/pkg/params/settings/validation_test.go
+++ b/pkg/params/settings/validation_test.go
@@ -55,7 +55,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "invalid check source ip value",
 			config: map[string]string{
-				BitbucketCloudCheckSourceIPKey: "tru",
+				BitbucketCloudCheckSourceIPKey: "ncntru",
 			},
 			wantErr: "invalid value for key bitbucket-cloud-check-source-ip, acceptable values: true or false",
 		},

--- a/pkg/pipelineascode/concurrency.go
+++ b/pkg/pipelineascode/concurrency.go
@@ -43,9 +43,19 @@ func (c *ConcurrencyManager) GetExecutionOrder() (string, []*v1.PipelineRun) {
 		return "", nil
 	}
 
+	if len(c.pipelineRuns) == 0 {
+		return "", nil
+	}
+
 	runtimeObjs := []runtime.Object{}
 	for _, pr := range c.pipelineRuns {
-		runtimeObjs = append(runtimeObjs, pr)
+		if pr != nil && pr.Name != "" {
+			runtimeObjs = append(runtimeObjs, pr)
+		}
+	}
+
+	if len(runtimeObjs) == 0 {
+		return "", nil
 	}
 
 	// sort runs by name

--- a/pkg/pipelineascode/concurrency_test.go
+++ b/pkg/pipelineascode/concurrency_test.go
@@ -29,3 +29,18 @@ func TestExecutionOrder(t *testing.T) {
 	assert.Equal(t, order, "test/abc,test/def,test/mno,test/pqr")
 	assert.Equal(t, len(runs), 4)
 }
+
+func TestExecutionOrder_SinglePRun(t *testing.T) {
+	cm := NewConcurrencyManager()
+
+	testNs := "test"
+	abcPR := &tektonv1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: testNs}}
+	cm.Enable()
+
+	// add pipelineRuns in random order
+	cm.AddPipelineRun(abcPR)
+
+	order, runs := cm.GetExecutionOrder()
+	assert.Equal(t, order, "test/abc")
+	assert.Equal(t, len(runs), 1)
+}

--- a/pkg/provider/bitbucketserver/bitbucketserver.go
+++ b/pkg/provider/bitbucketserver/bitbucketserver.go
@@ -52,7 +52,7 @@ func (v *Provider) SetLogger(logger *zap.SugaredLogger) {
 func (v *Provider) Validate(_ context.Context, _ *params.Run, event *info.Event) error {
 	signature := event.Request.Header.Get("X-Hub-Signature")
 	if event.Provider.WebhookSecret == "" && signature != "" {
-		return fmt.Errorf("bitbucket-server failed validaton: failed to find webhook secret")
+		return fmt.Errorf("bitbucket-server failed validation: failed to find webhook secret")
 	}
 	return github.ValidateSignature(signature, event.Request.Payload, []byte(event.Provider.WebhookSecret))
 }

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -69,11 +69,11 @@ func (v *Provider) SetLogger(logger *zap.SugaredLogger) {
 func (v *Provider) Validate(_ context.Context, _ *params.Run, event *info.Event) error {
 	token := event.Request.Header.Get("X-Gitlab-Token")
 	if event.Provider.WebhookSecret == "" && token != "" {
-		return fmt.Errorf("gitlab failed validaton: failed to find webhook secret")
+		return fmt.Errorf("gitlab failed validation: failed to find webhook secret")
 	}
 
 	if subtle.ConstantTimeCompare([]byte(event.Provider.WebhookSecret), []byte(token)) == 0 {
-		return fmt.Errorf("gitlab failed validaton: event's secret doesn't match with webhook secret")
+		return fmt.Errorf("gitlab failed validation: event's secret doesn't match with webhook secret")
 	}
 	return nil
 }

--- a/pkg/sort/runtime_sort.go
+++ b/pkg/sort/runtime_sort.go
@@ -17,7 +17,7 @@ import (
 
 // The following code has been take from kubectl get command
 // instead of importing all the dependencies, copying only the required part
-// https://github.com/kubernetes/kubernetes/blob/8e48df135318026d5f8a972a96a2ff665889568a/staging/src/k8s.io/kubectl/pkg/cmd/get/sorter.go#L151
+// https://github.com/kubernetes/kubernetes/blob/20d0ab7ae808aaddb1556c3c38ca0607663c50ac/staging/src/k8s.io/kubectl/pkg/cmd/get/sorter.go#L150
 
 // RuntimeSort is an implementation of the golang sort interface that knows how to sort
 // lists of runtime.Object.
@@ -56,7 +56,7 @@ func isLess(i, j reflect.Value) (bool, error) {
 		return i.Float() < j.Float(), nil
 	case reflect.String:
 		return sortorder.NaturalLess(i.String(), j.String()), nil
-	case reflect.Ptr:
+	case reflect.Pointer:
 		return isLess(i.Elem(), j.Elem())
 	case reflect.Struct:
 		// sort metav1.Time
@@ -210,6 +210,8 @@ func (r *RuntimeSort) Less(i, j int) bool {
 }
 
 // OriginalPosition returns the starting (original) position of a particular index.
+// e.g. If OriginalPosition(0) returns 5 than the
+// item currently at position 0 was at position 5 in the original unsorted array.
 func (r *RuntimeSort) OriginalPosition(ix int) int {
 	if ix < 0 || ix > len(r.origPosition) {
 		return -1
@@ -227,5 +229,7 @@ func findJSONPathResults(parser *jsonpath.JSONPath, from runtime.Object) ([][]re
 // ByField sorts the runtime objects passed by the field.
 func ByField(field string, runTimeObj []runtime.Object) {
 	sorter := NewRuntimeSort(field, runTimeObj)
-	sort.Sort(sorter)
+	if len(runTimeObj) > 0 {
+		sort.Sort(sorter)
+	}
 }

--- a/test/github_pullrequest_concurrency_test.go
+++ b/test/github_pullrequest_concurrency_test.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/sort"
 	tgithub "github.com/openshift-pipelines/pipelines-as-code/test/pkg/github"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
@@ -20,14 +22,37 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestGithubPullRequestConcurrency(t *testing.T) {
+func TestGithubSecondPullRequestConcurrency1by1(t *testing.T) {
 	ctx := context.Background()
-	label := "Github PullRequest Concurrent"
+	label := "Github PullRequest Concurrent, sequentially one by one"
+	numberOfPipelineRuns := 5
+	maxNumberOfConcurrentPipelineRuns := 1
+	testGithubConcurrency(ctx, t, maxNumberOfConcurrentPipelineRuns, numberOfPipelineRuns, label, true, map[string]string{})
+}
+
+func TestGithubSecondPullRequestConcurrency3by3(t *testing.T) {
+	ctx := context.Background()
+	label := "Github PullRequest Concurrent three at time"
 	numberOfPipelineRuns := 10
 	maxNumberOfConcurrentPipelineRuns := 3
+	testGithubConcurrency(ctx, t, maxNumberOfConcurrentPipelineRuns, numberOfPipelineRuns, label, false, map[string]string{})
+}
 
+// TestGithubSecondPullRequestConcurrency1by1WithError will test concurrency and an error, this used to crash for us previously.
+func TestGithubSecondPullRequestConcurrency1by1WithError(t *testing.T) {
+	ctx := context.Background()
+	label := "Github PullRequest Concurrent, sequentially one by one with one bad apple"
+	numberOfPipelineRuns := 1
+	maxNumberOfConcurrentPipelineRuns := 1
+	testGithubConcurrency(ctx, t, maxNumberOfConcurrentPipelineRuns, numberOfPipelineRuns, label, false, map[string]string{
+		".tekton/00-bad-apple.yaml": "testdata/failures/bad-runafter-task.yaml",
+	})
+}
+
+func testGithubConcurrency(ctx context.Context, t *testing.T, maxNumberOfConcurrentPipelineRuns, numberOfPipelineRuns int, label string, checkOrdering bool, yamlFiles map[string]string) {
+	pipelineRunFileNamePrefix := "prlongrunnning-"
 	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
-	_, runcnx, opts, ghcnx, err := tgithub.Setup(ctx, false, false)
+	_, runcnx, opts, ghcnx, err := tgithub.Setup(ctx, true, false)
 	assert.NilError(t, err)
 
 	logmsg := fmt.Sprintf("Testing %s with Github APPS integration on %s", label, targetNS)
@@ -45,12 +70,11 @@ func TestGithubPullRequestConcurrency(t *testing.T) {
 	err = tgithub.CreateCRD(ctx, t, repoinfo, runcnx, opts, targetNS)
 	assert.NilError(t, err)
 
-	yamlFiles := map[string]string{}
 	for i := 1; i <= numberOfPipelineRuns; i++ {
-		yamlFiles[fmt.Sprintf(".tekton/prlongrunnning-%d.yaml", i)] = "testdata/pipelinerun_long_running.yaml"
+		yamlFiles[fmt.Sprintf(".tekton/%s%d.yaml", pipelineRunFileNamePrefix, i)] = "testdata/pipelinerun_long_running.yaml"
 	}
 
-	entries, err := payload.GetEntries(yamlFiles, targetNS, options.MainBranch, options.PullRequestEvent, map[string]string{})
+	entries, err := payload.GetEntries(yamlFiles, targetNS, options.MainBranch, "pull_request", map[string]string{})
 	assert.NilError(t, err)
 
 	targetRefName := fmt.Sprintf("refs/heads/%s",
@@ -79,7 +103,7 @@ func TestGithubPullRequestConcurrency(t *testing.T) {
 	assert.NilError(t, wait.UntilMinPRAppeared(ctx, runcnx.Clients, waitOpts, numberOfPipelineRuns))
 
 	finished := false
-	maxLoop := 15
+	maxLoop := 30
 	for i := 0; i < maxLoop; i++ {
 		unsuccessful := 0
 		prs, err := runcnx.Clients.Tekton.TektonV1().PipelineRuns(targetNS).List(ctx, metav1.ListOptions{})
@@ -101,11 +125,23 @@ func TestGithubPullRequestConcurrency(t *testing.T) {
 			finished = true
 			break
 		}
-		runcnx.Clients.Log.Infof("number of unsuccessful PR %d out of %d, waiting 10s more, %d/%d", unsuccessful, numberOfPipelineRuns*2, i, maxLoop)
+		runcnx.Clients.Log.Infof("number of unsuccessful PR %d out of %d, waiting 10s more in the waiting loop: %d/%d", unsuccessful, numberOfPipelineRuns, i, maxLoop)
 		// it's high because it takes time to process on kind
-		time.Sleep(15 * time.Second)
+		time.Sleep(10 * time.Second)
 	}
 	if !finished {
 		t.Errorf("the %d pipelineruns has not successfully finished, some of them are still pending or it's abnormally slow to process the Q", numberOfPipelineRuns)
+	}
+
+	// sort all the PR by when they have started
+	if checkOrdering {
+		prs, err := runcnx.Clients.Tekton.TektonV1().PipelineRuns(targetNS).List(ctx, metav1.ListOptions{})
+		assert.NilError(t, err)
+		sort.PipelineRunSortByStartTime(prs.Items)
+		for i := 0; i < numberOfPipelineRuns; i++ {
+			prExpectedName := fmt.Sprintf("%s%d", pipelineRunFileNamePrefix, len(prs.Items)-i)
+			prActualName := prs.Items[i].GetName()
+			assert.Assert(t, strings.HasPrefix(prActualName, prExpectedName), "prActualName: %s does not start with expected prefix %s, was is ordered properly at start time", prActualName, prExpectedName)
+		}
 	}
 }


### PR DESCRIPTION
we use sort code from k8s repo, this updates the code to the latest master
but keeps using integer.IntMin to continue using golang 1.20
&
check pipelinrun is not nil and its name is not empty string
then only add for sorting# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
