### PR TITLE
Fix dependabot-automerge

### DIFF
--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -7,4 +7,3 @@ jobs:
       - uses: ahmadnassri/action-dependabot-auto-merge@v2
         with:
           github-token: ${{ secrets.GH_TOKEN }}
-          update_type: all


### PR DESCRIPTION
Fix dependabot-automerge as there is no update_type: all and we do no
need to set it up anyway.

it was buggy previously and printing this on run:

![image](https://github.com/user-attachments/assets/ac33e9fd-8e4e-4bd7-84e6-a279d24e0796)
