### PR TITLE
Added changes field in push event struct for Bitbucket server

### DIFF
--- a/pkg/provider/bitbucketserver/types/types.go
+++ b/pkg/provider/bitbucketserver/types/types.go
@@ -23,13 +23,29 @@ type PullRequestEvent struct {
 }
 
 type PushRequestEventChange struct {
-	ToHash string `json:"toHash"`
-	RefID  string `json:"refId"`
+	Ref      Ref    `json:"ref"`
+	FromHash string `json:"fromHash"`
+	ToHash   string `json:"toHash"`
+	RefID    string `json:"refId"`
+	Type     string `json:"type"`
+}
+
+type Ref struct {
+	ID        string `json:"id"`
+	DisplayID string `json:"displayId"`
+	Type      string `json:"type"`
 }
 
 type PushRequestEvent struct {
+	EventKey   string                   `json:"eventKey"`
 	Actor      bbv1.UserWithLinks       `json:"actor"`
 	Repository bbv1.Repository          `json:"repository"`
 	Changes    []PushRequestEventChange `json:"changes"`
 	Commits    []bbv1.Commit            `json:"commits"`
+	ToCommit   ToCommit                 `json:"toCommit"`
+}
+
+type ToCommit struct {
+	bbv1.Commit
+	Parents []bbv1.Commit `json:"parents"` // bbv1.Commit also has Parents field, but its Parents has only two fields while actual payload has more.
 }

--- a/test/bitbucket_server_dynamic_variables_test.go
+++ b/test/bitbucket_server_dynamic_variables_test.go
@@ -1,0 +1,71 @@
+//go:build e2e
+// +build e2e
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
+	tbbs "github.com/openshift-pipelines/pipelines-as-code/test/pkg/bitbucketserver"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/scm"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
+
+	"github.com/tektoncd/pipeline/pkg/names"
+	"gotest.tools/v3/assert"
+)
+
+func TestBitbucketServerDynamicVariables(t *testing.T) {
+	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
+	ctx := context.Background()
+	bitbucketWSOwner := os.Getenv("TEST_BITBUCKET_SERVER_E2E_REPOSITORY")
+
+	ctx, runcnx, opts, client, err := tbbs.Setup(ctx)
+	assert.NilError(t, err)
+
+	repo := tbbs.CreateCRD(ctx, t, client, runcnx, bitbucketWSOwner, targetNS)
+	runcnx.Clients.Log.Infof("Repository %s has been created", repo.Name)
+	defer tbbs.TearDownNs(ctx, t, runcnx, targetNS)
+
+	branch, _, err := client.Git.CreateRef(ctx, bitbucketWSOwner, targetNS, "refs/heads/main")
+	assert.NilError(t, err)
+	runcnx.Clients.Log.Infof("Branch %s has been created", branch.Name)
+
+	files := map[string]string{
+		".tekton/pipelinerun.yaml": "testdata/pipelinerun-dynamic-vars.yaml",
+	}
+
+	files, err = payload.GetEntries(files, targetNS, targetNS, triggertype.Push.String(), map[string]string{})
+	assert.NilError(t, err)
+	gitCloneURL, err := scm.MakeGitCloneURL(repo.Clone, opts.UserName, opts.Password)
+	assert.NilError(t, err)
+
+	commitMsg := fmt.Sprintf("commit %s", targetNS)
+	scmOpts := &scm.Opts{
+		GitURL:        gitCloneURL,
+		Log:           runcnx.Clients.Log,
+		WebURL:        repo.Clone,
+		TargetRefName: targetNS,
+		BaseRefName:   repo.Branch,
+		CommitTitle:   commitMsg,
+	}
+	scm.PushFilesToRefGit(t, scmOpts, files)
+	runcnx.Clients.Log.Infof("Files has been pushed to branch %s", targetNS)
+
+	successOpts := wait.SuccessOpt{
+		TargetNS:        targetNS,
+		OnEvent:         triggertype.Push.String(),
+		NumberofPRMatch: 1,
+		MinNumberStatus: 1,
+	}
+	wait.Succeeded(ctx, t, runcnx, opts, successOpts)
+
+	reg := *regexp.MustCompile(fmt.Sprintf("event: repo:refs_changed, refId: refs/heads/%s, message: %s", targetNS, commitMsg))
+	err = wait.RegexpMatchingInPodLog(ctx, runcnx, targetNS, "pipelinesascode.tekton.dev/original-prname=pipelinerun-dynamic-vars", "step-task", reg, "", 2)
+	assert.NilError(t, err)
+}

--- a/test/bitbucket_server_pull_request_test.go
+++ b/test/bitbucket_server_pull_request_test.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 package test
 
 import (

--- a/test/testdata/pipelinerun-dynamic-vars.yaml
+++ b/test/testdata/pipelinerun-dynamic-vars.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: "pipelinerun-dynamic-vars"
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
+    pipelinesascode.tekton.dev/on-event: "[push]"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: task
+        taskSpec:
+          steps:
+            - name: task
+              image: registry.access.redhat.com/ubi9/ubi-micro
+              command: ["/bin/echo", "event: {{ body.eventKey }}, refId: {{ body.changes[0].ref.id }}, message: {{ body.toCommit.message }}"]


### PR DESCRIPTION
added changes field in push event struct for Bitbucket to make it available in PipelineRun's dynamic variable

https://issues.redhat.com/browse/SRVKP-6981

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [ ] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [ ] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [ ] 📖 Document any user-facing features or changes in behavior.

- [ ] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [ ] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [ ] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

| Git Provider     | Supported |
|------------------|-----------|
| GitHub App       | ❌️        |
| GitHub Webhook   | ❌️        |
| Gitea            | ❌️        |
| GitLab           | ❌️        |
| Bitbucket Cloud  | ❌️        |
| Bitbucket Server | ✅️        |

  (update the documentation accordingly)
