### PR TITLE
fix: strip spaces and newlines from the comment before matching

### DIFF
--- a/docs/content/docs/guide/gitops_commands.md
+++ b/docs/content/docs/guide/gitops_commands.md
@@ -102,9 +102,9 @@ grep "string" /tmp/comment
 
 ## Custom GitOps Commands
 
-Using the [on-comment]({{< relref "/docs/guide/matchingevents.md#matching-a-pipelinerun-on-a-regexp-in-a-comment" >}}) annotation on your `PipelineRun`, you can define custom GitOps commands that will be triggered by comments on the Pull Request.
+Using the [on-comment]({{< relref "/docs/guide/matchingevents.md#matching-a-pipelinerun-on-a-regex-in-a-comment" >}}) annotation on your `PipelineRun`, you can define custom GitOps commands that will be triggered by comments on the Pull Request.
 
-See the [on-comment]({{< relref "/docs/guide/matchingevents.md#matching-a-pipelinerun-on-a-regexp-in-a-comment" >}}) guide for more detailed information.
+See the [on-comment]({{< relref "/docs/guide/matchingevents.md#matching-a-pipelinerun-on-a-regex-in-a-comment" >}}) guide for more detailed information.
 
 For a complete example, you can see how Pipelines-as-Code's own repo implemented some prow comments via the `on-comment` annotation:
 

--- a/docs/content/docs/guide/matchingevents.md
+++ b/docs/content/docs/guide/matchingevents.md
@@ -175,18 +175,26 @@ and you have a `Pull Request` changing the files `.tekton/pipelinerun.yaml`,
 `on-path-change-ignore` annotation will ignore the `***.md` and `***.yaml`
 files.
 
-## Matching a PipelineRun on a Regexp in a comment
+## Matching a PipelineRun on a Regex in a comment
 
-{{< tech_preview "Matching PipelineRun on regexp in comments" >}}
+{{< tech_preview "Matching PipelineRun on regex in comments" >}}
 {{< support_matrix github_app="true" github_webhook="true" gitea="true" gitlab="true" bitbucket_cloud="false" bitbucket_server="false" >}}
 
-You can match a PipelineRun on a comment on a Pull Request or a [Pushed Commit]({{< relref "/docs/guide/running.md#gitops-commands-on-pushed-commits">}})
-with the annotation `pipelinesascode.tekton.dev/on-comment`.
+You can trigger a PipelineRun based on a comment on a Pull Request or a [Pushed
+Commit]({{< relref
+"/docs/guide/running.md#gitops-commands-on-pushed-commits">}}) using the
+annotation `pipelinesascode.tekton.dev/on-comment`.
 
-The comment is a regexp and if a newly created comment has this regexp it will
-automatically match the PipelineRun and start it.
+The comment is treated as a regular expression (regex). The spaces and newlines
+are stripped at the beginning or the end of the comment before matching so `^`
+will match the beginning of the comment and `$` will match the end of the
+comment without newlines or space.
 
-For example:
+If a new comment on a Pull Request matches the specified regex, the PipelineRun
+will be triggered and started. This only applies to newly created comments;
+updates or edits to existing comments will not trigger the PipelineRun.
+
+Example:
 
 ```yaml
 ---
@@ -198,23 +206,23 @@ metadata:
     pipelinesascode.tekton.dev/on-comment: "^/merge-pr"
 ```
 
-This will match the merge-pr `PipelineRun` when a comment on a pull request
+This will trigger the merge-pr PipelineRun when a comment on a pull request
 starts with `/merge-pr`.
 
-When the PipelineRun that has been triggered with the `on-comment` annotation
-gets started, the template variable `{{ trigger_comment }}` gets set. See the
-documentation [here]({{< relref "/docs/guide/gitops_commands.md#accessing-the-comment-triggering-the-pipelinerun" >}})
+When a PipelineRun is getting triggered by the `on-comment` annotation starts,
+the template variable {{ trigger_comment }} is set. For more details, refer to
+the [documentation]({{< relref
+"/docs/guide/gitops_commands.md#accessing-the-comment-triggering-the-pipelinerun"
+>}}).
 
-Note that the `on-comment` annotation will respect the `pull_request` [Policy]({{< relref "/docs/guide/policy" >}}) rule,
-so only users in the `pull_request` policy will be able to trigger the
-PipelineRun.
+Note that the on-comment annotation adheres to the pull_request [Policy]({{<
+relref "/docs/guide/policy" >}}) rule. Only users specified in the pull_request
+policy will be able to trigger the PipelineRun.
 
 {{< hint info >}}
-
-- The `on-comment` annotation is supported on `pull_request`. On  `push` events,
-it is only supported [when targeting the main branch without arguments]({{< relref
-"/docs/guide/gitops_commands.md#gitops-commands-on-pushed-commits" >}}).
-
+The on-comment annotation is supported for pull_request events. For push events,
+it is only supported [when targeting the main branch without arguments]({{<
+relref "/docs/guide/gitops_commands.md#gitops-commands-on-pushed-commits" >}}).
 {{< /hint >}}
 
 ## Matching PipelineRun to a Pull Request labels
@@ -304,7 +312,7 @@ You can find more information about the CEL language spec here:
 <https://github.com/google/cel-spec/blob/master/doc/langdef.md>
 {{< /hint >}}
 
-### Matching a PipelineRun to a branch with a regexp
+### Matching a PipelineRun to a branch with a regex
 
 In a CEL expression, you can match a field name using a regular expression. For
 example, if you want to trigger a `PipelineRun` for the`pull_request` event and

--- a/pkg/matcher/annotation_matcher.go
+++ b/pkg/matcher/annotation_matcher.go
@@ -204,7 +204,10 @@ func MatchPipelinerunByAnnotation(ctx context.Context, logger *zap.SugaredLogger
 				logger.Warnf("could not compile regexp %s from pipelineRun %s", targetComment, prName)
 				continue
 			}
-			if re.MatchString(event.TriggerComment) {
+
+			strippedComment := strings.TrimSpace(
+				strings.TrimPrefix(strings.TrimSuffix(event.TriggerComment, "\r\n"), "\r\n"))
+			if re.MatchString(strippedComment) {
 				event.EventType = opscomments.OnCommentEventType.String()
 				logger.Infof("matched pipelinerun with name: %s on gitops comment: %q", prName, event.TriggerComment)
 				matchedPRs = append(matchedPRs, prMatch)

--- a/pkg/matcher/annotation_matcher_test.go
+++ b/pkg/matcher/annotation_matcher_test.go
@@ -1520,7 +1520,7 @@ func TestMatchPipelinerunByAnnotation(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "pipeline-on-comment",
 			Annotations: map[string]string{
-				keys.OnComment: "^/hello-world",
+				keys.OnComment: "^/hello-world$",
 			},
 		},
 	}
@@ -1690,7 +1690,7 @@ func TestMatchPipelinerunByAnnotation(t *testing.T) {
 			args: args{
 				pruns: []*tektonv1.PipelineRun{pipelineGood, pipelineOnComment},
 				runevent: info.Event{
-					TriggerComment: "/hello-world",
+					TriggerComment: "   /hello-world   \r\n",
 					TriggerTarget:  "pull_request",
 					EventType:      opscomments.OnCommentEventType.String(),
 					BaseBranch:     "main",


### PR DESCRIPTION
We are now stripping spaces and newlines from the beginning and the end to make sure that the regex matches correctly. The ^ will match the beginning of the comment and $ will match the end of the comment without newlines or space.

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [ ] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [ ] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [ ] 📖 Document any user-facing features or changes in behavior.

- [ ] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [ ] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [ ] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

  (update the documentation accordingly)
