### PR TITLE
fix: change receiver to pointer for listener and priorityQueue

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,6 +30,8 @@ linters-settings:
     extra-rules: true
 linters:
   enable:
+    - recvcheck
+    - iface
     - asasalint
     - asciicheck
     - bidichk

--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -108,7 +108,7 @@ func (l *listener) Start(ctx context.Context) error {
 	return nil
 }
 
-func (l listener) handleEvent(ctx context.Context) http.HandlerFunc {
+func (l *listener) handleEvent(ctx context.Context) http.HandlerFunc {
 	return func(response http.ResponseWriter, request *http.Request) {
 		if request.Method != http.MethodPost {
 			l.writeResponse(response, http.StatusOK, "ok")
@@ -206,7 +206,7 @@ func (l listener) handleEvent(ctx context.Context) http.HandlerFunc {
 	}
 }
 
-func (l listener) processRes(processEvent bool, provider provider.Interface, logger *zap.SugaredLogger, skipReason string, err error) (provider.Interface, *zap.SugaredLogger, error) {
+func (l *listener) processRes(processEvent bool, provider provider.Interface, logger *zap.SugaredLogger, skipReason string, err error) (provider.Interface, *zap.SugaredLogger, error) {
 	if processEvent {
 		provider.SetLogger(logger)
 		return provider, logger, nil
@@ -223,7 +223,7 @@ func (l listener) processRes(processEvent bool, provider provider.Interface, log
 	return nil, logger, fmt.Errorf("skipping non supported event")
 }
 
-func (l listener) detectProvider(req *http.Request, reqBody string) (provider.Interface, *zap.SugaredLogger, error) {
+func (l *listener) detectProvider(req *http.Request, reqBody string) (provider.Interface, *zap.SugaredLogger, error) {
 	log := *l.logger
 
 	// payload validation
@@ -267,7 +267,7 @@ func (l listener) detectProvider(req *http.Request, reqBody string) (provider.In
 	return l.processRes(false, nil, logger, "", fmt.Errorf("no supported Git provider has been detected"))
 }
 
-func (l listener) writeResponse(response http.ResponseWriter, statusCode int, message string) {
+func (l *listener) writeResponse(response http.ResponseWriter, statusCode int, message string) {
 	response.WriteHeader(statusCode)
 	response.Header().Set("Content-Type", "application/json")
 	body := Response{

--- a/pkg/adapter/tls.go
+++ b/pkg/adapter/tls.go
@@ -13,7 +13,7 @@ const tlsMountPath = "/etc/pipelines-as-code/tls"
 
 // isTLSEnabled validates if tls secret exist and if the required fields are defined
 // this is used to enable tls on the listener.
-func (l listener) isTLSEnabled() (bool, string, string) {
+func (l *listener) isTLSEnabled() (bool, string, string) {
 	tlsSecret := os.Getenv("TLS_SECRET_NAME")
 	tlsKey := os.Getenv("TLS_KEY")
 	tlsCert := os.Getenv("TLS_CERT")

--- a/pkg/sync/priority_queue.go
+++ b/pkg/sync/priority_queue.go
@@ -49,13 +49,13 @@ func (pq *priorityQueue) peek() *item {
 	return pq.items[0]
 }
 
-func (pq priorityQueue) Len() int { return len(pq.items) }
+func (pq *priorityQueue) Len() int { return len(pq.items) }
 
-func (pq priorityQueue) Less(i, j int) bool {
+func (pq *priorityQueue) Less(i, j int) bool {
 	return pq.items[i].priority < pq.items[j].priority
 }
 
-func (pq priorityQueue) Swap(i, j int) {
+func (pq *priorityQueue) Swap(i, j int) {
 	pq.items[i], pq.items[j] = pq.items[j], pq.items[i]
 	pq.items[i].index = i
 	pq.items[j].index = j


### PR DESCRIPTION
- Updated receiver from value to pointer for listener methods:
  - handleEvent
  - processRes
  - detectProvider
  - writeResponse
  - isTLSEnabled

- Updated receiver from value to pointer for priorityQueue methods:
  - Len
  - Less
  - Swap

This change ensures that the methods modify the original struct instead of a copy, improving performance and correctness.

Added golangci-lint linters to check for value receivers.

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
