### PR TITLE
Remove double check for toRef and added checks for fromRef field

### DIFF
--- a/pkg/provider/bitbucketserver/parse_payload.go
+++ b/pkg/provider/bitbucketserver/parse_payload.go
@@ -18,16 +18,6 @@ import (
 // checkValidPayload checks if the payload is valid.
 func checkValidPayload(e *types.PullRequestEvent) error {
 	if e.PullRequest.ToRef.Repository.Project == nil {
-		return fmt.Errorf("bitbucket project is nil")
-	}
-	if e.PullRequest.ToRef.Repository.Project.Key == "" {
-		return fmt.Errorf("bitbucket project key is empty")
-	}
-	if e.PullRequest.ToRef.Repository.Name == "" {
-		return fmt.Errorf("bitbucket toRef repository name is empty")
-	}
-
-	if e.PullRequest.ToRef.Repository.Project == nil {
 		return fmt.Errorf("bitbucket toRef project is nil")
 	}
 	if e.PullRequest.ToRef.Repository.Project.Key == "" {
@@ -35,6 +25,19 @@ func checkValidPayload(e *types.PullRequestEvent) error {
 	}
 	if e.PullRequest.ToRef.Repository.Name == "" {
 		return fmt.Errorf("bitbucket toRef repository name is empty")
+	}
+	if e.PullRequest.ToRef.LatestCommit == "" {
+		return fmt.Errorf("bitbucket toRef latest commit is empty")
+	}
+
+	if e.PullRequest.FromRef.Repository.Project == nil {
+		return fmt.Errorf("bitbucket fromRef project is nil")
+	}
+	if e.PullRequest.FromRef.Repository.Project.Key == "" {
+		return fmt.Errorf("bitbucket fromRef project key is empty")
+	}
+	if e.PullRequest.FromRef.Repository.Name == "" {
+		return fmt.Errorf("bitbucket fromRef repository name is empty")
 	}
 	if e.PullRequest.FromRef.LatestCommit == "" {
 		return fmt.Errorf("bitbucket fromRef latest commit is empty")

--- a/pkg/provider/bitbucketserver/parse_payload_test.go
+++ b/pkg/provider/bitbucketserver/parse_payload_test.go
@@ -21,7 +21,7 @@ func TestCheckValidPayload(t *testing.T) {
 		payloadEvent  types.PullRequestEvent
 	}{
 		{
-			name: "missing project",
+			name: "missing toRef.project",
 			payloadEvent: types.PullRequestEvent{
 				PullRequest: bbv1.PullRequest{
 					ToRef: bbv1.PullRequestRef{
@@ -29,10 +29,10 @@ func TestCheckValidPayload(t *testing.T) {
 					},
 				},
 			},
-			wantErrString: "bitbucket project is nil",
+			wantErrString: "bitbucket toRef project is nil",
 		},
 		{
-			name: "empty project key",
+			name: "empty toRef.project.key",
 			payloadEvent: types.PullRequestEvent{
 				PullRequest: bbv1.PullRequest{
 					ToRef: bbv1.PullRequestRef{
@@ -42,10 +42,10 @@ func TestCheckValidPayload(t *testing.T) {
 					},
 				},
 			},
-			wantErrString: "bitbucket project key is empty",
+			wantErrString: "bitbucket toRef project key is empty",
 		},
 		{
-			name: "empty repository name",
+			name: "empty toRef.repositoryName",
 			payloadEvent: types.PullRequestEvent{
 				PullRequest: bbv1.PullRequest{
 					ToRef: bbv1.PullRequestRef{
@@ -60,11 +60,107 @@ func TestCheckValidPayload(t *testing.T) {
 			wantErrString: "bitbucket toRef repository name is empty",
 		},
 		{
-			name: "missing latest commit",
+			name: "missing toRef.latestCommit",
 			payloadEvent: types.PullRequestEvent{
 				PullRequest: bbv1.PullRequest{
 					FromRef: bbv1.PullRequestRef{},
 					ToRef: bbv1.PullRequestRef{
+						Repository: bbv1.Repository{
+							Name: "repo",
+							Project: &bbv1.Project{
+								Key:  "PROJ",
+								Name: "repo",
+							},
+						},
+					},
+				},
+			},
+			wantErrString: "bitbucket toRef latest commit is empty",
+		},
+		{
+			name: "missing fromRef.project",
+			payloadEvent: types.PullRequestEvent{
+				PullRequest: bbv1.PullRequest{
+					ToRef: bbv1.PullRequestRef{
+						Repository: bbv1.Repository{
+							Name: "repo",
+							Project: &bbv1.Project{
+								Key:  "PROJ",
+								Name: "repo",
+							},
+						},
+						LatestCommit: "abcd",
+					},
+					FromRef: bbv1.PullRequestRef{
+						Repository: bbv1.Repository{},
+					},
+				},
+			},
+			wantErrString: "bitbucket fromRef project is nil",
+		},
+		{
+			name: "empty fromRef.projectKey",
+			payloadEvent: types.PullRequestEvent{
+				PullRequest: bbv1.PullRequest{
+					ToRef: bbv1.PullRequestRef{
+						Repository: bbv1.Repository{
+							Name: "repo",
+							Project: &bbv1.Project{
+								Key:  "PROJ",
+								Name: "repo",
+							},
+						},
+						LatestCommit: "abcd",
+					},
+					FromRef: bbv1.PullRequestRef{
+						Repository: bbv1.Repository{
+							Project: &bbv1.Project{},
+						},
+					},
+				},
+			},
+			wantErrString: "bitbucket fromRef project key is empty",
+		},
+		{
+			name: "empty fromRef.repositoryName",
+			payloadEvent: types.PullRequestEvent{
+				PullRequest: bbv1.PullRequest{
+					ToRef: bbv1.PullRequestRef{
+						Repository: bbv1.Repository{
+							Name: "repo",
+							Project: &bbv1.Project{
+								Key:  "PROJ",
+								Name: "repo",
+							},
+						},
+						LatestCommit: "abcd",
+					},
+					FromRef: bbv1.PullRequestRef{
+						Repository: bbv1.Repository{
+							Project: &bbv1.Project{
+								Key: "PROJ",
+							},
+						},
+					},
+				},
+			},
+			wantErrString: "bitbucket fromRef repository name is empty",
+		},
+		{
+			name: "missing fromRef.latestCommit",
+			payloadEvent: types.PullRequestEvent{
+				PullRequest: bbv1.PullRequest{
+					ToRef: bbv1.PullRequestRef{
+						Repository: bbv1.Repository{
+							Name: "repo",
+							Project: &bbv1.Project{
+								Key:  "PROJ",
+								Name: "repo",
+							},
+						},
+						LatestCommit: "abcd",
+					},
+					FromRef: bbv1.PullRequestRef{
 						Repository: bbv1.Repository{
 							Name: "repo",
 							Project: &bbv1.Project{
@@ -89,8 +185,16 @@ func TestCheckValidPayload(t *testing.T) {
 								Name: "repo",
 							},
 						},
+						LatestCommit: "abcd",
 					},
 					FromRef: bbv1.PullRequestRef{
+						Repository: bbv1.Repository{
+							Name: "repo",
+							Project: &bbv1.Project{
+								Key:  "PROJ",
+								Name: "repo",
+							},
+						},
 						LatestCommit: "abcd",
 					},
 				},
@@ -109,8 +213,16 @@ func TestCheckValidPayload(t *testing.T) {
 								Name: "repo",
 							},
 						},
+						LatestCommit: "abcd",
 					},
 					FromRef: bbv1.PullRequestRef{
+						Repository: bbv1.Repository{
+							Name: "repo",
+							Project: &bbv1.Project{
+								Key:  "PROJ",
+								Name: "repo",
+							},
+						},
 						LatestCommit: "abcd",
 					},
 					ID: 1,
@@ -137,8 +249,16 @@ func TestCheckValidPayload(t *testing.T) {
 								Name: "repo",
 							},
 						},
+						LatestCommit: "abcd",
 					},
 					FromRef: bbv1.PullRequestRef{
+						Repository: bbv1.Repository{
+							Name: "repo",
+							Project: &bbv1.Project{
+								Key:  "PROJ",
+								Name: "repo",
+							},
+						},
 						LatestCommit: "abcd",
 					},
 					ID: 1,
@@ -168,10 +288,20 @@ func TestCheckValidPayload(t *testing.T) {
 								},
 							},
 						},
-						DisplayID: "main",
+						DisplayID:    "main",
+						LatestCommit: "abcd",
 					},
-					FromRef: bbv1.PullRequestRef{LatestCommit: "latet"},
-					ID:      1,
+					FromRef: bbv1.PullRequestRef{
+						Repository: bbv1.Repository{
+							Name: "repo",
+							Project: &bbv1.Project{
+								Key:  "PROJ",
+								Name: "repo",
+							},
+						},
+						LatestCommit: "abcd",
+					},
+					ID: 1,
 				},
 			},
 			wantErrString: "bitbucket fromRef display ID is empty",
@@ -198,9 +328,17 @@ func TestCheckValidPayload(t *testing.T) {
 								},
 							},
 						},
-						DisplayID: "main",
+						DisplayID:    "main",
+						LatestCommit: "abcd",
 					},
 					FromRef: bbv1.PullRequestRef{
+						Repository: bbv1.Repository{
+							Name: "repo",
+							Project: &bbv1.Project{
+								Key:  "PROJ",
+								Name: "repo",
+							},
+						},
 						DisplayID:    "feature",
 						LatestCommit: "abcd",
 					},
@@ -231,12 +369,17 @@ func TestCheckValidPayload(t *testing.T) {
 								},
 							},
 						},
-						DisplayID: "main",
+						DisplayID:    "main",
+						LatestCommit: "abcd",
 					},
 					FromRef: bbv1.PullRequestRef{
 						DisplayID:    "feature",
 						LatestCommit: "abcd",
 						Repository: bbv1.Repository{
+							Project: &bbv1.Project{
+								Key:  "PROJ",
+								Name: "repo",
+							},
 							Links: &struct {
 								Clone []bbv1.CloneLink `json:"clone,omitempty"`
 								Self  []bbv1.SelfLink  `json:"self,omitempty"`
@@ -275,12 +418,17 @@ func TestCheckValidPayload(t *testing.T) {
 								},
 							},
 						},
-						DisplayID: "main",
+						DisplayID:    "main",
+						LatestCommit: "abcd",
 					},
 					FromRef: bbv1.PullRequestRef{
 						DisplayID:    "feature",
 						LatestCommit: "abcd",
 						Repository: bbv1.Repository{
+							Project: &bbv1.Project{
+								Key:  "PROJ",
+								Name: "repo",
+							},
 							Links: &struct {
 								Clone []bbv1.CloneLink `json:"clone,omitempty"`
 								Self  []bbv1.SelfLink  `json:"self,omitempty"`

--- a/pkg/provider/bitbucketserver/test/test.go
+++ b/pkg/provider/bitbucketserver/test/test.go
@@ -287,12 +287,15 @@ func MakePREvent(event *info.Event, comment string) *types.PullRequestEvent {
 						},
 					},
 				},
-				DisplayID: "base",
+				DisplayID:    "base",
+				LatestCommit: "abcd",
 			},
 			FromRef: bbv1.PullRequestRef{
 				DisplayID:    "head",
 				LatestCommit: event.SHA,
 				Repository: bbv1.Repository{
+					Project: &bbv1.Project{Key: event.Organization},
+					Name:    event.Repository,
 					Links: &struct {
 						Clone []bbv1.CloneLink `json:"clone,omitempty"`
 						Self  []bbv1.SelfLink  `json:"self,omitempty"`


### PR DESCRIPTION
removed double checks in payload validation for toRef field in bitbucker server event payload and added checks for fromRef field and added test accordingly.

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
