### PR TITLE
Add gitlint to Makefile target

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,10 +13,6 @@ repos:
       - id: check-vcs-permalinks
       - id: detect-private-key
         exclude: ".*_test.go"
-  - repo: https://github.com/jorisroovers/gitlint
-    rev: v0.19.1
-    hooks:
-      - id: gitlint
   - repo: https://github.com/codespell-project/codespell
     rev: v2.3.0
     hooks:
@@ -49,4 +45,10 @@ repos:
         entry: "shellcheck"
         language: system
         types: [shell]
+      - id: gitlint
+        name: "Gitlint"
+        entry: "make"
+        language: system
+        types: [text]
+        args: ["gitlint"]
 # TODO: add a lint-sh when we have the errors fix

--- a/Makefile
+++ b/Makefile
@@ -197,6 +197,11 @@ generated: update-golden fumpt ## generate all files that needs to be generated
 .PHONY: download-hugo
 download-hugo: 
 	./hack/download-hugo.sh $(HUGO_VERSION) $(TMPDIR)/hugo
+
+.PHONY: gitlint
+gitlint: ## Run gitlint
+	@gitlint --commit "`git log --format=format:%H --no-merges -1`" --ignore "Merge branch"
+
 	
 .PHONY: clean
 clean: ## clean build artifacts


### PR DESCRIPTION
# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

And make pre-commit-config.yaml to use it. It wasn't working properly
before.

Let's detect those stupid linting error before sending the PR.

# Submitter Checklist

- [x] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).
   x
- [x] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.
   x
- [x] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).
   x
- [x] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.
   x
- [x] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.
   x
- [x] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
   x
- [x] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
