### PR TITLE
Fix error with ko when building ko image on release

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -41,14 +41,12 @@ jobs:
           set -x
           releaseBranchFormat='release-v'
           if [[ ${{ github.ref_name }} == ${releaseBranchFormat}* ]]; then
-            tag="${${{ github.ref_name }}#*-}" 
+            tag=v$(echo ${{ github.ref_name }}|sed "s,${releaseBranchFormat},,")
           elif [[ ${{ github.ref }} == refs/pull/* ]]; then
             tag=pr-$(echo ${{ github.ref }} | cut -c11-|sed 's,/merge,,')
           else
             tag=$(echo ${{ github.ref_name }}|sed 's,/merge,,')
           fi
-
-
           for image in ./cmd/*;do
             ko build -B -t "${tag}" --platform="${{ env.PLATFORMS }}" "${image}"
           done


### PR DESCRIPTION
getting this error when releasing:

```
+ releaseBranchFormat=release-v
+ [[ release-v0.33.0 == release-v* ]]
+ tag='v0.33.0#*-'
+ for image in ./cmd/*
+ ko build -B -t 'v0.33.0#*-'
  --platform=linux/amd64,linux/arm64,linux/ppc64le
  ./cmd/pipelines-as-code-controller
2025/02/14 14:15:54 Using base
Error: failed to publish images: error publishing
tag can only contain the characters
`abcdefghijklmnopqrstuvwxyz0123456789_-.ABCDEFGHIJKLMNOPQRSTUVWXYZ`:
v0.33.0#*-
Error: Process completed with exit code 1.
```

Fixes #1935


