### PR TITLE
fix: Cancel PipelineRuns on MR change in Gitlab

### DIFF
--- a/pkg/pipelineascode/cancel_pipelineruns.go
+++ b/pkg/pipelineascode/cancel_pipelineruns.go
@@ -16,7 +16,6 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/opscomments"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 )
 
@@ -87,9 +86,6 @@ func (p *PacRun) cancelInProgressMatchingPR(ctx context.Context, matchPR *tekton
 		labelMap[keys.PullRequest] = strconv.Itoa(p.event.PullRequestNumber)
 	}
 	labelSelector := getLabelSelector(labelMap)
-	if p.event.TriggerTarget == triggertype.PullRequest {
-		labelSelector += fmt.Sprintf(",%s in (pull_request, %s)", keys.EventType, opscomments.AnyOpsKubeLabelInSelector())
-	}
 	p.run.Clients.Log.Infof("cancel-in-progress: selecting pipelineRuns to cancel with labels: %v", labelSelector)
 	prs, err := p.run.Clients.Tekton.TektonV1().PipelineRuns(matchPR.GetNamespace()).List(ctx, metav1.ListOptions{
 		LabelSelector: labelSelector,

--- a/pkg/pipelineascode/cancel_pipelineruns.go
+++ b/pkg/pipelineascode/cancel_pipelineruns.go
@@ -27,13 +27,14 @@ var cancelMergePatch = map[string]interface{}{
 	},
 }
 
-// cancelAllInProgressBelongingToPullRequest cancels all in-progress PipelineRuns
-// that belong to a specific pull request in the given repository.
-func (p *PacRun) cancelAllInProgressBelongingToPullRequest(ctx context.Context, repo *v1alpha1.Repository) error {
-	labelSelector := getLabelSelector(map[string]string{
-		keys.URLRepository: formatting.CleanValueKubernetes(p.event.Repository),
-		keys.PullRequest:   strconv.Itoa(int(p.event.PullRequestNumber)),
-	})
+// cancelInProgressPipelineRunsForRepository cancels all in-progress PipelineRuns
+// that are selected by the given labelSelectorMap and for which the matchFunc returns true.
+func (p *PacRun) cancelInProgressPipelineRunsForRepository(ctx context.Context, repo *v1alpha1.Repository, labelSelectorMap map[string]string, matchFunc matchingCond) error {
+	labelSelectorMap[keys.URLRepository] = formatting.CleanValueKubernetes(p.event.Repository)
+
+	labelSelector := getLabelSelector(labelSelectorMap)
+	p.run.Clients.Log.Infof("cancel-in-progress: selecting pipelineRuns to cancel with labels: %v", labelSelector)
+
 	prs, err := p.run.Clients.Tekton.TektonV1().PipelineRuns(repo.Namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: labelSelector,
 	})
@@ -48,20 +49,29 @@ func (p *PacRun) cancelAllInProgressBelongingToPullRequest(ctx context.Context, 
 		return nil
 	}
 
-	p.cancelPipelineRuns(ctx, prs, repo, func(_ tektonv1.PipelineRun) bool {
-		return true
-	})
+	p.cancelPipelineRuns(ctx, prs, repo, matchFunc)
 
 	return nil
 }
 
-// cancelInProgressMatchingPR cancels all PipelineRuns associated with a given repository and pull request,
+// cancelAllInProgressBelongingToPullRequest cancels all in-progress PipelineRuns
+// which are associated with the event's Pull Request.
+func (p *PacRun) cancelAllInProgressBelongingToPullRequest(ctx context.Context, repo *v1alpha1.Repository) error {
+	return p.cancelInProgressPipelineRunsForRepository(
+		ctx,
+		repo,
+		map[string]string{keys.PullRequest: strconv.Itoa(int(p.event.PullRequestNumber))},
+		func(_ tektonv1.PipelineRun) bool { return true },
+	)
+}
+
+// cancelInProgressExceptMatchingPR cancels all PipelineRuns associated with a given repository and pull request,
 // except for the one that triggered the cancellation. It first checks if the cancellation is in progress
 // and if the repository has a concurrency limit. If a concurrency limit is set, it returns an error as
 // cancellation is not supported with concurrency limits. It then retrieves the original pull request name
 // from the annotations and lists all PipelineRuns with matching labels. For each PipelineRun that is not
 // already done, cancelled, or gracefully stopped, it patches the PipelineRun to cancel it.
-func (p *PacRun) cancelInProgressMatchingPR(ctx context.Context, matchPR *tektonv1.PipelineRun, repo *v1alpha1.Repository) error {
+func (p *PacRun) cancelInProgressExceptMatchingPR(ctx context.Context, matchPR *tektonv1.PipelineRun, repo *v1alpha1.Repository) error {
 	if matchPR == nil {
 		return nil
 	}
@@ -79,68 +89,46 @@ func (p *PacRun) cancelInProgressMatchingPR(ctx context.Context, matchPR *tekton
 	}
 
 	labelMap := map[string]string{
-		keys.URLRepository:  formatting.CleanValueKubernetes(p.event.Repository),
 		keys.OriginalPRName: prName,
 	}
 	if p.event.TriggerTarget == triggertype.PullRequest {
 		labelMap[keys.PullRequest] = strconv.Itoa(p.event.PullRequestNumber)
 	}
-	labelSelector := getLabelSelector(labelMap)
-	p.run.Clients.Log.Infof("cancel-in-progress: selecting pipelineRuns to cancel with labels: %v", labelSelector)
-	prs, err := p.run.Clients.Tekton.TektonV1().PipelineRuns(matchPR.GetNamespace()).List(ctx, metav1.ListOptions{
-		LabelSelector: labelSelector,
-	})
-	if err != nil {
-		return fmt.Errorf("failed to list pipelineRuns : %w", err)
-	}
-
-	p.cancelPipelineRuns(ctx, prs, repo, func(pr tektonv1.PipelineRun) bool {
-		// skip our own for cancellation
-		if sourceBranch, ok := pr.GetAnnotations()[keys.SourceBranch]; ok {
-			// NOTE(chmouel): Every PR has their own branch and so is every push to different branch
-			// it means we only cancel pipelinerun of the same name that runs to
-			// the unique branch. Note: HeadBranch is the branch from where the PR
-			// comes from in git jargon.
-			if sourceBranch != p.event.HeadBranch {
-				p.logger.Infof("cancel-in-progress: skipping pipelinerun %v/%v as it is not from the same branch, annotation source-branch: %s event headbranch: %s", pr.GetNamespace(), pr.GetName(), sourceBranch, p.event.HeadBranch)
-				return false
+	return p.cancelInProgressPipelineRunsForRepository(
+		ctx,
+		repo,
+		labelMap,
+		func(pr tektonv1.PipelineRun) bool {
+			// skip our own for cancellation
+			if sourceBranch, ok := pr.GetAnnotations()[keys.SourceBranch]; ok {
+				// NOTE(chmouel): Every PR has their own branch and so is every push to different branch
+				// it means we only cancel pipelinerun of the same name that runs to
+				// the unique branch. Note: HeadBranch is the branch from where the PR
+				// comes from in git jargon.
+				if sourceBranch != p.event.HeadBranch {
+					p.logger.Infof("cancel-in-progress: skipping pipelinerun %v/%v as it is not from the same branch, annotation source-branch: %s event headbranch: %s", pr.GetNamespace(), pr.GetName(), sourceBranch, p.event.HeadBranch)
+					return false
+				}
 			}
-		}
 
-		return pr.GetName() != matchPR.GetName()
-	})
-	return nil
+			return pr.GetName() != matchPR.GetName()
+		})
 }
 
 // cancelPipelineRunsOpsComment cancels all PipelineRuns associated with a given repository and pull request.
 // when the user issue a cancel comment.
 func (p *PacRun) cancelPipelineRunsOpsComment(ctx context.Context, repo *v1alpha1.Repository) error {
-	labelSelector := getLabelSelector(map[string]string{
-		keys.URLRepository: formatting.CleanValueKubernetes(p.event.Repository),
-		keys.SHA:           formatting.CleanValueKubernetes(p.event.SHA),
-	})
+	labelMap := map[string]string{
+		keys.SHA: formatting.CleanValueKubernetes(p.event.SHA),
+	}
 
 	if p.event.TriggerTarget == triggertype.PullRequest {
-		labelSelector = getLabelSelector(map[string]string{
+		labelMap = map[string]string{
 			keys.PullRequest: strconv.Itoa(p.event.PullRequestNumber),
-		})
+		}
 	}
 
-	prs, err := p.run.Clients.Tekton.TektonV1().PipelineRuns(repo.Namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: labelSelector,
-	})
-	if err != nil {
-		return fmt.Errorf("failed to list pipelineRuns : %w", err)
-	}
-
-	if len(prs.Items) == 0 {
-		msg := fmt.Sprintf("no pipelinerun found for repository: %v , sha: %v and pulRequest %v",
-			p.event.Repository, p.event.SHA, p.event.PullRequestNumber)
-		p.eventEmitter.EmitMessage(repo, zap.InfoLevel, "RepositoryPipelineRun", msg)
-		return nil
-	}
-
-	p.cancelPipelineRuns(ctx, prs, repo, func(pr tektonv1.PipelineRun) bool {
+	return p.cancelInProgressPipelineRunsForRepository(ctx, repo, labelMap, func(pr tektonv1.PipelineRun) bool {
 		if p.event.TargetCancelPipelineRun != "" {
 			if prName, ok := pr.GetAnnotations()[keys.OriginalPRName]; !ok || prName != p.event.TargetCancelPipelineRun {
 				return false
@@ -148,8 +136,6 @@ func (p *PacRun) cancelPipelineRunsOpsComment(ctx context.Context, repo *v1alpha
 		}
 		return true
 	})
-
-	return nil
 }
 
 func (p *PacRun) cancelPipelineRuns(ctx context.Context, prs *tektonv1.PipelineRunList, repo *v1alpha1.Repository, condition matchingCond) {

--- a/pkg/pipelineascode/cancel_pipelineruns_test.go
+++ b/pkg/pipelineascode/cancel_pipelineruns_test.go
@@ -789,7 +789,7 @@ func TestCancelInProgressMatchingPR(t *testing.T) {
 			if len(tt.pipelineRuns) > 0 {
 				firstPr = tt.pipelineRuns[0]
 			}
-			err := pac.cancelInProgressMatchingPR(ctx, firstPr, tt.repo)
+			err := pac.cancelInProgressExceptMatchingPR(ctx, firstPr, tt.repo)
 			if tt.wantErrString != "" {
 				assert.ErrorContains(t, err, tt.wantErrString)
 				return

--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -124,7 +124,7 @@ func (p *PacRun) Run(ctx context.Context) error {
 				}
 			}
 			p.manager.AddPipelineRun(pr)
-			if err := p.cancelInProgressMatchingPR(ctx, pr, repo); err != nil {
+			if err := p.cancelInProgressExceptMatchingPR(ctx, pr, repo); err != nil {
 				p.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "RepositoryPipelineRun", fmt.Sprintf("error cancelling in progress pipelineRuns: %s", err))
 			}
 		}(match, i)

--- a/pkg/provider/gitlab/parse_payload.go
+++ b/pkg/provider/gitlab/parse_payload.go
@@ -97,7 +97,7 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 		processedEvent.BaseBranch = gitEvent.Ref
 		processedEvent.HeadURL = gitEvent.Project.WebURL
 		processedEvent.BaseURL = processedEvent.HeadURL
-		processedEvent.TriggerTarget = "push"
+		processedEvent.TriggerTarget = triggertype.Push
 		v.pathWithNamespace = gitEvent.Project.PathWithNamespace
 		processedEvent.Organization, processedEvent.Repository = getOrgRepo(v.pathWithNamespace)
 		v.targetProjectID = gitEvent.ProjectID
@@ -121,7 +121,7 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 		processedEvent.BaseBranch = gitEvent.Ref
 		processedEvent.HeadURL = gitEvent.Project.WebURL
 		processedEvent.BaseURL = processedEvent.HeadURL
-		processedEvent.TriggerTarget = "push"
+		processedEvent.TriggerTarget = triggertype.Push
 		v.pathWithNamespace = gitEvent.Project.PathWithNamespace
 		processedEvent.Organization, processedEvent.Repository = getOrgRepo(v.pathWithNamespace)
 		v.targetProjectID = gitEvent.ProjectID

--- a/test/gitlab_merge_request_test.go
+++ b/test/gitlab_merge_request_test.go
@@ -277,6 +277,119 @@ func TestGitlabOnComment(t *testing.T) {
 	assert.NilError(t, err)
 }
 
+func TestGitlabCancelInProgressOnChange(t *testing.T) {
+	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
+	ctx := context.Background()
+	runcnx, opts, glprovider, err := tgitlab.Setup(ctx)
+	assert.NilError(t, err)
+	ctx, err = cctx.GetControllerCtxInfo(ctx, runcnx)
+	assert.NilError(t, err)
+	runcnx.Clients.Log.Info("Testing Gitlab cancel in progress on pr close")
+	projectinfo, resp, err := glprovider.Client.Projects.GetProject(opts.ProjectID, nil)
+	assert.NilError(t, err)
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
+	}
+
+	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, targetNS, nil)
+	assert.NilError(t, err)
+
+	entries, err := payload.GetEntries(map[string]string{
+		".tekton/in-progress.yaml": "testdata/pipelinerun-cancel-in-progress.yaml",
+	}, targetNS, projectinfo.DefaultBranch,
+		triggertype.PullRequest.String(), map[string]string{})
+	assert.NilError(t, err)
+	targetRefName := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test")
+
+	gitCloneURL, err := scm.MakeGitCloneURL(projectinfo.WebURL, opts.UserName, opts.Password)
+	assert.NilError(t, err)
+	mrTitle := "TestCancelInProgress initial commit - " + targetRefName
+	scmOpts := &scm.Opts{
+		GitURL:        gitCloneURL,
+		Log:           runcnx.Clients.Log,
+		WebURL:        projectinfo.WebURL,
+		TargetRefName: targetRefName,
+		BaseRefName:   projectinfo.DefaultBranch,
+		CommitTitle:   mrTitle,
+	}
+
+	oldSha := scm.PushFilesToRefGit(t, scmOpts, entries)
+	runcnx.Clients.Log.Infof("Branch %s has been created and pushed with files", targetRefName)
+	mrID, err := tgitlab.CreateMR(glprovider.Client, opts.ProjectID, targetRefName, projectinfo.DefaultBranch, mrTitle)
+	assert.NilError(t, err)
+	runcnx.Clients.Log.Infof("MergeRequest %s/-/merge_requests/%d has been created", projectinfo.WebURL, mrID)
+	defer tgitlab.TearDown(ctx, t, runcnx, glprovider, mrID, targetRefName, targetNS, opts.ProjectID)
+
+	runcnx.Clients.Log.Infof("Waiting for the pipelinerun to be created")
+	waitOpts := twait.Opts{
+		RepoName:        targetNS,
+		Namespace:       targetNS,
+		MinNumberStatus: 1,
+		PollTimeout:     twait.DefaultTimeout,
+		TargetSHA:       oldSha,
+	}
+	err = twait.UntilPipelineRunCreated(ctx, runcnx.Clients, waitOpts)
+	assert.NilError(t, err)
+
+	newEntries := map[string]string{
+		"new-file.txt": "plz work",
+	}
+
+	changeTitle := "TestCancelInProgress second commit - " + targetRefName
+	scmOpts = &scm.Opts{
+		GitURL:        gitCloneURL,
+		Log:           runcnx.Clients.Log,
+		WebURL:        projectinfo.WebURL,
+		TargetRefName: targetRefName,
+		BaseRefName:   targetRefName,
+		CommitTitle:   changeTitle,
+	}
+	newSha := scm.PushFilesToRefGit(t, scmOpts, newEntries)
+
+	runcnx.Clients.Log.Infof("Waiting for new pipeline to be created")
+	changeWaitOpts := twait.Opts{
+		RepoName:        targetNS,
+		Namespace:       targetNS,
+		MinNumberStatus: 1,
+		PollTimeout:     twait.DefaultTimeout,
+		TargetSHA:       newSha,
+	}
+	err = twait.UntilPipelineRunCreated(ctx, runcnx.Clients, changeWaitOpts)
+	assert.NilError(t, err)
+
+	runcnx.Clients.Log.Infof("Sleeping for 10 seconds to let the pipelinerun to be canceled")
+
+	i := 0
+	foundCancelled := false
+	for i < 10 {
+		prs, err := runcnx.Clients.Tekton.TektonV1().PipelineRuns(targetNS).List(ctx, metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("%s=%s", keys.SHA, oldSha),
+		})
+		assert.NilError(t, err)
+
+		for _, pr := range prs.Items {
+			if pr.GetStatusCondition() == nil {
+				continue
+			}
+			if len(pr.Status.Conditions) == 0 {
+				continue
+			}
+			if pr.Status.Conditions[0].Reason == "Cancelled" {
+				runcnx.Clients.Log.Infof("PipelineRun %s has been canceled", pr.Name)
+				foundCancelled = true
+				break
+			}
+		}
+		if foundCancelled {
+			break
+		}
+
+		time.Sleep(5 * time.Second)
+		i++
+	}
+	assert.Assert(t, foundCancelled, "No Pipelines has been found cancedl in NS %s", targetNS)
+}
+
 func TestGitlabCancelInProgressOnPRClose(t *testing.T) {
 	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
 	ctx := context.Background()
@@ -303,7 +416,7 @@ func TestGitlabCancelInProgressOnPRClose(t *testing.T) {
 
 	gitCloneURL, err := scm.MakeGitCloneURL(projectinfo.WebURL, opts.UserName, opts.Password)
 	assert.NilError(t, err)
-	mrTitle := "TestCancelInProgress - " + targetRefName
+	mrTitle := "TestCancelInProgressOnClose - " + targetRefName
 	scmOpts := &scm.Opts{
 		GitURL:        gitCloneURL,
 		Log:           runcnx.Clients.Log,

--- a/test/pkg/wait/wait.go
+++ b/test/pkg/wait/wait.go
@@ -79,7 +79,7 @@ func UntilPipelineRunCreated(ctx context.Context, clients clients.Clients, opts 
 			return true, err
 		}
 
-		clients.Log.Info("still waiting for pipelinerun to be created")
+		clients.Log.Infof("still waiting for pipelinerun to be created with label '%s=%s' in %s namespace", keys.SHA, opts.TargetSHA, opts.Namespace)
 		return len(prs.Items) == opts.MinNumberStatus, nil
 	})
 }


### PR DESCRIPTION
# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

- Remove seemingly redundant label selector when cancelling PipelineRuns for a Pull Request Change which was incompatible with GitLab Merge Requests. 
- Consolidated git repo initialization in tests

# Submitter Checklist

- [ ] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [x] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [x] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [ ] 📖 Document any user-facing features or changes in behavior.

- [x] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [x] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [x] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

| Git Provider     | Supported |
|------------------|-----------|
| GitHub App       | ✅️        |
| GitHub Webhook   |  ✅️        |
| Gitea            | ❌️        |
| GitLab           |  ✅️        |
| Bitbucket Cloud  | ❌️        |
| Bitbucket Server | ❌️        |

  (update the documentation accordingly)
