### PR TITLE
Correct Docs Typos About CEL Expression Annotation

### DIFF
--- a/docs/content/docs/guide/matchingevents.md
+++ b/docs/content/docs/guide/matchingevents.md
@@ -303,7 +303,7 @@ not the `experimental` branch you could have:
 
 ```yaml
 pipelinesascode.tekton.dev/on-cel-expression: |
-  event == "pull_request" && target_branch != experimental"
+  event == "pull_request" && target_branch != "experimental"
 ```
 
 {{< hint info >}}
@@ -385,9 +385,9 @@ For example, this expression when run on GitHub:
 
 ```yaml
 pipelinesascode.tekton.dev/on-cel-expression: |
-  body.pull_request.base.ref == "main" &&
-    body.pull_request.user.login == "superuser" &&
-    body.action == "synchronize"
+  "{{ body.pull_request.base.ref }}" == "main" &&
+    "{{ body.pull_request.user.login }}" == "superuser" &&
+    "{{ body.action }}" == "synchronize"
 ```
 
 will only match if the pull request is targeting the `main` branch, the author
@@ -430,7 +430,7 @@ For example, this is how to make sure the event is a pull_request on [GitHub](ht
 
 ```yaml
 pipelinesascode.tekton.dev/on-cel-expression: |
-  headers['x-github-event'] == "pull_request"
+  "{{ headers['x-github-event'] }}" == "pull_request"
 ```
 
 ## Matching a PipelineRun to a branch with a comma


### PR DESCRIPTION
corrected docs typos for on-cel-expression annotation. it was not specified in docs that when using body fields in PipelineRun definition, it should be wrapped with curly braces e.g. "{{ body.actor.name }}" so that PAC resolver could resolve it to its value.

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [ ] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [ ] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [ ] 📖 Document any user-facing features or changes in behavior.

- [ ] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [ ] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [ ] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

| Git Provider     | Supported |
|------------------|-----------|
| GitHub App       | ✅️        |
| GitHub Webhook   | ❌️        |
| Gitea            | ❌️        |
| GitLab           | ❌️        |
| Bitbucket Cloud  | ❌️        |
| Bitbucket Server | ❌️        |

  (update the documentation accordingly)
