### PR TITLE
Fix incoming webhook PLR match with generateName

### DIFF
--- a/docs/content/docs/guide/incoming_webhook.md
+++ b/docs/content/docs/guide/incoming_webhook.md
@@ -88,7 +88,9 @@ stringData:
 After setting this up, you will be able to start the PipelineRun with a POST
 request sent to the controller URL appended with /incoming. The request
 includes the very-secure-shared-secret, the repository name (repo), the target
-branch (main), and the PipelineRun name (or the generateName if used) (target_pipelinerun).
+branch (main), and the PipelineRun name.
+
+You can use the `generateName` field as the PipelineRun name but you will need to make sure to specify the hyphen (-) at the end.
 
 As an example here is a curl snippet starting the PipelineRun:
 

--- a/pkg/matcher/annotation_matcher.go
+++ b/pkg/matcher/annotation_matcher.go
@@ -344,12 +344,8 @@ func MatchRunningPipelineRunForIncomingWebhook(eventType, incomingPipelineRun st
 	}
 
 	for _, pr := range prs {
-		// check incomingPipelineRun with pr name
-		if incomingPipelineRun == pr.GetName() {
-			return []*tektonv1.PipelineRun{pr}
-		}
-		// check incomingPipelineRun with pr generateName
-		if incomingPipelineRun == strings.TrimSuffix(pr.GetGenerateName(), "-") {
+		// check incomingPipelineRun with pr name or generateName
+		if incomingPipelineRun == pr.GetName() || incomingPipelineRun == pr.GetGenerateName() {
 			return []*tektonv1.PipelineRun{pr}
 		}
 	}

--- a/pkg/matcher/annotation_matcher_test.go
+++ b/pkg/matcher/annotation_matcher_test.go
@@ -2190,7 +2190,7 @@ func TestMatchRunningPipelineRunForIncomingWebhook(t *testing.T) {
 			name: "return matched pipelinerun for matching pipelinerun generateName",
 			runevent: info.Event{
 				EventType:         "incoming",
-				TargetPipelineRun: "pr1",
+				TargetPipelineRun: "pr1-",
 			},
 			pruns: []*tektonv1.PipelineRun{
 				{

--- a/test/github_incoming_test.go
+++ b/test/github_incoming_test.go
@@ -34,7 +34,7 @@ func TestGithubAppIncoming(t *testing.T) {
 	}, randomedString, randomedString, triggertype.Incoming.String(), map[string]string{})
 	assert.NilError(t, err)
 
-	verifyIncomingWebhook(t, randomedString, entries, false, false)
+	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming", entries, false, false)
 }
 
 func TestGithubSecondIncoming(t *testing.T) {
@@ -45,7 +45,7 @@ func TestGithubSecondIncoming(t *testing.T) {
 	}, randomedString, randomedString, triggertype.Incoming.String(), map[string]string{})
 	assert.NilError(t, err)
 
-	verifyIncomingWebhook(t, randomedString, entries, false, true)
+	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming", entries, false, true)
 }
 
 func TestGithubWebhookIncoming(t *testing.T) {
@@ -56,7 +56,7 @@ func TestGithubWebhookIncoming(t *testing.T) {
 	}, randomedString, randomedString, triggertype.Incoming.String(), map[string]string{})
 	assert.NilError(t, err)
 
-	verifyIncomingWebhook(t, randomedString, entries, true, false)
+	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming", entries, true, false)
 }
 
 // TestGithubAppIncomingForDifferentEvent tests that a Pipelinerun with the incoming event
@@ -70,10 +70,10 @@ func TestGithubAppIncomingForDifferentEvent(t *testing.T) {
 	}, randomedString, randomedString, triggertype.PullRequest.String(), map[string]string{})
 	assert.NilError(t, err)
 
-	verifyIncomingWebhook(t, randomedString, entries, false, false)
+	verifyIncomingWebhook(t, randomedString, "pipelinerun-incoming-", entries, false, false)
 }
 
-func verifyIncomingWebhook(t *testing.T, randomedString string, entries map[string]string, onWebhook, onSecondController bool) {
+func verifyIncomingWebhook(t *testing.T, randomedString, pipelinerunName string, entries map[string]string, onWebhook, onSecondController bool) {
 	ctx := context.Background()
 	ctx, runcnx, opts, ghprovider, err := tgithub.Setup(ctx, onSecondController, onWebhook)
 	assert.NilError(t, err)
@@ -120,7 +120,7 @@ func verifyIncomingWebhook(t *testing.T, randomedString string, entries map[stri
 	runcnx.Clients.Log.Infof("Commit %s has been created and pushed to branch %s", sha, vref.GetURL())
 
 	incomingURL := fmt.Sprintf("%s/incoming?repository=%s&branch=%s&pipelinerun=%s&secret=%s", opts.ControllerURL,
-		randomedString, randomedString, "pipelinerun-incoming", incomingSecreteValue)
+		randomedString, randomedString, pipelinerunName, incomingSecreteValue)
 	body := `{"params":{"the_best_superhero_is":"Superman"}}`
 	client := &http.Client{}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, incomingURL, strings.NewReader(body))


### PR DESCRIPTION
fixed an issue in PAC when pipelinerun name is defined via genetateName field on incoming webhook, it wasn't matching pipelinrun.

https://issues.redhat.com/browse/SRVKP-6808

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
