### PR TITLE
feat: Add support for uninitialized custom params

### DIFF
--- a/docs/content/docs/guide/customparams.md
+++ b/docs/content/docs/guide/customparams.md
@@ -45,11 +45,25 @@ spec:
         key: companyname
 ```
 
+Lastly, if no default value makes sense for a custom param, it can be defined
+without a value:
+
+```yaml
+spec:
+  params:
+    - name: start_time
+```
+
+If the custom parameter is not defined with any value, it is only expanded
+if a value is supplied via [a GitOps command]({{< relref "/docs/guide/gitops_commands#passing-parameters-to-gitops-commands-as-arguments" >}}).
+
 {{< hint info >}}
 
 - If you have a `value` and a `secret_ref` defined, the `value` will be used.
-- If you don't have a `value` or a `secret_ref`, the parameter will not be
-  parsed, and it will be shown as `{{ param }}` in the `PipelineRun`.
+- If you don't have a `value` or a `secret_ref`, and the parameter is not
+  [overridden by a GitOps command]({{< relref "/docs/guide/gitops_commands#passing-parameters-to-gitops-commands-as-arguments" >}}),
+  the parameter will not be parsed, and it will be shown as `{{ param }}` in
+  the `PipelineRun`.
 - If you don't have a `name` in the `params`, the parameter will not be parsed.
 - If you have multiple `params` with the same `name`, the last one will be used.
 {{< /hint >}}

--- a/pkg/customparams/customparams_test.go
+++ b/pkg/customparams/customparams_test.go
@@ -265,6 +265,22 @@ func TestProcessTemplates(t *testing.T) {
 			},
 		},
 		{
+			name: "params/override params with no value via gitops arguments",
+			expected: map[string]string{
+				"event_type":      "push",
+				"hello":           `"yolo"`,
+				"trigger_comment": triggerCommentArgs,
+			},
+			event: &info.Event{EventType: "pull_request", TriggerComment: triggerCommentArgs},
+			repository: &v1alpha1.Repository{
+				Spec: v1alpha1.RepositorySpec{
+					Params: &[]v1alpha1.Params{
+						{Name: "hello"},
+					},
+				},
+			},
+		},
+		{
 			name:               "params/skip with no name",
 			expectedLogSnippet: "no name has been set in params[0] of repo",
 			repository: &v1alpha1.Repository{
@@ -272,6 +288,19 @@ func TestProcessTemplates(t *testing.T) {
 					Params: &[]v1alpha1.Params{
 						{
 							Value: "batman",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "params/skip with no value",
+			expected: map[string]string{},
+			repository: &v1alpha1.Repository{
+				Spec: v1alpha1.RepositorySpec{
+					Params: &[]v1alpha1.Params{
+						{
+							Name: "empty-param",
 						},
 					},
 				},

--- a/test/gitea_gitops_commands_test.go
+++ b/test/gitea_gitops_commands_test.go
@@ -65,8 +65,10 @@ func TestGiteaOnCommentAnnotation(t *testing.T) {
 				Value: "bar",
 			},
 			{
-				Name:  "custom3",
-				Value: "moto",
+				Name: "custom_no_initial_value",
+			},
+			{
+				Name: "custom_never_value",
 			},
 		},
 	}
@@ -112,7 +114,7 @@ func TestGiteaOnCommentAnnotation(t *testing.T) {
 		fmt.Sprintf("tekton.dev/pipelineRun=%s", last.PipelineRunName),
 		"step-task", strings.ReplaceAll(fmt.Sprintf("%s-pipelinerun-on-comment-annotation.golden", t.Name()), "/", "-"), 2)
 
-	tgitea.PostCommentOnPullRequest(t, topts, fmt.Sprintf(`%s revision=main custom1=thisone custom2="another one" custom3="a \"quote\""`, triggerComment))
+	tgitea.PostCommentOnPullRequest(t, topts, fmt.Sprintf(`%s revision=main custom1=thisone custom2="another one" custom_no_initial_value="a \"quote\""`, triggerComment))
 	waitOpts.MinNumberStatus = 4
 	repo, err = twait.UntilRepositoryUpdated(context.Background(), topts.ParamsRun.Clients, waitOpts)
 	assert.NilError(t, err)

--- a/test/gitea_params_test.go
+++ b/test/gitea_params_test.go
@@ -294,6 +294,9 @@ func TestGiteaParamsOnRepoCR(t *testing.T) {
 					Key:  "unknowsecret",
 				},
 			},
+			{
+				Name: "no_initial_value",
+			},
 		},
 	}
 	topts.TargetRefName = names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test")
@@ -317,7 +320,7 @@ func TestGiteaParamsOnRepoCR(t *testing.T) {
 	assert.NilError(t,
 		twait.RegexpMatchingInPodLog(context.Background(), topts.ParamsRun, topts.TargetNS, fmt.Sprintf("tekton.dev/pipelineRun=%s,tekton.dev/pipelineTask=params",
 			repo.Status[0].PipelineRunName), "step-test-params-value", *regexp.MustCompile(
-			"I am the most Kawaī params\nSHHHHHHH\nFollow me on my ig #nofilter\n{{ no_match }}\nHey I show up from a payload match\n{{ secret_nothere }}"), "", 2))
+			"I am the most Kawaī params\nSHHHHHHH\nFollow me on my ig #nofilter\n{{ no_match }}\nHey I show up from a payload match\n{{ secret_nothere }}\n{{ no_initial_value }}"), "", 2))
 }
 
 // TestGiteaParamsBodyHeadersCEL Test that we can access the pull request body and headers in params

--- a/test/testdata/TestGiteaGlobalRepoParams.golden
+++ b/test/testdata/TestGiteaGlobalRepoParams.golden
@@ -4,3 +4,4 @@ I come from the global params
 {{ no_match }}
 {{ filter_on_body }}
 {{ secret_nothere }}
+{{ no_initial_value }}

--- a/test/testdata/TestGiteaGlobalRepoUseLocalDef.golden
+++ b/test/testdata/TestGiteaGlobalRepoUseLocalDef.golden
@@ -4,3 +4,4 @@ I come from the local params
 {{ no_match }}
 {{ filter_on_body }}
 {{ secret_nothere }}
+{{ no_initial_value }}

--- a/test/testdata/TestGiteaOnCommentAnnotation-pipelinerun-on-comment-annotation.golden
+++ b/test/testdata/TestGiteaOnCommentAnnotation-pipelinerun-on-comment-annotation.golden
@@ -3,4 +3,5 @@ The comment is:
 The event is on-comment
 The custom1 value is foo
 The custom2 value is bar
-The custom3 value is moto
+The custom_no_initial_value value is {{ custom_no_initial_value }}
+The custom_never_value value is {{ custom_never_value }}

--- a/test/testdata/TestGiteaOnCommentAnnotation.golden
+++ b/test/testdata/TestGiteaOnCommentAnnotation.golden
@@ -1,6 +1,7 @@
 The comment is:
-/hello-world\n\n revision=main custom1=thisone custom2="another one" custom3="a \"quote\""
+/hello-world\n\n revision=main custom1=thisone custom2="another one" custom_no_initial_value="a \"quote\""
 The event is on-comment
 The custom1 value is thisone
 The custom2 value is another one
-The custom3 value is a quote
+The custom_no_initial_value value is a quote
+The custom_never_value value is {{ custom_never_value }}

--- a/test/testdata/params.yaml
+++ b/test/testdata/params.yaml
@@ -22,3 +22,4 @@ spec:
                 echo "{{ no_match }}"
                 echo "{{ filter_on_body }}"
                 echo "{{ secret_nothere }}"
+                echo "{{ no_initial_value }}"

--- a/test/testdata/pipelinerun-on-comment-annotation.yaml
+++ b/test/testdata/pipelinerun-on-comment-annotation.yaml
@@ -23,4 +23,5 @@ spec:
                 echo "The event is {{ event_type }}"
                 echo "The custom1 value is {{ custom1 }}"
                 echo "The custom2 value is {{ custom2 }}"
-                echo "The custom3 value is {{ custom3 }}"
+                echo "The custom_no_initial_value value is {{ custom_no_initial_value }}"
+                echo "The custom_never_value value is {{ custom_never_value }}"


### PR DESCRIPTION
# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Add support for defining Custom Params in the Repository without any value, allowing the value to be supplied by the webhook. 
If a Custom Param is defined without any value and no value is supplied in the payload, then the param is omitted from substitution and the behavior has no change from the current state. To this extent the feature is backwards compatible.

Documentation is not included yet in chase semantic changes are requested. 

# Submitter Checklist

- [x] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [ ] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [ ] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [ ] 📖 Document any user-facing features or changes in behavior.

- [ ] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [ ] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [ ] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

| Git Provider     | Supported |
|------------------|-----------|
| GitHub App       | ✅️        |
| GitHub Webhook   | ❌️        |
| Gitea            | ❌️        |
| GitLab           | ❌️        |
| Bitbucket Cloud  | ❌️        |
| Bitbucket Server | ❌️        |

  (update the documentation accordingly)
