### PR TITLE
Fix panic in PAC controller on delete tag event in GitLab

### DIFF
--- a/test/gitlab_delete_tag_event_test.go
+++ b/test/gitlab_delete_tag_event_test.go
@@ -1,0 +1,58 @@
+//go:build e2e
+// +build e2e
+
+package test
+
+import (
+	"context"
+	"net/http"
+	"regexp"
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/cctx"
+	tgitlab "github.com/openshift-pipelines/pipelines-as-code/test/pkg/gitlab"
+	twait "github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
+	"github.com/tektoncd/pipeline/pkg/names"
+	"github.com/xanzy/go-gitlab"
+	"gotest.tools/v3/assert"
+)
+
+func TestGitlabDeleteTagEvent(t *testing.T) {
+	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
+	ctx := context.Background()
+	runcnx, opts, glprovider, err := tgitlab.Setup(ctx)
+	assert.NilError(t, err)
+	ctx, err = cctx.GetControllerCtxInfo(ctx, runcnx)
+	assert.NilError(t, err)
+	runcnx.Clients.Log.Info("Testing with Gitlab")
+
+	projectinfo, resp, err := glprovider.Client.Projects.GetProject(opts.ProjectID, nil)
+	assert.NilError(t, err)
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
+	}
+	defer tgitlab.TearDown(ctx, t, runcnx, glprovider, -1, "", targetNS, opts.ProjectID)
+
+	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, targetNS, nil)
+	assert.NilError(t, err)
+
+	tagName := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("v1.0")
+	err = tgitlab.CreateTag(glprovider.Client, projectinfo.ID, tagName)
+	// if something goes wrong in creating tag and tag remains in
+	// repository CleanTag will clear that and doesn't throw any error.
+	defer tgitlab.CleanTag(glprovider.Client, projectinfo.ID, tagName)
+	assert.NilError(t, err)
+	runcnx.Clients.Log.Infof("Created Tag %s in %s repository", tagName, projectinfo.Name)
+
+	err = tgitlab.DeleteTag(glprovider.Client, projectinfo.ID, tagName)
+	assert.NilError(t, err)
+	runcnx.Clients.Log.Infof("Deleted Tag %s in %s repository", tagName, projectinfo.Name)
+
+	reg := regexp.MustCompile("event Delete Tag Push Hook is not supported*")
+	err = twait.RegexpMatchingInControllerLog(ctx, runcnx, *reg, 10, "controller", gitlab.Ptr(int64(20)))
+	assert.NilError(t, err)
+}
+
+// Local Variables:
+// compile-command: "go test -tags=e2e -v -run TestGitlabDeleteTagEvent$ ."
+// End:

--- a/test/pkg/gitlab/setup.go
+++ b/test/pkg/gitlab/setup.go
@@ -72,8 +72,9 @@ func TearDown(ctx context.Context, t *testing.T, runcnx *params.Run, glprovider 
 		runcnx.Clients.Log.Infof("Not cleaning up and closing PR since TEST_NOCLEANUP is set")
 		return
 	}
-	runcnx.Clients.Log.Infof("Closing PR %d", mrNumber)
+
 	if mrNumber != -1 {
+		runcnx.Clients.Log.Infof("Closing PR %d", mrNumber)
 		_, _, err := glprovider.Client.MergeRequests.UpdateMergeRequest(projectid, mrNumber,
 			&gitlab2.UpdateMergeRequestOptions{StateEvent: gitlab2.Ptr("close")})
 		if err != nil {
@@ -81,7 +82,14 @@ func TearDown(ctx context.Context, t *testing.T, runcnx *params.Run, glprovider 
 		}
 	}
 	repository.NSTearDown(ctx, t, runcnx, targetNS)
-	runcnx.Clients.Log.Infof("Deleting Ref %s", ref)
-	_, err := glprovider.Client.Branches.DeleteBranch(projectid, ref)
-	assert.NilError(t, err)
+	if ref != "" {
+		runcnx.Clients.Log.Infof("Deleting Ref %s", ref)
+		_, err := glprovider.Client.Branches.DeleteBranch(projectid, ref)
+		assert.NilError(t, err)
+	}
+}
+
+// CleanTag a wrapper function on DeleteTag to ignore errors in cleaning.
+func CleanTag(client *gitlab2.Client, pid int, tagName string) {
+	_ = DeleteTag(client, pid, tagName)
 }

--- a/test/pkg/gitlab/test.go
+++ b/test/pkg/gitlab/test.go
@@ -1,6 +1,9 @@
 package gitlab
 
 import (
+	"fmt"
+	"net/http"
+
 	ghlib "github.com/xanzy/go-gitlab"
 )
 
@@ -14,4 +17,33 @@ func CreateMR(client *ghlib.Client, pid int, sourceBranch, targetBranch, title s
 		return -1, err
 	}
 	return mr.IID, nil
+}
+
+func CreateTag(client *ghlib.Client, pid int, tagName string) error {
+	_, resp, err := client.Tags.CreateTag(pid, &ghlib.CreateTagOptions{
+		TagName: ghlib.Ptr(tagName),
+		Ref:     ghlib.Ptr("main"),
+	})
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("failed to create tag : %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func DeleteTag(client *ghlib.Client, pid int, tagName string) error {
+	resp, err := client.Tags.DeleteTag(pid, tagName)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("failed to delete tag : %d", resp.StatusCode)
+	}
+
+	return nil
 }


### PR DESCRIPTION
fixed panic in PAC controller when a tag is deleted on gitlab.

https://issues.redhat.com/browse/SRVKP-6636

https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1727708590297089

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
