### PR TITLE
test: set all gitea tests as parallel

### DIFF
--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -530,7 +530,6 @@ func TestGiteaPush(t *testing.T) {
 }
 
 func TestGiteaWithCLI(t *testing.T) {
-	t.Parallel()
 	topts := &tgitea.TestOpts{
 		Regexp:      successRegexp,
 		TargetEvent: "pull_request, push",

--- a/test/pkg/gitea/test.go
+++ b/test/pkg/gitea/test.go
@@ -93,6 +93,7 @@ func TestPR(t *testing.T, topts *TestOpts) (context.Context, func()) {
 	ctx := context.Background()
 	if topts.ParamsRun == nil {
 		runcnx, opts, giteacnx, err := Setup(ctx)
+		runcnx.Clients.Log = runcnx.Clients.Log.With("test", t.Name())
 		assert.NilError(t, err, fmt.Errorf("cannot do gitea setup: %w", err))
 		topts.GiteaCNX = giteacnx
 		topts.ParamsRun = runcnx
@@ -126,6 +127,7 @@ func TestPR(t *testing.T, topts *TestOpts) (context.Context, func()) {
 
 	if topts.TargetRepoName == "" {
 		topts.TargetRepoName = topts.TargetRefName
+		t.Parallel()
 	}
 
 	if topts.DefaultBranch == "" {


### PR DESCRIPTION
Since gitea tests create their own repositories there is theoretically no issue with each targetting the same cluster concurrently

*This PR is a POC test*

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [ ] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [ ] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [ ] 📖 Document any user-facing features or changes in behavior.

- [ ] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [ ] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [ ] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

| Git Provider     | Supported |
|------------------|-----------|
| GitHub App       | ✅️        |
| GitHub Webhook   | ❌️        |
| Gitea            | ❌️        |
| GitLab           | ❌️        |
| Bitbucket Cloud  | ❌️        |
| Bitbucket Server | ❌️        |

  (update the documentation accordingly)
