### PR TITLE
Add New Metric to Show Number of Running PipelineRuns

### DIFF
--- a/docs/content/docs/install/metrics.md
+++ b/docs/content/docs/install/metrics.md
@@ -14,3 +14,4 @@ You can configure these exporters by referring to the [observability configurati
 |------------------------------------------------------|---------|--------------------------------------------------------------------|
 | `pipelines_as_code_pipelinerun_count`                | Counter | Number of pipelineruns created by pipelines-as-code                |
 | `pipelines_as_code_pipelinerun_duration_seconds_sum` | Counter | Number of seconds all pipelineruns have taken in pipelines-as-code |
+| `pipelines_as_code_running_pipelineruns_count`       | Gauge   | Number of running pipelineruns in pipelines-as-code                |

--- a/pkg/metrics/injection.go
+++ b/pkg/metrics/injection.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2024 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+
+	pipelineruninformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1/pipelinerun"
+	listers "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1"
+	"k8s.io/client-go/rest"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/injection"
+	"knative.dev/pkg/logging"
+)
+
+// nolint: gochecknoinits
+func init() {
+	injection.Default.RegisterClient(func(ctx context.Context, _ *rest.Config) context.Context { return WithClient(ctx) })
+	injection.Default.RegisterInformer(WithInformer)
+}
+
+// RecorderKey is used for associating the Recorder inside the context.Context.
+type RecorderKey struct{}
+
+// WithClient adds a metrics recorder to the given context.
+func WithClient(ctx context.Context) context.Context {
+	rec, err := NewRecorder()
+	if err != nil {
+		logging.FromContext(ctx).Errorf("Failed to create pipelinerun metrics recorder %v", err)
+	}
+	return context.WithValue(ctx, RecorderKey{}, rec)
+}
+
+// Get extracts the pipelinerunmetrics.Recorder from the context.
+func Get(ctx context.Context) *Recorder {
+	untyped := ctx.Value(RecorderKey{})
+	if untyped == nil {
+		logging.FromContext(ctx).Panic("Unable to fetch *pipelinerunmetrics.Recorder from context.")
+	}
+	// nolint: forcetypeassert
+	return untyped.(*Recorder)
+}
+
+// InformerKey is used for associating the Informer inside the context.Context.
+type InformerKey struct{}
+
+// WithInformer returns the given context, and a configured informer.
+func WithInformer(ctx context.Context) (context.Context, controller.Informer) {
+	return ctx, &recorderInformer{
+		ctx:     ctx,
+		metrics: Get(ctx),
+		lister:  pipelineruninformer.Get(ctx).Lister(),
+	}
+}
+
+type recorderInformer struct {
+	ctx     context.Context
+	metrics *Recorder
+	lister  listers.PipelineRunLister
+}
+
+var _ controller.Informer = (*recorderInformer)(nil)
+
+// Run starts the recorder informer in a goroutine.
+func (ri *recorderInformer) Run(stopCh <-chan struct{}) {
+	// Turn the stopCh into a context for reporting metrics.
+	ctx, cancel := context.WithCancel(ri.ctx)
+	go func() {
+		<-stopCh
+		cancel()
+	}()
+
+	go ri.metrics.ReportRunningPipelineRuns(ctx, ri.lister)
+}
+
+// HasSynced returns whether the informer has synced, which in this case will always be true.
+func (ri *recorderInformer) HasSynced() bool {
+	return true
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -3,20 +3,31 @@ package metrics
 import (
 	"context"
 	"fmt"
+	"strings"
+	"sync"
 	"time"
 
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	listers "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
+	"k8s.io/apimachinery/pkg/labels"
+	"knative.dev/pkg/logging"
 	"knative.dev/pkg/metrics"
 )
 
 var prCount = stats.Float64("pipelines_as_code_pipelinerun_count",
-	"number of pipeline runs by pipelines as code",
+	"number of pipelineruns by pipelines as code",
 	stats.UnitDimensionless)
 
 var prDurationCount = stats.Float64("pipelines_as_code_pipelinerun_duration_seconds_sum",
 	"number of seconds all pipelineruns completed in by pipelines as code",
+	stats.UnitDimensionless)
+
+var runningPRCount = stats.Float64("pipelines_as_code_running_pipelineruns_count",
+	"number of running pipelineruns by pipelines as code",
 	stats.UnitDimensionless)
 
 // Recorder holds keys for metrics.
@@ -31,79 +42,98 @@ type Recorder struct {
 	ReportingPeriod time.Duration
 }
 
+var (
+	Once           sync.Once
+	R              *Recorder
+	ErrRegistering error
+)
+
 // NewRecorder creates a new metrics recorder instance
 // to log the PAC PipelineRun related metrics.
 func NewRecorder() (*Recorder, error) {
-	r := &Recorder{
-		initialized: true,
+	Once.Do(func() {
+		R = &Recorder{
+			initialized: true,
 
-		// Default to 30s intervals.
-		ReportingPeriod: 30 * time.Second,
-	}
+			// Default to 30s intervals.
+			ReportingPeriod: 30 * time.Second,
+		}
 
-	provider, err := tag.NewKey("provider")
-	if err != nil {
-		return nil, err
-	}
-	r.provider = provider
+		provider, errRegistering := tag.NewKey("provider")
+		if errRegistering != nil {
+			return
+		}
+		R.provider = provider
 
-	eventType, err := tag.NewKey("event-type")
-	if err != nil {
-		return nil, err
-	}
-	r.eventType = eventType
+		eventType, errRegistering := tag.NewKey("event-type")
+		if errRegistering != nil {
+			return
+		}
+		R.eventType = eventType
 
-	namespace, err := tag.NewKey("namespace")
-	if err != nil {
-		return nil, err
-	}
-	r.namespace = namespace
+		namespace, errRegistering := tag.NewKey("namespace")
+		if errRegistering != nil {
+			return
+		}
+		R.namespace = namespace
 
-	repository, err := tag.NewKey("repository")
-	if err != nil {
-		return nil, err
-	}
-	r.repository = repository
+		repository, errRegistering := tag.NewKey("repository")
+		if errRegistering != nil {
+			return
+		}
+		R.repository = repository
 
-	status, err := tag.NewKey("status")
-	if err != nil {
-		return nil, err
-	}
-	r.status = status
+		status, errRegistering := tag.NewKey("status")
+		if errRegistering != nil {
+			return
+		}
+		R.status = status
 
-	reason, err := tag.NewKey("reason")
-	if err != nil {
-		return nil, err
-	}
-	r.reason = reason
+		reason, errRegistering := tag.NewKey("reason")
+		if errRegistering != nil {
+			return
+		}
+		R.reason = reason
 
-	err = view.Register(
-		&view.View{
-			Description: prCount.Description(),
-			Measure:     prCount,
-			Aggregation: view.Count(),
-			TagKeys:     []tag.Key{r.provider, r.eventType, r.namespace, r.repository},
-		},
-		&view.View{
-			Description: prDurationCount.Description(),
-			Measure:     prDurationCount,
-			Aggregation: view.Sum(),
-			TagKeys:     []tag.Key{r.namespace, r.repository, r.status, r.reason},
-		},
-	)
-	if err != nil {
-		r.initialized = false
-		return r, err
-	}
+		var (
+			prCountView = &view.View{
+				Description: prCount.Description(),
+				Measure:     prCount,
+				Aggregation: view.Count(),
+				TagKeys:     []tag.Key{R.provider, R.eventType, R.namespace, R.repository},
+			}
 
-	return r, nil
+			prDurationView = &view.View{
+				Description: prDurationCount.Description(),
+				Measure:     prDurationCount,
+				Aggregation: view.Sum(),
+				TagKeys:     []tag.Key{R.namespace, R.repository, R.status, R.reason},
+			}
+
+			runningPRView = &view.View{
+				Description: runningPRCount.Description(),
+				Measure:     runningPRCount,
+				Aggregation: view.LastValue(),
+				TagKeys:     []tag.Key{R.namespace, R.repository},
+			}
+		)
+
+		view.Unregister(prCountView, prDurationView, runningPRView)
+		errRegistering = view.Register(prCountView, prDurationView, runningPRView)
+		if errRegistering != nil {
+			R.initialized = false
+			return
+		}
+	})
+
+	return R, ErrRegistering
 }
 
 // Count logs number of times a pipelinerun is ran for a provider.
 func (r *Recorder) Count(provider, event, namespace, repository string) error {
 	if !r.initialized {
 		return fmt.Errorf(
-			"ignoring the metrics recording for pipeline runs,  failed to initialize the metrics recorder")
+			"ignoring the metrics recording for pipelineruns, failed to initialize the metrics recorder")
 	}
 
 	ctx, err := tag.New(
@@ -141,4 +171,103 @@ func (r *Recorder) CountPRDuration(namespace, repository, status, reason string,
 
 	metrics.Record(ctx, prDurationCount.M(duration.Seconds()))
 	return nil
+}
+
+// RunningPipelineRuns emits the number of running PipelineRuns for a repository and namespace.
+func (r *Recorder) RunningPipelineRuns(namespace, repository string, runningPRs float64) error {
+	if !r.initialized {
+		return fmt.Errorf(
+			"ignoring the metrics recording for pipelineruns, failed to initialize the metrics recorder")
+	}
+
+	ctx, err := tag.New(
+		context.Background(),
+		tag.Insert(r.namespace, namespace),
+		tag.Insert(r.repository, repository),
+	)
+	if err != nil {
+		return err
+	}
+
+	metrics.Record(ctx, runningPRCount.M(runningPRs))
+	return nil
+}
+
+func (r *Recorder) EmitRunningPRsMetrics(prl []*tektonv1.PipelineRun) error {
+	if len(prl) == 0 {
+		return nil
+	}
+
+	// bifurcate PipelineRuns based on their namespace and repository
+	runningPRs := map[string]int{}
+	completedPRsKeys := map[string]struct{}{}
+	for _, pr := range prl {
+		// Check if PipelineRun has Repository annotation it means PR is created by PAC.
+		if repository, ok := pr.GetAnnotations()[keys.Repository]; ok {
+			key := fmt.Sprintf("%s/%s", pr.GetNamespace(), repository)
+			// check if PipelineRun is running.
+			if !pr.IsDone() {
+				runningPRs[key]++
+			} else {
+				// add it in completed, and we don't want completed PipelineRuns count.
+				completedPRsKeys[key] = struct{}{}
+			}
+		}
+	}
+
+	for k, v := range runningPRs {
+		nsKeys := strings.Split(k, "/")
+		if err := r.RunningPipelineRuns(nsKeys[0], nsKeys[1], float64(v)); err != nil {
+			return err
+		}
+	}
+
+	// report zero for the keys which aren't in runningPRs.
+	for key := range completedPRsKeys {
+		// if key isn't there in runningPRs then it should be reported 0
+		// otherwise it was reported in previous loop.
+		if _, ok := runningPRs[key]; !ok {
+			nsKeys := strings.Split(key, "/")
+			if err := r.RunningPipelineRuns(nsKeys[0], nsKeys[1], 0); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// ReportRunningPipelineRuns reports running PipelineRuns on our configured ReportingPeriod
+// until the context is cancelled.
+func (r *Recorder) ReportRunningPipelineRuns(ctx context.Context, lister listers.PipelineRunLister) {
+	logger := logging.FromContext(ctx)
+
+	for {
+		delay := time.NewTimer(r.ReportingPeriod)
+		select {
+		case <-ctx.Done():
+			// When the context is cancelled, stop reporting.
+			if !delay.Stop() {
+				<-delay.C
+			}
+			return
+
+		case <-delay.C:
+			prl, err := lister.List(labels.Everything())
+			if err != nil {
+				logger.Warnf("Failed to list PipelineRuns : %v", err)
+				continue
+			}
+			// Every 30s surface a metric for the number of running pipelines.
+			if err := r.EmitRunningPRsMetrics(prl); err != nil {
+				logger.Warnf("Failed to log the metrics : %v", err)
+			}
+		}
+	}
+}
+
+func ResetRecorder() {
+	Once = sync.Once{}
+	R = nil
+	ErrRegistering = nil
 }


### PR DESCRIPTION
added new gauge metric to show number of running pipelineruns. added tests and docs accordingly.

https://issues.redhat.com/browse/SRVKP-6375

![running pipelineruns](https://github.com/user-attachments/assets/8fe6682d-0459-44c3-b55d-4c1b2940088e)


# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
