### PR TITLE
Add E2E tests to test error reporting on UI for invalid PipelineRun definition

### DIFF
--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -134,6 +134,21 @@ func TestGiteaBadYaml(t *testing.T) {
 		"pipelinerun.*has failed.*expected exactly one, got neither: spec.pipelineRef, spec.pipelineSpec"), 10, "controller", github.Int64(20)))
 }
 
+// TestGiteaInvalidSpecValues tests invalid field values of a PipelinRun and ensures that these
+// validation errors are reported on UI.
+func TestGiteaInvalidSpecValues(t *testing.T) {
+	topts := &tgitea.TestOpts{
+		TargetEvent:    triggertype.PullRequest.String(),
+		YAMLFiles:      map[string]string{".tekton/pr-bad-format.yaml": "testdata/failures/invalid-timeouts-values-pipelinerun.yaml"},
+		CheckForStatus: "failure",
+		ExpectEvents:   true,
+		Regexp:         regexp.MustCompile(options.InvalidYamlErrorPattern),
+	}
+
+	_, f := tgitea.TestPR(t, topts)
+	defer f()
+}
+
 // don't test concurrency limit here, just parallel pipeline.
 func TestGiteaMultiplesParallelPipelines(t *testing.T) {
 	maxParallel := 10

--- a/test/github_pullrequest_test.go
+++ b/test/github_pullrequest_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -14,8 +15,10 @@ import (
 	"github.com/google/go-github/v61/github"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/opscomments"
 	tgithub "github.com/openshift-pipelines/pipelines-as-code/test/pkg/github"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
 	twait "github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/golden"
 )
 
@@ -133,6 +136,54 @@ func TestGithubPullRequestSecondBadYaml(t *testing.T) {
 	// may be fragile if we change the application name, but life goes on if it fails and we fix the name if that happen
 	assert.Equal(t, res.CheckRuns[0].GetOutput().GetSummary(), "Pipelines as Code GHE has <b>failed</b>.")
 	golden.Assert(t, res.CheckRuns[0].GetOutput().GetText(), strings.ReplaceAll(fmt.Sprintf("%s.golden", t.Name()), "/", "-"))
+}
+
+// TestGithubPullRequestInvalidSpecValues tests invalid field values of a PipelinRun and
+// ensures that these validation errors are reported on UI.
+func TestGithubPullRequestInvalidSpecValues(t *testing.T) {
+	if os.Getenv("NIGHTLY_E2E_TEST") != "true" {
+		t.Skip("Skipping test since only enabled for nightly")
+	}
+	ctx := context.Background()
+	g := &tgithub.PRTest{
+		Label:            "Github Invalid Yaml",
+		YamlFiles:        []string{"testdata/failures/invalid-timeouts-values-pipelinerun.yaml"},
+		SecondController: true,
+		NoStatusCheck:    true,
+	}
+	g.RunPullRequest(ctx, t)
+	defer g.TearDown(ctx, t)
+
+	opt := github.ListOptions{}
+	res := &github.ListCheckRunsResults{}
+	resp := &github.Response{}
+	var err error
+	counter := 0
+	for {
+		res, resp, err = g.Provider.Client.Checks.ListCheckRunsForRef(ctx, g.Options.Organization, g.Options.Repo, g.SHA, &github.ListCheckRunsOptions{
+			AppID:       g.Provider.ApplicationID,
+			Status:      github.String("completed"),
+			ListOptions: opt,
+		})
+		assert.NilError(t, err)
+		assert.Equal(t, resp.StatusCode, 200)
+		if len(res.CheckRuns) > 0 {
+			break
+		}
+		g.Cnx.Clients.Log.Infof("Waiting for the check run to be created")
+		if counter > 10 {
+			t.Errorf("Check run not created after 10 tries")
+			break
+		}
+		time.Sleep(5 * time.Second)
+	}
+
+	assert.Equal(t, len(res.CheckRuns), 1)
+	assert.Equal(t, res.CheckRuns[0].GetOutput().GetTitle(), "pipelinerun start failure")
+	reg := regexp.MustCompile("Pipelines as Code.* has <b>failed</b>.")
+	assert.Assert(t, cmp.Regexp(reg, res.CheckRuns[0].GetOutput().GetSummary()))
+	reg = regexp.MustCompile(options.InvalidYamlErrorPattern)
+	assert.Assert(t, cmp.Regexp(reg, res.CheckRuns[0].GetOutput().GetText()))
 }
 
 func TestGithubSecondTestExplicitelyNoMatchedPipelineRun(t *testing.T) {

--- a/test/pkg/options/options.go
+++ b/test/pkg/options/options.go
@@ -15,3 +15,9 @@ var (
 	RemoteTaskURL  = "https://raw.githubusercontent.com/openshift-pipelines/pipelines-as-code/main/pkg/pipelineascode/testdata/pull_request/.tekton/task.yaml"
 	RemoteTaskName = "task-from-tektondir"
 )
+
+const (
+	InvalidYamlErrorPattern = `invalid value: ([\d\w]+) should be <= pipeline duration: ([\w\.\/\-]+)(?:, ([\w\.\/\-]+))?` +
+		`|invalid value: ([\d\w]+) \+ ([\d\w]+) should be <= pipeline duration: ([\w\.\/\-]+), ([\w\.\/\-]+)` +
+		`|invalid value: ([\d\w]+) should be <= pipeline duration: ([\w\.\/\-]+)`
+)

--- a/test/testdata/failures/invalid-timeouts-values-pipelinerun.yaml
+++ b/test/testdata/failures/invalid-timeouts-values-pipelinerun.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: "\\ .PipelineName //"
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
+    pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: task
+        displayName: "The Task name is Task"
+        taskSpec:
+          steps:
+            - name: task
+              image: registry.access.redhat.com/ubi9/ubi-micro
+              command: ["/bin/echo", "HELLOMOTO"]
+  timeouts:
+    pipeline: "0h1m0s"
+    tasks: "0h2m0s"
+    finally: "0h0m0s"


### PR DESCRIPTION
adds E2E tests for gitea and github to ensure that if user supplies invalid PipelineRun definition, PAC should report errors on UI.

it was created as bug on JIRA but I confirmed it is working as expected. 
https://issues.redhat.com/browse/SRVKP-5776