### PR TITLE
Fix e2e tests and uploading artifacts

### DIFF
--- a/.github/workflows/kind-e2e-tests.yaml
+++ b/.github/workflows/kind-e2e-tests.yaml
@@ -122,7 +122,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: logs
+          name: logs-e2e-tests-${{ matrix.provider }}
           path: /tmp/logs
 
       - name: Report Status

--- a/Makefile
+++ b/Makefile
@@ -73,8 +73,8 @@ test-e2e-cleanup: ## cleanup test e2e namespace/pr left open
 
 .PHONY: test-e2e
 test-e2e:  test-e2e-cleanup ## run e2e tests
-	@env GODEBUG=asynctimerchan=1 \
-		go test $(GO_TEST_FLAGS) -timeout $(TIMEOUT_E2E)  -failfast -count=1 -tags=e2e $(GO_TEST_FLAGS) ./test
+	env GODEBUG=asynctimerchan=1 \
+		go test -timeout $(TIMEOUT_E2E)  -failfast -count=1 -tags=e2e -v $(GO_TEST_FLAGS) ./test
 
 .PHONY: html-coverage
 html-coverage: ## generate html coverage

--- a/hack/gh-workflow-ci.sh
+++ b/hack/gh-workflow-ci.sh
@@ -141,10 +141,8 @@ run_e2e_tests() {
 
   mapfile -t tests < <(get_tests "${target}")
   echo "About to run ${#tests[@]} tests: ${tests[*]}"
-  env GO_TEST_FLAGS="-run '$(
-    IFS='|'
-    echo "${tests[*]}"
-  )'" make test-e2e
+  # shellcheck disable=SC2001
+  GO_TEST_FLAGS="-run \"$(echo "${tests[*]}" | sed 's/ /|/g')\"" make test-e2e
 }
 
 collect_logs() {


### PR DESCRIPTION
Shell script was wrong, let's fix it
Fix uploading with matrix jobs we would otherwise get those:

```
Error: Failed to CreateArtifact: Received non-retryable error: Failed
request: (409) Conflict: an artifact with this name already exists on
the workflow run

```

<details><summary>Details</summary></details>

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
