### PR TITLE
Make sure to check if we can make API calls

### DIFF
--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -241,6 +241,14 @@ func parseTS(headerTS string) (time.Time, error) {
 // the issue was.
 func (v *Provider) checkWebhookSecretValidity(ctx context.Context, cw clockwork.Clock) error {
 	rl, resp, err := v.Client.RateLimit.Get(ctx)
+	if resp.StatusCode == http.StatusNotFound {
+		v.Logger.Info("skipping checking if token has expired, rate_limit api is not enabled on token")
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("error making request to the GitHub API checking rate limit: %w", err)
+	}
 	if resp.Header.Get("GitHub-Authentication-Token-Expiration") != "" {
 		ts, err := parseTS(resp.Header.Get("GitHub-Authentication-Token-Expiration"))
 		if err != nil {
@@ -251,16 +259,6 @@ func (v *Provider) checkWebhookSecretValidity(ctx context.Context, cw clockwork.
 			errm := fmt.Sprintf("token has expired at %s", resp.TokenExpiration.Format(time.RFC1123))
 			return fmt.Errorf(errm)
 		}
-	}
-
-	if resp.StatusCode == http.StatusNotFound {
-		v.Logger.Info("skipping checking if token has expired, rate_limit api is not enabled on token")
-		return nil
-	}
-
-	// some other error happened that is not rate limited related
-	if err != nil {
-		return fmt.Errorf("error using token to access API: %w", err)
 	}
 
 	if rl.SCIM.Remaining == 0 {
@@ -280,6 +278,9 @@ func (v *Provider) SetClient(ctx context.Context, run *params.Run, event *info.E
 	// from unittesting.
 	if v.Client == nil {
 		v.Client = client
+	}
+	if v.Client == nil {
+		return fmt.Errorf("no github client has been initialized")
 	}
 
 	v.APIURL = apiURL

--- a/pkg/provider/github/github_test.go
+++ b/pkg/provider/github/github_test.go
@@ -836,6 +836,7 @@ func TestProvider_checkWebhookSecretValidity(t *testing.T) {
 		expHeaderSet   bool
 		apiNotEnabled  bool
 		wantLogSnippet string
+		report500      bool
 	}{
 		{
 			name:         "remaining scim calls",
@@ -866,6 +867,11 @@ func TestProvider_checkWebhookSecretValidity(t *testing.T) {
 			wantSubErr: "token is ratelimited",
 		},
 		{
+			name:       "api error",
+			wantSubErr: "error making request to the GitHub API checking rate limit",
+			report500:  true,
+		},
+		{
 			name:           "not enabled",
 			apiNotEnabled:  true,
 			wantLogSnippet: "skipping checking",
@@ -879,6 +885,10 @@ func TestProvider_checkWebhookSecretValidity(t *testing.T) {
 
 			if !tt.apiNotEnabled {
 				mux.HandleFunc("/rate_limit", func(rw http.ResponseWriter, _ *http.Request) {
+					if tt.report500 {
+						rw.WriteHeader(http.StatusInternalServerError)
+						return
+					}
 					s := &github.RateLimits{
 						SCIM: &github.Rate{
 							Remaining: tt.remaining,


### PR DESCRIPTION
We didn't check for the error, which could crash the tekton controller.

That call is the first API call we make so is the first one that would crash. Report the run as error if that happen, since it's probably a GitHub API outage (and a lot of other things would be wrong)

Jira: https://issues.redhat.com/browse/SRVKP-5508

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
