### PR TITLE
feat: add prow like PR management

### DIFF
--- a/.tekton/prow.yaml
+++ b/.tekton/prow.yaml
@@ -1,0 +1,102 @@
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: prow-commands
+  annotations:
+    pipelinesascode.tekton.dev/on-comment: "^/(help|(assign|unassign|label|unlabel)[ ].*)"
+    pipelinesascode.tekton.dev/max-keep-runs: "5"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: manage-pr
+        displayName: Manage PR Assignments & Labels
+        taskSpec:
+          steps:
+            - name: manage-pr
+              image: registry.access.redhat.com/ubi9/ubi
+              env:
+                - name: GITHUB_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: "{{ git_auth_secret }}"
+                      key: "git-provider-token"
+              script: |
+                #!/usr/bin/env python3
+                import os
+                import re
+                import requests
+                import sys
+
+                GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
+                if not GITHUB_TOKEN:
+                    print("❌ GITHUB_TOKEN environment variable is missing", file=sys.stderr)
+                    sys.exit(1)
+
+                API_BASE = "https://api.github.com/repos/{{ repo_owner }}/{{ repo_name }}/issues/{{ pull_request_number }}"
+                HEADERS = {
+                    "Authorization": f"Bearer {GITHUB_TOKEN}",
+                    "Accept": "application/vnd.github.v3+json",
+                    "X-GitHub-Api-Version": "2022-11-28"
+                }
+
+                COMMENT = """{{ trigger_comment }}"""
+                match = re.match(r"^/(assign|unassign|label|unlabel|help)\s*(.*)", COMMENT)
+
+                if not match:
+                    print(f"⚠️ No valid command found in comment: {COMMENT}", file=sys.stderr)
+                    sys.exit(1)
+
+                command, values = match.groups()
+                values = values.split()
+
+                def make_request(method, url, data=None):
+                    try:
+                        if method == "POST":
+                            response = requests.post(url, json=data, headers=HEADERS)
+                        elif method == "DELETE":
+                            response = requests.delete(url, json=data, headers=HEADERS)
+                        else:
+                            return None
+                        response.raise_for_status()
+                        return response
+                    except requests.exceptions.RequestException as e:
+                        print(f"❌ API request failed: {e}", file=sys.stderr)
+                        sys.exit(1)
+
+                if command == "assign":
+                    API_URL = f"{API_BASE}/assignees"
+                    data = {"assignees": values}
+                    response = make_request("POST", API_URL, data)
+                elif command == "unassign":
+                    API_URL = f"{API_BASE}/assignees"
+                    data = {"assignees": values}
+                    response = make_request("DELETE", API_URL, data)
+                elif command == "label":
+                    API_URL = f"{API_BASE}/labels"
+                    data = {"labels": values}
+                    response = make_request("POST", API_URL, data)
+                elif command == "unlabel":
+                    API_URL = f"{API_BASE}/labels/{'/'.join(values)}"
+                    for label in values:
+                        response = make_request("DELETE", f"{API_BASE}/labels/{label}")
+                elif command == "help":
+                    API_URL = f"{API_BASE}/comments"
+                    help_text = """### 🤖 Available Commands
+                | Command | Description |
+                |---------|-------------|
+                | `/assign user1 user2` | Assigns users to the PR |
+                | `/unassign user1 user2` | Removes assigned users |
+                | `/label bug feature` | Adds labels to the PR |
+                | `/unlabel bug feature` | Removes labels from the PR |
+                | `/help` | Shows this help message |
+                """
+                    response = make_request("POST", API_URL, {"body": help_text})
+                    print(f"✅ Posted help message")
+                    sys.exit(0)
+
+                if response and response.status_code in [200, 201, 204]:
+                    print(f"✅ Successfully processed {command}: {', '.join(values) if values else ''}")
+                else:
+                    print(f"❌ Failed to process {command}: {response.status_code if response else 'N/A'} - {response.text if response else 'N/A'}", file=sys.stderr)
+                    sys.exit(1)

--- a/docs/content/docs/guide/gitops_commands.md
+++ b/docs/content/docs/guide/gitops_commands.md
@@ -100,6 +100,10 @@ Using the [on-comment]({{< relref "/docs/guide/matchingevents.md#matching-a-pipe
 
 See the [on-comment]({{< relref "/docs/guide/matchingevents.md#matching-a-pipelinerun-on-a-regexp-in-a-comment" >}}) guide for more detailed information.
 
+For a complete example, you can see how Pipelines-as-Code's own repo implemented some prow comments via the `on-comment` annotation:
+
+<https://github.com/openshift-pipelines/pipelines-as-code/blob/main/.tekton/prow.yaml>
+
 ## Cancelling a PipelineRun
 
 You can cancel a running PipelineRun by commenting on the Pull Request.


### PR DESCRIPTION
This add a Pac PipelineRun that enables managing PRs through
GitHub comments, replacing Prow-like commands with Pipelines as Code.

- `/assign user1 user2` → Assign users to a PR.
- `/unassign user1 user2` → Remove assigned users from a PR.
- `/label bug enhancement` → Add labels to a PR.
- `/unlabel bug` → Remove specific labels from a PR.
- `/help` → Posts a comment listing all supported commands in a markdown table.

- Uses embedded Python in a Tekton Task to interact with the GitHub API.
- Extracts GitHub token from `git_auth_secret` for authentication.
- Parses `{{ trigger_comment }}` to determine the appropriate action.
- Handles API errors with proper logging and graceful failures.
- Supports both `POST` and `DELETE` requests for GitHub issue APIs.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
