### PR TITLE
fix: handle nil repo in GitHub event payloads

### DIFF
--- a/hack/gh-workflow-ci.sh
+++ b/hack/gh-workflow-ci.sh
@@ -37,7 +37,7 @@ create_second_github_app_controller_on_ghe() {
   local test_github_second_webhook_secret="${3}"
 
   if [[ -n "$(type -p apt)" ]]; then
-   sudo apt update &&
+    sudo apt update &&
       sudo apt install -y python3-yaml
   elif [[ -n "$(type -p dnf)" ]]; then
     dnf install -y python3-pyyaml
@@ -140,7 +140,7 @@ run_e2e_tests() {
   mapfile -t tests < <(get_tests "${target}")
   echo "About to run ${#tests[@]} tests: ${tests[*]}"
   # shellcheck disable=SC2001
-  make test-e2e GO_TEST_FLAGS="-run \"$(echo "${tests[*]}" | sed 's/ /|/g')\"" 
+  make test-e2e GO_TEST_FLAGS="-run \"$(echo "${tests[*]}" | sed 's/ /|/g')\""
 }
 
 collect_logs() {
@@ -173,7 +173,7 @@ collect_logs() {
 
 detect_panic() {
   # shellcheck disable=SC2016
-  (find /tmp/logs/ -type f -regex '.*/pipelines-as-code.*/[0-9]\.log$' | xargs -r sed -n '/stderr F panic:.*/,$p') >/tmp/panic.log
+  (find /tmp/logs/ -type f -regex '.*/pipelines-as-code.*/[0-9]\.log$' | xargs -r sed -n '/stderr F panic:.*/,$p' | head -n 80) >/tmp/panic.log
   if [[ -s /tmp/panic.log ]]; then
     set +x
     echo "=====================  PANIC DETECTED ====================="

--- a/hack/gh-workflow-ci.sh
+++ b/hack/gh-workflow-ci.sh
@@ -37,8 +37,8 @@ create_second_github_app_controller_on_ghe() {
   local test_github_second_webhook_secret="${3}"
 
   if [[ -n "$(type -p apt)" ]]; then
-    apt update &&
-      apt install -y python3-yaml
+   sudo apt update &&
+      sudo apt install -y python3-yaml
   elif [[ -n "$(type -p dnf)" ]]; then
     dnf install -y python3-pyyaml
   else
@@ -96,8 +96,6 @@ run_e2e_tests() {
   export TEST_GITHUB_PRIVATE_TASK_URL="https://github.com/openshift-pipelines/pipelines-as-code-e2e-tests-private/blob/main/remote_task.yaml"
   export TEST_GITHUB_PRIVATE_TASK_NAME="task-remote"
 
-  export GO_TEST_FLAGS="-v -race -failfast"
-
   export TEST_BITBUCKET_CLOUD_API_URL=https://api.bitbucket.org/2.0
   export TEST_BITBUCKET_CLOUD_E2E_REPOSITORY=cboudjna/pac-e2e-tests
   export TEST_BITBUCKET_CLOUD_TOKEN=${bitbucket_cloud_token}
@@ -142,7 +140,7 @@ run_e2e_tests() {
   mapfile -t tests < <(get_tests "${target}")
   echo "About to run ${#tests[@]} tests: ${tests[*]}"
   # shellcheck disable=SC2001
-  GO_TEST_FLAGS="-run \"$(echo "${tests[*]}" | sed 's/ /|/g')\"" make test-e2e
+  make test-e2e GO_TEST_FLAGS="-run \"$(echo "${tests[*]}" | sed 's/ /|/g')\"" 
 }
 
 collect_logs() {

--- a/pkg/provider/github/parse_payload.go
+++ b/pkg/provider/github/parse_payload.go
@@ -254,6 +254,9 @@ func (v *Provider) processEvent(ctx context.Context, event *info.Event, eventInt
 			return nil, err
 		}
 	case *github.PushEvent:
+		if gitEvent.GetRepo() == nil {
+			return nil, errors.New("error parsing payload the repository should not be nil")
+		}
 		processedEvent.Organization = gitEvent.GetRepo().GetOwner().GetLogin()
 		processedEvent.Repository = gitEvent.GetRepo().GetName()
 		processedEvent.DefaultBranch = gitEvent.GetRepo().GetDefaultBranch()
@@ -274,6 +277,9 @@ func (v *Provider) processEvent(ctx context.Context, event *info.Event, eventInt
 		processedEvent.HeadURL = processedEvent.BaseURL // in push events Head URL is the same as BaseURL
 	case *github.PullRequestEvent:
 		processedEvent.Repository = gitEvent.GetRepo().GetName()
+		if gitEvent.GetRepo() == nil {
+			return nil, errors.New("error parsing payload the repository should not be nil")
+		}
 		processedEvent.Organization = gitEvent.GetRepo().Owner.GetLogin()
 		processedEvent.DefaultBranch = gitEvent.GetRepo().GetDefaultBranch()
 		processedEvent.SHA = gitEvent.GetPullRequest().Head.GetSHA()
@@ -306,6 +312,9 @@ func (v *Provider) processEvent(ctx context.Context, event *info.Event, eventInt
 
 func (v *Provider) handleReRequestEvent(ctx context.Context, event *github.CheckRunEvent) (*info.Event, error) {
 	runevent := info.NewEvent()
+	if event.GetRepo() == nil {
+		return nil, errors.New("error parsing payload the repository should not be nil")
+	}
 	runevent.Organization = event.GetRepo().GetOwner().GetLogin()
 	runevent.Repository = event.GetRepo().GetName()
 	runevent.URL = event.GetRepo().GetHTMLURL()
@@ -331,6 +340,9 @@ func (v *Provider) handleReRequestEvent(ctx context.Context, event *github.Check
 
 func (v *Provider) handleCheckSuites(ctx context.Context, event *github.CheckSuiteEvent) (*info.Event, error) {
 	runevent := info.NewEvent()
+	if event.GetRepo() == nil {
+		return nil, errors.New("error parsing payload the repository should not be nil")
+	}
 	runevent.Organization = event.GetRepo().GetOwner().GetLogin()
 	runevent.Repository = event.GetRepo().GetName()
 	runevent.URL = event.GetRepo().GetHTMLURL()
@@ -393,6 +405,9 @@ func (v *Provider) handleIssueCommentEvent(ctx context.Context, event *github.Is
 func (v *Provider) handleCommitCommentEvent(ctx context.Context, event *github.CommitCommentEvent) (*info.Event, error) {
 	action := "push"
 	runevent := info.NewEvent()
+	if event.GetRepo() == nil {
+		return nil, errors.New("error parsing payload the repository should not be nil")
+	}
 	runevent.Organization = event.GetRepo().GetOwner().GetLogin()
 	runevent.Repository = event.GetRepo().GetName()
 	runevent.Sender = event.GetSender().GetLogin()

--- a/pkg/provider/github/parse_payload_test.go
+++ b/pkg/provider/github/parse_payload_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
 	ghtesthelper "github.com/openshift-pipelines/pipelines-as-code/pkg/test/github"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/test/logger"
@@ -88,6 +89,9 @@ var samplePRAnother = github.PullRequest{
 }
 
 func TestParsePayLoad(t *testing.T) {
+	samplePRNoRepo := samplePRevent
+	samplePRNoRepo.Repo = nil
+
 	tests := []struct {
 		name                       string
 		wantErrString              string
@@ -184,6 +188,20 @@ func TestParsePayLoad(t *testing.T) {
 				},
 			},
 			shaRet: "samplePRsha",
+		},
+		{
+			name:               "bad/pull request",
+			eventType:          "pull_request",
+			triggerTarget:      triggertype.PullRequest.String(),
+			payloadEventStruct: samplePRNoRepo,
+			wantErrString:      "error parsing payload the repository should not be nil",
+		},
+		{
+			name:               "bad/push",
+			eventType:          "push",
+			triggerTarget:      triggertype.Push.String(),
+			payloadEventStruct: github.PushEvent{},
+			wantErrString:      "error parsing payload the repository should not be nil",
 		},
 		{
 			// specific run from a check_suite

--- a/test/invalid_event_test.go
+++ b/test/invalid_event_test.go
@@ -82,7 +82,7 @@ func TestSkippedEvent(t *testing.T) {
 	assert.NilError(t, err)
 	defer resp.Body.Close()
 
-	assert.Equal(t, resp.StatusCode, http.StatusOK, "%s reply expected 200 OK", elURL)
+	assert.Assert(t, resp.StatusCode >= 200 && resp.StatusCode < 300, "%s reply expected 2xx OK: %d", elURL, resp.StatusCode)
 }
 
 func TestGETCall(t *testing.T) {


### PR DESCRIPTION
We were getting a crash on the controller due to a nil pointer dereference
when the repository was nil in the payload. This commit adds checks to
ensure the repository is not nil before accessing its properties.

TestSkippedEvent shows the issue but it wasn't detected that the controller
was crashing and happily returned ok.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
