### PR TITLE
(chore) Only run gitlint on pull requests

### DIFF
--- a/.tekton/linter.yaml
+++ b/.tekton/linter.yaml
@@ -99,6 +99,17 @@ spec:
               image: registry.access.redhat.com/ubi9/python-312
               workingDir: $(workspaces.source.path)
               script: |
+                set -x
+                if [[ "{{ headers['X-Github-Event'] }}" == "" ]]; then
+                  echo "Not a GitHub event, skipping gitlint"
+                  exit 0
+                fi
+
+                if [[ "{{ headers['X-Github-Event'] }}" != "pull_request" ]]; then
+                  echo "Not a pull request, skipping gitlint"
+                  exit 0
+                fi
+
                 git config --global --add safe.directory $(workspaces.source.path)
                 git log -1 --format=format:%s |grep -E -q '^Merge branch' && exit 0
                 pip3 install gitlint

--- a/docs/content/docs/guide/authoringprs.md
+++ b/docs/content/docs/guide/authoringprs.md
@@ -377,11 +377,11 @@ The expression are CEL expressions so you can as well make some conditional:
 if the PR is open the condition then return `true` and the shell script see this
 as a valid boolean.
 
-Headers from the payload body can be accessed from the `headers` keyword, for
-example
+Headers from the payload body can be accessed from the `headers` keyword, note that headers are case sensitive,
+for example this will show the GitHub event type for a GitHub event:
 
 ```yaml
-{{ headers['x-github-event'] }}
+{{ headers['X-Github-Event'] }}
 ```
 
 and then you can do the same conditional or access as described above for the `body` keyword.


### PR DESCRIPTION
(chore) Only run gitlint on pull requests

Because this cause issues with the gitlint running on the main branch
when doing a squash or Merge commit.
Adjust documentation for how to sue headers mentioning that headers are
case sensitive in params.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>