### PR TITLE
Fix Default Branch Issue on GitOps Comment Event in Github

### DIFF
--- a/pkg/provider/github/parse_payload.go
+++ b/pkg/provider/github/parse_payload.go
@@ -429,8 +429,9 @@ func (v *Provider) handleCommitCommentEvent(ctx context.Context, event *github.C
 	runevent.TriggerTarget = triggertype.Push
 	opscomments.SetEventTypeAndTargetPR(runevent, event.GetComment().GetBody())
 
-	// Set main as default branch to runevent.HeadBranch, runevent.BaseBranch
-	runevent.HeadBranch, runevent.BaseBranch = "main", "main"
+	defaultBranch := event.GetRepo().GetDefaultBranch()
+	// Set Event.Repository.DefaultBranch as default branch to runevent.HeadBranch, runevent.BaseBranch
+	runevent.HeadBranch, runevent.BaseBranch = defaultBranch, defaultBranch
 	var (
 		branchName string
 		prName     string

--- a/pkg/provider/github/parse_payload_test.go
+++ b/pkg/provider/github/parse_payload_test.go
@@ -48,7 +48,7 @@ var sampleRepo = &github.Repository{
 		Login: github.Ptr("owner"),
 	},
 	Name:          github.Ptr("reponame"),
-	DefaultBranch: github.Ptr("defaultbranch"),
+	DefaultBranch: github.Ptr("main"),
 	HTMLURL:       github.Ptr("https://github.com/owner/repo"),
 }
 


### PR DESCRIPTION
Issue: when a user uses GitOps comment on pushed commit in Github, Head and Base branch is set as `main` in hardcoded string and considered default branch here but default could differ by repos like it could be `master` or `trunk` as well.

Fix: use Event.Repository.DefaultBranch field for Head and Base branch value in this case.

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [ ] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [ ] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [ ] 📖 Document any user-facing features or changes in behavior.

- [ ] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [ ] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [ ] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

| Git Provider     | Supported |
|------------------|-----------|
| GitHub App       | ✅️        |
| GitHub Webhook   | ❌️        |
| Gitea            | ❌️        |
| GitLab           | ❌️        |
| Bitbucket Cloud  | ❌️        |
| Bitbucket Server | ❌️        |

  (update the documentation accordingly)
