### PR TITLE
Add support for `ready_for_review` GitHub PR event

### DIFF
--- a/docs/content/docs/guide/running.md
+++ b/docs/content/docs/guide/running.md
@@ -24,8 +24,20 @@ For example, if a PipelineRun has this annotation:
 pipelinesascode.tekton.dev/on-event: "[pull_request]"
 ```
 
-it will be matched when a pull request is created and run on the cluster, as
-long as the submitter is allowed to run it.
+When a Pull Request is created, the PipelineRun will be automatically triggered
+and executed, provided that the person who submitted it has the appropriate
+permissions (see below).
+
+When using GitHub as a provider, Pipelines-as-Code will not run on draft Pull Requests until
+you set the Pull Request as ready for review.
+
+And if you are using the GitHub provider with GitHub Apps and have installed it
+on an organization, Pipelines-as-Code will only be triggered if it detects a
+Repo CR that matches one of the repositories in a URL on a repository that
+belongs to the organization where the GitHub App has been installed. Otherwise,
+Pipelines-as-Code will not be triggered.
+
+## ACL Permissions for running on a event
 
 The rules for determining whether a submitter is allowed to run a PipelineRun
 on CI are as follows. Any of the following conditions will allow a submitter to
@@ -45,14 +57,6 @@ run a PipelineRun on CI:
 If the pull request author does not have the necessary permissions to run a
 PipelineRun, another user who does have the necessary permissions can comment
 `/ok-to-test` on the pull request to run the PipelineRun.
-
-{{< hint info >}}
-If you are using the GitHub Apps and have installed it on an organization,
-Pipelines-as-Code will only be triggered if it detects a Repo CR that matches
-one of the repositories in a URL on a repository that belongs to the
-organization where the GitHub App has been installed. Otherwise, Pipelines as
-Code will not be triggered.
-{{< /hint >}}
 
 ## OWNERS file
 

--- a/docs/content/docs/guide/running.md
+++ b/docs/content/docs/guide/running.md
@@ -26,8 +26,13 @@ pipelinesascode.tekton.dev/on-event: "[pull_request]"
 
 it will be automatically triggered and executed when a user with appropriate permissions submits a Pull Request. See ACL Permissions for running on a event below.
 
-When using GitHub as a provider, Pipelines-as-Code will not run on draft Pull Requests until
-you set the Pull Request as ready for review.
+When using GitHub as a provider, Pipelines-as-Code runs on draft Pull Requests by default. However, you can prevent pipelines from triggering on draft Pull Requests by using the following annotation:
+
+\```yaml
+pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && !body.pull_request.draft
+\```
+
+With this configuration, your pipeline will only be triggered when the Pull Request is converted to "Ready for Review." For additional examples, see [Advanced event matching using CEL](https://pipelinesascode.com/docs/guide/matchingevents/#advanced-event-matching-using-cel).
 
 And if you are using the GitHub provider with GitHub Apps and have installed it
 on an organization, Pipelines-as-Code will only be triggered if it detects a

--- a/docs/content/docs/guide/running.md
+++ b/docs/content/docs/guide/running.md
@@ -24,7 +24,7 @@ For example, if a PipelineRun has this annotation:
 pipelinesascode.tekton.dev/on-event: "[pull_request]"
 ```
 
-it will be automatically triggered and executed when a user with appropriate permissions submits a Pull Request. See ACL Permissions for running on a event below.
+it will be automatically triggered and executed when a user with appropriate permissions submits a Pull Request. See ACL Permissions for triggering PipelineRuns below.
 
 When using GitHub as a provider, Pipelines-as-Code runs on draft Pull Requests by default. However, you can prevent pipelines from triggering on draft Pull Requests by using the following annotation:
 
@@ -40,7 +40,7 @@ Repo CR that matches one of the repositories in a URL on a repository that
 belongs to the organization where the GitHub App has been installed. Otherwise,
 Pipelines-as-Code will not be triggered.
 
-## ACL Permissions for running on a event
+## ACL Permissions for triggering PipelineRuns
 
 The rules for determining whether a submitter is allowed to run a PipelineRun
 on CI are as follows. Any of the following conditions will allow a submitter to

--- a/docs/content/docs/guide/running.md
+++ b/docs/content/docs/guide/running.md
@@ -28,9 +28,9 @@ it will be automatically triggered and executed when a user with appropriate per
 
 When using GitHub as a provider, Pipelines-as-Code runs on draft Pull Requests by default. However, you can prevent pipelines from triggering on draft Pull Requests by using the following annotation:
 
-\```yaml
+```yaml
 pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && !body.pull_request.draft
-\```
+```
 
 With this configuration, your pipeline will only be triggered when the Pull Request is converted to "Ready for Review." For additional examples, see [Advanced event matching using CEL](https://pipelinesascode.com/docs/guide/matchingevents/#advanced-event-matching-using-cel).
 

--- a/docs/content/docs/guide/running.md
+++ b/docs/content/docs/guide/running.md
@@ -24,9 +24,7 @@ For example, if a PipelineRun has this annotation:
 pipelinesascode.tekton.dev/on-event: "[pull_request]"
 ```
 
-When a Pull Request is created, the PipelineRun will be automatically triggered
-and executed, provided that the person who submitted it has the appropriate
-permissions (see below).
+it will be automatically triggered and executed when a user with appropriate permissions submits a Pull Request. See ACL Permissions for running on a event below.
 
 When using GitHub as a provider, Pipelines-as-Code will not run on draft Pull Requests until
 you set the Pull Request as ready for review.

--- a/pkg/provider/github/detect.go
+++ b/pkg/provider/github/detect.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	pullRequestOpenSyncEvent = []string{"opened", "synchronize", "synchronized", "reopened"}
+	pullRequestOpenSyncEvent = []string{"opened", "synchronize", "synchronized", "reopened", "ready_for_review"}
 	pullRequestLabelEvent    = []string{"labeled"}
 )
 

--- a/pkg/provider/github/detect_test.go
+++ b/pkg/provider/github/detect_test.go
@@ -210,6 +210,15 @@ func TestProvider_Detect(t *testing.T) {
 			processReq: true,
 		},
 		{
+			name: "pull request event converted from draft to active",
+			event: github.PullRequestEvent{
+				Action: github.Ptr("ready_for_review"),
+			},
+			eventType:  "pull_request",
+			isGH:       true,
+			processReq: true,
+		},
+		{
 			name: "pull request event not supported action",
 			event: github.PullRequestEvent{
 				Action: github.Ptr("deleted"),


### PR DESCRIPTION
# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Add support for a GitHub PR event `ready_for_review`, which is triggered when a PR is converted from draft to active.

Resolves: https://github.com/openshift-pipelines/pipelines-as-code/issues/1953

# Submitter Checklist

- [ ] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [ ] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [ ] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [ ] 📖 Document any user-facing features or changes in behavior.

- [ ] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [ ] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [ ] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

| Git Provider     | Supported |
|------------------|-----------|
| GitHub App       | ❌️        |
| GitHub Webhook   | ✅️        |
| Gitea            | ❌️        |
| GitLab           | ❌️        |
| Bitbucket Cloud  | ❌️        |
| Bitbucket Server | ❌️        |
