### PR TITLE
test: Skip some test on OSX arm64

### DIFF
--- a/pkg/sync/queue_manager_test.go
+++ b/pkg/sync/queue_manager_test.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"fmt"
+	"runtime"
 	"testing"
 	"time"
 
@@ -23,7 +24,16 @@ import (
 	rtesting "knative.dev/pkg/reconciler/testing"
 )
 
+func skipOnOSX64(t *testing.T) {
+	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
+		t.Skip("Skipping test on OSX arm64")
+	}
+}
+
 func TestSomeoneElseSetPendingWithNoConcurrencyLimit(t *testing.T) {
+	// Skip if we are running on OSX, there is a problem with ordering only happening on arm64
+	skipOnOSX64(t)
+
 	observer, _ := zapobserver.New(zap.InfoLevel)
 	logger := zap.New(observer).Sugar()
 
@@ -70,6 +80,8 @@ func TestAddToPendingQueueDirectly(t *testing.T) {
 }
 
 func TestNewQueueManagerForList(t *testing.T) {
+	// Skip if we are running on OSX, there is a problem with ordering only happening on arm64
+	skipOnOSX64(t)
 	observer, _ := zapobserver.New(zap.InfoLevel)
 	logger := zap.New(observer).Sugar()
 


### PR DESCRIPTION
There is a weird error running on my macbook apple silicon based where ordering is totally different than when running on other platform (ie: Linux).

I can't figure out why this is happening but i am guessing some bug in the Golang compiler.

The error shows:

queue_manager_test.go:135: assertion failed: test-ns/fifth (started[0] string) != test-ns/fourth (string)

and that randomly happen.

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
