### PR TITLE
Refactor configutil and fix bug with catalog parsing

### DIFF
--- a/hack/dev/kind/install.sh
+++ b/hack/dev/kind/install.sh
@@ -185,6 +185,8 @@ function configure_pac() {
 		kubectl patch configmap -n pipelines-as-code -p "{\"data\":{\"tekton-dashboard-url\": \"http://dashboard.${DOMAIN_NAME}\"}}" --type merge pipelines-as-code
 	# add custom catalog so we can use it in e2e, this will points to the normal upstream hub so we can easily use it
 	kubectl patch configmap -n pipelines-as-code -p '{"data":{"catalog-1-id": "custom", "catalog-1-name": "tekton", "catalog-1-url": "https://api.hub.tekton.dev/v1"}}' --type merge pipelines-as-code
+	# add one more custom catalog so we can use it in e2e for multiple catalog support, this will points to the normal upstream hub so we can easily use it
+  kubectl patch configmap -n pipelines-as-code -p '{"data":{"catalog-2-id": "custom2", "catalog-2-name": "tekton", "catalog-2-url": "https://api.hub.tekton.dev/v1"}}' --type merge pipelines-as-code
 	set +x
 	if [[ -n ${PAC_PASS_SECRET_FOLDER} ]]; then
 		echo "Installing PAC secrets"

--- a/pkg/cmd/tknpac/resolve/resolve.go
+++ b/pkg/cmd/tknpac/resolve/resolve.go
@@ -104,7 +104,7 @@ func Command(run *params.Run, streams *cli.IOStreams) *cobra.Command {
 				return fmt.Errorf("you need to at least specify a file with -f")
 			}
 
-			if err := settings.SyncConfig(run.Clients.Log, &run.Info.Pac.Settings, map[string]string{}); err != nil {
+			if err := settings.SyncConfig(run.Clients.Log, &run.Info.Pac.Settings, map[string]string{}, settings.DefaultValidators()); err != nil {
 				return err
 			}
 

--- a/pkg/consoleui/custom.go
+++ b/pkg/consoleui/custom.go
@@ -29,7 +29,7 @@ func NewCustomConsole(pacInfo *info.PacOpts) *CustomConsole {
 
 func (o *CustomConsole) GetName() string {
 	if o.pacInfo.CustomConsoleName == "" {
-		return "Not configured"
+		return fmt.Sprintf("https://url.setting.%s.is.not.configured", settings.CustomConsoleNameKey)
 	}
 	return o.pacInfo.CustomConsoleName
 }

--- a/pkg/consoleui/custom_test.go
+++ b/pkg/consoleui/custom_test.go
@@ -102,7 +102,7 @@ func TestCustomBad(t *testing.T) {
 			Name:      "pr",
 		},
 	}
-	assert.Assert(t, strings.Contains(c.GetName(), "Not configured"))
+	assert.Assert(t, strings.Contains(c.GetName(), "is.not.configured"))
 	assert.Assert(t, strings.Contains(c.URL(), "is.not.configured"))
 	assert.Assert(t, strings.Contains(c.DetailURL(pr), "is.not.configured"))
 	assert.Assert(t, strings.Contains(c.TaskLogURL(pr, nil), "is.not.configured"))

--- a/pkg/hub/get_test.go
+++ b/pkg/hub/get_test.go
@@ -20,15 +20,15 @@ func TestGetTask(t *testing.T) {
 	var hubCatalogs sync.Map
 	hubCatalogs.Store(
 		"default", settings.HubCatalog{
-			ID:   "default",
-			URL:  testHubURL,
-			Name: testCatalogHubName,
+			Index: "default",
+			URL:   testHubURL,
+			Name:  testCatalogHubName,
 		})
 	hubCatalogs.Store(
 		"anotherHub", settings.HubCatalog{
-			ID:   "anotherHub",
-			URL:  testHubURL,
-			Name: testCatalogHubName,
+			Index: "1",
+			URL:   testHubURL,
+			Name:  testCatalogHubName,
 		})
 	tests := []struct {
 		name        string

--- a/pkg/matcher/annotation_tasks_install_test.go
+++ b/pkg/matcher/annotation_tasks_install_test.go
@@ -50,15 +50,15 @@ func TestRemoteTasksGetTaskFromAnnotations(t *testing.T) {
 	var hubCatalogs sync.Map
 	hubCatalogs.Store(
 		"default", settings.HubCatalog{
-			ID:   "default",
-			URL:  testHubURL,
-			Name: testCatalogHubName,
+			Index: "default",
+			URL:   testHubURL,
+			Name:  testCatalogHubName,
 		})
 	hubCatalogs.Store(
 		"anotherHub", settings.HubCatalog{
-			ID:   "anotherHub",
-			URL:  testHubURL,
-			Name: testCatalogHubName,
+			Index: "1",
+			URL:   testHubURL,
+			Name:  testCatalogHubName,
 		})
 	tests := []struct {
 		annotations            map[string]string
@@ -304,15 +304,15 @@ func TestGetPipelineFromAnnotations(t *testing.T) {
 	var hubCatalogs sync.Map
 	hubCatalogs.Store(
 		"default", settings.HubCatalog{
-			ID:   "default",
-			URL:  testHubURL,
-			Name: testCatalogHubName,
+			Index: "default",
+			URL:   testHubURL,
+			Name:  testCatalogHubName,
 		})
 	hubCatalogs.Store(
 		"anotherHub", settings.HubCatalog{
-			ID:   "anotherHub",
-			URL:  testHubURL,
-			Name: testCatalogHubName,
+			Index: "1",
+			URL:   testHubURL,
+			Name:  testCatalogHubName,
 		})
 	tests := []struct {
 		annotations     map[string]string

--- a/pkg/params/info/info.go
+++ b/pkg/params/info/info.go
@@ -43,7 +43,7 @@ func (i *Info) UpdatePacOpts(logger *zap.SugaredLogger, configData map[string]st
 	i.pacMutex.Lock()
 	defer i.pacMutex.Unlock()
 
-	if err := settings.SyncConfig(logger, &i.Pac.Settings, configData); err != nil {
+	if err := settings.SyncConfig(logger, &i.Pac.Settings, configData, settings.DefaultValidators()); err != nil {
 		return nil, err
 	}
 	return &i.Pac.Settings, nil

--- a/pkg/params/info/info_test.go
+++ b/pkg/params/info/info_test.go
@@ -16,6 +16,6 @@ func TestNewInfo(t *testing.T) {
 
 	catalog, ok := value.(settings.HubCatalog)
 	assert.Equal(t, true, ok)
-	assert.Equal(t, catalog.ID, "default")
+	assert.Equal(t, catalog.Index, "default")
 	assert.Equal(t, catalog.Name, settings.HubCatalogNameDefaultValue)
 }

--- a/pkg/params/settings/config_test.go
+++ b/pkg/params/settings/config_test.go
@@ -139,7 +139,7 @@ func TestSyncConfig(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var test Settings
 
-			err := SyncConfig(logger, &test, tc.configMap)
+			err := SyncConfig(logger, &test, tc.configMap, DefaultValidators())
 
 			// set hub catalogs to nil to avoid comparison error
 			// test separately
@@ -166,5 +166,5 @@ func TestDefaultSettings(t *testing.T) {
 	assert.Assert(t, ok)
 	catalog, ok := catalogValue.(HubCatalog)
 	assert.Assert(t, ok)
-	assert.Equal(t, catalog.ID, "default")
+	assert.Equal(t, catalog.Index, "default")
 }

--- a/pkg/params/settings/convert.go
+++ b/pkg/params/settings/convert.go
@@ -1,0 +1,65 @@
+package settings
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+func ConvertPacStructToConfigMap(settings *Settings) map[string]string {
+	config := map[string]string{}
+	if settings == nil {
+		return config
+	}
+	structValue := reflect.ValueOf(settings).Elem()
+	structType := reflect.TypeOf(settings).Elem()
+
+	for i := 0; i < structType.NumField(); i++ {
+		field := structType.Field(i)
+		fieldName := field.Name
+
+		jsonTag := field.Tag.Get("json")
+		if jsonTag == "-" {
+			continue
+		}
+		key := strings.ToLower(jsonTag)
+		element := structValue.FieldByName(fieldName)
+		if !element.IsValid() {
+			continue
+		}
+
+		//nolint
+		switch field.Type.Kind() {
+		case reflect.String:
+			config[key] = element.String()
+		case reflect.Bool:
+			config[key] = strconv.FormatBool(element.Bool())
+		case reflect.Int:
+			config[key] = strconv.FormatInt(element.Int(), 10)
+		case reflect.Ptr:
+			// for hub catalogs map
+			if key == "" {
+				data := element.Interface().(*sync.Map)
+				data.Range(func(key, value interface{}) bool {
+					catalogData := value.(HubCatalog)
+					if key == "default" {
+						config[HubURLKey] = catalogData.URL
+						config[HubCatalogNameKey] = catalogData.Name
+						return true
+					}
+					config[fmt.Sprintf("%s-%s-%s", "catalog", catalogData.Index, "id")] = key.(string)
+					config[fmt.Sprintf("%s-%s-%s", "catalog", catalogData.Index, "name")] = catalogData.Name
+					config[fmt.Sprintf("%s-%s-%s", "catalog", catalogData.Index, "url")] = catalogData.URL
+					return true
+				})
+			}
+		default:
+			// Skip unsupported field types
+			continue
+		}
+	}
+
+	return config
+}

--- a/pkg/params/settings/convert_test.go
+++ b/pkg/params/settings/convert_test.go
@@ -1,0 +1,192 @@
+package settings
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+	zapobserver "go.uber.org/zap/zaptest/observer"
+	"gotest.tools/v3/assert"
+)
+
+func TestConvert(t *testing.T) {
+	tests := []struct {
+		name           string
+		inputConfig    map[string]string
+		expectedConfig map[string]string
+	}{
+		{
+			name:        "empty configmap",
+			inputConfig: map[string]string{},
+			expectedConfig: map[string]string{
+				"application-name":                       "Pipelines as Code CI",
+				"auto-configure-new-github-repo":         "false",
+				"auto-configure-repo-namespace-template": "",
+				"bitbucket-cloud-additional-source-ip":   "",
+				"bitbucket-cloud-check-source-ip":        "true",
+				"custom-console-name":                    "",
+				"custom-console-url":                     "",
+				"custom-console-url-namespace":           "",
+				"custom-console-url-pr-details":          "",
+				"custom-console-url-pr-tasklog":          "",
+				"default-max-keep-runs":                  "0",
+				"error-detection-from-container-logs":    "true",
+				"error-detection-max-number-of-lines":    "50",
+				"error-detection-simple-regexp":          "^(?P<filename>[^:]*):(?P<line>[0-9]+):(?P<column>[0-9]+)?([ ]*)?(?P<error>.*)",
+				"error-log-snippet":                      "true",
+				"hub-catalog-name":                       "tekton",
+				"hub-url":                                "https://api.hub.tekton.dev/v1",
+				"max-keep-run-upper-limit":               "0",
+				"remember-ok-to-test":                    "true",
+				"remote-tasks":                           "true",
+				"secret-auto-create":                     "true",
+				"secret-github-app-scope-extra-repos":    "",
+				"secret-github-app-token-scoped":         "true",
+				"tekton-dashboard-url":                   "",
+			},
+		},
+		{
+			name: "with few fields",
+			inputConfig: map[string]string{
+				"application-name":                       "Pipelines as Code CI test name",
+				"auto-configure-new-github-repo":         "false",
+				"auto-configure-repo-namespace-template": "",
+				"bitbucket-cloud-additional-source-ip":   "",
+				"error-detection-from-container-logs":    "true",
+				"error-detection-max-number-of-lines":    "100",
+				"remote-tasks":                           "",
+			},
+			expectedConfig: map[string]string{
+				"application-name":                       "Pipelines as Code CI test name",
+				"auto-configure-new-github-repo":         "false",
+				"auto-configure-repo-namespace-template": "",
+				"bitbucket-cloud-additional-source-ip":   "",
+				"bitbucket-cloud-check-source-ip":        "true",
+				"custom-console-name":                    "",
+				"custom-console-url":                     "",
+				"custom-console-url-namespace":           "",
+				"custom-console-url-pr-details":          "",
+				"custom-console-url-pr-tasklog":          "",
+				"default-max-keep-runs":                  "0",
+				"error-detection-from-container-logs":    "true",
+				"error-detection-max-number-of-lines":    "100",
+				"error-detection-simple-regexp":          "^(?P<filename>[^:]*):(?P<line>[0-9]+):(?P<column>[0-9]+)?([ ]*)?(?P<error>.*)",
+				"error-log-snippet":                      "true",
+				"hub-catalog-name":                       "tekton",
+				"hub-url":                                "https://api.hub.tekton.dev/v1",
+				"max-keep-run-upper-limit":               "0",
+				"remember-ok-to-test":                    "true",
+				"remote-tasks":                           "true",
+				"secret-auto-create":                     "true",
+				"secret-github-app-scope-extra-repos":    "",
+				"secret-github-app-token-scoped":         "true",
+				"tekton-dashboard-url":                   "",
+			},
+		},
+		{
+			name: "with few fields and default catalog",
+			inputConfig: map[string]string{
+				"application-name":                       "Pipelines as Code CI test name",
+				"auto-configure-new-github-repo":         "false",
+				"auto-configure-repo-namespace-template": "",
+				"bitbucket-cloud-additional-source-ip":   "",
+				"error-detection-from-container-logs":    "true",
+				"error-detection-max-number-of-lines":    "100",
+				"hub-catalog-name":                       "test tekton",
+				"hub-url":                                "https://api.hub.tekton.dev/v2",
+			},
+			expectedConfig: map[string]string{
+				"application-name":                       "Pipelines as Code CI test name",
+				"auto-configure-new-github-repo":         "false",
+				"auto-configure-repo-namespace-template": "",
+				"bitbucket-cloud-additional-source-ip":   "",
+				"bitbucket-cloud-check-source-ip":        "true",
+				"custom-console-name":                    "",
+				"custom-console-url":                     "",
+				"custom-console-url-namespace":           "",
+				"custom-console-url-pr-details":          "",
+				"custom-console-url-pr-tasklog":          "",
+				"default-max-keep-runs":                  "0",
+				"error-detection-from-container-logs":    "true",
+				"error-detection-max-number-of-lines":    "100",
+				"error-detection-simple-regexp":          "^(?P<filename>[^:]*):(?P<line>[0-9]+):(?P<column>[0-9]+)?([ ]*)?(?P<error>.*)",
+				"error-log-snippet":                      "true",
+				"hub-catalog-name":                       "test tekton",
+				"hub-url":                                "https://api.hub.tekton.dev/v2",
+				"max-keep-run-upper-limit":               "0",
+				"remember-ok-to-test":                    "true",
+				"remote-tasks":                           "true",
+				"secret-auto-create":                     "true",
+				"secret-github-app-scope-extra-repos":    "",
+				"secret-github-app-token-scoped":         "true",
+				"tekton-dashboard-url":                   "",
+			},
+		},
+		{
+			name: "with few fields and multi catalogs",
+			inputConfig: map[string]string{
+				"application-name":                       "Pipelines as Code CI test name",
+				"auto-configure-new-github-repo":         "false",
+				"auto-configure-repo-namespace-template": "",
+				"bitbucket-cloud-additional-source-ip":   "",
+				"catalog-1-id":                           "anotherhub",
+				"catalog-1-name":                         "tekton",
+				"catalog-1-url":                          "https://api.other.com/v1",
+				"catalog-5-id":                           "anotherhub5",
+				"catalog-5-name":                         "tekton1",
+				"catalog-5-url":                          "https://api.other.com/v2",
+				"error-detection-from-container-logs":    "true",
+				"error-detection-max-number-of-lines":    "100",
+				"hub-catalog-name":                       "test tekton",
+				"hub-url":                                "https://api.hub.tekton.dev/v2",
+			},
+			expectedConfig: map[string]string{
+				"application-name":                       "Pipelines as Code CI test name",
+				"auto-configure-new-github-repo":         "false",
+				"auto-configure-repo-namespace-template": "",
+				"bitbucket-cloud-additional-source-ip":   "",
+				"bitbucket-cloud-check-source-ip":        "true",
+				"catalog-1-id":                           "anotherhub",
+				"catalog-1-name":                         "tekton",
+				"catalog-1-url":                          "https://api.other.com/v1",
+				"catalog-5-id":                           "anotherhub5",
+				"catalog-5-name":                         "tekton1",
+				"catalog-5-url":                          "https://api.other.com/v2",
+				"custom-console-name":                    "",
+				"custom-console-url":                     "",
+				"custom-console-url-namespace":           "",
+				"custom-console-url-pr-details":          "",
+				"custom-console-url-pr-tasklog":          "",
+				"default-max-keep-runs":                  "0",
+				"error-detection-from-container-logs":    "true",
+				"error-detection-max-number-of-lines":    "100",
+				"error-detection-simple-regexp":          "^(?P<filename>[^:]*):(?P<line>[0-9]+):(?P<column>[0-9]+)?([ ]*)?(?P<error>.*)",
+				"error-log-snippet":                      "true",
+				"hub-catalog-name":                       "test tekton",
+				"hub-url":                                "https://api.hub.tekton.dev/v2",
+				"max-keep-run-upper-limit":               "0",
+				"remember-ok-to-test":                    "true",
+				"remote-tasks":                           "true",
+				"secret-auto-create":                     "true",
+				"secret-github-app-scope-extra-repos":    "",
+				"secret-github-app-token-scoped":         "true",
+				"tekton-dashboard-url":                   "",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			observer, _ := zapobserver.New(zap.InfoLevel)
+			fakelogger := zap.New(observer).Sugar()
+			if tt.inputConfig == nil {
+				tt.inputConfig = map[string]string{}
+			}
+			settings := &Settings{}
+			err := SyncConfig(fakelogger, settings, tt.inputConfig, map[string]func(string) error{})
+			if err != nil {
+				t.Errorf("not expecting error but got %s", err)
+			}
+			actualConfigData := ConvertPacStructToConfigMap(settings)
+			assert.DeepEqual(t, actualConfigData, tt.expectedConfig)
+		})
+	}
+}

--- a/pkg/params/settings/default.go
+++ b/pkg/params/settings/default.go
@@ -21,26 +21,26 @@ func getHubCatalogs(logger *zap.SugaredLogger, catalogs *sync.Map, config map[st
 		config[HubCatalogNameKey] = HubCatalogNameDefaultValue
 	}
 	catalogs.Store("default", HubCatalog{
-		ID:   "default",
-		Name: config[HubCatalogNameKey],
-		URL:  config[HubURLKey],
+		Index: "default",
+		Name:  config[HubCatalogNameKey],
+		URL:   config[HubURLKey],
 	})
 
 	for k := range config {
 		m := hubCatalogNameRegex.FindStringSubmatch(k)
 		if len(m) > 0 {
-			id := m[1]
-			cPrefix := fmt.Sprintf("catalog-%s", id)
+			index := m[1]
+			cPrefix := fmt.Sprintf("catalog-%s", index)
 			skip := false
 			for _, kk := range []string{"id", "name", "url"} {
 				cKey := fmt.Sprintf("%s-%s", cPrefix, kk)
 				// check if key exist in config
 				if _, ok := config[cKey]; !ok {
-					logger.Warnf("CONFIG: hub %v should have the key %s, skipping catalog configuration", id, cKey)
+					logger.Warnf("CONFIG: hub %v should have the key %s, skipping catalog configuration", index, cKey)
 					skip = true
 					break
 				} else if config[cKey] == "" {
-					logger.Warnf("CONFIG: hub %v catalog configuration is empty, skipping catalog configuration", id)
+					logger.Warnf("CONFIG: hub %v catalog configuration have empty value for key %s, skipping catalog configuration", index, cKey)
 					skip = true
 					break
 				}
@@ -61,15 +61,15 @@ func getHubCatalogs(logger *zap.SugaredLogger, catalogs *sync.Map, config map[st
 				value, ok := catalogs.Load(catalogID)
 				if ok {
 					catalogValues, ok := value.(HubCatalog)
-					if ok && (catalogValues.Name == catalogName) && (catalogValues.URL == catalogURL) {
-						break
+					if ok && (catalogValues.Name == catalogName) && (catalogValues.URL == catalogURL) && (catalogValues.Index == index) {
+						continue
 					}
 				}
 				logger.Infof("CONFIG: setting custom hub %s, catalog %s", catalogID, catalogURL)
 				catalogs.Store(catalogID, HubCatalog{
-					ID:   catalogID,
-					Name: catalogName,
-					URL:  catalogURL,
+					Index: index,
+					Name:  catalogName,
+					URL:   catalogURL,
 				})
 			}
 		}

--- a/pkg/pipelineascode/pipelineascode_test.go
+++ b/pkg/pipelineascode/pipelineascode_test.go
@@ -104,15 +104,15 @@ func TestRun(t *testing.T) {
 	var hubCatalogs sync.Map
 	hubCatalogs.Store(
 		"default", settings.HubCatalog{
-			ID:   "default",
-			URL:  testHubURL,
-			Name: testCatalogHubName,
+			Index: "default",
+			URL:   testHubURL,
+			Name:  testCatalogHubName,
 		})
 	hubCatalogs.Store(
 		"anotherHub", settings.HubCatalog{
-			ID:   "anotherHub",
-			URL:  testHubURL,
-			Name: testCatalogHubName,
+			Index: "1",
+			URL:   testHubURL,
+			Name:  testCatalogHubName,
 		})
 	observer, log := zapobserver.New(zap.InfoLevel)
 	logger := zap.New(observer).Sugar()

--- a/test/testdata/pipelinerun_remote_task_annotations.yaml
+++ b/test/testdata/pipelinerun_remote_task_annotations.yaml
@@ -9,8 +9,8 @@ metadata:
     pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
     pipelinesascode.tekton.dev/task: "[.other-tasks/task-referenced-internally.yaml]"
     pipelinesascode.tekton.dev/task-1: "[\\ .RemoteTaskURL //]"
-    pipelinesascode.tekton.dev/task-2: "pylint"
-    pipelinesascode.tekton.dev/task-3: "custom://curl"
+    pipelinesascode.tekton.dev/task-2: "custom://pylint"
+    pipelinesascode.tekton.dev/task-3: "custom2://curl"
 spec:
   pipelineRef:
     name: pipeline-in-tekton-dir


### PR DESCRIPTION
This will refactor configutil to pass the validators
in sync config function so that defaulting and validation can
be performed separately

default validators are exposed to be used by deps

catalog parsing was broken as soon as it find the other key
for same catalog so fixed that

refactored internal catalog parsing to have index data in map
to convert the strut back to configmap

added utility to convert struct back to configmap to be
used by deps and added unit tests

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
