### PR TITLE
Fix 503 http error when handling incoming webhook requests

### DIFF
--- a/config/openshift/10-routes.yaml
+++ b/config/openshift/10-routes.yaml
@@ -15,6 +15,8 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
+  annotations:
+    haproxy.router.openshift.io/timeout: 600s
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default

--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -30,6 +30,11 @@ import (
 
 const globalAdapterPort = "8080"
 
+// For incoming webhook requests and GitHub Apps with many installations the handler takes long
+// e.g GitHub App with ~400 installations, it takes ~180s. For OpenShift deployments this also
+// requires matching timeout on the pipelines-as-code-controller route (default is 30s).
+const httpTimeoutHandler = 600 * time.Second
+
 type envConfig struct {
 	adapter.EnvConfig
 }
@@ -87,7 +92,7 @@ func (l *listener) Start(ctx context.Context) error {
 	srv := &http.Server{
 		Addr: ":" + adapterPort,
 		Handler: http.TimeoutHandler(mux,
-			10*time.Second, "Listener Timeout!\n"),
+			httpTimeoutHandler, "Listener Timeout!\n"),
 	}
 
 	enabled, tlsCertFile, tlsKeyFile := l.isTLSEnabled()


### PR DESCRIPTION
Incoming webhook request especially involving GitHub Apps with many installations take minutes, so the existing http handler timeout of 10s was causing 503 failures. Once increased, OpenShift deployments were failing with http 504 (Gateway Time-out) because of the default 30s timeout on the pipelines-as-code-controller route.

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
