### PR TITLE
[DNM] [Backport] Make sure to check if we can make API calls

### DIFF
--- a/.tekton/doc.yaml
+++ b/.tekton/doc.yaml
@@ -40,7 +40,7 @@ spec:
             - name: source
           steps:
             - name: hugo-gen
-              image: registry.access.redhat.com/ubi9/python-311 # using this image since it has git and curl and python
+              image: registry.access.redhat.com/ubi9/python-311
               workingDir: $(workspaces.source.path)
               env:
                 - name: UPLOADER_PUBLIC_URL

--- a/pkg/consoleui/custom_test.go
+++ b/pkg/consoleui/custom_test.go
@@ -19,14 +19,12 @@ func TestCustomGood(t *testing.T) {
 	consolePRtasklog := "https://mycorp.console/{{ namespace }}/{{ pr }}/{{ task }}/{{ pod }}/{{ firstFailedStep }}/params/{{ foo }}/{{ nonewline }}"
 
 	c := CustomConsole{
-		Info: &info.Info{
-			Pac: &info.PacOpts{
-				Settings: &settings.Settings{
-					CustomConsoleName:      consoleName,
-					CustomConsoleURL:       consoleURL,
-					CustomConsolePRdetail:  consolePRdetail,
-					CustomConsolePRTaskLog: consolePRtasklog,
-				},
+		PacInfo: &info.PacOpts{
+			Settings: &settings.Settings{
+				CustomConsoleName:      consoleName,
+				CustomConsoleURL:       consoleURL,
+				CustomConsolePRdetail:  consolePRdetail,
+				CustomConsolePRTaskLog: consolePRtasklog,
 			},
 		},
 	}
@@ -73,14 +71,12 @@ func TestCustomGood(t *testing.T) {
 
 	// test if we fallback properly
 	f := CustomConsole{
-		Info: &info.Info{
-			Pac: &info.PacOpts{
-				Settings: &settings.Settings{
-					CustomConsoleName:      consoleName,
-					CustomConsoleURL:       consoleURL,
-					CustomConsolePRdetail:  "{{ notthere}}",
-					CustomConsolePRTaskLog: "{{ notthere}}",
-				},
+		PacInfo: &info.PacOpts{
+			Settings: &settings.Settings{
+				CustomConsoleName:      consoleName,
+				CustomConsoleURL:       consoleURL,
+				CustomConsolePRdetail:  "{{ notthere}}",
+				CustomConsolePRTaskLog: "{{ notthere}}",
 			},
 		},
 	}
@@ -89,15 +85,13 @@ func TestCustomGood(t *testing.T) {
 	assert.Assert(t, strings.Contains(c.TaskLogURL(pr, trStatus), consoleURL))
 
 	o := CustomConsole{
-		Info: &info.Info{
-			Pac: &info.PacOpts{
-				Settings: &settings.Settings{
-					CustomConsoleName:         consoleName,
-					CustomConsoleURL:          consoleURL,
-					CustomConsolePRdetail:     "{{ notthere}}",
-					CustomConsolePRTaskLog:    "{{ notthere}}",
-					CustomConsoleNamespaceURL: "https://mycorp.console/{{ namespace }}",
-				},
+		PacInfo: &info.PacOpts{
+			Settings: &settings.Settings{
+				CustomConsoleName:         consoleName,
+				CustomConsoleURL:          consoleURL,
+				CustomConsolePRdetail:     "{{ notthere}}",
+				CustomConsolePRTaskLog:    "{{ notthere}}",
+				CustomConsoleNamespaceURL: "https://mycorp.console/{{ namespace }}",
 			},
 		},
 	}
@@ -108,10 +102,8 @@ func TestCustomGood(t *testing.T) {
 
 func TestCustomBad(t *testing.T) {
 	c := CustomConsole{
-		Info: &info.Info{
-			Pac: &info.PacOpts{
-				Settings: &settings.Settings{},
-			},
+		PacInfo: &info.PacOpts{
+			Settings: &settings.Settings{},
 		},
 	}
 	pr := &tektonv1.PipelineRun{

--- a/pkg/params/run.go
+++ b/pkg/params/run.go
@@ -52,7 +52,7 @@ func (r *Run) UpdatePACInfo(ctx context.Context) error {
 	}
 	if r.Info.Pac.Settings.CustomConsoleURL != "" {
 		r.Clients.Log.Infof("updating console url to: %s", r.Info.Pac.Settings.CustomConsoleURL)
-		r.Clients.ConsoleUI = &consoleui.CustomConsole{Info: &r.Info}
+		r.Clients.ConsoleUI = &consoleui.CustomConsole{PacInfo: r.Info.Pac}
 	}
 
 	// This is the case when reverted settings for CustomConsole and TektonDashboard then URL should point to OpenshiftConsole for Openshift platform


### PR DESCRIPTION
* We didn't check for the error, which could crash the tekton controller.
  That call is the first API call we make so is the first one that would
  crash. Report the run as error if that happen, since it's probably a 
  GitHub API outage (and a lot of other things would be wrong)
* Add 027d39f3104d9f54557e5d23505f854e4abd9d1d https://issues.redhat.com/browse/SRVKP-5507

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com># Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
