### PR TITLE
fix: controller crash when provenance is set only on the global repo

### DIFF
--- a/pkg/apis/pipelinesascode/v1alpha1/types.go
+++ b/pkg/apis/pipelinesascode/v1alpha1/types.go
@@ -83,7 +83,7 @@ func (r *RepositorySpec) Merge(newRepo RepositorySpec) {
 	if newRepo.ConcurrencyLimit != nil && r.ConcurrencyLimit == nil {
 		r.ConcurrencyLimit = newRepo.ConcurrencyLimit
 	}
-	if newRepo.Settings != nil {
+	if newRepo.Settings != nil && r.Settings != nil {
 		r.Settings.Merge(newRepo.Settings)
 	}
 	if r.GitProvider != nil && newRepo.GitProvider != nil {

--- a/test/pkg/scm/scm.go
+++ b/test/pkg/scm/scm.go
@@ -17,13 +17,14 @@ import (
 )
 
 type Opts struct {
-	GitURL        string
-	TargetRefName string
-	BaseRefName   string
-	WebURL        string
-	Log           *zap.SugaredLogger
-	CommitTitle   string
-	PushForce     bool
+	GitURL             string
+	TargetRefName      string
+	BaseRefName        string
+	WebURL             string
+	Log                *zap.SugaredLogger
+	CommitTitle        string
+	PushForce          bool
+	NoCheckOutFromBase bool
 }
 
 type FileChange struct {
@@ -93,7 +94,14 @@ func PushFilesToRefGit(t *testing.T, opts *Opts, entries map[string]string) {
 	if strings.HasPrefix(opts.TargetRefName, "refs/tags") {
 		_, err = git.RunGit(path, "reset", "--hard", "origin/"+opts.BaseRefName)
 	} else {
-		_, err = git.RunGit(path, "checkout", "-B", opts.TargetRefName, "origin/"+opts.BaseRefName)
+		if opts.NoCheckOutFromBase {
+			// Create a new branch without the base reference,
+			// which can be helpful for testing when you only want to add specific requested files
+			_, err = git.RunGit(path, "checkout", "-B", opts.TargetRefName)
+		} else {
+			// checkout new branch from base branch
+			_, err = git.RunGit(path, "checkout", "-B", opts.TargetRefName, "origin/"+opts.BaseRefName)
+		}
 	}
 	assert.NilError(t, err)
 

--- a/test/testdata/pipelinerun-provenance-test.yaml
+++ b/test/testdata/pipelinerun-provenance-test.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: "\\ .PipelineName //"
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
+    pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: task
+        displayName: "The Task name is Task"
+        taskSpec:
+          steps:
+            - name: source-provenance-test
+              image: registry.access.redhat.com/ubi9/ubi-micro
+              command: ["/bin/echo", "testing provenance for source"]


### PR DESCRIPTION
This commit fixes the controller crash by adding
a nil pointer check before accessing the elements of an object. Issue: https://issues.redhat.com/browse/SRVKP-5571

Verification:

Created Global Repo like below

```
apiVersion: pipelinesascode.tekton.dev/v1alpha1
kind: Repository
metadata:  
  name: pipelines-as-code  
  namespace: openshift-pipelines
spec:  
  settings:    
    pipelinerun_provenance: "default_branch"
```

created local Repo like below

```
apiVersion: pipelinesascode.tekton.dev/v1alpha1
kind: Repository
metadata:  
  name: test  
  namespace: test
spec:  
  settings: {}
  url: https://github.com/savitaashture/test-pac
```

Signed-off-by: Savita Ashture <sashture@redhat.com>

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
