### PR TITLE
fix: cancel-in-progress with retest comment

### DIFF
--- a/pkg/opscomments/comments.go
+++ b/pkg/opscomments/comments.go
@@ -5,11 +5,12 @@ import (
 	"regexp"
 	"strings"
 
+	"go.uber.org/zap"
+
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/events"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
-	"go.uber.org/zap"
 )
 
 var (
@@ -120,6 +121,20 @@ func IsAnyOpsEventType(eventType string) bool {
 		eventType == CancelCommentAllEventType.String() ||
 		eventType == OkToTestCommentEventType.String() ||
 		eventType == OnCommentEventType.String()
+}
+
+// AnyOpsKubeLabelInSelector will output a Kubernetes label out of all possible
+// CommentEvent Type for selection.
+func AnyOpsKubeLabelInSelector() string {
+	return fmt.Sprintf("%s,%s,%s,%s,%s,%s,%s,%s",
+		TestSingleCommentEventType.String(),
+		TestAllCommentEventType.String(),
+		RetestAllCommentEventType.String(),
+		RetestSingleCommentEventType.String(),
+		CancelCommentSingleEventType.String(),
+		CancelCommentAllEventType.String(),
+		OkToTestCommentEventType.String(),
+		OnCommentEventType.String())
 }
 
 func GetPipelineRunFromTestComment(comment string) string {

--- a/pkg/opscomments/comments_test.go
+++ b/pkg/opscomments/comments_test.go
@@ -1,7 +1,13 @@
 package opscomments
 
 import (
+	"strings"
 	"testing"
+
+	"go.uber.org/zap"
+	zapobserver "go.uber.org/zap/zaptest/observer"
+	"gotest.tools/v3/assert"
+	rtesting "knative.dev/pkg/reconciler/testing"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/events"
@@ -9,10 +15,6 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
 	testnewrepo "github.com/openshift-pipelines/pipelines-as-code/pkg/test/repository"
-	"go.uber.org/zap"
-	zapobserver "go.uber.org/zap/zaptest/observer"
-	"gotest.tools/v3/assert"
-	rtesting "knative.dev/pkg/reconciler/testing"
 )
 
 func TestLabelsBackwardCompat(t *testing.T) {
@@ -726,4 +728,8 @@ func TestGetPipelineRunAndBranchNameFromCancelComment(t *testing.T) {
 			assert.Equal(t, tt.prName, prName)
 		})
 	}
+}
+
+func TestAnyOpsKubeLabelInSelector(t *testing.T) {
+	assert.Assert(t, strings.Contains(AnyOpsKubeLabelInSelector(), RetestSingleCommentEventType.String()))
 }

--- a/pkg/pipelineascode/cancel_pipelineruns.go
+++ b/pkg/pipelineascode/cancel_pipelineruns.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/opscomments"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 )
 
@@ -51,12 +52,14 @@ func (p *PacRun) cancelInProgress(ctx context.Context, matchPR *tektonv1.Pipelin
 	labelMap := map[string]string{
 		keys.URLRepository:  formatting.CleanValueKubernetes(p.event.Repository),
 		keys.OriginalPRName: prName,
-		keys.EventType:      p.event.TriggerTarget.String(),
 	}
 	if p.event.TriggerTarget == triggertype.PullRequest {
 		labelMap[keys.PullRequest] = strconv.Itoa(p.event.PullRequestNumber)
 	}
 	labelSelector := getLabelSelector(labelMap)
+	if p.event.TriggerTarget == triggertype.PullRequest {
+		labelSelector += fmt.Sprintf(",%s in (pull_request, %s)", keys.EventType, opscomments.AnyOpsKubeLabelInSelector())
+	}
 	p.run.Clients.Log.Infof("cancel-in-progress: selecting pipelineRuns to cancel with labels: %v", labelSelector)
 	prs, err := p.run.Clients.Tekton.TektonV1().PipelineRuns(matchPR.GetNamespace()).List(ctx, metav1.ListOptions{
 		LabelSelector: labelSelector,


### PR DESCRIPTION
fix cancel-in-progress on /retest /test /ok-to-test or any gitops comments variable.

Since when we set the trigger event to the test comment like retest-all instead of pull_request on the label of the pipelinerun we can't rely on that to group the pipelinerun for cancellation.

We now have a helper function to do a label select to any pipelinerun that has the gitops comments as event_type or pull_request

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
