### PR TITLE
Expose config for Watcher performance tuning

### DIFF
--- a/cmd/pipelines-as-code-watcher/main.go
+++ b/cmd/pipelines-as-code-watcher/main.go
@@ -8,7 +8,10 @@ import (
 	"time"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/reconciler"
+	"k8s.io/client-go/rest"
+	"knative.dev/pkg/injection"
 	"knative.dev/pkg/injection/sharedmain"
+	"knative.dev/pkg/signals"
 )
 
 const globalProbesPort = "8080"
@@ -44,5 +47,18 @@ func main() {
 	}()
 	<-c
 
-	sharedmain.Main("pac-watcher", reconciler.NewController())
+	// This parses flags.
+	cfg := injection.ParseAndGetRESTConfigOrDie()
+
+	if cfg.QPS == 0 {
+		cfg.QPS = 2 * rest.DefaultQPS
+	}
+	if cfg.Burst == 0 {
+		cfg.Burst = rest.DefaultBurst
+	}
+	// multiply by no of controllers being created
+	cfg.QPS = 5 * cfg.QPS
+	cfg.Burst = 5 * cfg.Burst
+	ctx := signals.NewContext()
+	sharedmain.MainWithConfig(ctx, "pac-watcher", cfg, reconciler.NewController())
 }


### PR DESCRIPTION
This changes the watcher to start with a performance config. We expose ThreadsPerController, QPS and Burst for performance tuning as we do for pipelines controller.

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
