### PR TITLE
Fixed Error Message in Issue Comment and Commit Comment

### DIFF
--- a/pkg/provider/github/parse_payload.go
+++ b/pkg/provider/github/parse_payload.go
@@ -235,7 +235,8 @@ func (v *Provider) processEvent(ctx context.Context, event *info.Event, eventInt
 		return v.handleCheckSuites(ctx, gitEvent)
 	case *github.IssueCommentEvent:
 		if v.Client == nil {
-			return nil, fmt.Errorf("gitops style comments operation is only supported with github apps integration")
+			return nil, fmt.Errorf("no github client has been initialized, " +
+				"exiting... (hint: did you forget setting a secret on your repo?)")
 		}
 		if gitEvent.GetAction() != "created" {
 			return nil, fmt.Errorf("only newly created comment is supported, received: %s", gitEvent.GetAction())
@@ -246,7 +247,8 @@ func (v *Provider) processEvent(ctx context.Context, event *info.Event, eventInt
 		}
 	case *github.CommitCommentEvent:
 		if v.Client == nil {
-			return nil, fmt.Errorf("gitops style comments operation is only supported with github apps integration")
+			return nil, fmt.Errorf("no github client has been initialized, " +
+				"exiting... (hint: did you forget setting a secret on your repo?)")
 		}
 		processedEvent, err = v.handleCommitCommentEvent(ctx, gitEvent)
 		if err != nil {

--- a/pkg/provider/github/parse_payload_test.go
+++ b/pkg/provider/github/parse_payload_test.go
@@ -145,7 +145,7 @@ func TestParsePayLoad(t *testing.T) {
 		},
 		{
 			name:               "bad/issue comment retest only with github apps",
-			wantErrString:      "only supported with github apps",
+			wantErrString:      "no github client has been initialized",
 			eventType:          "issue_comment",
 			triggerTarget:      "pull_request",
 			payloadEventStruct: github.IssueCommentEvent{Action: github.Ptr("created")},
@@ -369,10 +369,37 @@ func TestParsePayLoad(t *testing.T) {
 		},
 		{
 			name:               "bad/commit comment retest only with github apps",
-			wantErrString:      "only supported with github apps",
+			wantErrString:      "no github client has been initialized",
 			eventType:          "commit_comment",
 			triggerTarget:      "push",
 			payloadEventStruct: github.CommitCommentEvent{Action: github.Ptr("created")},
+		},
+		{
+			name:               "bad/commit comment for event has no repository reference",
+			wantErrString:      "error parsing payload the repository should not be nil",
+			eventType:          "commit_comment",
+			triggerTarget:      "push",
+			githubClient:       true,
+			payloadEventStruct: github.CommitCommentEvent{},
+		},
+		{
+			name:          "bad/commit comment for /test command does not contain branch keyword",
+			wantErrString: "the GitOps comment dummy rbanch does not contain a branch word",
+			eventType:     "commit_comment",
+			triggerTarget: "push",
+			githubClient:  true,
+			payloadEventStruct: github.CommitCommentEvent{
+				Repo: sampleRepo,
+				Comment: &github.RepositoryComment{
+					CommitID: github.Ptr("samplePRsha"),
+					HTMLURL:  github.Ptr("/777"),
+					Body:     github.Ptr("/test dummy rbanch:test"), // rbanch is wrong word for branch 🙂
+				},
+			},
+			muxReplies:        map[string]interface{}{"/repos/owner/reponame/pulls/777": samplePR},
+			shaRet:            "samplePRsha",
+			targetPipelinerun: "dummy",
+			wantedBranchName:  "main",
 		},
 		{
 			name:          "good/commit comment for retest a pr",


### PR DESCRIPTION
when ParsePayload processes issue_comment and commit_comment events and checks for Client == nil, it shows wrong messsage which deviates understanding of reader so changed the message to good one and added uncovered unit tests.

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [x] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [x] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [x] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [ ] 📖 Document any user-facing features or changes in behavior.

- [x] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [ ] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [ ] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

| Git Provider     | Supported |
|------------------|-----------|
| GitHub App       | ✅️        |
| GitHub Webhook   | ✅️        |
| Gitea            | ❌️        |
| GitLab           | ❌️        |
| Bitbucket Cloud  | ❌️        |
| Bitbucket Server | ❌️        |

  (update the documentation accordingly)
