### PR TITLE
disable healthchk with env instead of doing it on ha is disabled

### DIFF
--- a/cmd/pipelines-as-code-controller/main.go
+++ b/cmd/pipelines-as-code-controller/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"log"
+	"os"
+	"strings"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/adapter"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
@@ -10,6 +12,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	evadapter "knative.dev/eventing/pkg/adapter/v2"
 	"knative.dev/pkg/client/injection/kube/client"
+	"knative.dev/pkg/injection/sharedmain"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/signals"
 	"knative.dev/pkg/system"
@@ -41,6 +44,12 @@ func main() {
 
 	ctx = info.StoreNS(ctx, system.Namespace())
 	ctx = info.StoreCurrentControllerName(ctx, run.Info.Controller.Name)
+
+	if val, ok := os.LookupEnv("PAC_DISABLE_HEALTH_PROBE"); ok {
+		if strings.ToLower(val) == "true" {
+			ctx = sharedmain.WithHealthProbesDisabled(ctx)
+		}
+	}
 
 	ctx = context.WithValue(ctx, client.Key{}, run.Clients.Kube)
 	ctx = evadapter.WithNamespace(ctx, system.Namespace())

--- a/cmd/pipelines-as-code-watcher/main.go
+++ b/cmd/pipelines-as-code-watcher/main.go
@@ -65,6 +65,11 @@ func main() {
 	if val, ok := os.LookupEnv("PAC_DISABLE_HA"); ok {
 		if strings.ToLower(val) == "true" {
 			ctx = sharedmain.WithHADisabled(ctx)
+		}
+	}
+
+	if val, ok := os.LookupEnv("PAC_DISABLE_HEALTH_PROBE"); ok {
+		if strings.ToLower(val) == "true" {
 			ctx = sharedmain.WithHealthProbesDisabled(ctx)
 		}
 	}

--- a/cmd/pipelines-as-code-webhook/main.go
+++ b/cmd/pipelines-as-code-webhook/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"os"
+	"strings"
 
 	validationWebhook "github.com/openshift-pipelines/pipelines-as-code/pkg/webhook"
 	"knative.dev/pkg/configmap"
@@ -31,6 +32,12 @@ func main() {
 		Port:        8443,
 		SecretName:  secretName,
 	})
+
+	if val, ok := os.LookupEnv("PAC_DISABLE_HEALTH_PROBE"); ok {
+		if strings.ToLower(val) == "true" {
+			ctx = sharedmain.WithHealthProbesDisabled(ctx)
+		}
+	}
 
 	sharedmain.WebhookMainWithConfig(ctx, "pipelines-as-code-webhook",
 		injection.ParseAndGetRESTConfigOrDie(),


### PR DESCRIPTION
Added functionality to disable health probes in the controller, watcher, and webhook components by setting the environment variable PAC_DISABLE_HEALTH_PROBE to "true". This allows for more flexible configuration in environments where health probes are not needed (debugging on local machine, etc.).

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [ ] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [ ] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [ ] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [ ] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).
