### PR TITLE
test: add unit tests for IOStreams package

### DIFF
--- a/pkg/cli/iostreams_test.go
+++ b/pkg/cli/iostreams_test.go
@@ -1,0 +1,93 @@
+package cli
+
+import (
+	"os"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestNewIOStreams(t *testing.T) {
+	ios := NewIOStreams()
+	assert.Assert(t, ios != nil)
+	assert.Assert(t, ios.In != nil)
+	assert.Assert(t, ios.Out != nil)
+	assert.Assert(t, ios.ErrOut != nil)
+}
+
+func TestIOStreams_ColorEnabled(t *testing.T) {
+	ios := &IOStreams{colorEnabled: true}
+	assert.Equal(t, ios.ColorEnabled(), true)
+
+	ios.SetColorEnabled(false)
+	assert.Equal(t, ios.ColorEnabled(), false)
+}
+
+func TestIOStreams_ColorSupport256(t *testing.T) {
+	ios := &IOStreams{is256enabled: true}
+	assert.Equal(t, ios.ColorSupport256(), true)
+
+	ios.is256enabled = false
+	assert.Equal(t, ios.ColorSupport256(), false)
+}
+
+func TestIOStreams_IsStdoutTTY(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func() *IOStreams
+		expected bool
+	}{
+		{
+			name: "with override true",
+			setup: func() *IOStreams {
+				ios := &IOStreams{}
+				ios.SetStdoutTTY(true)
+				return ios
+			},
+			expected: true,
+		},
+		{
+			name: "with override false",
+			setup: func() *IOStreams {
+				ios := &IOStreams{}
+				ios.SetStdoutTTY(false)
+				return ios
+			},
+			expected: false,
+		},
+		{
+			name: "with actual file",
+			setup: func() *IOStreams {
+				return &IOStreams{Out: os.Stdout}
+			},
+			expected: isTerminal(os.Stdout),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ios := tt.setup()
+			assert.Equal(t, ios.IsStdoutTTY(), tt.expected)
+		})
+	}
+}
+
+func TestIOTest(t *testing.T) {
+	ios, in, out, errOut := IOTest()
+	assert.Assert(t, ios != nil)
+	assert.Assert(t, in != nil)
+	assert.Assert(t, out != nil)
+	assert.Assert(t, errOut != nil)
+
+	// Test writing to streams
+	testData := []byte("test")
+	n, err := out.Write(testData)
+	assert.NilError(t, err)
+	assert.Equal(t, n, len(testData))
+	assert.DeepEqual(t, out.Bytes(), testData)
+
+	n, err = errOut.Write(testData)
+	assert.NilError(t, err)
+	assert.Equal(t, n, len(testData))
+	assert.DeepEqual(t, errOut.Bytes(), testData)
+}


### PR DESCRIPTION
Add comprehensive unit tests for the IOStreams package covering core functionality:
- Stream initialization and nil checks
- Color support and TTY detection
- Stream writing capabilities
- Test helper functions validation

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [ ] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [ ] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [ ] 📖 Document any user-facing features or changes in behavior.

- [ ] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [ ] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [ ] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

| Git Provider     | Supported |
|------------------|-----------|
| GitHub App       | ✅️        |
| GitHub Webhook   | ❌️        |
| Gitea            | ❌️        |
| GitLab           | ❌️        |
| Bitbucket Cloud  | ❌️        |
| Bitbucket Server | ❌️        |

  (update the documentation accordingly)
