### PR TITLE
fix: improve user feedback

### DIFF
--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -377,7 +377,7 @@ func (p *PacRun) checkAccessOrErrror(ctx context.Context, repo *v1alpha1.Reposit
 	p.eventEmitter.EmitMessage(repo, zap.InfoLevel, "RepositoryPermissionDenied", msg)
 	status := provider.StatusOpts{
 		Status:     queuedStatus,
-		Title:      "Pending approval",
+		Title:      "Pending approval, needs /ok-to-test",
 		Conclusion: pendingConclusion,
 		Text:       msg,
 		DetailsURL: p.event.URL,

--- a/pkg/provider/github/status.go
+++ b/pkg/provider/github/status.go
@@ -321,7 +321,7 @@ func (v *Provider) createStatusCommit(ctx context.Context, runevent *info.Event,
 		runevent.Organization, runevent.Repository, runevent.SHA, ghstatus); err != nil {
 		return err
 	}
-	if (status.Status == "completed" || (status.Status == "queued" && status.Title == "Pending approval")) && status.Text != "" && runevent.EventType == triggertype.PullRequest.String() {
+	if (status.Status == "completed" || (status.Status == "queued" && status.Title == "Pending approval, needs /ok-to-test")) && status.Text != "" && runevent.EventType == triggertype.PullRequest.String() {
 		_, _, err = v.Client.Issues.CreateComment(ctx, runevent.Organization, runevent.Repository,
 			runevent.PullRequestNumber,
 			&github.IssueComment{

--- a/pkg/provider/github/status_test.go
+++ b/pkg/provider/github/status_test.go
@@ -169,7 +169,7 @@ func TestGetExistingPendingApprovalCheckRunID(t *testing.T) {
 					"id": %v,
 					"external_id": "%s",
 					"output": {
-						"title": "Pending approval",
+						"title": "Pending approval, needs /ok-to-test",
 						"summary": "My CI is waiting for approval"
 					}
 				}
@@ -414,7 +414,7 @@ func TestGithubProviderCreateStatus(t *testing.T) {
                                 "status": "queued",
                                 "conclusion": "pending", 
 								"output": {
-									"title": "Pending approval",
+									"title": "Pending approval, needs /ok-to-test",
 									"summary": "My CI is waiting for approval"
 								}
 							}

--- a/test/pkg/gitea/test.go
+++ b/test/pkg/gitea/test.go
@@ -388,7 +388,7 @@ func WaitForStatus(t *testing.T, topts *TestOpts, ref, forcontext string, onlyla
 		}
 		for _, cstatus := range statuses {
 			if topts.CheckForStatus == "Skipped" {
-				if strings.HasSuffix(cstatus.Description, "Pending approval") {
+				if strings.HasSuffix(cstatus.Description, "Pending approval, needs /ok-to-test") {
 					numstatus++
 					break
 				}


### PR DESCRIPTION
# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

When PaC is used with other CIs (eg openshift-ci), it can happen that a `ok-to-test` label managed by the other CI is present. That label may persist after a change, but PaC will report the need for the latest content to be approved. This state is likely to confuse the user.

In order to improve the UX, the required action is now explicitely stated in the message in the UI.

# Submitter Checklist

- [x] 📝 Please ensure your commit message is clear and informative. For guidance on crafting effective commit messages, refer to the How to write a git commit message guide. We prefer the commit message to be included in the PR body itself rather than a link to an external website (ie: Jira ticket).

- [ ] ♽ Before submitting a PR, run make test lint to avoid unnecessary CI processing. For an even more efficient workflow, consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the root of this repository.

- [ ] ✨ We use linters to maintain clean and consistent code. Please ensure you've run make lint before submitting a PR. Some linters offer a --fix mode, which can be executed with the command make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) tools are installed first).

- [x] 📖 If you're introducing a user-facing feature or changing existing behavior, please ensure it's properly documented.

- [x] 🧪 While 100% coverage isn't a requirement, we encourage unit tests for any code changes where possible.

- [x] 🎁 If feasible, please check if an end-to-end test can be added. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.

- [x] 🔎 If there's any flakiness in the CI tests, don't necessarily ignore it. It's better to address the issue before merging, or provide a valid reason to bypass it if fixing isn't possible (e.g., token rate limitations).

- If you are adding a provider feature, please fill up the following details which provider this feature supports:

  - [ ] GitHub
  - [ ] GitHub Webhook
  - [ ] Gitea
  - [ ] Gitlab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Server/DC

  (make sure to update the documentation accordingly)
