### PR TITLE
Fix ok-to-test comment issue for external user on GitHub

### DIFF
--- a/docs/content/docs/guide/gitops_commands.md
+++ b/docs/content/docs/guide/gitops_commands.md
@@ -214,6 +214,15 @@ Here are the possible event types:
 * `cancel-comment`: The event is a `/cancel <PipelineRun>` that would cancel a specific PipelineRun.
 * `ok-to-test-comment`: The event is a `/ok-to-test` that would allow running the CI for an unauthorized user.
 
+When a repository owner issues the `/ok-to-test` command on a pull request raised by an unauthorized user, and no PipelineRun exists in the .tekton directory for `pull_request` event,
+Pipelines-as-Code will create a neutral check-run status. This status serves to indicate that no PipelineRun has been matched, preventing any workflows from being blocked such as auto-merge, will proceed as expected.
+
+{{< hint info >}}
+
+Note: This neutral check-run status functionality is only supported on GitHub.
+
+{{< /hint >}}
+
 When using the `{{ event_type }}` [dynamic variable]({{< relref "/docs/guide/authoringprs.md#dynamic-variables" >}}) for the following event types:
 
 * `test-all-comment`

--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -32,6 +32,7 @@ const (
 	queuedStatus      = "queued"
 	failureConclusion = "failure"
 	pendingConclusion = "pending"
+	neutralConclusion = "neutral"
 )
 
 type PacRun struct {

--- a/pkg/provider/github/status.go
+++ b/pkg/provider/github/status.go
@@ -370,8 +370,10 @@ func (v *Provider) CreateStatus(ctx context.Context, runevent *info.Event, statu
 		statusOpts.Title = "Cancelled"
 		statusOpts.Summary = "has been <b>cancelled</b>."
 	case "neutral":
-		statusOpts.Title = "Unknown"
-		statusOpts.Summary = "doesn't know what happened with this commit."
+		if statusOpts.Title == "" {
+			statusOpts.Title = "Unknown"
+		}
+		statusOpts.Summary = "<b>Completed</b>"
 	}
 
 	if statusOpts.Status == "in_progress" {


### PR DESCRIPTION
Issue: when an external user sends a pull request on a repository PAC create a pending check-run but after ok-to-test comment from an authorized user if there is not matching PipelineRun on in the repositoy the pending status of the check-run created by PAC still there and it hinders pull request to be merged automatically if auto-merge is setup on the repository.

Solution: If ok-to-test comment is sent on a pull request and there is no matching PipelineRun in .tekton directory then create neutral check-run on the pull request letting auto-merge work in its way.

https://issues.redhat.com/browse/KONFLUX-6565

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [ ] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [ ] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [ ] 📖 Document any user-facing features or changes in behavior.

- [ ] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [ ] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [ ] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

| Git Provider     | Supported |
|------------------|-----------|
| GitHub App       | ✅️        |
| GitHub Webhook   | ❌️        |
| Gitea            | ❌️        |
| GitLab           | ❌️        |
| Bitbucket Cloud  | ❌️        |
| Bitbucket Server | ❌️        |

  (update the documentation accordingly)
