### PR TITLE
Fix repository name breaking for bb cloud when it's not in url slug form

### DIFF
--- a/pkg/provider/bitbucketcloud/parse_payload.go
+++ b/pkg/provider/bitbucketcloud/parse_payload.go
@@ -136,7 +136,7 @@ func (v *Provider) ParsePayload(ctx context.Context, run *params.Run, request *h
 			opscomments.SetEventTypeAndTargetPR(processedEvent, e.Comment.Content.Raw)
 		}
 		processedEvent.Organization = e.Repository.Workspace.Slug
-		processedEvent.Repository = e.Repository.Name
+		processedEvent.Repository = strings.Split(e.Repository.FullName, "/")[1]
 		processedEvent.SHA = e.PullRequest.Source.Commit.Hash
 		processedEvent.URL = e.Repository.Links.HTML.HRef
 		processedEvent.BaseBranch = e.PullRequest.Destination.Branch.Name
@@ -152,7 +152,7 @@ func (v *Provider) ParsePayload(ctx context.Context, run *params.Run, request *h
 		processedEvent.TriggerTarget = "push"
 		processedEvent.EventType = "push"
 		processedEvent.Organization = e.Repository.Workspace.Slug
-		processedEvent.Repository = e.Repository.Name
+		processedEvent.Repository = strings.Split(e.Repository.FullName, "/")[1]
 		processedEvent.SHA = e.Push.Changes[0].New.Target.Hash
 		processedEvent.URL = e.Repository.Links.HTML.HRef
 		processedEvent.HeadBranch = e.Push.Changes[0].Old.Name

--- a/pkg/provider/bitbucketcloud/test/bbcloudtest.go
+++ b/pkg/provider/bitbucketcloud/test/bbcloudtest.go
@@ -240,7 +240,8 @@ func MakePREvent(accountid, nickname, sha, comment string) types.PullRequestEven
 			Workspace: types.Workspace{
 				Slug: "organization",
 			},
-			Name: "repo",
+			Name:     "repo",
+			FullName: "organization/repo",
 			Links: types.Links{
 				HTML: types.HTMLLink{
 					HRef: "https://notgh.org/organization/repo",
@@ -317,7 +318,8 @@ func MakePushEvent(accountid, nickname, sha, changeType string) types.PushReques
 			Workspace: types.Workspace{
 				Slug: "org",
 			},
-			Name: "repo",
+			Name:     "repo",
+			FullName: "org/repo",
 			Links: types.Links{
 				HTML: types.HTMLLink{
 					HRef: "https://vavar/repo/org",

--- a/pkg/provider/bitbucketcloud/types/types.go
+++ b/pkg/provider/bitbucketcloud/types/types.go
@@ -7,6 +7,7 @@ type Workspace struct {
 type Repository struct {
 	Workspace Workspace `json:"workspace"`
 	Name      string    `json:"name"`
+	FullName  string    `json:"full_name"`
 	Links     Links     `json:"links"`
 }
 


### PR DESCRIPTION
# Changes

The repository `name` field provided by the Bitbucket Cloud webhook is the raw name of the repository in Bitbucket and can contain characters such as spaces. When this is combined with the organisation to generate the url for the repository it subsequently breaks. This PR uses the `full_name` field for the repository which is properly formatted.

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
