### PR TITLE
Fix GitLab MR Not Updated Issue on Forked Repository

### DIFF
--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -138,6 +138,15 @@ func (v *Provider) SetClient(_ context.Context, run *params.Run, runevent *info.
 	}
 	v.Token = &runevent.Provider.Token
 
+	// In a scenario where the source repository is forked and a merge request (MR) is created on the upstream
+	// repository, runevent.SourceProjectID will not be 0 when SetClient is called from the pac-watcher code.
+	// This is because, in the controller, SourceProjectID is set in the annotation of the pull request,
+	// and runevent.SourceProjectID is set before SetClient is called. Therefore, we need to take
+	// the ID from runevent.SourceProjectID.
+	if runevent.SourceProjectID > 0 {
+		v.sourceProjectID = runevent.SourceProjectID
+	}
+
 	// if we don't have sourceProjectID (ie: incoming-webhook) then try to set
 	// it ASAP if we can.
 	if v.sourceProjectID == 0 && runevent.Organization != "" && runevent.Repository != "" {


### PR DESCRIPTION
In this issue MR status was being created by PAC controller but wasn't updated in reconciler (watcher) and `404 Not Found` was noticed in logs:
```
{"level":"error","ts":"2025-01-22T09:49:03.343Z","logger":"pac-watcher","caller":"events/emit.go:46","msg":"cannot set status with the GitLab token because of: 404 Not Found",...}
```
this was happening due to wrong [Event.SourceProjectID](https://github.com/openshift-pipelines/pipelines-as-code/blob/3b251fbba4b376e4ad56e994ff2def1b5ece2588/pkg/params/info/events.go#L64). In implementation of [SetClinet](https://github.com/openshift-pipelines/pipelines-as-code/blob/3b251fbba4b376e4ad56e994ff2def1b5ece2588/pkg/provider/gitlab/gitlab.go#L109) func of GitLab provider, if [provider.SourceProjectID](https://github.com/openshift-pipelines/pipelines-as-code/blob/3b251fbba4b376e4ad56e994ff2def1b5ece2588/pkg/provider/gitlab/gitlab.go#L143) is empty (0) then it [project is fetched](https://github.com/openshift-pipelines/pipelines-as-code/blob/3b251fbba4b376e4ad56e994ff2def1b5ece2588/pkg/provider/gitlab/gitlab.go#L145) from GitLab API (I think this is intended for incoming webhook and workable when sourceProject and targetProject are same raising MR in same repo), but when MR is from a "Forked" respository they are different. and as [ParsePayload](https://github.com/openshift-pipelines/pipelines-as-code/blob/3b251fbba4b376e4ad56e994ff2def1b5ece2588/pkg/provider/gitlab/parse_payload.go#L17) is only called in controller (really intended for that), when [SetClient](https://github.com/openshift-pipelines/pipelines-as-code/blob/3b251fbba4b376e4ad56e994ff2def1b5ece2588/pkg/provider/gitlab/gitlab.go#L109) is called in pac-watcher code provider.SourceProjectID is empty [here](https://github.com/openshift-pipelines/pipelines-as-code/blob/3b251fbba4b376e4ad56e994ff2def1b5ece2588/pkg/provider/gitlab/gitlab.go#L143). But before [SetClient is called](https://github.com/openshift-pipelines/pipelines-as-code/blob/3b251fbba4b376e4ad56e994ff2def1b5ece2588/pkg/reconciler/reconciler.go#L264) in reconciler, [detectProvider is called](https://github.com/openshift-pipelines/pipelines-as-code/blob/3b251fbba4b376e4ad56e994ff2def1b5ece2588/pkg/reconciler/reconciler.go#L234) there, and detectProvider in its definition calls [buildEventFromPipelineRun](https://github.com/openshift-pipelines/pipelines-as-code/blob/3b251fbba4b376e4ad56e994ff2def1b5ece2588/pkg/reconciler/event.go#L27) which sets [Event.SourceProjectID](https://github.com/openshift-pipelines/pipelines-as-code/blob/3b251fbba4b376e4ad56e994ff2def1b5ece2588/pkg/reconciler/event.go#L87) and Event.TargetProjectID.

## Solution
I am assigning [event.SourceProjectID](https://github.com/openshift-pipelines/pipelines-as-code/blob/3b251fbba4b376e4ad56e994ff2def1b5ece2588/pkg/provider/gitlab/gitlab.go#L54) from runevent.TargetProjectID. and it works

## Demo

https://github.com/user-attachments/assets/ffc509bd-b4fa-4ed8-9263-81b272a9938f



https://issues.redhat.com/browse/SRVKP-6100

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [ ] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [ ] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [ ] 📖 Document any user-facing features or changes in behavior.

- [ ] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [ ] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [ ] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

| Git Provider     | Supported |
|------------------|-----------|
| GitHub App       | ❌️        |
| GitHub Webhook   | ❌️        |
| Gitea            | ❌️        |
| GitLab           | ✅️        |
| Bitbucket Cloud  | ❌️        |
| Bitbucket Server | ❌️        |

  (update the documentation accordingly)
