### PR TITLE
Update Github UI on ok-to-test comment event

### DIFF
--- a/pkg/matcher/annotation_matcher.go
+++ b/pkg/matcher/annotation_matcher.go
@@ -233,6 +233,17 @@ func MatchPipelinerunByAnnotation(ctx context.Context, logger *zap.SugaredLogger
 		return matchedPRs, nil
 	}
 
+	// check whether user is repository owner or  not
+	allowed, err := vcx.IsAllowed(ctx, event)
+	if err != nil {
+		return matchedPRs, err
+	}
+
+	// check if trigger comment is /ok-to-test comment and user is an authorized user
+	if allowed && opscomments.IsOkToTestComment(event.TriggerComment) {
+		return matchedPRs, nil
+	}
+
 	return nil, fmt.Errorf(buildAvailableMatchingAnnotationErr(event, pruns))
 }
 


### PR DESCRIPTION
This will allow repository owner to make a PR ready to test by sending ok-to-test comment event and update Github UI accordingly when there is no matching Pipelinerun in .tekton directory.

[SRVKP-4345](https://issues.redhat.com/browse/SRVKP-4345)