### PR TITLE
fix: Revert GitOps event_type to pull_request

### DIFF
--- a/docs/content/docs/guide/authoringprs.md
+++ b/docs/content/docs/guide/authoringprs.md
@@ -50,7 +50,7 @@ checkout the code that is being tested.
 | Variable            | Description                                                                                       | Example                             | Example Output               |
 |---------------------|---------------------------------------------------------------------------------------------------|-------------------------------------|------------------------------|
 | body                | The full payload body (see [below](#using-the-body-and-headers-in-a-pipelines-as-code-parameter)) | `{{body.pull_request.user.email }}` | <email@domain.com>           |
-| event_type          | The event type (eg: `pull_request` or `push`)                                                     | `{{event_type}}`                    | pull_request                 |
+| event_type          | The event type (eg: `pull_request` or `push`)                                                     | `{{event_type}}`                    | pull_request          (see the note for Gitops Comments [here]({{< relref "/docs/guide/gitops_commands.md#event-type-annotation-and-dynamic-variables" >}}) )     |
 | git_auth_secret     | The secret name auto generated with provider token to check out private repos.                    | `{{git_auth_secret}}`               | pac-gitauth-xkxkx            |
 | headers             | The request headers (see [below](#using-the-body-and-headers-in-a-pipelines-as-code-parameter))   | `{{headers['x-github-event']}}`     | push                         |
 | pull_request_number | The pull or merge request number, only defined when we are in a `pull_request` event type.        | `{{pull_request_number}}`           | 1                            |

--- a/docs/content/docs/guide/gitops_commands.md
+++ b/docs/content/docs/guide/gitops_commands.md
@@ -227,3 +227,35 @@ There is different format that can get accepted, which let you pass values with 
 * key="another \"value\" defined"
 * key="another
   value with newline"
+
+## Event Type Annotation and dynamic variables
+
+The `pipeline.tekton.dev/event-type` annotation indicates the type of GitOps
+command that has triggered the PipelineRun.
+
+Here are the possible event types:
+
+* `test-all-comment` : The event is a single `/test` that would test every matched pipelinerun.
+* `test-comment` : The event is a `/test <PipelineRun>` comment that would test a specific PipelineRun.
+* `retest-all-comment` : The event is a single `/retest` that would retest every matched pipelinerun.
+* `retest-comment` : The event is a `/retest <PipelineRun>` that would retest a specific PipelineRun.
+* `on-comment`: The event is coming from a  custom comment that would trigger a PipelineRun.
+* `cancel-all-comment` : The event is a single `/cancel` that would cancel every matched pipelinerun.
+* `cancel-comment` : The event is a `/cancel <PipelineRun>` that would cancel a specific PipelineRun.
+* `ok-to-test-comment` : The event is a `/ok-to-test` that would allow running the CI for a unauthorized user.
+
+When using the `{{ event_type }}` [dynamic variable]({{< relref "/docs/guide/authoringprs.md#dynamic-variables" >}}) for the following event types:
+
+* `test-all-comment`
+* `test-comment`
+* `retest-all-comment`
+* `retest-comment`
+* `cancel-all-comment`
+* `ok-to-test-comment`
+
+The dynamic variable will return `pull_request` as the event type instead of the specific
+categorized GitOps command type. This is to handle backward compatibility with
+previous release for users relying on this dynamic variable.
+
+This currently only issue a warning in the repository matched namespace but then deprecated and changed to return
+the specific event type.

--- a/pkg/customparams/standard.go
+++ b/pkg/customparams/standard.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/changedfiles"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/opscomments"
 	"go.uber.org/zap"
 )
 
@@ -44,7 +45,7 @@ func (p *CustomParams) makeStandardParamsFromEvent(ctx context.Context) (map[str
 			"source_url":       p.event.HeadURL,
 			"sender":           strings.ToLower(p.event.Sender),
 			"target_namespace": p.repo.GetNamespace(),
-			"event_type":       p.event.EventType,
+			"event_type":       opscomments.EventTypeBackwardCompat(p.eventEmitter, p.repo, p.event.EventType),
 			"trigger_comment":  triggerCommentAsSingleLine,
 		}, map[string]interface{}{
 			"all":      changedFiles.All,

--- a/test/gitea_gitops_commands_test.go
+++ b/test/gitea_gitops_commands_test.go
@@ -206,7 +206,8 @@ func TestGiteaRetestAll(t *testing.T) {
 	assert.NilError(t, err)
 	var rt bool
 	for _, status := range repo.Status {
-		if *status.EventType == opscomments.RetestAllCommentEventType.String() {
+		// TODO(chmouel): Revert back to opscomments.RetestAllCommentEventType.String(), as pull_request now due of https://issues.redhat.com/browse/SRVKP-5775
+		if *status.EventType == triggertype.PullRequest.String() {
 			rt = true
 		}
 	}


### PR DESCRIPTION
Reverted the following event types to 'pull_request':

  * NoOpsCommentEventType
  * TestAllCommentEventType
  * TestSingleCommentEventType
  * RetestSingleCommentEventType
  * RetestAllCommentEventType
  * OnCommentEventType
  * CancelCommentSingleEventType
  * CancelCommentAllEventType
  * OkToTestCommentEventType

- This change restores compatibility for users relying on
  'pull_request' event type for filtering GitOps comments.

- Added deprecation notice in documentation for future changes to event types.

- Added deprecation notice in the events stream when deprecated events
  comment is used.

- Planned deprecation period to be determined and communicated in future
  updates.

Breaking Changes:
- None. This change restores previous behavior.

Deprecated:
- Specific event types for GitOps comments (to be deprecated in future release).

TODO:
- Plan and communicate deprecation timeline for specific GitOps comment
  event types.
- Update documentation with clear migration path for future changes.

Fixes https://issues.redhat.com/browse/SRVKP-5775

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
