### PR TITLE
Add secrets for bitbucket server on upstream PAC repo

### DIFF
--- a/.github/workflows/kind-e2e-tests.yaml
+++ b/.github/workflows/kind-e2e-tests.yaml
@@ -11,7 +11,7 @@ on:
         required: false
         default: false
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    types: [ opened, synchronize, reopened ]
     paths:
       - "**.go"
 jobs:
@@ -84,7 +84,10 @@ jobs:
            "${{ secrets.INSTALLATION_ID }}" \
            "${{ secrets.GH_APPS_TOKEN }}" \
            "${{ secrets.TEST_GITHUB_SECOND_TOKEN }}" \
-           "${{ secrets.GITLAB_TOKEN }}"
+           "${{ secrets.GITLAB_TOKEN }}" \
+           "${{ secrets.BITBUCKET_SERVER_TOKEN }}" \
+           "${{ secrets.BITBUCKET_SERVER_API_URL }}" \
+           "${{ secrets.BITBUCKET_SERVER_WEBHOOK_SECRET }}"
 
       - name: Run E2E Tests on nightly
         if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
@@ -97,7 +100,10 @@ jobs:
            "${{ secrets.INSTALLATION_ID }}" \
            "${{ secrets.GH_APPS_TOKEN }}" \
            "${{ secrets.TEST_GITHUB_SECOND_TOKEN }}" \
-           "${{ secrets.GITLAB_TOKEN }}"
+           "${{ secrets.GITLAB_TOKEN }}" \
+           "${{ secrets.BITBUCKET_SERVER_TOKEN }}" \
+           "${{ secrets.BITBUCKET_SERVER_API_URL }}" \
+           "${{ secrets.BITBUCKET_SERVER_WEBHOOK_SECRET }}"
 
       - name: Collect logs
         if: ${{ always() }}

--- a/hack/gh-workflow-ci.sh
+++ b/hack/gh-workflow-ci.sh
@@ -71,6 +71,9 @@ run_e2e_tests() {
   gh_apps_token="${5}"
   test_github_second_token="${6}"
   gitlab_token="${7}"
+  bitbucket_server_token="${8}"
+  bitbucket_server_api_url="${9}"
+  bitbucket_server_webhook_secret="${10}"
 
   # Nothing specific to webhook here it  just that repo is private in that org and that's what we want to test
   export TEST_GITHUB_PRIVATE_TASK_URL="https://github.com/openshift-pipelines/pipelines-as-code-e2e-tests-private/blob/main/remote_task.yaml"
@@ -112,6 +115,12 @@ run_e2e_tests() {
   export TEST_GITLAB_PROJECT_ID="34405323"
   export TEST_GITLAB_TOKEN=${gitlab_token}
   # https://gitlab.com/gitlab-com/alliances/ibm-red-hat/sandbox/openshift-pipelines/pac-e2e-tests
+
+  export TEST_BITBUCKET_SERVER_TOKEN="${bitbucket_server_token}"
+  export TEST_BITBUCKET_SERVER_API_URL="${bitbucket_server_api_url}"
+  export TEST_BITBUCKET_SERVER_WEBHOOK_SECRET="${bitbucket_server_webhook_secret}"
+  export TEST_BITBUCKET_SERVER_USER="pipelines"
+  export TEST_BITBUCKET_SERVER_E2E_REPOSITORY="PAC/pac-e2e-tests"
   make test-e2e
 }
 
@@ -147,7 +156,7 @@ help() {
   create_second_github_app_controller_on_ghe <test_github_second_smee_url> <test_github_second_private_key> <test_github_second_webhook_secret>
     Create the second controller on GHE
 
-  run_e2e_tests <bitbucket_cloud_token> <webhook_secret> <test_gitea_smeeurl> <installation_id> <gh_apps_token> <test_github_second_token> <gitlab_token>
+  run_e2e_tests <bitbucket_cloud_token> <webhook_secret> <test_gitea_smeeurl> <installation_id> <gh_apps_token> <test_github_second_token> <gitlab_token> <bitbucket_server_token> <bitbucket_server_api_url> <bitbucket_server_webhook_secret>
     Run the e2e tests
 
   collect_logs
@@ -163,7 +172,7 @@ create_second_github_app_controller_on_ghe)
   create_second_github_app_controller_on_ghe "${2}" "${3}" "${4}"
   ;;
 run_e2e_tests)
-  run_e2e_tests "${2}" "${3}" "${4}" "${5}" "${6}" "${7}" "${8}"
+  run_e2e_tests "${2}" "${3}" "${4}" "${5}" "${6}" "${7}" "${8}" "${9}" "${10}" "${11}"
   ;;
 collect_logs)
   collect_logs


### PR DESCRIPTION
added secrets for bitbucket server for E2E testing on upstream PAC repo.

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
