### PR TITLE
feat(docs): use /dev/random for generating secrets

### DIFF
--- a/docs/content/docs/install/bitbucket_server.md
+++ b/docs/content/docs/install/bitbucket_server.md
@@ -29,7 +29,7 @@ recreate it.
 * Add a Secret or generate a random one with :
 
 ```shell
-  openssl rand -hex 20
+  head -c 30 /dev/random | base64
 ```
 
 * Set the payload URL to Pipelines-as-Code public URL. On OpenShift, you can get the

--- a/docs/content/docs/install/github_apps.md
+++ b/docs/content/docs/install/github_apps.md
@@ -31,7 +31,7 @@ Alternatively, you could set up manually by following the steps [here](./#setup-
   * **GitHub Application Name**: `OpenShift Pipelines`
   * **Homepage URL**: *[OpenShift Console URL]*
   * **Webhook URL**: *[the Pipelines-as-Code route or ingress URL as copied in the previous section]*
-  * **Webhook secret**: *[an arbitrary secret, you can generate one with `openssl rand -hex 20`]*
+  * **Webhook secret**: *[an arbitrary secret, you can generate one with `head -c 30 /dev/random | base64`]*
 
 * Select the following repository permissions:
   * **Checks**: `Read & Write`

--- a/docs/content/docs/install/github_webhook.md
+++ b/docs/content/docs/install/github_webhook.md
@@ -126,7 +126,7 @@ $ tkn pac create repo
   * Add a Webhook secret or generate a random one with this command (and note it, we will need it later):
 
     ```shell
-    openssl rand -hex 20
+    head -c 30 /dev/random | base64
     ```
 
   * Click "Let me select individual events" and select these events:

--- a/docs/content/docs/install/gitlab.md
+++ b/docs/content/docs/install/gitlab.md
@@ -78,7 +78,7 @@ $ tkn pac create repo
   * Add a secret or generate a random one with this command  :
 
     ```shell
-    openssl rand -hex 20
+    head -c 30 /dev/random | base64
     ```
 
   * [Refer to this screenshot](/images/gitlab-add-webhook.png) on how to configure the Webhook.


### PR DESCRIPTION
The documentation has been updated to use /dev/random instead of openssl for generating secrets. Since openssl is not ubiquitously available everywhere as is used to be. This change has been applied to the installation guides for Bitbucket Server, GitHub Apps, GitHub Webhook, and GitLab.

Suggested by @ifireball on slack

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
