### PR TITLE
fix: Correct event-type setting for on-comment prs

### DIFF
--- a/test/testdata/TestGiteaOnCommentAnnotation.golden
+++ b/test/testdata/TestGiteaOnCommentAnnotation.golden
@@ -1,5 +1,6 @@
 The comment is:
 /hello-world revision=main custom1=thisone custom2="another one" custom3="a \"quote\""
+The event is on-comment
 The revision is main
 The custom1 value is thisone
 The custom2 value is another one

--- a/test/testdata/pipelinerun-on-comment-annotation.yaml
+++ b/test/testdata/pipelinerun-on-comment-annotation.yaml
@@ -20,6 +20,7 @@ spec:
                 cat <<EOF
                 {{ trigger_comment }}
                 EOF
+                echo "The event is {{ event_type }}"
                 echo "The revision is {{ revision }}"
                 echo "The custom1 value is {{ custom1 }}"
                 echo "The custom2 value is {{ custom2 }}"


### PR DESCRIPTION
This commit fixes the event-type setting for PipelineRuns that match the `on-comment` annotation. Previously, the `event_type` was set to `no-ops-comment` instead of `on-comment` when a git provider's issue comment event matched a comment in an annotation. This fix ensures that the `event_type` is correctly set.

on-comment is a brand new TP feature, so no worries that we may have breaking things for users relying on that behaviour.

Issue: https://issue.redhat.com/browse/SRVKP-5779

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
