### PR TITLE
Add Repository and Namespace Tags to PipelineRun Count Metric

### DIFF
--- a/pkg/reconciler/emit_metrics.go
+++ b/pkg/reconciler/emit_metrics.go
@@ -10,6 +10,7 @@ import (
 func (r *Reconciler) emitMetrics(pr *tektonv1.PipelineRun) error {
 	gitProvider := pr.GetAnnotations()[keys.GitProvider]
 	eventType := pr.GetAnnotations()[keys.EventType]
+	repository := pr.GetAnnotations()[keys.Repository]
 
 	switch gitProvider {
 	case "github", "github-enterprise":
@@ -24,5 +25,5 @@ func (r *Reconciler) emitMetrics(pr *tektonv1.PipelineRun) error {
 		return fmt.Errorf("no supported Git provider")
 	}
 
-	return r.metrics.Count(gitProvider, eventType)
+	return r.metrics.Count(gitProvider, eventType, pr.GetNamespace(), repository)
 }


### PR DESCRIPTION
adds repository and namespace tags to `pipelines_as_code_pipelinerun_count` metric counter to enable filteration of PipelineRun count by repository or namespace in Pipelines as code metrics.

https://issues.redhat.com/browse/SRVKP-6217