### PR TITLE
 Replace deprecated GetMergeRequestChanges function

### DIFF
--- a/pkg/matcher/annotation_matcher_test.go
+++ b/pkg/matcher/annotation_matcher_test.go
@@ -1021,7 +1021,7 @@ func TestMatchPipelinerunAnnotationAndRepositories(t *testing.T) {
 				Token:  github.String("None"),
 			}
 			if len(tt.args.fileChanged) > 0 {
-				commitFiles := &gitlab.MergeRequest{}
+				commitFiles := []*gitlab.MergeRequestDiff{}
 				pushFileChanges := []*gitlab.Diff{}
 				if tt.args.runevent.TriggerTarget == "push" {
 					for _, v := range tt.args.fileChanged {
@@ -1040,14 +1040,14 @@ func TestMatchPipelinerunAnnotationAndRepositories(t *testing.T) {
 					})
 				} else {
 					for _, v := range tt.args.fileChanged {
-						commitFiles.Changes = append(commitFiles.Changes, &gitlab.MergeRequestDiff{
+						commitFiles = append(commitFiles, &gitlab.MergeRequestDiff{
 							NewPath:     v.FileName,
 							RenamedFile: v.RenamedFile,
 							DeletedFile: v.DeletedFile,
 							NewFile:     v.NewFile,
 						})
 					}
-					url := fmt.Sprintf("/projects/0/merge_requests/%d/changes", tt.args.runevent.PullRequestNumber)
+					url := fmt.Sprintf("/projects/0/merge_requests/%d/diffs", tt.args.runevent.PullRequestNumber)
 					glMux.HandleFunc(url, func(w http.ResponseWriter, _ *http.Request) {
 						jeez, err := json.Marshal(commitFiles)
 						assert.NilError(t, err)

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -331,14 +331,13 @@ func (v *Provider) GetFiles(_ context.Context, runevent *info.Event) (changedfil
 			"exiting... (hint: did you forget setting a secret on your repo?)")
 	}
 	if runevent.TriggerTarget == triggertype.PullRequest {
-		//nolint: staticcheck
-		mrchanges, _, err := v.Client.MergeRequests.GetMergeRequestChanges(v.targetProjectID, runevent.PullRequestNumber, &gitlab.GetMergeRequestChangesOptions{})
+		mrchanges, _, err := v.Client.MergeRequests.ListMergeRequestDiffs(v.targetProjectID, runevent.PullRequestNumber, &gitlab.ListMergeRequestDiffsOptions{})
 		if err != nil {
 			return changedfiles.ChangedFiles{}, err
 		}
 
 		changedFiles := changedfiles.ChangedFiles{}
-		for _, change := range mrchanges.Changes {
+		for _, change := range mrchanges {
 			changedFiles.All = append(changedFiles.All, change.NewPath)
 			if change.NewFile {
 				changedFiles.Added = append(changedFiles.Added, change.NewPath)

--- a/pkg/provider/gitlab/gitlab_test.go
+++ b/pkg/provider/gitlab/gitlab_test.go
@@ -486,7 +486,7 @@ func TestGetFiles(t *testing.T) {
 	tests := []struct {
 		name                             string
 		event                            *info.Event
-		mrchanges                        *gitlab.MergeRequest
+		mrchanges                        []*gitlab.MergeRequestDiff
 		pushChanges                      []*gitlab.Diff
 		wantAddedFilesCount              int
 		wantDeletedFilesCount            int
@@ -503,23 +503,21 @@ func TestGetFiles(t *testing.T) {
 				Repository:        "pullrequestrepository",
 				PullRequestNumber: 10,
 			},
-			mrchanges: &gitlab.MergeRequest{
-				Changes: []*gitlab.MergeRequestDiff{
-					{
-						NewPath: "modified.yaml",
-					},
-					{
-						NewPath: "added.doc",
-						NewFile: true,
-					},
-					{
-						NewPath:     "removed.yaml",
-						DeletedFile: true,
-					},
-					{
-						NewPath:     "renamed.doc",
-						RenamedFile: true,
-					},
+			mrchanges: []*gitlab.MergeRequestDiff{
+				{
+					NewPath: "modified.yaml",
+				},
+				{
+					NewPath: "added.doc",
+					NewFile: true,
+				},
+				{
+					NewPath:     "removed.yaml",
+					DeletedFile: true,
+				},
+				{
+					NewPath:     "renamed.doc",
+					RenamedFile: true,
 				},
 			},
 			wantAddedFilesCount:    1,
@@ -536,23 +534,21 @@ func TestGetFiles(t *testing.T) {
 				Repository:        "pullrequestrepository",
 				PullRequestNumber: 10,
 			},
-			mrchanges: &gitlab.MergeRequest{
-				Changes: []*gitlab.MergeRequestDiff{
-					{
-						NewPath: "modified.yaml",
-					},
-					{
-						NewPath: "added.doc",
-						NewFile: true,
-					},
-					{
-						NewPath:     "removed.yaml",
-						DeletedFile: true,
-					},
-					{
-						NewPath:     "renamed.doc",
-						RenamedFile: true,
-					},
+			mrchanges: []*gitlab.MergeRequestDiff{
+				{
+					NewPath: "modified.yaml",
+				},
+				{
+					NewPath: "added.doc",
+					NewFile: true,
+				},
+				{
+					NewPath:     "removed.yaml",
+					DeletedFile: true,
+				},
+				{
+					NewPath:     "renamed.doc",
+					RenamedFile: true,
 				},
 			},
 			wantAddedFilesCount:    0,
@@ -599,27 +595,25 @@ func TestGetFiles(t *testing.T) {
 			ctx, _ := rtesting.SetupFakeContext(t)
 			fakeclient, mux, teardown := thelp.Setup(t)
 			defer teardown()
-			mergeFileChanges := &gitlab.MergeRequest{
-				Changes: []*gitlab.MergeRequestDiff{
-					{
-						NewPath: "modified.yaml",
-					},
-					{
-						NewPath: "added.doc",
-						NewFile: true,
-					},
-					{
-						NewPath:     "removed.yaml",
-						DeletedFile: true,
-					},
-					{
-						NewPath:     "renamed.doc",
-						RenamedFile: true,
-					},
+			mergeFileChanges := []*gitlab.MergeRequestDiff{
+				{
+					NewPath: "modified.yaml",
+				},
+				{
+					NewPath: "added.doc",
+					NewFile: true,
+				},
+				{
+					NewPath:     "removed.yaml",
+					DeletedFile: true,
+				},
+				{
+					NewPath:     "renamed.doc",
+					RenamedFile: true,
 				},
 			}
 			if tt.event.TriggerTarget == "pull_request" {
-				mux.HandleFunc(fmt.Sprintf("/projects/10/merge_requests/%d/changes",
+				mux.HandleFunc(fmt.Sprintf("/projects/10/merge_requests/%d/diffs",
 					tt.event.PullRequestNumber), func(rw http.ResponseWriter, _ *http.Request) {
 					jeez, err := json.Marshal(mergeFileChanges)
 					assert.NilError(t, err)
@@ -664,7 +658,7 @@ func TestGetFiles(t *testing.T) {
 
 			if tt.event.TriggerTarget == "pull_request" {
 				for i := range changedFiles.All {
-					assert.Equal(t, tt.mrchanges.Changes[i].NewPath, changedFiles.All[i])
+					assert.Equal(t, tt.mrchanges[i].NewPath, changedFiles.All[i])
 				}
 			}
 			if tt.event.TriggerTarget == "push" {


### PR DESCRIPTION
This will replace deprecated GetMergeRequestChanges function
to new function ListMergeRequestDiffs and related changes
in unit test with respect to return types and api url changes

fix https://github.com/openshift-pipelines/pipelines-as-code/issues/1708 and #1470 

Signed-off-by: Zaki Shaikh <zashaikh@zashaikh-thinkpadp1gen4i.bengluru.csb>


# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
