### PR TITLE
Fix: PipelineRun Definition Fetching Issue When Provenance is Set in GitLab

### DIFF
--- a/pkg/provider/gitlab/acl_test.go
+++ b/pkg/provider/gitlab/acl_test.go
@@ -108,7 +108,7 @@ func TestIsAllowed(t *testing.T) {
 					thelp.MuxDisallowUserID(mux, tt.fields.targetProjectID, tt.allowMemberID)
 				}
 				if tt.ownerFile != "" {
-					thelp.MuxGetFile(mux, tt.fields.targetProjectID, "OWNERS", tt.ownerFile)
+					thelp.MuxGetFile(mux, tt.fields.targetProjectID, "OWNERS", tt.ownerFile, false)
 				}
 				if tt.commentContent != "" {
 					thelp.MuxDiscussionsNote(mux, tt.fields.targetProjectID,

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -291,16 +291,16 @@ func (v *Provider) GetTektonDir(_ context.Context, event *info.Event, path, prov
 		}
 	}
 
-	return v.concatAllYamlFiles(nodes, event)
+	return v.concatAllYamlFiles(nodes, revision)
 }
 
 // concatAllYamlFiles concat all yaml files from a directory as one big multi document yaml string.
-func (v *Provider) concatAllYamlFiles(objects []*gitlab.TreeNode, runevent *info.Event) (string, error) {
+func (v *Provider) concatAllYamlFiles(objects []*gitlab.TreeNode, revision string) (string, error) {
 	var allTemplates string
 	for _, value := range objects {
 		if strings.HasSuffix(value.Name, ".yaml") ||
 			strings.HasSuffix(value.Name, ".yml") {
-			data, _, err := v.getObject(value.Path, runevent.HeadBranch, v.sourceProjectID)
+			data, _, err := v.getObject(value.Path, revision, v.sourceProjectID)
 			if err != nil {
 				return "", err
 			}

--- a/pkg/provider/gitlab/gitlab_test.go
+++ b/pkg/provider/gitlab/gitlab_test.go
@@ -292,6 +292,8 @@ func TestGetTektonDir(t *testing.T) {
 		args                 args
 		wantStr              string
 		wantErr              string
+		wantTreeAPIErr       bool
+		wantFilesAPIErr      bool
 		wantClient           bool
 		prcontent            string
 		filterMessageSnippet string
@@ -365,6 +367,38 @@ func TestGetTektonDir(t *testing.T) {
 			wantClient: true,
 			wantStr:    "kind: PipelineRun",
 		},
+		{
+			name:      "list tekton dir tree api call error",
+			prcontent: strings.TrimPrefix(string(samplePR), "---"),
+			args: args{
+				path: ".tekton",
+				event: &info.Event{
+					HeadBranch: "main",
+				},
+			},
+			fields: fields{
+				sourceProjectID: 100,
+			},
+			wantClient:     true,
+			wantTreeAPIErr: true,
+			wantErr:        "failed to list .tekton dir",
+		},
+		{
+			name:      "get file raw api call error",
+			prcontent: strings.TrimPrefix(string(samplePR), "---"),
+			args: args{
+				path: ".tekton",
+				event: &info.Event{
+					HeadBranch: "main",
+				},
+			},
+			fields: fields{
+				sourceProjectID: 100,
+			},
+			wantClient:      true,
+			wantFilesAPIErr: true,
+			wantErr:         "failed to get filename from api pr.yaml dir",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -386,7 +420,7 @@ func TestGetTektonDir(t *testing.T) {
 					muxbranch = tt.args.event.DefaultBranch
 				}
 				if tt.args.path != "" && tt.prcontent != "" {
-					thelp.MuxListTektonDir(t, mux, tt.fields.sourceProjectID, muxbranch, tt.prcontent)
+					thelp.MuxListTektonDir(t, mux, tt.fields.sourceProjectID, muxbranch, tt.prcontent, tt.wantTreeAPIErr, tt.wantFilesAPIErr)
 				}
 				defer tearDown()
 			}
@@ -421,7 +455,7 @@ func TestGetFileInsideRepo(t *testing.T) {
 		sourceProjectID: 10,
 		Client:          client,
 	}
-	thelp.MuxListTektonDir(t, mux, v.sourceProjectID, event.HeadBranch, content)
+	thelp.MuxListTektonDir(t, mux, v.sourceProjectID, event.HeadBranch, content, false, false)
 	got, err := v.GetFileInsideRepo(ctx, event, "pr.yaml", "")
 	assert.NilError(t, err)
 	assert.Equal(t, content, got)


### PR DESCRIPTION
Issue: In GitLab, when provenance is set to default_branch, the API call to get .tekton directory tree is correct and fetching the tree as per provenance but when each is file is fetched as raw its using `source` as provenance no matter what value has been set in Repository CR.

Solution: This pull request use revision correctly in concatAllYamlFiles func to make it obey provenance settings.

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [x] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [x] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [x] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [x] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- If adding a provider feature, fill in the following details:

| Git Provider     | Supported |
|------------------|-----------|
| GitHub App       | ❌️        |
| GitHub Webhook   | ❌️        |
| Gitea            | ❌️        |
| GitLab           | ✅️        |
| Bitbucket Cloud  | ❌️        |
| Bitbucket Server | ❌️        |

  (update the documentation accordingly)
