### PR TITLE
chore: fix hack install script variable expansion, help message

### DIFF
--- a/hack/dev/kind/install.sh
+++ b/hack/dev/kind/install.sh
@@ -24,9 +24,10 @@ export KUBECONFIG=${HOME}/.kube/config.${KIND_CLUSTER_NAME}
 export TARGET=kubernetes
 export DOMAIN_NAME=paac-127-0-0-1.nip.io
 
-if [ -z "${TEST_GITEA_SMEEURL}" ]; then
+if [ -z "${TEST_GITEA_SMEEURL:-}" ]; then
   echo "You should forward the URL via smee, create a URL in there by going to https://hook.pipelinesascode.com"
-  echo "set it up as environement variable in the 'TEST_GITEA_SMEEURL=https://hook.pipelinesascode.com/XXXXXXXX' variable"
+  echo "set it up as environement variable in the \`TEST_GITEA_SMEEURL=https://hook.pipelinesascode.com/XXXXXXXX\` variable"
+  echo "Alternatively, use command: \`TEST_GITEA_SMEEURL=\$(curl https://hook.pipelinesascode.com -o=/dev/null -sw '%{redirect_url}')\`"
   exit 1
 fi
 if ! builtin type -p kind &>/dev/null; then


### PR DESCRIPTION
Fix the TEST_GITEA_SMEEURL variable presence test to expand correctly. Before this change, if `TEST_GITEA_SMEEURL` is not set, then the script will not enter the `if` block as expected and will instead exit with an `unbound variable` error because the script uses `set -u`

Additionally, since it's not strictly necessary to navigate to `hook.pipelinesascode.com` to get a URRL, this change adds a one-liner command to the help suggestion which will create a new hook URL and set it to the variable a the same time.


# Submitter Checklist

- [x] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [ ] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [x] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [ ] 📖 Document any user-facing features or changes in behavior.

- [ ] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [ ] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [ ] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

| Git Provider     | Supported |
|------------------|-----------|
| GitHub App       | ✅️        |
| GitHub Webhook   | ❌️        |
| Gitea            | ❌️        |
| GitLab           | ❌️        |
| Bitbucket Cloud  | ❌️        |
| Bitbucket Server | ❌️        |

  (update the documentation accordingly)
