### PR TITLE
fix TestGithubSecondCancelInProgress test conditio

### DIFF
--- a/test/github_pullrequest_test.go
+++ b/test/github_pullrequest_test.go
@@ -327,6 +327,9 @@ func TestGithubSecondCancelInProgress(t *testing.T) {
 			if pr.GetStatusCondition() == nil {
 				continue
 			}
+			if len(pr.Status.Conditions) == 0 {
+				continue
+			}
 			if pr.Status.Conditions[0].Reason == "Cancelled" {
 				g.Cnx.Clients.Log.Infof("PipelineRun %s has been canceled", pr.Name)
 				foundCancelled = true


### PR DESCRIPTION
fixing this crash when running the e2e test, do not occur all the time
only when the tetkon is slow to act:

--- FAIL: TestGithubSecondCancelInProgress (17.21s)
panic: runtime error: index out of range [0] with length 0 [recovered]

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [x] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).
   x
- [x] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.
   x
- [x] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).
   x
- [x] 📖 Document any user-facing features or changes in behavior.
   x
- [x] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.
   x
- [x] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.
   x
- [x] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

| Git Provider     | Supported |
|------------------|-----------|
| GitHub App       | ✅️        |
| GitHub Webhook   | ❌️        |
| Gitea            | ❌️        |
| GitLab           | ❌️        |
| Bitbucket Cloud  | ❌️        |
| Bitbucket Server | ❌️        |

  (update the documentation accordingly)
