### PR TITLE
Define label for controller in python scnd-ctrl.py

### DIFF
--- a/hack/second-controller.py
+++ b/hack/second-controller.py
@@ -134,6 +134,7 @@ with open("config/400-controller.yaml", "r", encoding="utf-8") as f:
     )
     for container in controller["spec"]["template"]["spec"]["containers"]:
         if container["name"] == "pac-controller":
+            container["name"] = args.label + "-controller"
             if args.controller_image and args.controller_image != "ko":
                 container["image"] = args.controller_image
             for env in container["env"]:


### PR DESCRIPTION
This will let standout the controller name in the logs when watching
multiple of them, instead of all mixed from the same name


used to be all pac-controller, now shows like this (see the difference between ghe-controller and pac-controller)

![image](https://github.com/user-attachments/assets/d111168c-d333-41b4-8c70-e0d3a15b3714)

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
