### PR TITLE
Add test for when concurrency and startPR error

### DIFF
--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -595,8 +595,7 @@ func TestGiteaBadLinkOfTask(t *testing.T) {
 	assert.NilError(t, twait.RegexpMatchingInControllerLog(ctx, topts.ParamsRun, *errre, 10, "controller", github.Int64(20)))
 }
 
-// TestGiteaParamsOnRepoCR test gitea params on CR and its filters
-
+// TestGiteaProvenance will test the provenance feature of the pipeline run if we check from the default branch (ie main).
 func TestGiteaProvenance(t *testing.T) {
 	topts := &tgitea.TestOpts{
 		SkipEventsCheck:       true,


### PR DESCRIPTION
when we cannot create the PipelineRun and we got an error from the controller, if we had concurrency set the controller would crash.

This was fixed in e553256f9c1d51371ac2b59320a257164c8276bb but added test for this

```
💡 11:25:51 pac-controller pipelinerun test-gh-kjtd8 has been created in
namespace pac-e2e-ns-7bw6b for SHA:
4a82af8eb94e78576bc0f9ab3e1a7c5582825412 Target Branch: main 🚨 11:25:51
pac-controller There was an error starting the PipelineRun
00-bad-apple-tdza-, creating pipelinerun 00-bad-apple-tdza- in namespace
pac-e2e-ns-7bw6b has failed.

Tekton Controller has reported this error: ```admission webhook
"validation.webhook.pipeline.tekton.dev" denied the request: validation
failed: invalid value: couldn't add link between noexist and donotexist:
task noexist depends on donotexist but donotexist wasn't present in
Pipeline: spec.pipelineSpec.tasks``` 💡 11:25:52 pac-controller patched
pipelinerun with checkRunID and logURL: pac-e2e-ns-7bw6b/test-gh-1-6x879
💡 11:25:52 pac-controller patched pipelinerun with checkRunID and
logURL: pac-e2e-ns-7bw6b/test-gh-kjtd8 💡 11:25:52 pac-controller
patched pipelinerun with checkRunID and logURL:
pac-e2e-ns-7bw6b/prlongrunnning-1-fjrs-qckbv 💡 11:25:52 pac-controller
patched pipelinerun with checkRunID and logURL:
pac-e2e-ns-7bw6b/test-gh-2-tjdwf 💡 11:25:52 pac-controller skipping
event: check_run: unsupported action "created" 💡 11:25:52
pac-controller skipping event: check_run: unsupported action "created"
💡 11:25:52 pac-controller skipping event: check_run: unsupported action
"created" 💡 11:25:52 pac-controller skipping event: check_run:
unsupported action "created" 💡 11:25:52 pac-controller skipping event:
check_run: unsupported action "created"
pipelines-as-code/ghe-controller-6b68d9cfb-dc6lg[pac-controller]: panic:
reflect: call of reflect.Value.Interface on zero Value
pipelines-as-code/ghe-controller-6b68d9cfb-dc6lg[pac-controller]:
pipelines-as-code/ghe-controller-6b68d9cfb-dc6lg[pac-controller]:
goroutine 563 [running]:
pipelines-as-code/ghe-controller-6b68d9cfb-dc6lg[pac-controller]:
reflect.valueInterface({0x0?, 0x0?, 0x4000da0d40?}, 0xe0?)
pipelines-as-code/ghe-controller-6b68d9cfb-dc6lg[pac-controller]:
reflect/value.go:1501 +0xfc
pipelines-as-code/ghe-controller-6b68d9cfb-dc6lg[pac-controller]:
```

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
