### PR TITLE
feat: support commas in PipelineRun annotations

### DIFF
--- a/docs/content/docs/guide/authoringprs.md
+++ b/docs/content/docs/guide/authoringprs.md
@@ -85,7 +85,15 @@ provider events target the branch `main` and it's coming from a `[pull_request]`
 Multiple target branch can be specified separated by comma, i.e:
 
 ```yaml
-[main, release-nightly]
+pipelinesascode.tekton.dev/on-target-branch: [main, release-nightly]
+```
+
+If you want to match a branch that has a comma (,) in its name you can html escape entity
+`&#44;` as comma, for example if you want to match main and the branch
+called `release,nightly` you can do this:
+
+```yaml
+pipelinesascode.tekton.dev/on-target-branch: [main, release&#44;nightly]
 ```
 
 You can match on `pull_request` events as above, and you can as well match
@@ -140,7 +148,9 @@ To trigger a `PipelineRun` based on specific path changes in an event, use the
 annotation `pipelinesascode.tekton.dev/on-path-change`.
 
 Multiple paths can be specified, separated by commas. The first glob matching
-the files changes in the PR will trigger the `PipelineRun`.
+the files changes in the PR will trigger the `PipelineRun`. If you want to match
+a file or path that has a comma you can html escape it with the `&#44;` html
+entity.
 
 You still need to specify the event type and target branch. If you have a [CEL
 expression](#matching-pipelinerun-by-path-change) the `on-path-change`

--- a/pkg/matcher/annotation_matcher.go
+++ b/pkg/matcher/annotation_matcher.go
@@ -71,13 +71,15 @@ func getAnnotationValues(annotation string) ([]string, error) {
 
 	// if it's not an array then it would be a single string
 	if !strings.HasPrefix(annotation, "[") {
-		return []string{annotation}, nil
+		// replace &#44; with comma so users can have comma in the annotation
+		annot := strings.ReplaceAll(annotation, "&#44;", ",")
+		return []string{annot}, nil
 	}
 
 	// Split all tasks by comma and make sure to trim spaces in there
 	split := strings.Split(re.FindStringSubmatch(annotation)[1], ",")
 	for i := range split {
-		split[i] = strings.TrimSpace(split[i])
+		split[i] = strings.TrimSpace(strings.ReplaceAll(split[i], "&#44;", ","))
 	}
 
 	if split[0] == "" {

--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -680,6 +680,19 @@ func TestGiteaOnPathChange(t *testing.T) {
 	defer f()
 }
 
+func TestGiteaBranchWithComma(t *testing.T) {
+	topts := &tgitea.TestOpts{
+		TargetEvent:   triggertype.PullRequest.String(),
+		DefaultBranch: "branch,with,comma",
+		YAMLFiles: map[string]string{
+			".tekton/pr.yaml": "testdata/pipelinerun-target-branch-with-comma.yaml",
+		},
+		CheckForStatus: "success",
+	}
+	_, f := tgitea.TestPR(t, topts)
+	defer f()
+}
+
 // TestGiteaOnPathChangeIgnore will test that pipelinerun is not triggered when
 // a path is ignored but all other will do.
 func TestGiteaOnPathChangeIgnore(t *testing.T) {

--- a/test/pkg/gitea/scm.go
+++ b/test/pkg/gitea/scm.go
@@ -106,7 +106,7 @@ func GetIssueTimeline(ctx context.Context, topts *TestOpts) (Timelines, error) {
 	return tls, nil
 }
 
-func CreateGiteaRepo(giteaClient *gitea.Client, user, name, hookURL string, onOrg bool, logger *zap.SugaredLogger) (*gitea.Repository, error) {
+func CreateGiteaRepo(giteaClient *gitea.Client, user, name, defaultBranch, hookURL string, onOrg bool, logger *zap.SugaredLogger) (*gitea.Repository, error) {
 	var repo *gitea.Repository
 	var err error
 	// Create a new repo
@@ -131,9 +131,10 @@ func CreateGiteaRepo(giteaClient *gitea.Client, user, name, hookURL string, onOr
 	} else {
 		logger.Infof("Creating gitea repository %s for user %s", name, user)
 		repo, _, err = giteaClient.AdminCreateRepo(user, gitea.CreateRepoOption{
-			Name:        name,
-			Description: "This is a repo it's a wonderful thing",
-			AutoInit:    true,
+			Name:          name,
+			Description:   "This is a repo it's a wonderful thing",
+			AutoInit:      true,
+			DefaultBranch: defaultBranch,
 		})
 	}
 	if err != nil {

--- a/test/testdata/pipelinerun-target-branch-with-comma.yaml
+++ b/test/testdata/pipelinerun-target-branch-with-comma.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: "\\ .PipelineName //"
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[ branch&#44;with&#44;comma ]"
+    pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: task
+        taskSpec:
+          steps:
+            - name: success
+              image: registry.access.redhat.com/ubi9/ubi-micro
+              script: |
+                echo "I am a such a good booooy"
+                exit 0


### PR DESCRIPTION
This commit introduces support for using commas within annotations by
allowing users to escape them with the HTML entity `&#44;`. This ensures
compatibility with annotations that rely on comma-separated values while
also permitting the inclusion of literal commas in file paths or branch
names.

This enhancement maintains backward compatibility while enabling more
precise and flexible use of annotations.

**Jira**: https://issues.redhat.com/browse/SRVKP-6790
**Signed-off-by**: Chmouel Boudjnah <chmouel@redhat.com>

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
