### PR TITLE
fix handle multiline trigger comment var properly

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -115,7 +115,6 @@ linters:
     - stylecheck
     - tagalign
     #- tagliatelle
-    - tenv
     - testableexamples
     # - testifylint
     #- testpackage

--- a/docs/content/docs/guide/gitops_commands.md
+++ b/docs/content/docs/guide/gitops_commands.md
@@ -31,7 +31,7 @@ Roses are red, violets are blue. Pipelines are bound to flake by design.
 
 {{< hint info >}}
 
-Please be aware that GitOps commands such as `/test` and others will not function on closed Pull Requests or Merge Requests.  
+Please be aware that GitOps commands such as `/test` and others will not function on closed Pull Requests or Merge Requests.
 
 {{< /hint >}}
 
@@ -87,20 +87,44 @@ The PipelineRun will be restarted regardless of the annotations if the comment `
 
 ## Accessing the Comment Triggering the PipelineRun
 
-When you trigger a PipelineRun via a GitOps Command, the template variable `{{ trigger_comment }}` is set to the actual comment that triggered it.
+When you trigger a PipelineRun via a GitOps Command, the template variable `{{
+trigger_comment }}` is set to the actual comment that triggered it.
 
-You can then perform actions based on the comment content with a shell script or other methods.
+You can then perform actions based on the comment content with a shell script
+or other methods.
 
-There is a restriction with the `trigger_comment` variable: we modify it to replace newlines with `\n` since multi-line comments can cause issues when replaced inside the YAML.
+Expanding `{{ trigger_comment }}` in YAML can break parsing if the comment
+contains newlines. For example, a GitHub comment like:
 
-It is up to you to replace it back with newlines. For example, with shell scripts, you can use `echo -e` to expand the newline back.
+```console
+/help
 
-Example of a shell script:
+This is a test.
+```
+
+Expands to:
+
+```yaml
+params:
+  - name: trigger_comment
+    value: "/help
+
+This is a test."
+```
+
+The empty line makes the YAML invalid. To prevent this, we replace `\r\n` with
+`\n` to ensure proper formatting.
+
+You can restore the newlines in your task as needed.
+
+For example, in a shell script, use `echo -e` to expand `\n` back into actual newlines:
 
 ```shell
 echo -e "{{ trigger_comment }}" > /tmp/comment
-grep "string" /tmp/comment
+grep "/help" /tmp/comment # will output only /help
 ```
+
+This ensures the comment is correctly formatted when processed.
 
 ## Custom GitOps Commands
 

--- a/pkg/customparams/standard.go
+++ b/pkg/customparams/standard.go
@@ -33,7 +33,7 @@ func (p *CustomParams) makeStandardParamsFromEvent(ctx context.Context) (map[str
 		repoURL = p.event.CloneURL
 	}
 	changedFiles := p.getChangedFiles(ctx)
-	triggerCommentAsSingleLine := strings.ReplaceAll(p.event.TriggerComment, "\n", "\\n")
+	triggerCommentAsSingleLine := strings.ReplaceAll(strings.ReplaceAll(p.event.TriggerComment, "\r\n", "\\n"), "\n", "\\n")
 	pullRequestLabels := strings.Join(p.event.PullRequestLabel, "\\n")
 
 	return map[string]string{

--- a/pkg/customparams/standard_test.go
+++ b/pkg/customparams/standard_test.go
@@ -12,71 +12,157 @@ import (
 )
 
 func TestMakeStandardParamsFromEvent(t *testing.T) {
-	event := &info.Event{
-		SHA:              "1234567890",
-		Organization:     "Org",
-		Repository:       "Repo",
-		BaseBranch:       "main",
-		HeadBranch:       "foo",
-		EventType:        "pull_request",
-		Sender:           "SENDER",
-		URL:              "https://paris.com",
-		HeadURL:          "https://india.com",
-		TriggerComment:   "/test me\nHelp me obiwan kenobi",
-		PullRequestLabel: []string{"bugs", "enhancements"},
-	}
-
-	result := map[string]string{
-		"event_type":          "pull_request",
-		"repo_name":           "repo",
-		"repo_owner":          "org",
-		"repo_url":            "https://paris.com",
-		"source_url":          "https://india.com",
-		"revision":            "1234567890",
-		"sender":              "sender",
-		"source_branch":       "foo",
-		"target_branch":       "main",
-		"target_namespace":    "myns",
-		"trigger_comment":     "/test me\\nHelp me obiwan kenobi",
-		"pull_request_labels": "bugs\\nenhancements",
-	}
-
-	repo := &v1alpha1.Repository{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "myname",
-			Namespace: "myns",
+	tests := []struct {
+		name    string
+		event   *info.Event
+		repo    *v1alpha1.Repository
+		want    map[string]string
+		wantVCX *testprovider.TestProviderImp
+	}{
+		{
+			name: "basic event test",
+			event: &info.Event{
+				SHA:              "1234567890",
+				Organization:     "Org",
+				Repository:       "Repo",
+				BaseBranch:       "main",
+				HeadBranch:       "foo",
+				EventType:        "pull_request",
+				Sender:           "SENDER",
+				URL:              "https://paris.com",
+				HeadURL:          "https://india.com",
+				TriggerComment:   "\n/test me\nHelp me obiwan kenobi\r\n\r\n\r\nTo test or not to test, is the question?\n\n\n",
+				PullRequestLabel: []string{"bugs", "enhancements"},
+			},
+			repo: &v1alpha1.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "myname",
+					Namespace: "myns",
+				},
+			},
+			want: map[string]string{
+				"event_type":          "pull_request",
+				"repo_name":           "repo",
+				"repo_owner":          "org",
+				"repo_url":            "https://paris.com",
+				"source_url":          "https://india.com",
+				"revision":            "1234567890",
+				"sender":              "sender",
+				"source_branch":       "foo",
+				"target_branch":       "main",
+				"target_namespace":    "myns",
+				"trigger_comment":     `\n/test me\nHelp me obiwan kenobi\n\n\nTo test or not to test, is the question?\n\n\n`,
+				"pull_request_labels": "bugs\\nenhancements",
+			},
+			wantVCX: &testprovider.TestProviderImp{
+				WantAllChangedFiles: []string{"added.go", "deleted.go", "modified.go", "renamed.go"},
+				WantAddedFiles:      []string{"added.go"},
+				WantDeletedFiles:    []string{"deleted.go"},
+				WantModifiedFiles:   []string{"modified.go"},
+				WantRenamedFiles:    []string{"renamed.go"},
+			},
+		},
+		{
+			name: "basic event test",
+			event: &info.Event{
+				SHA:              "1234567890",
+				Organization:     "Org",
+				Repository:       "Repo",
+				BaseBranch:       "main",
+				HeadBranch:       "foo",
+				EventType:        "pull_request",
+				Sender:           "SENDER",
+				URL:              "https://paris.com",
+				HeadURL:          "https://india.com",
+				TriggerComment:   "/test me\nHelp me obiwan kenobi",
+				PullRequestLabel: []string{"bugs", "enhancements"},
+			},
+			repo: &v1alpha1.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "myname",
+					Namespace: "myns",
+				},
+			},
+			want: map[string]string{
+				"event_type":          "pull_request",
+				"repo_name":           "repo",
+				"repo_owner":          "org",
+				"repo_url":            "https://paris.com",
+				"source_url":          "https://india.com",
+				"revision":            "1234567890",
+				"sender":              "sender",
+				"source_branch":       "foo",
+				"target_branch":       "main",
+				"target_namespace":    "myns",
+				"trigger_comment":     "/test me\\nHelp me obiwan kenobi",
+				"pull_request_labels": "bugs\\nenhancements",
+			},
+			wantVCX: &testprovider.TestProviderImp{
+				WantAllChangedFiles: []string{"added.go", "deleted.go", "modified.go", "renamed.go"},
+				WantAddedFiles:      []string{"added.go"},
+				WantDeletedFiles:    []string{"deleted.go"},
+				WantModifiedFiles:   []string{"modified.go"},
+				WantRenamedFiles:    []string{"renamed.go"},
+			},
+		},
+		{
+			name: "event with different clone URL",
+			event: &info.Event{
+				SHA:              "1234567890",
+				Organization:     "Org",
+				Repository:       "Repo",
+				BaseBranch:       "main",
+				HeadBranch:       "foo",
+				EventType:        "pull_request",
+				Sender:           "SENDER",
+				URL:              "https://paris.com",
+				HeadURL:          "https://india.com",
+				TriggerComment:   "/test me\nHelp me obiwan kenobi",
+				PullRequestLabel: []string{"bugs", "enhancements"},
+				CloneURL:         "https://blahblah",
+			},
+			repo: &v1alpha1.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "myname",
+					Namespace: "myns",
+				},
+			},
+			want: map[string]string{
+				"event_type":          "pull_request",
+				"repo_name":           "repo",
+				"repo_owner":          "org",
+				"repo_url":            "https://blahblah",
+				"source_url":          "https://india.com",
+				"revision":            "1234567890",
+				"sender":              "sender",
+				"source_branch":       "foo",
+				"target_branch":       "main",
+				"target_namespace":    "myns",
+				"trigger_comment":     "/test me\\nHelp me obiwan kenobi",
+				"pull_request_labels": "bugs\\nenhancements",
+			},
+			wantVCX: &testprovider.TestProviderImp{
+				WantAllChangedFiles: []string{"added.go", "deleted.go", "modified.go", "renamed.go"},
+				WantAddedFiles:      []string{"added.go"},
+				WantDeletedFiles:    []string{"deleted.go"},
+				WantModifiedFiles:   []string{"modified.go"},
+				WantRenamedFiles:    []string{"renamed.go"},
+			},
 		},
 	}
 
-	ctx, _ := rectesting.SetupFakeContext(t)
-	vcx := &testprovider.TestProviderImp{
-		WantAllChangedFiles: []string{"added.go", "deleted.go", "modified.go", "renamed.go"},
-		WantAddedFiles:      []string{"added.go"},
-		WantDeletedFiles:    []string{"deleted.go"},
-		WantModifiedFiles:   []string{"modified.go"},
-		WantRenamedFiles:    []string{"renamed.go"},
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rectesting.SetupFakeContext(t)
+			p := NewCustomParams(tt.event, tt.repo, nil, nil, nil, tt.wantVCX)
+			params, changedFiles := p.makeStandardParamsFromEvent(ctx)
+
+			assert.DeepEqual(t, params, tt.want)
+			assert.DeepEqual(t, changedFiles["all"], tt.wantVCX.WantAllChangedFiles)
+			assert.DeepEqual(t, changedFiles["added"], tt.wantVCX.WantAddedFiles)
+			assert.DeepEqual(t, changedFiles["deleted"], tt.wantVCX.WantDeletedFiles)
+			assert.DeepEqual(t, changedFiles["modified"], tt.wantVCX.WantModifiedFiles)
+			assert.DeepEqual(t, changedFiles["renamed"], tt.wantVCX.WantRenamedFiles)
+		})
 	}
-
-	p := NewCustomParams(event, repo, nil, nil, nil, vcx)
-	params, changedFiles := p.makeStandardParamsFromEvent(ctx)
-	assert.DeepEqual(t, params, result)
-	assert.DeepEqual(t, changedFiles["all"], vcx.WantAllChangedFiles)
-	assert.DeepEqual(t, changedFiles["added"], vcx.WantAddedFiles)
-	assert.DeepEqual(t, changedFiles["deleted"], vcx.WantDeletedFiles)
-	assert.DeepEqual(t, changedFiles["modified"], vcx.WantModifiedFiles)
-	assert.DeepEqual(t, changedFiles["renamed"], vcx.WantRenamedFiles)
-
-	nevent := &info.Event{}
-	event.DeepCopyInto(nevent)
-	nevent.CloneURL = "https://blahblah"
-	p.event = nevent
-	nparams, nchangedFiles := p.makeStandardParamsFromEvent(ctx)
-	result["repo_url"] = nevent.CloneURL
-	assert.DeepEqual(t, nparams, result)
-
-	assert.DeepEqual(t, nchangedFiles["all"], vcx.WantAllChangedFiles)
-	assert.DeepEqual(t, nchangedFiles["added"], vcx.WantAddedFiles)
-	assert.DeepEqual(t, nchangedFiles["deleted"], vcx.WantDeletedFiles)
-	assert.DeepEqual(t, nchangedFiles["modified"], vcx.WantModifiedFiles)
-	assert.DeepEqual(t, nchangedFiles["renamed"], vcx.WantRenamedFiles)
 }

--- a/pkg/templates/templating.go
+++ b/pkg/templates/templating.go
@@ -71,44 +71,48 @@ func ReplacePlaceHoldersVariables(template string, dico map[string]string, rawEv
 					if v, ok := val.Value().(string); ok {
 						b = []byte(v)
 					}
-				case types.Bytes:
+
+				case types.Bytes, types.Double, types.Int:
 					raw, err = val.ConvertToNative(structType)
 					if err == nil {
-						b, err = raw.(*structpb.Value).MarshalJSON()
-						if err != nil {
-							b = []byte{}
+						if structVal, ok := raw.(*structpb.Value); ok {
+							b, err = structVal.MarshalJSON()
+							if err != nil {
+								b = []byte{}
+							}
 						}
 					}
-				case types.Double, types.Int:
-					raw, err = val.ConvertToNative(structType)
-					if err == nil {
-						b, err = raw.(*structpb.Value).MarshalJSON()
-						if err != nil {
-							b = []byte{}
-						}
-					}
+
 				case traits.Lister:
 					raw, err = val.ConvertToNative(listType)
 					if err == nil {
-						s, err := protojson.Marshal(raw.(proto.Message))
-						if err == nil {
-							b = s
+						if msg, ok := raw.(proto.Message); ok {
+							b, err = protojson.Marshal(msg)
+							if err != nil {
+								b = []byte{}
+							}
 						}
 					}
+
 				case traits.Mapper:
 					raw, err = val.ConvertToNative(mapType)
 					if err == nil {
-						s, err := protojson.Marshal(raw.(proto.Message))
-						if err == nil {
-							b = s
+						if msg, ok := raw.(proto.Message); ok {
+							b, err = protojson.Marshal(msg)
+							if err != nil {
+								b = []byte{}
+							}
 						}
 					}
+
 				case types.Bool:
 					raw, err = val.ConvertToNative(structType)
 					if err == nil {
-						b, err = json.Marshal(raw.(*structpb.Value).GetBoolValue())
-						if err != nil {
-							b = []byte{}
+						if structVal, ok := raw.(*structpb.Value); ok {
+							b, err = json.Marshal(structVal.GetBoolValue())
+							if err != nil {
+								b = []byte{}
+							}
 						}
 					}
 

--- a/test/gitea_gitops_commands_test.go
+++ b/test/gitea_gitops_commands_test.go
@@ -70,7 +70,7 @@ func TestGiteaOnCommentAnnotation(t *testing.T) {
 			},
 		},
 	}
-	triggerComment := "/hello-world"
+	triggerComment := "/hello-world\r\n\r\n"
 	topts.TargetNS = topts.TargetRefName
 	topts.ParamsRun, topts.Opts, topts.GiteaCNX, err = tgitea.Setup(ctx)
 	assert.NilError(t, err, fmt.Errorf("cannot do gitea setup: %w", err))
@@ -108,8 +108,9 @@ func TestGiteaOnCommentAnnotation(t *testing.T) {
 	assert.Equal(t, *repo.Status[len(repo.Status)-1].EventType, opscomments.OnCommentEventType.String(), "should have a on comment event type")
 
 	last := repo.Status[len(repo.Status)-1]
-	err = twait.RegexpMatchingInPodLog(context.Background(), topts.ParamsRun, topts.TargetNS, fmt.Sprintf("tekton.dev/pipelineRun=%s", last.PipelineRunName), "step-task", *regexp.MustCompile(triggerComment), "", 2)
-	assert.NilError(t, err)
+	twait.GoldenPodLog(context.Background(), t, topts.ParamsRun, topts.TargetNS,
+		fmt.Sprintf("tekton.dev/pipelineRun=%s", last.PipelineRunName),
+		"step-task", strings.ReplaceAll(fmt.Sprintf("%s-pipelinerun-on-comment-annotation.golden", t.Name()), "/", "-"), 2)
 
 	tgitea.PostCommentOnPullRequest(t, topts, fmt.Sprintf(`%s revision=main custom1=thisone custom2="another one" custom3="a \"quote\""`, triggerComment))
 	waitOpts.MinNumberStatus = 4

--- a/test/testdata/TestGiteaOnCommentAnnotation-pipelinerun-on-comment-annotation.golden
+++ b/test/testdata/TestGiteaOnCommentAnnotation-pipelinerun-on-comment-annotation.golden
@@ -1,0 +1,6 @@
+The comment is:
+/hello-world\n\n
+The event is on-comment
+The custom1 value is foo
+The custom2 value is bar
+The custom3 value is moto

--- a/test/testdata/TestGiteaOnCommentAnnotation.golden
+++ b/test/testdata/TestGiteaOnCommentAnnotation.golden
@@ -1,7 +1,6 @@
 The comment is:
-/hello-world revision=main custom1=thisone custom2="another one" custom3="a \"quote\""
+/hello-world\n\n revision=main custom1=thisone custom2="another one" custom3="a \"quote\""
 The event is on-comment
-The revision is main
 The custom1 value is thisone
 The custom2 value is another one
 The custom3 value is a quote

--- a/test/testdata/pipelinerun-on-comment-annotation.yaml
+++ b/test/testdata/pipelinerun-on-comment-annotation.yaml
@@ -21,7 +21,6 @@ spec:
                 {{ trigger_comment }}
                 EOF
                 echo "The event is {{ event_type }}"
-                echo "The revision is {{ revision }}"
                 echo "The custom1 value is {{ custom1 }}"
                 echo "The custom2 value is {{ custom2 }}"
                 echo "The custom3 value is {{ custom3 }}"


### PR DESCRIPTION
# Submitter Checklist

- **fix handle multiline trigger_comment var properly**
  When using `{{ trigger_comment }}` in a PipelineRun YAML, GitHub
  comments containing newlines (e.g., `/help`) can break YAML parsing due
  to improper expansion.
  
  This change replaces `\r\n` with `\n` in `trigger_comment`, similar to
  how  we did for only \n previously are handled. This ensures valid YAML
  formatting and avoids parser errors.
  
  Fixes #1929
  
- [x] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).
  
- [x] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.
   
- [x] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).
   
- [x] 📖 Document any user-facing features or changes in behavior.
   
- [x] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.
   
- [x] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.
   
- [x] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

| Git Provider     | Supported |
|------------------|-----------|
| GitHub App       | ✅️        |
| GitHub Webhook   | ✅️        |
| Gitea            | ✅️        |
| GitLab           | ✅️        |
| Bitbucket Cloud  | ✅️        |
| Bitbucket Server | ✅️        |

