### PR TITLE
chore(bousdsole): Set default merge to squash

### DIFF
--- a/.tekton/boussole.yaml
+++ b/.tekton/boussole.yaml
@@ -23,6 +23,8 @@ spec:
       value: "{{ git_auth_secret }}"
     - name: comment_sender
       value: "{{ sender }}"
+    - name: merge_method
+      value: "squash"
   #
   # Optional parameters (value is the default):
   #
@@ -44,8 +46,5 @@ spec:
   # - name: lgtm_review_event
   #   value: "APPROVE"
   #
-  # The merge method to use. Can be one of: merge, squash, rebase
-  # - name: merge_method
-  #   value: "rebase"
   pipelineRef:
     name: boussole


### PR DESCRIPTION
The merge method in the boussole configuration file is now set to "squash" by default. This ensures that all merges will use the squash strategy unless otherwise specified.

