### PR TITLE
feat: Add Support for GitOps Commands on Pushed Commits in GitLab

### DIFF
--- a/docs/content/docs/guide/gitops_commands.md
+++ b/docs/content/docs/guide/gitops_commands.md
@@ -37,6 +37,8 @@ Please be aware that GitOps commands such as `/test` and others will not functio
 
 ## GitOps Commands on Pushed Commits
 
+{{< support_matrix github_app="true" github_webhook="true" gitea="false" gitlab="true" bitbucket_cloud="false" bitbucket_server="false" >}}
+
 If you want to trigger a GitOps command on a pushed commit, you can include the `GitOps` comments within your commit messages. These comments can be used to restart either all pipelines or specific ones. Here's how it works:
 
 For restarting all pipeline runs:
@@ -72,6 +74,18 @@ This means:
 
 Please note that the `/ok-to-test` command does not work on pushed commits, as it is specifically intended for pull requests to manage authorization. Since only authorized users are allowed to send `GitOps` commands on pushed commits,
 there is no need to use the `ok-to-test` command in this context.
+
+For example, when executing a GitOps command like `/test test-pr branch:test` on a pushed commit, verify that the `test-pr` is on the test branch in your repository and includes the `on-event` and `on-target-branch` annotations as demonstrated below:
+
+```yaml
+kind: PipelineRun
+metadata:
+  name: "test-pr"
+  annotations:
+    pipelinesascode.tekton.dev/on-target-branch: "[test]"
+    pipelinesascode.tekton.dev/on-event: "[push]"
+spec:
+```
 
 To issue a `GitOps` comment on a pushed commit, you can follow these steps:
 

--- a/pkg/pipelineascode/secret.go
+++ b/pkg/pipelineascode/secret.go
@@ -29,7 +29,7 @@ type SecretFromRepository struct {
 	Logger      *zap.SugaredLogger
 }
 
-// SecretFromRepository grab the secret from the repository CRD.
+// Get grab the secret from the repository CRD.
 func (s *SecretFromRepository) Get(ctx context.Context) error {
 	var err error
 	if s.Repo.Spec.GitProvider == nil {

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -586,8 +586,8 @@ func uniqueRepositoryID(repoIDs []int64, id int64) []int64 {
 	return r
 }
 
-// isBranchContainsCommit checks whether provided branch has sha or not.
-func (v *Provider) isBranchContainsCommit(ctx context.Context, runevent *info.Event, branchName string) error {
+// isHeadCommitOfBranch checks whether provided branch is valid or not and SHA is HEAD commit of the branch.
+func (v *Provider) isHeadCommitOfBranch(ctx context.Context, runevent *info.Event, branchName string) error {
 	if v.Client == nil {
 		return fmt.Errorf("no github client has been initialized, " +
 			"exiting... (hint: did you forget setting a secret on your repo?)")

--- a/pkg/provider/github/github_test.go
+++ b/pkg/provider/github/github_test.go
@@ -1087,7 +1087,7 @@ func TestCreateToken(t *testing.T) {
 	}
 }
 
-func TestGetBranch(t *testing.T) {
+func TestIsHeadCommitOfBranch(t *testing.T) {
 	tests := []struct {
 		name       string
 		sha        string
@@ -1125,7 +1125,7 @@ func TestGetBranch(t *testing.T) {
 
 			ctx, _ := rtesting.SetupFakeContext(t)
 			provider := &Provider{Client: fakeclient}
-			err := provider.isBranchContainsCommit(ctx, runEvent, "test1")
+			err := provider.isHeadCommitOfBranch(ctx, runEvent, "test1")
 			assert.Equal(t, err != nil, tt.wantErr)
 		})
 	}

--- a/pkg/provider/github/parse_payload.go
+++ b/pkg/provider/github/parse_payload.go
@@ -466,7 +466,7 @@ func (v *Provider) handleCommitCommentEvent(ctx context.Context, event *github.C
 	}
 
 	// Check if the specified branch contains the commit
-	if err = v.isBranchContainsCommit(ctx, runevent, branchName); err != nil {
+	if err = v.isHeadCommitOfBranch(ctx, runevent, branchName); err != nil {
 		if provider.IsCancelComment(event.GetComment().GetBody()) {
 			runevent.CancelPipelineRuns = false
 		}
@@ -476,6 +476,6 @@ func (v *Provider) handleCommitCommentEvent(ctx context.Context, event *github.C
 	runevent.HeadBranch = branchName
 	runevent.BaseBranch = branchName
 
-	v.Logger.Infof("commit_comment: pipelinerun %s on %s/%s#%s has been requested", action, runevent.Organization, runevent.Repository, runevent.SHA)
+	v.Logger.Infof("github commit_comment: pipelinerun %s on %s/%s#%s has been requested", action, runevent.Organization, runevent.Repository, runevent.SHA)
 	return runevent, nil
 }

--- a/pkg/provider/github/parse_payload_test.go
+++ b/pkg/provider/github/parse_payload_test.go
@@ -530,7 +530,7 @@ func TestParsePayLoad(t *testing.T) {
 			isCancelPipelineRunEnabled: true,
 		},
 		{
-			name:          "good/commit comment for cancel a pr with invalid branch name",
+			name:          "bad/commit comment for cancel a pr with invalid branch name",
 			eventType:     "commit_comment",
 			triggerTarget: "push",
 			githubClient:  true,
@@ -550,7 +550,7 @@ func TestParsePayLoad(t *testing.T) {
 			wantErrString:              "404 Not Found",
 		},
 		{
-			name:          "commit comment to retest a pr with a SHA that does not exist in the main branch",
+			name:          "commit comment to retest a pr with a SHA is not HEAD commit of the main branch",
 			eventType:     "commit_comment",
 			triggerTarget: "push",
 			githubClient:  true,

--- a/pkg/provider/gitlab/parse_payload.go
+++ b/pkg/provider/gitlab/parse_payload.go
@@ -7,14 +7,20 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/matcher"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/opscomments"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/pipelineascode"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
+
 	gitlab "gitlab.com/gitlab-org/api/client-go"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.Request,
+func (v *Provider) ParsePayload(ctx context.Context, run *params.Run, request *http.Request,
 	payload string,
 ) (*info.Event, error) {
 	event := request.Header.Get("X-Gitlab-Event")
@@ -153,11 +159,147 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 		v.userID = gitEvent.User.ID
 		processedEvent.SourceProjectID = gitEvent.MergeRequest.SourceProjectID
 		processedEvent.TargetProjectID = gitEvent.MergeRequest.TargetProjectID
+	case *gitlab.CommitCommentEvent:
+		// need run in fetching repository
+		v.run = run
+		return v.handleCommitCommentEvent(ctx, gitEvent)
 	default:
 		return nil, fmt.Errorf("event %s is not supported", event)
 	}
 
 	v.repoURL = processedEvent.URL
+	return processedEvent, nil
+}
+
+func (v *Provider) initGitlabClient(ctx context.Context, event *info.Event) (*info.Event, error) {
+	// This is to ensure the base URL of the client is not reinitialized during tests.
+	if v.Client != nil {
+		return event, nil
+	}
+
+	// need repo here to get secret info and create gitlab api client
+	repo, err := matcher.MatchEventURLRepo(ctx, v.run, event, "")
+	if err != nil {
+		return event, err
+	}
+
+	if repo == nil {
+		return event, fmt.Errorf("cannot find a repository match for %s", event.URL)
+	}
+
+	// should check global repository for secrets
+	secretNS := repo.GetNamespace()
+	globalRepo, err := v.run.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(v.run.Info.Kube.Namespace).Get(
+		ctx, v.run.Info.Controller.GlobalRepository, metav1.GetOptions{},
+	)
+	if err == nil && globalRepo != nil {
+		if repo.Spec.GitProvider != nil && repo.Spec.GitProvider.Secret == nil && globalRepo.Spec.GitProvider != nil && globalRepo.Spec.GitProvider.Secret != nil {
+			secretNS = globalRepo.GetNamespace()
+		}
+		repo.Spec.Merge(globalRepo.Spec)
+	}
+
+	kubeInterface, err := kubeinteraction.NewKubernetesInteraction(v.run)
+	if err != nil {
+		return event, err
+	}
+
+	scm := pipelineascode.SecretFromRepository{
+		K8int:       kubeInterface,
+		Config:      v.GetConfig(),
+		Event:       event,
+		Repo:        repo,
+		WebhookType: v.pacInfo.WebhookType,
+		Logger:      v.Logger,
+		Namespace:   secretNS,
+	}
+	if err := scm.Get(ctx); err != nil {
+		return event, fmt.Errorf("cannot get secret from repository: %w", err)
+	}
+
+	err = v.SetClient(ctx, v.run, event, repo, v.eventEmitter)
+	if err != nil {
+		return event, err
+	}
+	return event, nil
+}
+
+func (v *Provider) handleCommitCommentEvent(ctx context.Context, event *gitlab.CommitCommentEvent) (*info.Event, error) {
+	action := "trigger"
+	processedEvent := info.NewEvent()
+	if event.Repository == nil {
+		return nil, fmt.Errorf("error parse_payload: the repository in event payload must not be nil")
+	}
+	// since comment is made on pushed commit, SourceProjectID and TargetProjectID will be equal.
+	v.sourceProjectID = event.ProjectID
+	v.targetProjectID = event.ProjectID
+	processedEvent.SourceProjectID = v.sourceProjectID
+	processedEvent.TargetProjectID = v.targetProjectID
+	v.userID = event.User.ID
+	v.pathWithNamespace = event.Project.PathWithNamespace
+	processedEvent.Organization, processedEvent.Repository = getOrgRepo(v.pathWithNamespace)
+	processedEvent.Sender = event.User.Username
+	processedEvent.Provider.User = processedEvent.Sender
+	processedEvent.URL = event.Project.WebURL
+	processedEvent.SHA = event.ObjectAttributes.CommitID
+	processedEvent.SHATitle = event.Commit.Title
+	processedEvent.HeadURL = processedEvent.URL
+	processedEvent.BaseURL = processedEvent.URL
+	processedEvent.TriggerTarget = triggertype.Push
+	opscomments.SetEventTypeAndTargetPR(processedEvent, event.ObjectAttributes.Note)
+	// Set Head and Base branch to default_branch of the repo as this comment is made on
+	// a pushed commit.
+	defaultBranch := event.Project.DefaultBranch
+	processedEvent.HeadBranch, processedEvent.BaseBranch = defaultBranch, defaultBranch
+	processedEvent.DefaultBranch = defaultBranch
+
+	var (
+		branchName string
+		prName     string
+		err        error
+	)
+
+	// get PipelineRun name from comment if it does contain e.g. `/test pr7`
+	if provider.IsTestRetestComment(event.ObjectAttributes.Note) {
+		prName, branchName, err = opscomments.GetPipelineRunAndBranchNameFromTestComment(event.ObjectAttributes.Note)
+		if err != nil {
+			return processedEvent, err
+		}
+		processedEvent.TargetTestPipelineRun = prName
+	}
+
+	if provider.IsCancelComment(event.ObjectAttributes.Note) {
+		action = "cancellation"
+		prName, branchName, err = opscomments.GetPipelineRunAndBranchNameFromCancelComment(event.ObjectAttributes.Note)
+		if err != nil {
+			return processedEvent, err
+		}
+		processedEvent.CancelPipelineRuns = true
+		processedEvent.TargetCancelPipelineRun = prName
+	}
+
+	if branchName == "" {
+		branchName = processedEvent.HeadBranch
+	}
+
+	// since we're going to make an API call to ensure that the commit is HEAD of the branch
+	// therefore we need to initialize GitLab client here
+	processedEvent, err = v.initGitlabClient(ctx, processedEvent)
+	if err != nil {
+		return processedEvent, err
+	}
+
+	// check if the commit on which comment is made, is HEAD commit of the branch
+	if err := v.isHeadCommitOfBranch(processedEvent, branchName); err != nil {
+		if provider.IsCancelComment(event.ObjectAttributes.Note) {
+			processedEvent.CancelPipelineRuns = false
+		}
+		return processedEvent, err
+	}
+
+	processedEvent.HeadBranch = branchName
+	processedEvent.BaseBranch = branchName
+	v.Logger.Infof("gitlab commit_comment: pipelinerun %s has been requested on %s/%s#%s", action, processedEvent.Organization, processedEvent.Repository, processedEvent.SHA)
 	return processedEvent, nil
 }
 

--- a/pkg/provider/gitlab/parse_payload_test.go
+++ b/pkg/provider/gitlab/parse_payload_test.go
@@ -1,17 +1,28 @@
 package gitlab
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"testing"
 
 	"github.com/google/go-github/v69/github"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/events"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/opscomments"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	thelp "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/gitlab/test"
+	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/test/logger"
+
 	gitlab "gitlab.com/gitlab-org/api/client-go"
 	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	rtesting "knative.dev/pkg/reconciler/testing"
 )
 
@@ -41,12 +52,14 @@ func TestParsePayload(t *testing.T) {
 		payload string
 	}
 	tests := []struct {
-		name       string
-		fields     fields
-		args       args
-		want       *info.Event
-		wantErr    bool
-		wantClient bool
+		name           string
+		fields         fields
+		args           args
+		want           *info.Event
+		wantKubeClient bool
+		wantErrMsg     string
+		wantClient     bool
+		wantBranch     string
 	}{
 		{
 			name: "bad payload",
@@ -54,7 +67,7 @@ func TestParsePayload(t *testing.T) {
 				payload: "nono",
 				event:   "none",
 			},
-			wantErr: true,
+			wantErrMsg: "unexpected event type: none",
 		},
 		{
 			name: "event not supported",
@@ -62,7 +75,7 @@ func TestParsePayload(t *testing.T) {
 				event:   gitlab.EventTypePipeline,
 				payload: sample.MREventAsJSON("open", ""),
 			},
-			wantErr: true,
+			wantErrMsg: "json: cannot unmarshal object into Go struct field .object_attributes.source of type string",
 		},
 		{
 			name: "merge event",
@@ -97,7 +110,7 @@ func TestParsePayload(t *testing.T) {
 				event:   gitlab.EventTypePush,
 				payload: sample.PushEventAsJSON(false),
 			},
-			wantErr: true,
+			wantErrMsg: "no commits attached to this push event",
 		},
 		{
 			name: "push event",
@@ -179,33 +192,201 @@ func TestParsePayload(t *testing.T) {
 				State:         info.State{TargetCancelPipelineRun: "dummy"},
 			},
 		},
+		{
+			name: "bad/commit comment repository is nil",
+			args: args{
+				event:   gitlab.EventTypeNote,
+				payload: sample.CommitNoteEventAsJSON("/test", "create", "null"),
+			},
+			wantErrMsg: "error parse_payload: the repository in event payload must not be nil",
+		},
+		{
+			name: "bad/commit comment wrong branch keyword",
+			args: args{
+				event:   gitlab.EventTypeNote,
+				payload: sample.CommitNoteEventAsJSON("/test brrranch:fix", "create", "{}"),
+			},
+			wantErrMsg: "the GitOps comment brrranch does not contain a branch word",
+		},
+		{
+			name:   "good/commit comment /test all pipelineruns",
+			fields: fields{sourceProjectID: 200},
+			args: args{
+				event:   gitlab.EventTypeNote,
+				payload: sample.CommitNoteEventAsJSON("/test", "create", "{}"),
+			},
+			want: &info.Event{
+				EventType:     opscomments.TestAllCommentEventType.String(),
+				TriggerTarget: triggertype.Push,
+				Organization:  "hello/this/is/me/ze",
+				Repository:    "project",
+			},
+			wantKubeClient: true,
+			wantClient:     true,
+		},
+		{
+			name:   "good/commit comment /test a single pipelinerun",
+			fields: fields{sourceProjectID: 200},
+			args: args{
+				event:   gitlab.EventTypeNote,
+				payload: sample.CommitNoteEventAsJSON("/test dummy", "create", "{}"),
+			},
+			want: &info.Event{
+				EventType:     opscomments.TestSingleCommentEventType.String(),
+				TriggerTarget: triggertype.Push,
+				Organization:  "hello/this/is/me/ze",
+				Repository:    "project",
+				State:         info.State{TargetTestPipelineRun: "dummy"},
+			},
+			wantKubeClient: true,
+			wantClient:     true,
+		},
+		{
+			name:   "good/commit comment /retest all pipelineruns",
+			fields: fields{sourceProjectID: 200},
+			args: args{
+				event:   gitlab.EventTypeNote,
+				payload: sample.CommitNoteEventAsJSON("/retest", "create", "{}"),
+			},
+			want: &info.Event{
+				EventType:     opscomments.RetestAllCommentEventType.String(),
+				TriggerTarget: triggertype.Push,
+				Organization:  "hello/this/is/me/ze",
+				Repository:    "project",
+			},
+			wantKubeClient: true,
+			wantClient:     true,
+		},
+		{
+			name:   "good/commit comment /retest a single pipelinerun",
+			fields: fields{sourceProjectID: 200},
+			args: args{
+				event:   gitlab.EventTypeNote,
+				payload: sample.CommitNoteEventAsJSON("/retest dummy", "create", "{}"),
+			},
+			want: &info.Event{
+				EventType:     opscomments.RetestSingleCommentEventType.String(),
+				TriggerTarget: triggertype.Push,
+				Organization:  "hello/this/is/me/ze",
+				Repository:    "project",
+				State:         info.State{TargetTestPipelineRun: "dummy"},
+			},
+			wantKubeClient: true,
+			wantClient:     true,
+		},
+		{
+			name:   "good/commit comment /cancel all pipelineruns",
+			fields: fields{sourceProjectID: 200},
+			args: args{
+				event:   gitlab.EventTypeNote,
+				payload: sample.CommitNoteEventAsJSON("/cancel", "create", "{}"),
+			},
+			want: &info.Event{
+				EventType:     opscomments.CancelCommentAllEventType.String(),
+				TriggerTarget: triggertype.Push,
+				Organization:  "hello/this/is/me/ze",
+				Repository:    "project",
+			},
+			wantKubeClient: true,
+			wantClient:     true,
+		},
+		{
+			name:   "good/commit comment /retest a single pipelinerun",
+			fields: fields{sourceProjectID: 200},
+			args: args{
+				event:   gitlab.EventTypeNote,
+				payload: sample.CommitNoteEventAsJSON("/retest dummy", "create", "{}"),
+			},
+			want: &info.Event{
+				EventType:     opscomments.RetestSingleCommentEventType.String(),
+				TriggerTarget: triggertype.Push,
+				Organization:  "hello/this/is/me/ze",
+				Repository:    "project",
+				State:         info.State{TargetTestPipelineRun: "dummy"},
+			},
+			wantKubeClient: true,
+			wantClient:     true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, _ := rtesting.SetupFakeContext(t)
+			logger, _ := logger.GetLogger()
+			run := &params.Run{
+				Info: info.NewInfo(),
+			}
+			if tt.wantKubeClient {
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "fakeNs",
+						Name:      "gitlab-webhook-config",
+					},
+					Data: map[string][]byte{
+						"provider.token": []byte("glpat_124ABC"),
+						"webhook.secret": []byte("shhhhhhit'ssecret"),
+					},
+				}
+
+				repo := &v1alpha1.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "fakeNs",
+						Name:      "repo",
+					},
+					Spec: v1alpha1.RepositorySpec{
+						URL: "https://foo.com",
+						GitProvider: &v1alpha1.GitProvider{
+							Secret:        &v1alpha1.Secret{Name: "gitlab-webhook-config"},
+							WebhookSecret: &v1alpha1.Secret{Name: "gitlab-webhook-config"},
+						},
+					},
+				}
+				run.Info.Kube.Namespace = "fakeNs"
+				data := testclient.Data{
+					Repositories: []*v1alpha1.Repository{repo},
+					Secret:       []*corev1.Secret{secret},
+				}
+				stdata, _ := testclient.SeedTestData(t, ctx, data)
+				run.Clients = clients.Clients{Kube: stdata.Kube, PipelineAsCode: stdata.PipelineAsCode}
+			}
 			v := &Provider{
 				Token:           github.Ptr("tokeneuneu"),
 				targetProjectID: tt.fields.targetProjectID,
 				sourceProjectID: tt.fields.sourceProjectID,
 				userID:          tt.fields.userID,
+				run:             run,
+				pacInfo: &info.PacOpts{
+					Settings: settings.Settings{
+						ApplicationName: settings.PACApplicationNameDefaultValue,
+					},
+				},
+				eventEmitter: events.NewEventEmitter(run.Clients.Kube, logger),
+				Logger:       logger,
 			}
 			if tt.wantClient {
-				client, _, tearDown := thelp.Setup(t)
+				client, mux, tearDown := thelp.Setup(t)
 				v.Client = client
+				branchName := "main"
+				if tt.wantBranch != "" {
+					branchName = tt.wantBranch
+				}
+				mux.HandleFunc(fmt.Sprintf("/projects/200/repository/branches/%s", branchName),
+					func(rw http.ResponseWriter, _ *http.Request) {
+						branch := &gitlab.Branch{Name: branchName, Commit: &gitlab.Commit{ID: "sha"}}
+						bytes, _ := json.Marshal(branch)
+						_, _ = rw.Write(bytes)
+					})
 				defer tearDown()
-			}
-			run := &params.Run{
-				Info: info.Info{},
 			}
 
 			request := &http.Request{Header: map[string][]string{}}
 			request.Header.Set("X-Gitlab-Event", string(tt.args.event))
 
 			got, err := v.ParsePayload(ctx, run, request, tt.args.payload)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("ParsePayload() error = %v, wantErr %v", err, tt.wantErr)
+			if tt.wantErrMsg != "" {
+				assert.ErrorContains(t, err, tt.wantErrMsg)
 				return
 			}
+			assert.NilError(t, err)
 			if tt.want != nil {
 				assert.Equal(t, tt.want.TriggerTarget, got.TriggerTarget)
 				assert.Equal(t, tt.want.EventType, got.EventType)

--- a/pkg/provider/gitlab/test/test.go
+++ b/pkg/provider/gitlab/test/test.go
@@ -247,3 +247,31 @@ func (t TEvent) MREventAsJSON(action, extraStuff string) string {
 		t.BaseURL,
 		t.HeadURL, extraStuff)
 }
+
+func (t TEvent) CommitNoteEventAsJSON(comment, action, repository string) string {
+	//nolint:misspell
+	return fmt.Sprintf(`{
+	"object_kind": "note",
+	"event_type": "note",
+    "object_attributes": {
+	    "commit_id": "%s",
+        "noteable_type": "Commit",
+	    "note": "%s",
+	    "action": "%s"
+    },
+    "user": {
+	    "id": %d,
+        "username": "%s"
+    },
+	"project_id": %d,
+    "project": {
+        "default_branch": "%s",
+        "web_url": "%s",
+        "path_with_namespace": "%s"
+    },
+    "repository": %s,
+    "commit": {
+        "title": "test title"
+    }
+}`, t.SHA, comment, action, t.UserID, t.Username, t.SourceProjectID, t.DefaultBranch, t.URL, t.PathWithNameSpace, repository)
+}

--- a/pkg/reconciler/event.go
+++ b/pkg/reconciler/event.go
@@ -72,6 +72,7 @@ func buildEventFromPipelineRun(pr *tektonv1.PipelineRun) *info.Event {
 	prNumber := prAnno[keys.PullRequest]
 	if prNumber != "" {
 		event.PullRequestNumber, _ = strconv.Atoi(prNumber)
+		event.TriggerTarget = triggertype.PullRequest
 	}
 
 	// GitHub

--- a/test/gitlab_push_gitops_command_test.go
+++ b/test/gitlab_push_gitops_command_test.go
@@ -1,0 +1,168 @@
+//go:build e2e
+// +build e2e
+
+package test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/opscomments"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/cctx"
+	tgitlab "github.com/openshift-pipelines/pipelines-as-code/test/pkg/gitlab"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/scm"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
+
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"github.com/tektoncd/pipeline/pkg/names"
+	gitlab "gitlab.com/gitlab-org/api/client-go"
+	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGitlabGitOpsCommandTestOnPush(t *testing.T) {
+	targetNs := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
+	ctx := context.Background()
+	runcnx, opts, glprovider, err := tgitlab.Setup(ctx)
+	assert.NilError(t, err)
+	ctx, err = cctx.GetControllerCtxInfo(ctx, runcnx)
+	assert.NilError(t, err)
+	runcnx.Clients.Log.Info("Testing with Gitlab")
+	projectinfo, resp, err := glprovider.Client.Projects.GetProject(opts.ProjectID, nil)
+	assert.NilError(t, err)
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
+	}
+
+	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, targetNs, nil)
+	assert.NilError(t, err)
+
+	entries, err := payload.GetEntries(map[string]string{
+		".tekton/pipelinerun-on-push.yaml": "testdata/pipelinerun-on-push.yaml",
+	}, targetNs, targetNs, triggertype.Push.String(), map[string]string{})
+	assert.NilError(t, err)
+
+	title := "Test GitOps Commands on Push - " + targetNs
+	gitCloneURL, err := scm.MakeGitCloneURL(projectinfo.WebURL, opts.UserName, opts.Password)
+	assert.NilError(t, err)
+	scmOpts := &scm.Opts{
+		GitURL:        gitCloneURL,
+		Log:           runcnx.Clients.Log,
+		WebURL:        projectinfo.WebURL,
+		TargetRefName: targetNs,
+		BaseRefName:   projectinfo.DefaultBranch,
+		CommitTitle:   title,
+	}
+	_ = scm.PushFilesToRefGit(t, scmOpts, entries)
+	runcnx.Clients.Log.Infof("Branch %s has been created and pushed with files", targetNs)
+	defer tgitlab.TearDown(ctx, t, runcnx, glprovider, -1, targetNs, targetNs, opts.ProjectID)
+
+	branch, _, err := glprovider.Client.Branches.GetBranch(opts.ProjectID, targetNs)
+	assert.NilError(t, err)
+
+	waitOpts := wait.Opts{
+		RepoName:        targetNs,
+		Namespace:       targetNs,
+		MinNumberStatus: 1,
+		PollTimeout:     wait.DefaultTimeout,
+		TargetSHA:       branch.Commit.ID,
+	}
+
+	err = wait.UntilPipelineRunCreated(ctx, runcnx.Clients, waitOpts)
+	assert.NilError(t, err)
+
+	commentOpts := &gitlab.PostCommitCommentOptions{
+		Note: gitlab.Ptr("/test branch:" + targetNs),
+	}
+	cc, _, err := glprovider.Client.Commits.PostCommitComment(opts.ProjectID, branch.Commit.ID, commentOpts)
+	assert.NilError(t, err)
+	runcnx.Clients.Log.Infof("Commit comment %s has been created", cc.Note)
+
+	sopt := wait.SuccessOpt{
+		Title:           title,
+		OnEvent:         opscomments.TestSingleCommentEventType.String(),
+		TargetNS:        targetNs,
+		NumberofPRMatch: 2,
+	}
+	wait.Succeeded(ctx, t, runcnx, opts, sopt)
+	prsNew, err := runcnx.Clients.Tekton.TektonV1().PipelineRuns(targetNs).List(ctx, metav1.ListOptions{})
+	assert.NilError(t, err)
+	assert.Assert(t, len(prsNew.Items) == 2)
+}
+
+func TestGitlabGitOpsCommandCancelOnPush(t *testing.T) {
+	targetNs := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
+	ctx := context.Background()
+	runcnx, opts, glprovider, err := tgitlab.Setup(ctx)
+	assert.NilError(t, err)
+	ctx, err = cctx.GetControllerCtxInfo(ctx, runcnx)
+	assert.NilError(t, err)
+	runcnx.Clients.Log.Info("Testing with Gitlab")
+	projectinfo, resp, err := glprovider.Client.Projects.GetProject(opts.ProjectID, nil)
+	assert.NilError(t, err)
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
+	}
+
+	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, targetNs, nil)
+	assert.NilError(t, err)
+
+	entries, err := payload.GetEntries(map[string]string{
+		".tekton/pipelinerun-on-push.yaml": "testdata/pipelinerun-on-push.yaml",
+	}, targetNs, targetNs, triggertype.Push.String(), map[string]string{})
+	assert.NilError(t, err)
+
+	title := "Test GitOps Commands on Push - " + targetNs
+	gitCloneURL, err := scm.MakeGitCloneURL(projectinfo.WebURL, opts.UserName, opts.Password)
+	assert.NilError(t, err)
+	scmOpts := &scm.Opts{
+		GitURL:        gitCloneURL,
+		Log:           runcnx.Clients.Log,
+		WebURL:        projectinfo.WebURL,
+		TargetRefName: targetNs,
+		BaseRefName:   projectinfo.DefaultBranch,
+		CommitTitle:   title,
+	}
+	_ = scm.PushFilesToRefGit(t, scmOpts, entries)
+	runcnx.Clients.Log.Infof("Branch %s has been created and pushed with files", targetNs)
+	defer tgitlab.TearDown(ctx, t, runcnx, glprovider, -1, targetNs, targetNs, opts.ProjectID)
+
+	branch, _, err := glprovider.Client.Branches.GetBranch(opts.ProjectID, targetNs)
+	assert.NilError(t, err)
+
+	commentOpts := &gitlab.PostCommitCommentOptions{
+		Note: gitlab.Ptr("/test branch:" + targetNs),
+	}
+	cc, _, err := glprovider.Client.Commits.PostCommitComment(opts.ProjectID, branch.Commit.ID, commentOpts)
+	assert.NilError(t, err)
+	runcnx.Clients.Log.Infof("Commit comment %s has been created", cc.Note)
+
+	numberOfStatus := 2
+	waitOpts := wait.Opts{
+		RepoName:        targetNs,
+		Namespace:       targetNs,
+		MinNumberStatus: numberOfStatus,
+		PollTimeout:     wait.DefaultTimeout,
+		TargetSHA:       branch.Commit.ID,
+	}
+
+	err = wait.UntilPipelineRunCreated(ctx, runcnx.Clients, waitOpts)
+	assert.NilError(t, err)
+
+	prsNew, err := runcnx.Clients.Tekton.TektonV1().PipelineRuns(targetNs).List(ctx, metav1.ListOptions{})
+	assert.NilError(t, err)
+	assert.Assert(t, len(prsNew.Items) == numberOfStatus)
+
+	commentOpts = &gitlab.PostCommitCommentOptions{
+		Note: gitlab.Ptr("/cancel pipelinerun-on-push branch:" + targetNs),
+	}
+	cc, _, err = glprovider.Client.Commits.PostCommitComment(opts.ProjectID, branch.Commit.ID, commentOpts)
+	assert.NilError(t, err)
+	runcnx.Clients.Log.Infof("Commit comment %s has been created", cc.Note)
+
+	err = wait.UntilPipelineRunHasReason(ctx, runcnx.Clients, v1.PipelineRunReasonCancelled, waitOpts)
+	assert.NilError(t, err)
+}

--- a/test/pkg/wait/wait.go
+++ b/test/pkg/wait/wait.go
@@ -9,6 +9,8 @@ import (
 	pacv1alpha1 "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
+
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -81,5 +83,29 @@ func UntilPipelineRunCreated(ctx context.Context, clients clients.Clients, opts 
 
 		clients.Log.Infof("still waiting for pipelinerun to be created with label '%s=%s' in %s namespace", keys.SHA, opts.TargetSHA, opts.Namespace)
 		return len(prs.Items) == opts.MinNumberStatus, nil
+	})
+}
+
+// UntilPipelineRunHasReason Checks for certain reason of PipelineRuns.
+func UntilPipelineRunHasReason(ctx context.Context, clients clients.Clients, desiredReason v1.PipelineRunReason, opts Opts) error {
+	ctx, cancel := context.WithTimeout(ctx, opts.PollTimeout)
+	defer cancel()
+	return kubeinteraction.PollImmediateWithContext(ctx, opts.PollTimeout, func() (bool, error) {
+		prs, err := clients.Tekton.TektonV1().PipelineRuns(opts.Namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("%s=%s", keys.SHA, opts.TargetSHA),
+		})
+		if err != nil {
+			return true, err
+		}
+
+		var prsWithReason []v1.PipelineRun
+		for _, pr := range prs.Items {
+			if len(pr.Status.Conditions) > 0 && pr.Status.Conditions[0].Reason == desiredReason.String() {
+				prsWithReason = append(prsWithReason, pr)
+			}
+		}
+
+		clients.Log.Infof("still waiting for pipelinerun to have reason %s in %s namespace", desiredReason.String(), opts.Namespace)
+		return len(prsWithReason) >= opts.MinNumberStatus, nil
 	})
 }


### PR DESCRIPTION
This adds support of GitOps commands on pushed commits in GitLab so that users can trigger PipelineRuns on pushed commit. below commands are supported:
1) [/test, /retest]
2) [/test, /retest] prName
3) [/test, /retest] branch:test
4) /cancel
5) /cancel prName
6) /cancel branch:test

https://issues.redhat.com/browse/SRVKP-7105

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [x] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [x] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [x] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [x] 📖 Document any user-facing features or changes in behavior.

- [x] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [x] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- If adding a provider feature, fill in the following details:

| Git Provider     | Supported |
|------------------|-----------|
| GitHub App       | ❌️        |
| GitHub Webhook   | ❌️        |
| Gitea            | ❌️        |
| GitLab           | ✅️        |
| Bitbucket Cloud  | ❌️        |
| Bitbucket Server | ❌️        |

  (update the documentation accordingly)
