### PR TITLE
misc(docs): add JSON template for default layout

### DIFF
--- a/docs/content/docs/guide/gitops_commands.md
+++ b/docs/content/docs/guide/gitops_commands.md
@@ -132,9 +132,14 @@ Using the [on-comment]({{< relref "/docs/guide/matchingevents.md#matching-a-pipe
 
 See the [on-comment]({{< relref "/docs/guide/matchingevents.md#matching-a-pipelinerun-on-a-regex-in-a-comment" >}}) guide for more detailed information.
 
-For a complete example, you can see how Pipelines-as-Code's own repo implemented some prow comments via the `on-comment` annotation:
+The `on-comment` annotation offers a powerful and flexible way to build a
+GitOps command system, letting you trigger specific actions based on comments
+made on a Pull Request.
 
-<https://github.com/openshift-pipelines/pipelines-as-code/blob/main/.tekton/prow.yaml>
+For a practical example, check out the related project
+[pac-boussole](https://github.com/openshift-pipelines/pac-boussole), which
+utilizes the `on-comment` annotation to create a PipelineRun experience similar
+to [Prow](https://docs.prow.k8s.io/).
 
 ## Cancelling a PipelineRun
 

--- a/docs/content/docs/guide/running.md
+++ b/docs/content/docs/guide/running.md
@@ -40,31 +40,7 @@ run a PipelineRun on CI:
 
 - The author of the pull request is listed in the `OWNERS` file located in the main
   directory of the default branch on GitHub or your other service provider.
-
-  The OWNERS file adheres to a specific format, similar to the Prow OWNERS
-  file format (available at <https://www.kubernetes.dev/docs/guide/owners/>). We
-  support simple OWNERS configuration including `approvers` and `reviewers` lists
-  and they are treated equally in terms of permissions for executing a PipelineRun.
-  If the OWNERS file includes `filters` instead of a simple OWNERS configuration,
-  we only look for the everything matching `.*` filter and take the `approvers`
-  and `reviewers` lists from there. All other filters (matching specific files or
-  directories) are ignored.
-
-  OWNERS_ALIASES is also supported and can be used for mapping of an alias name
-  to a list of usernames.
-
-  When you include contributors to the lists of `approvers` or `reviewers` in your
-  OWNERS files, Pipelines-as-Code enables those contributors to execute a PipelineRun.
-
-  For instance, if the `approvers` section of your OWNERS file in the main or
-  master branch of your repository appears as follows:
-
-  ```yaml
-  approvers:
-    - approved
-  ```
-
-  then the user with the username "approved" will be granted permission.
+(see below for the OWNERS file format).
 
 If the pull request author does not have the necessary permissions to run a
 PipelineRun, another user who does have the necessary permissions can comment
@@ -77,6 +53,35 @@ one of the repositories in a URL on a repository that belongs to the
 organization where the GitHub App has been installed. Otherwise, Pipelines as
 Code will not be triggered.
 {{< /hint >}}
+
+## OWNERS file
+
+The `OWNERS` file follows a specific format similar to the Prow `OWNERS` file
+format (detailed at <https://www.kubernetes.dev/docs/guide/owners/>). We
+support a basic `OWNERS` configuration with `approvers` and `reviewers` lists,
+both of which have equal permissions for executing a `PipelineRun`.  
+
+If the `OWNERS` file uses `filters` instead of a simple configuration, we only
+consider the `.*` filter and extract the `approvers` and `reviewers` lists from
+it. Any other filters targeting specific files or directories are ignored.  
+
+Additionally, `OWNERS_ALIASES` is supported and allows mapping alias names to
+lists of usernames.  
+
+Including contributors in the `approvers` or `reviewers` lists within your
+`OWNERS` file grants them the ability to execute a `PipelineRun` via
+Pipelines-as-Code.  
+
+For example, if your repository’s `main` or `master` branch contains the
+following `approvers` section:  
+
+```yaml
+approvers:
+  - approved
+```  
+
+The user with the username `"approved"` will have the necessary
+permissions.
 
 ## PipelineRun Execution
 

--- a/docs/layouts/_default/index.json
+++ b/docs/layouts/_default/index.json
@@ -1,0 +1,4 @@
+{
+  "title": "{{ .Title }}",
+  "description": "{{ .Description }}"
+}


### PR DESCRIPTION
Add a new JSON template file for the default layout in docs/ that will output structured data with title, description and content fields to build the site search functionality.

Rephrase a bit the gitops_commands about on-comment and prow like experience (which had a bad link).

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [ ] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [ ] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [ ] 📖 Document any user-facing features or changes in behavior.

- [ ] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [ ] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [ ] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

| Git Provider     | Supported |
|------------------|-----------|
| GitHub App       | ✅️        |
| GitHub Webhook   | ❌️        |
| Gitea            | ❌️        |
| GitLab           | ❌️        |
| Bitbucket Cloud  | ❌️        |
| Bitbucket Server | ❌️        |

  (update the documentation accordingly)
