### PR TITLE
Use prow from the pipelines-as-code-prow repo

### DIFF
--- a/.tekton/prow.yaml
+++ b/.tekton/prow.yaml
@@ -4,97 +4,23 @@ kind: PipelineRun
 metadata:
   name: prow-commands
   annotations:
-    pipelinesascode.tekton.dev/on-comment: "^/(help|(assign|unassign|label|unlabel)[ ].*)"
-    pipelinesascode.tekton.dev/max-keep-runs: "5"
+    pipelinesascode.tekton.dev/pipeline: "https://raw.githubusercontent.com/openshift-pipelines/pipelines-as-code-prow/refs/heads/main/pipeline-prow.yaml"
+    pipelinesascode.tekton.dev/on-comment: "^/(help|lgtm|(assign|unassign|label|unlabel)[ ].*)$"
+    pipelinesascode.tekton.dev/max-keep-runs: "2"
 spec:
-  pipelineSpec:
-    tasks:
-      - name: manage-pr
-        displayName: Manage PR Assignments & Labels
-        taskSpec:
-          steps:
-            - name: manage-pr
-              image: registry.access.redhat.com/ubi9/ubi
-              env:
-                - name: GITHUB_TOKEN
-                  valueFrom:
-                    secretKeyRef:
-                      name: "{{ git_auth_secret }}"
-                      key: "git-provider-token"
-              script: |
-                #!/usr/bin/env python3
-                import os
-                import re
-                import requests
-                import sys
-
-                GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
-                if not GITHUB_TOKEN:
-                    print("❌ GITHUB_TOKEN environment variable is missing", file=sys.stderr)
-                    sys.exit(1)
-
-                API_BASE = "https://api.github.com/repos/{{ repo_owner }}/{{ repo_name }}/issues/{{ pull_request_number }}"
-                HEADERS = {
-                    "Authorization": f"Bearer {GITHUB_TOKEN}",
-                    "Accept": "application/vnd.github.v3+json",
-                    "X-GitHub-Api-Version": "2022-11-28"
-                }
-
-                COMMENT = """{{ trigger_comment }}"""
-                match = re.match(r"^/(assign|unassign|label|unlabel|help)\s*(.*)", COMMENT)
-
-                if not match:
-                    print(f"⚠️ No valid command found in comment: {COMMENT}", file=sys.stderr)
-                    sys.exit(1)
-
-                command, values = match.groups()
-                values = values.split()
-
-                def make_request(method, url, data=None):
-                    try:
-                        if method == "POST":
-                            response = requests.post(url, json=data, headers=HEADERS)
-                        elif method == "DELETE":
-                            response = requests.delete(url, json=data, headers=HEADERS)
-                        else:
-                            return None
-                        response.raise_for_status()
-                        return response
-                    except requests.exceptions.RequestException as e:
-                        print(f"❌ API request failed: {e}", file=sys.stderr)
-                        sys.exit(1)
-
-                if command == "assign" or command == "unassign":
-                    method = "POST" if command == "assign" else "DELETE"
-                    API_URL = f"{API_BASE.replace('issues', 'pulls')}/requested_reviewers"
-                    values = [value.lstrip('@') for value in values]
-                    data = {"reviewers": values}
-                    response = make_request(method, API_URL, data)
-                elif command == "label":
-                    API_URL = f"{API_BASE}/labels"
-                    data = {"labels": values}
-                    response = make_request("POST", API_URL, data)
-                elif command == "unlabel":
-                    API_URL = f"{API_BASE}/labels/{'/'.join(values)}"
-                    for label in values:
-                        response = make_request("DELETE", f"{API_BASE}/labels/{label}")
-                elif command == "help":
-                    API_URL = f"{API_BASE}/comments"
-                    help_text = """### 🤖 Available Commands
-                | Command | Description |
-                |---------|-------------|
-                | `/assign user1 user2` | Assigns users to the PR |
-                | `/unassign user1 user2` | Removes assigned users |
-                | `/label bug feature` | Adds labels to the PR |
-                | `/unlabel bug feature` | Removes labels from the PR |
-                | `/help` | Shows this help message |
-                """
-                    response = make_request("POST", API_URL, {"body": help_text})
-                    print(f"✅ Posted help message")
-                    sys.exit(0)
-
-                if response and response.status_code in [200, 201, 204]:
-                    print(f"✅ Successfully processed {command}: {', '.join(values) if values else ''}")
-                else:
-                    print(f"❌ Failed to process {command}: {response.status_code if response else 'N/A'} - {response.text if response else 'N/A'}", file=sys.stderr)
-                    sys.exit(1)
+  params:
+    - name: trigger_comment
+      value: |
+        {{ trigger_comment }}
+    - name: repo_owner
+      value: "{{ repo_owner }}"
+    - name: repo_name
+      value: "{{ repo_name }}"
+    - name: pull_request_number
+      value: "{{ pull_request_number }}"
+    - name: git_auth_secret
+      value: "{{ git_auth_secret }}"
+    - name: pull_request_sender
+      value: "{{ body.issue.user.login }}"
+  pipelineRef:
+    name: prow-commands


### PR DESCRIPTION
We have now moved the pipeline the repository pipelines-as-code-prow.
This commit updates the prow pipeline to use the new location.
