### PR TITLE
Fix PAC watcher panic when concurrency_limit is set

### DIFF
--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -88,6 +88,13 @@ func (p *PacRun) Run(ctx context.Context) error {
 		if match.Repo == nil {
 			match.Repo = repo
 		}
+
+		// After matchRepo func fetched repo from k8s api repo is updated and
+		// need to merge global repo again
+		if p.globalRepo != nil {
+			match.Repo.Spec.Merge(p.globalRepo.Spec)
+		}
+
 		wg.Add(1)
 
 		go func(match matcher.Match, i int) {


### PR DESCRIPTION
This fixes a panic in PAC watcher when concurreny_limit is set via global repository and concurrency was not working as expected.

Solves these two issue:
https://issues.redhat.com/browse/SRVKP-5560