### PR TITLE
Fix crashing on bad bitbucketserver payload

### DIFF
--- a/pkg/provider/bitbucketserver/parse_payload.go
+++ b/pkg/provider/bitbucketserver/parse_payload.go
@@ -72,23 +72,23 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 			}
 		}
 		// TODO: It's Really not an OWNER but a PROJECT
-		processedEvent.Organization = e.PulRequest.ToRef.Repository.Project.Key
-		processedEvent.Repository = e.PulRequest.ToRef.Repository.Name
-		processedEvent.SHA = e.PulRequest.FromRef.LatestCommit
-		processedEvent.PullRequestNumber = e.PulRequest.ID
-		processedEvent.URL = e.PulRequest.ToRef.Repository.Links.Self[0].Href
-		processedEvent.BaseBranch = e.PulRequest.ToRef.DisplayID
-		processedEvent.HeadBranch = e.PulRequest.FromRef.DisplayID
-		processedEvent.BaseURL = e.PulRequest.ToRef.Repository.Links.Self[0].Href
-		processedEvent.HeadURL = e.PulRequest.FromRef.Repository.Links.Self[0].Href
+		processedEvent.Organization = e.PullRequest.ToRef.Repository.Project.Key
+		processedEvent.Repository = e.PullRequest.ToRef.Repository.Name
+		processedEvent.SHA = e.PullRequest.FromRef.LatestCommit
+		processedEvent.PullRequestNumber = e.PullRequest.ID
+		processedEvent.URL = e.PullRequest.ToRef.Repository.Links.Self[0].Href
+		processedEvent.BaseBranch = e.PullRequest.ToRef.DisplayID
+		processedEvent.HeadBranch = e.PullRequest.FromRef.DisplayID
+		processedEvent.BaseURL = e.PullRequest.ToRef.Repository.Links.Self[0].Href
+		processedEvent.HeadURL = e.PullRequest.FromRef.Repository.Links.Self[0].Href
 		processedEvent.AccountID = fmt.Sprintf("%d", e.Actor.ID)
 		processedEvent.Sender = e.Actor.Name
-		for _, value := range e.PulRequest.FromRef.Repository.Links.Clone {
+		for _, value := range e.PullRequest.FromRef.Repository.Links.Clone {
 			if value.Name == "http" {
 				processedEvent.CloneURL = value.Href
 			}
 		}
-		v.pullRequestNumber = e.PulRequest.ID
+		v.pullRequestNumber = e.PullRequest.ID
 	case *types.PushRequestEvent:
 		processedEvent.Event = "push"
 		processedEvent.TriggerTarget = "push"

--- a/pkg/provider/bitbucketserver/test/test.go
+++ b/pkg/provider/bitbucketserver/test/test.go
@@ -271,6 +271,7 @@ func MakePREvent(event *info.Event, comment string) *types.PullRequestEvent {
 	pr := &types.PullRequestEvent{
 		Actor: types.EventActor{ID: iii, Name: event.Sender},
 		PullRequest: bbv1.PullRequest{
+			ID: 1,
 			ToRef: bbv1.PullRequestRef{
 				Repository: bbv1.Repository{
 					Project: &bbv1.Project{Key: event.Organization},

--- a/pkg/provider/bitbucketserver/test/test.go
+++ b/pkg/provider/bitbucketserver/test/test.go
@@ -105,7 +105,7 @@ func MakeEvent(event *info.Event) *info.Event {
 	}
 	if rev.Event == nil {
 		rev.Event = &types.PullRequestEvent{
-			PulRequest: bbv1.PullRequest{ID: 666},
+			PullRequest: bbv1.PullRequest{ID: 666},
 		}
 	}
 	return rev
@@ -270,7 +270,7 @@ func MakePREvent(event *info.Event, comment string) *types.PullRequestEvent {
 
 	pr := &types.PullRequestEvent{
 		Actor: types.EventActor{ID: iii, Name: event.Sender},
-		PulRequest: bbv1.PullRequest{
+		PullRequest: bbv1.PullRequest{
 			ToRef: bbv1.PullRequestRef{
 				Repository: bbv1.Repository{
 					Project: &bbv1.Project{Key: event.Organization},

--- a/pkg/provider/bitbucketserver/types/types.go
+++ b/pkg/provider/bitbucketserver/types/types.go
@@ -10,9 +10,9 @@ type EventActor struct {
 }
 
 type PullRequestEvent struct {
-	Actor      EventActor
-	PulRequest bbv1.PullRequest `json:"pullRequest"`
-	Comment    bbv1.Comment     `json:"comment"`
+	Actor       EventActor
+	PullRequest bbv1.PullRequest `json:"pullRequest"`
+	Comment     bbv1.Comment     `json:"comment"`
 }
 
 type PushRequestEventChange struct {


### PR DESCRIPTION
Fix crashing on bad bitbucketserver payload

When the bitbucketserver payload is missing some fields, the parser
would crash with a panic. This change adds a check for the required
fields and returns an error if they are missing.

You can easily test this with the following curl command:

```
curl -X POST
https://controller
\ -H "Authorization: Bearer <SECRET>" \ -H "Content-Type:
application/json" \ -d
'{"eventKey":"pr:comment:added","comment":{"text":"/ok-to-test"}}' \ -H
"X-Event-Key: pr:comment:added"
```

### Testing

tested it manually it now report an error and not crash.
i tested as well that gitops comment like /retest and /test pr still works

![image](https://github.com/user-attachments/assets/8f20bb9b-380a-4002-b1cb-08e5ed0e067f)

Jira issue: https://issues.redhat.com/browse/SRVKP-6706

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
