### PR TITLE
Fix building with old Hugo versions

### DIFF
--- a/docs/themes/hugo-book/layouts/partials/docs/html-head.html
+++ b/docs/themes/hugo-book/layouts/partials/docs/html-head.html
@@ -23,7 +23,7 @@
 {{- end -}}
 
 <!-- Theme stylesheet, you can customize scss by creating `assets/custom.scss` in your website -->
-{{- $styles := resources.Get "book.scss" | resources.ExecuteAsTemplate "book.scss" . | css.Sass | resources.Minify | resources.Fingerprint }}
+{{- $styles := resources.Get "book.scss" | resources.ExecuteAsTemplate "book.scss" . | resources.ToCSS | resources.Minify | resources.Fingerprint }}
 <link rel="stylesheet" href="{{ $styles.RelPermalink }}" {{ template "integrity" $styles }}>
 
 {{- if default true .Site.Params.BookSearch -}}


### PR DESCRIPTION
cloudfare page is still using 0.96.x which does not have the css.Sass
function as per this error on the cloudfare console:

```
v0.96.0-2fd4a7d3d6845e75f8b8ae3a2a7bd91438967bbb+extended linux/amd64
templates:
"epo/docs/themes/hugo-book/layouts/partials/docs/html-head.html:26:1":
parse failed: template: partials/docs/html-head.html:26: function "css"
```

so backporting to the old change and keep the deprecation message until
i guess cloudfare upgrades it?

Signed-off-by: Chmouel Boudjnah <chmouel@chmouel.com>
