### PR TITLE
fix(cli): Skip dashboard URL prompt if not needed

### DIFF
--- a/pkg/cmd/tknpac/bootstrap/bootstrap_test.go
+++ b/pkg/cmd/tknpac/bootstrap/bootstrap_test.go
@@ -3,9 +3,11 @@ package bootstrap
 import (
 	"bytes"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli/prompt"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
@@ -13,6 +15,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/test/logger"
 	"gotest.tools/v3/assert"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	rtesting "knative.dev/pkg/reconciler/testing"
 )
@@ -141,5 +144,187 @@ func getConfigMapData(namespace, version string) *corev1.ConfigMap {
 		Data: map[string]string{
 			"version": version,
 		},
+	}
+}
+
+func TestGetDashboardURL(t *testing.T) {
+	testParams := []struct {
+		name           string
+		ingresses      []networkingv1.Ingress
+		askYNResponse  bool
+		surveyResponse string
+		wantURL        string
+		wantError      bool
+		errorMsg       string
+		askStubs       func(*prompt.AskStubber)
+	}{
+		{
+			name: "detect dashboard in ingress with http",
+			askStubs: func(as *prompt.AskStubber) {
+				as.StubOne(true)
+			},
+			ingresses: []networkingv1.Ingress{
+				{
+					Spec: networkingv1.IngressSpec{
+						Rules: []networkingv1.IngressRule{
+							{
+								Host: "tekton.example.com",
+								IngressRuleValue: networkingv1.IngressRuleValue{
+									HTTP: &networkingv1.HTTPIngressRuleValue{
+										Paths: []networkingv1.HTTPIngressPath{
+											{
+												Backend: networkingv1.IngressBackend{
+													Service: &networkingv1.IngressServiceBackend{
+														Name: tektonDashboardServiceName,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			askYNResponse: true,
+			wantURL:       "http://tekton.example.com",
+		},
+		{
+			name: "detect dashboard in ingress with https",
+			askStubs: func(as *prompt.AskStubber) {
+				as.StubOne(true)
+			},
+			ingresses: []networkingv1.Ingress{
+				{
+					Spec: networkingv1.IngressSpec{
+						TLS: []networkingv1.IngressTLS{{
+							Hosts: []string{"tekton.example.com"},
+						}},
+						Rules: []networkingv1.IngressRule{
+							{
+								Host: "tekton.example.com",
+								IngressRuleValue: networkingv1.IngressRuleValue{
+									HTTP: &networkingv1.HTTPIngressRuleValue{
+										Paths: []networkingv1.HTTPIngressPath{
+											{
+												Backend: networkingv1.IngressBackend{
+													Service: &networkingv1.IngressServiceBackend{
+														Name: tektonDashboardServiceName,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			askYNResponse: true,
+			wantURL:       "https://tekton.example.com",
+		},
+		{
+			name: "detect dashboard but user rejects it",
+			askStubs: func(as *prompt.AskStubber) {
+				as.StubOne(false)
+				as.StubOne("https://blah.com")
+			},
+			ingresses: []networkingv1.Ingress{
+				{
+					Spec: networkingv1.IngressSpec{
+						Rules: []networkingv1.IngressRule{
+							{
+								Host: "tekton.example.com",
+								IngressRuleValue: networkingv1.IngressRuleValue{
+									HTTP: &networkingv1.HTTPIngressRuleValue{
+										Paths: []networkingv1.HTTPIngressPath{
+											{
+												Backend: networkingv1.IngressBackend{
+													Service: &networkingv1.IngressServiceBackend{
+														Name: tektonDashboardServiceName,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			askYNResponse: false,
+			wantURL:       "https://blah.com",
+		},
+		{
+			name: "no dashboard detected, user provides url",
+			askStubs: func(as *prompt.AskStubber) {
+				as.StubOne("https://my-dashboard.example.org")
+			},
+			ingresses: []networkingv1.Ingress{},
+			wantURL:   "https://my-dashboard.example.org",
+		},
+		{
+			name:      "no dashboard detected, user provides empty url",
+			ingresses: []networkingv1.Ingress{},
+			askStubs: func(as *prompt.AskStubber) {
+				as.StubOne("")
+			},
+			wantURL: "",
+		},
+		{
+			name:      "no dashboard detected, user provides invalid url",
+			ingresses: []networkingv1.Ingress{},
+			askStubs: func(as *prompt.AskStubber) {
+				as.StubOne("invalid url")
+			},
+			wantError: true,
+			errorMsg:  "invalid url:",
+		},
+	}
+
+	for _, tt := range testParams {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			cs, _ := testclient.SeedTestData(t, ctx, testclient.Data{})
+			logger, _ := logger.GetLogger()
+
+			run := &params.Run{
+				Clients: clients.Clients{
+					PipelineAsCode: cs.PipelineAsCode,
+					Log:            logger,
+					Kube:           cs.Kube,
+				},
+				Info: info.Info{},
+			}
+
+			// Create test ingresses
+			for _, ing := range tt.ingresses {
+				if _, err := run.Clients.Kube.NetworkingV1().Ingresses("").Create(ctx, &ing, metav1.CreateOptions{}); err != nil {
+					t.Errorf("failed to create ingress: %v", err)
+				}
+			}
+
+			as, teardown := prompt.InitAskStubber()
+			defer teardown()
+
+			if tt.askStubs != nil {
+				tt.askStubs(as)
+			}
+
+			io, _ := newIOStream()
+			opts := &bootstrapOpts{ioStreams: io}
+
+			err := getDashboardURL(ctx, opts, run)
+			if tt.wantError {
+				assert.Assert(t, err != nil)
+				assert.Assert(t, strings.Contains(err.Error(), tt.errorMsg))
+			} else {
+				assert.NilError(t, err)
+				assert.Equal(t, tt.wantURL, opts.dashboardURL)
+			}
+		})
 	}
 }

--- a/pkg/cmd/tknpac/bootstrap/install.go
+++ b/pkg/cmd/tknpac/bootstrap/install.go
@@ -101,6 +101,9 @@ func getDashboardURL(ctx context.Context, opts *bootstrapOpts, run *params.Run) 
 	if err := prompt.SurveyAskOne(qs, &answer); err != nil {
 		return err
 	}
+	if answer == "" {
+		return nil
+	}
 	if _, err := url.ParseRequestURI(answer); err != nil {
 		return fmt.Errorf("invalid url: %w", err)
 	}


### PR DESCRIPTION
The bootstrap command was always prompting for a Tekton Dashboard URL, even when it wasn't strictly required. This commit modifies the `getDashboardURL` function to:

- Allow skipping the dashboard URL prompt by entering an empty string.
- Detect Tekton Dashboard URL from ingress resources and prompt the user if they want to use that URL.
- Prompt the user to provide a dashboard URL manually if no ingress resources are found.
- Added a lot of tests to cover these scenarios.

Fixes #1975
Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

