### PR TITLE
docs: clarify resolver matching in guide

### DIFF
--- a/.tekton/boussole.yaml
+++ b/.tekton/boussole.yaml
@@ -4,7 +4,7 @@ metadata:
   name: boussole
   annotations:
     pipelinesascode.tekton.dev/pipeline: "https://raw.githubusercontent.com/openshift-pipelines/pac-boussole/main/pipeline-boussole.yaml"
-    pipelinesascode.tekton.dev/on-comment: "^/(help|rebase|lgtm|(cherry-pick|assign|merge|unassign|label|unlabel)[ ].*)"
+    pipelinesascode.tekton.dev/on-comment: "^/(help|rebase|lgtm|cherry-pick|assign|merge|unassign|label|unlabel)"
     pipelinesascode.tekton.dev/max-keep-runs: "2"
 spec:
   params:
@@ -23,8 +23,8 @@ spec:
       value: "{{ git_auth_secret }}"
     - name: comment_sender
       value: "{{ sender }}"
-    - name: merge_method
-      value: "squash"
+  # - name: merge_method
+  #   value: "squash"
   #
   # Optional parameters (value is the default):
   #

--- a/docs/content/docs/guide/matchingevents.md
+++ b/docs/content/docs/guide/matchingevents.md
@@ -65,8 +65,15 @@ When multiple PipelineRuns match an event, it will run them in parallel
 and post the results to the provider as soon as the PipelineRun finishes.
 
 {{< hint info >}}
-Payload matching only occurs for events that `Pipelines-as-Code` supports, such as
-when a `Pull Request` is opened, updated, or when a branch receives a `Push`.
+
+* Payload matching happens only for events supported by `Pipelines-as-Code`,
+such as when a `Pull Request` is opened, updated, or when a branch receives a
+`Push`.
+
+* Typically, you need both `on-target-branch` and `on-event` annotations to
+match, except when using [CEL expressions](#advanced-event-matching-using-cel)
+or [matching based on a
+comment](#matching-a-pipelinerun-on-a-regex-in-a-comment).
 {{< /hint >}}
 
 ## Matching a PipelineRun to Specific Path Changes
@@ -239,21 +246,27 @@ can use this annotation:
 metadata:
   name: match-bugs-or-defect
   annotations:
-    pipelinesascode.tekton.dev/on-label: [bug, defect]
+    pipelinesascode.tekton.dev/on-label: "[bug, defect]"
+    pipelinesascode.tekton.dev/on-target-branch: "[main]"
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
 ```
 
-- The `on-label` annotation respects the `pull_request` [Policy]({{< relref
+* The `on-label` annotation respects the `pull_request` [Policy]({{< relref
   "/docs/guide/policy" >}}) rules.
-- This annotation is currently supported only on GitHub, Gitea, and GitLab
+* The `on-target-branch` is still needed to match the Pull Request event on the
+  targeted branch.
+* The `on-event` is still needed to match the Pull Request event on the
+  proper targeted event.
+* This annotation is currently supported only on GitHub, Gitea, and GitLab
   providers. Bitbucket Cloud and Bitbucket Server do not support adding labels
   to Pull Requests.
-- When you add a label to a Pull Request, the corresponding PipelineRun is
+* When you add a label to a Pull Request, the corresponding PipelineRun is
   triggered immediately, and no other PipelineRun matching the same Pull Request
   will be activated.
-- If you update the Pull Request by sending a new commit, the PipelineRun
+* If you update the Pull Request by sending a new commit, the PipelineRun
   with a matching `on-label` annotation will be triggered again if the label is
   still present.
-- You can access the `Pull Request` labels with the [dynamic variable]({{<
+* You can access the `Pull Request` labels with the [dynamic variable]({{<
   relref "/docs/guide/authoringprs#dynamic-variables" >}}) `{{ pull_request_labels }}`.
   The labels are separated by a Unix newline `\n`.
   For example, with a shell script, you can do this to print them:


### PR DESCRIPTION
Updated the matching events guide to improve clarity on resolver matching. Changes include:
- Rephrased payload matching conditions for better readability.
- Added details on `on-target-branch` and `on-event` annotations.
- Clarified the behavior of `on-label` annotation and its support across different providers.

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [ ] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [ ] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [ ] 📖 Document any user-facing features or changes in behavior.

- [ ] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [ ] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [ ] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

| Git Provider     | Supported |
|------------------|-----------|
| GitHub App       | ✅️        |
| GitHub Webhook   | ❌️        |
| Gitea            | ❌️        |
| GitLab           | ❌️        |
| Bitbucket Cloud  | ❌️        |
| Bitbucket Server | ❌️        |

  (update the documentation accordingly)
