### PR TITLE
(feature) Add a cli command to test globing patterns

### DIFF
--- a/.vale/styles/PaaC/Paac.yml
+++ b/.vale/styles/PaaC/Paac.yml
@@ -8,3 +8,4 @@ swap:
   "Pipelines as Code": Pipelines-as-Code
   "Pipeline-as-Code": Pipelines-as-Code
   "GitOPS": GitOps
+  "globing": globbing

--- a/docs/content/docs/guide/authoringprs.md
+++ b/docs/content/docs/guide/authoringprs.md
@@ -154,7 +154,7 @@ metadata:
   annotations:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
-    pipelinesascode.tekton.dev/on-path-change: "[docs/***.md, manual/***.rst]"
+    pipelinesascode.tekton.dev/on-path-change: "[docs/**.md, manual/**.rst]"
 ```
 
 This configuration will match and trigger the `PipelineRun` named
@@ -167,6 +167,16 @@ The patterns used are [glob](https://en.wikipedia.org/wiki/Glob_(programming))
 patterns, not regexp. Here are some
 [examples](https://github.com/gobwas/glob?tab=readme-ov-file#example) from the
 library used for matching.
+
+The `tkn pac` cli has a handy [globbing command]({{< relref "/docs/guide/cli.md#test-globbing-pattern" >}})
+to test the glob pattern matching:
+
+```bash
+tkn pac info globbing "[PATTERN]"
+```
+
+will match the files with `[PATTERN]` in the current directory.
+
 {{< /hint >}}
 
 ### Matching a PipelineRun by Ignoring Specific Path Changes
@@ -181,8 +191,8 @@ You still need to specify the event type and target branch. If you have a [CEL
 expression](#matching-pipelinerun-by-path-change) the `on-path-change-ignore`
 annotation will be ignored
 
-This example triggers a `PipelineRun` when there are no changes in the `docs`
-directory:
+This PipelineRun will run when there are changes outside the docs
+folder:
 
 ```yaml
 metadata:
@@ -325,11 +335,11 @@ PipelineRun.
 ### Matching PipelineRun by path change
 
 > *NOTE*: `Pipelines-as-Code` supports two ways to match files changed in a particular event. The `.pathChanged` suffix function supports [glob
-pattern](https://github.com/ganbarodigital/go_glob#what-does-a-glob-pattern-look-like) and does not support different types of "changes" i.e. added, modified, deleted and so on. The other option is to use the `files.` property (`files.all`, `files.added`, `files.deleted`, `files.modified`, `files.renamed`) which can target specific types of changed files and supports using CEL expressions i.e. `files.all.exists(x, x.matches('renamed.go'))`.
+pattern](https://github.com/gobwas/glob#example) and does not support different types of "changes" i.e. added, modified, deleted and so on. The other option is to use the `files.` property (`files.all`, `files.added`, `files.deleted`, `files.modified`, `files.renamed`) which can target specific types of changed files and supports using CEL expressions i.e. `files.all.exists(x, x.matches('renamed.go'))`.
 
 If you want to have a PipelineRun running only if a path has
 changed you can use the `.pathChanged` suffix function with a [glob
-pattern](https://github.com/ganbarodigital/go_glob#what-does-a-glob-pattern-look-like). Here
+pattern](https://github.com/gobwas/glob#example). Here
 is a concrete example matching every markdown files (as files who has the `.md`
 suffix) in the `docs` directory :
 

--- a/docs/content/docs/guide/cli.md
+++ b/docs/content/docs/guide/cli.md
@@ -358,9 +358,9 @@ GitHub API, but you can specify a custom GitHub API URL using the
 
 {{< /details >}}
 
-{{< details "tkn pac info globing" >}}
+{{< details "tkn pac info globbing" >}}
 
-### Test globing pattern
+### Test globbing pattern
 
 The `tkn pac info globbing` command allows you to test glob patterns to see if
 they match, for example, when using the `on-patch-change` annotation.

--- a/docs/content/docs/guide/cli.md
+++ b/docs/content/docs/guide/cli.md
@@ -358,6 +358,53 @@ GitHub API, but you can specify a custom GitHub API URL using the
 
 {{< /details >}}
 
+{{< details "tkn pac info globing" >}}
+
+### Test globing pattern
+
+The `tkn pac info globbing` command allows you to test glob patterns to see if
+they match, for example, when using the `on-patch-change` annotation.
+
+Here how it works, this example:
+
+```bash
+tkn pac info globbing 'docs/***/*.md'
+```
+
+will match all markdown files in the docs directory and its subdirectories if
+present in the current directory.
+
+By default, it tests the glob pattern against the current directory unless you
+specify the `-d` or `--dir` flag to test against a different directory.
+
+The first argument is the glob pattern to test (you will be prompted for it if
+you don't provide one) as specified by the [glob
+library](https://github.com/gobwas/glob?tab=readme-ov-file#example).
+
+If you want to test against a string to test other annotation that uses globbing
+patterns (like `on-target-branch` annotation) you can use the `-s` or `--string`
+flag.
+
+For example this will test if the globbing expression `refs/heads/*` matches
+`refs/heads/main`:
+
+```bash
+tkn pac info globbing -s "refs/heads/main" "refs/heads/*"
+```
+
+#### Example
+
+```bash
+tkn pac info globbing 'docs/***/*.md'
+```
+
+This will match all markdown files in the docs directory and its subdirectories if
+present in the current directory.
+
+You can specify a different directory than the current one by using the -d/--dir flag.
+
+{{< /details >}}
+
 ## Screenshot
 
 ![tkn-plug-in](/images/tkn-pac-cli.png)

--- a/pkg/cmd/tknpac/info/globbing.go
+++ b/pkg/cmd/tknpac/info/globbing.go
@@ -76,15 +76,20 @@ func globbingCommand(ioStreams *cli.IOStreams) *cobra.Command {
 				}
 			}
 
+			matched := false
 			g := glob.MustCompile(expression)
 			err := filepath.WalkDir(dir, func(path string, _ fs.DirEntry, _ error) error {
 				// remove the dir prefix with a regexp
 				p := strings.TrimPrefix(path, dir+"/")
 				if g.Match(p) {
+					matched = true
 					fmt.Fprintf(ioStreams.Out, "%s\n", p)
 				}
 				return nil
 			})
+			if err == nil && !matched {
+				return fmt.Errorf("no files matched the expression %s", expression)
+			}
 			return err
 		},
 		Annotations: map[string]string{

--- a/pkg/cmd/tknpac/info/globbing.go
+++ b/pkg/cmd/tknpac/info/globbing.go
@@ -1,0 +1,98 @@
+package info
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/gobwas/glob"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli/prompt"
+	"github.com/spf13/cobra"
+)
+
+var help = `
+tkn pac info globbing [expression]
+
+tkn pac info globbing allows you to test the globbing expressions as used in paac.
+
+By default the command will test globbing expressions against your current
+directory to test the pipelinesascode.tekton.dev/on-path-change annotation.
+ 
+The input is a path on your local filesystem (typically a git repository).
+
+For example this command:
+
+tkn pac info globbing 'docs/***/*.md'
+
+will match all markdown files in the docs directory and its subdirectories if
+present in the current directory.
+
+You can specify a different directory than the current one by using the -d/--dir
+flag.
+
+If you want to test against a string instead of a filesystem you can use the -s flag.
+For example this will test if the globbing expression refs/heads/* matches refs/heads/main:
+
+tkn pac info globbing -s "refs/heads/main" "refs/heads/*"
+`
+
+func globbingCommand(ioStreams *cli.IOStreams) *cobra.Command {
+	var dir, str, expression string
+	cmd := &cobra.Command{
+		Use:   "globbing",
+		Short: "Test globbing expression.",
+		Long:  help,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				q := "Please enter an expression"
+				if err := prompt.SurveyAskOne(&survey.Input{Message: q}, &expression, survey.WithValidator(survey.Required)); err != nil {
+					return err
+				}
+			} else {
+				expression = args[0]
+			}
+			if cmd.Flags().Changed("str") {
+				g := glob.MustCompile(expression)
+				if g.Match(str) {
+					fmt.Fprintf(ioStreams.Out, "expression %s has matched the string %s\n", expression, str)
+				} else {
+					return fmt.Errorf("expression %s has not matched the string %s", expression, str)
+				}
+				return nil
+			}
+			if !cmd.Flags().Changed("dir") {
+				cwd, err := os.Getwd()
+				if err != nil {
+					return err
+				}
+				dir = cwd
+			} else {
+				if _, err := os.Stat(dir); os.IsNotExist(err) {
+					return fmt.Errorf("directory %s does not exist", dir)
+				}
+			}
+
+			g := glob.MustCompile(expression)
+			err := filepath.WalkDir(dir, func(path string, _ fs.DirEntry, _ error) error {
+				// remove the dir prefix with a regexp
+				p := strings.TrimPrefix(path, dir+"/")
+				if g.Match(p) {
+					fmt.Fprintf(ioStreams.Out, "%s\n", p)
+				}
+				return nil
+			})
+			return err
+		},
+		Annotations: map[string]string{
+			"commandType": "main",
+		},
+	}
+	// add params for enteprise github
+	cmd.PersistentFlags().StringVarP(&dir, "dir", "d", "", "dir to start from")
+	cmd.PersistentFlags().StringVarP(&str, "str", "s", "", "string to use for the pattern")
+	return cmd
+}

--- a/pkg/cmd/tknpac/info/globbing_test.go
+++ b/pkg/cmd/tknpac/info/globbing_test.go
@@ -1,0 +1,65 @@
+package info
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tknpactest "github.com/openshift-pipelines/pipelines-as-code/test/pkg/cli"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/fs"
+	"gotest.tools/v3/golden"
+)
+
+func TestGlobbing(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		wantErr bool
+		files   []string
+		str     string
+	}{
+		{
+			name:    "File Globbing",
+			pattern: "***/*.md",
+			files: []string{
+				"README.md",
+				"docs/blah.md",
+				"hello/moto.md",
+			},
+		},
+		{
+			name:    "String Pattern",
+			pattern: "refs/*/release-*",
+			str:     "refs/heads/release-foo",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.str != "" {
+				output, err := tknpactest.ExecCommandNoRun(globbingCommand, "-s", tt.str, tt.pattern)
+				if tt.wantErr {
+					assert.Assert(t, tt.wantErr, err != nil, "wantErr: %v, got: %v", tt.wantErr, err)
+					return
+				}
+				golden.Assert(t, output, strings.ReplaceAll(fmt.Sprintf("%s.golden", t.Name()), "/", "-"))
+				return
+			}
+
+			tmpdir := fs.NewDir(t, t.Name())
+			defer tmpdir.Remove()
+			for _, file := range tt.files {
+				assert.NilError(t, os.MkdirAll(filepath.Dir(filepath.Join(tmpdir.Path(), file)), 0o755))
+				f, err := os.Create(filepath.Join(tmpdir.Path(), file))
+				assert.NilError(t, err)
+				_, _ = f.WriteString("")
+				f.Close()
+			}
+			output, err := tknpactest.ExecCommandNoRun(globbingCommand, "-d", tmpdir.Path(), tt.pattern)
+			assert.NilError(t, err)
+			golden.Assert(t, output, strings.ReplaceAll(fmt.Sprintf("%s.golden", t.Name()), "/", "-"))
+		})
+	}
+}

--- a/pkg/cmd/tknpac/info/root.go
+++ b/pkg/cmd/tknpac/info/root.go
@@ -19,5 +19,6 @@ func Root(clients *params.Run, ioStreams *cli.IOStreams) *cobra.Command {
 	}
 
 	cmd.AddCommand(installCommand(clients, ioStreams))
+	cmd.AddCommand(globbingCommand(ioStreams))
 	return cmd
 }

--- a/pkg/cmd/tknpac/info/testdata/TestGlobbing-File_Globbing.golden
+++ b/pkg/cmd/tknpac/info/testdata/TestGlobbing-File_Globbing.golden
@@ -1,0 +1,2 @@
+docs/blah.md
+hello/moto.md

--- a/pkg/cmd/tknpac/info/testdata/TestGlobbing-String_Pattern.golden
+++ b/pkg/cmd/tknpac/info/testdata/TestGlobbing-String_Pattern.golden
@@ -1,0 +1,1 @@
+expression refs/*/release-* has matched the string refs/heads/release-foo

--- a/test/pkg/cli/exec.go
+++ b/test/pkg/cli/exec.go
@@ -9,9 +9,22 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// ExecCommandNoRun setup a cobra command for running with params run and
+// custom iostream.
 func ExecCommand(runcnx *params.Run, cmd func(*params.Run, *cli.IOStreams) *cobra.Command, args ...string) (string, error) {
 	bufout := new(bytes.Buffer)
 	ecmd := cmd(runcnx, &cli.IOStreams{
+		Out: bufout,
+	})
+	_, err := cli2.ExecuteCommand(ecmd, args...)
+	return bufout.String(), err
+}
+
+// ExecCommandNoRun is a wrapper around ExecuteCommand that does not run the
+// command with the params.Run clients.
+func ExecCommandNoRun(cmd func(*cli.IOStreams) *cobra.Command, args ...string) (string, error) {
+	bufout := new(bytes.Buffer)
+	ecmd := cmd(&cli.IOStreams{
 		Out: bufout,
 	})
 	_, err := cli2.ExecuteCommand(ecmd, args...)

--- a/test/pkg/cli/exec.go
+++ b/test/pkg/cli/exec.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// ExecCommandNoRun setup a cobra command for running with params run and
+// ExecCommand setup a cobra command for running with params run and
 // custom iostream.
 func ExecCommand(runcnx *params.Run, cmd func(*params.Run, *cli.IOStreams) *cobra.Command, args ...string) (string, error) {
 	bufout := new(bytes.Buffer)


### PR DESCRIPTION
# Demo

https://www.youtube.com/watch?v=__P7oA0CuQ4



## Description
tkn pac info globbing allows you to test the globbing expressions as used in paac.

By default the command will test globbing expressions against your current
directory to test the 
pipelinesascode.tekton.dev/on-path-change-ignore annotation.
 
The input is a path on your local filesystem (typically a git repository).

For example this command:

```bash
tkn pac info globbing 'docs/***/*.md'
```
will match all markdown files in the docs directory and its subdirectories if
present in the current directory.

You can specify a different directory than the current one by using the -d/--dir
flag.

If you want to test against a string instead of a filesystem you can use the -s flag.
For example this will test if the globbing expression refs/heads/* matches refs/heads/main:
```bash
tkn pac info globbing -s "refs/heads/main" "refs/heads/*"
```

Fixes #1840 along the way

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
