### PR TITLE
fix: E2E tests flake failure on nightly

### DIFF
--- a/test/github_tkn_pac_cli_test.go
+++ b/test/github_tkn_pac_cli_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -27,9 +26,6 @@ import (
 )
 
 func TestGithubPacCli(t *testing.T) {
-	if os.Getenv("NIGHTLY_E2E_TEST") != "true" {
-		t.Skip("Skipping test since only enabled for nightly")
-	}
 	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
 	ctx := context.Background()
 	ctx, runcnx, opts, ghprovider, err := tgithub.Setup(ctx, false, false)
@@ -52,7 +48,7 @@ spec:
         taskSpec:
           steps:
             - name: task
-              image: gcr.io/google-containers/busybox
+              image: registry.access.redhat.com/ubi9/ubi-micro
               command: ["/bin/echo", "HELLOMOTO"]
 `, targetNS, options.MainBranch, triggertype.PullRequest.String()),
 	}
@@ -113,7 +109,7 @@ spec:
 	waitOpts := twait.Opts{
 		RepoName:        targetNS,
 		Namespace:       targetNS,
-		MinNumberStatus: 0,
+		MinNumberStatus: 1,
 		PollTimeout:     twait.DefaultTimeout,
 		TargetSHA:       sha,
 	}


### PR DESCRIPTION
fixed E2E test flake failure in nightly on TestGithubPacCli test. before this, [MinimumNumber](https://github.com/openshift-pipelines/pipelines-as-code/blob/92569786af761ea8d102c9214cce91ddde5e5026/test/github_tkn_pac_cli_test.go#L116) status was 0 so I think that it should first wait for [UntilRepositoryUpdated](https://github.com/openshift-pipelines/pipelines-as-code/blob/92569786af761ea8d102c9214cce91ddde5e5026/test/github_tkn_pac_cli_test.go#L120C17-L120C39) and then check for Succeeded substring.

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [ ] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [ ] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [ ] 📖 Document any user-facing features or changes in behavior.

- [ ] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [ ] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [ ] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

| Git Provider     | Supported |
|------------------|-----------|
| GitHub App       | ✅️        |
| GitHub Webhook   | ❌️        |
| Gitea            | ❌️        |
| GitLab           | ❌️        |
| Bitbucket Cloud  | ❌️        |
| Bitbucket Server | ❌️        |

  (update the documentation accordingly)
