### PR TITLE
fix: Invalidate `ok-to-test` Command on Pushed Commits in GitHub

### DIFF
--- a/docs/content/docs/guide/gitops_commands.md
+++ b/docs/content/docs/guide/gitops_commands.md
@@ -70,6 +70,9 @@ This means:
    3. `/retest <pipelinerun-name> branch:test`
    4. `/test <pipelinerun-name> branch:test`
 
+Please note that the `/ok-to-test` command does not work on pushed commits, as it is specifically intended for pull requests to manage authorization. Since only authorized users are allowed to send `GitOps` commands on pushed commits,
+there is no need to use the `ok-to-test` command in this context.
+
 To issue a `GitOps` comment on a pushed commit, you can follow these steps:
 
 1. Go to your repository.

--- a/pkg/provider/github/detect.go
+++ b/pkg/provider/github/detect.go
@@ -102,12 +102,13 @@ func (v *Provider) detectTriggerTypeFromPayload(ghEventType string, eventInt any
 			if provider.IsTestRetestComment(event.GetComment().GetBody()) {
 				return triggertype.Retest, ""
 			}
-			if provider.IsOkToTestComment(event.GetComment().GetBody()) {
-				return triggertype.OkToTest, ""
-			}
 			if provider.IsCancelComment(event.GetComment().GetBody()) {
 				return triggertype.Cancel, ""
 			}
+			// Here, the `/ok-to-test` command is ignored because it is intended for pull requests.
+			// For unauthorized users, it has no relevance to pushed commits, as only authorized users
+			// are allowed to run CI on pushed commits. Therefore, the `ok-to-test` command holds no significance in this context.
+			// However, it is left to be processed by the `on-comment` annotation rather than returning an error.
 		}
 		return triggertype.Comment, ""
 	}

--- a/pkg/provider/github/detect_test.go
+++ b/pkg/provider/github/detect_test.go
@@ -304,6 +304,19 @@ func TestProvider_Detect(t *testing.T) {
 			isGH:       true,
 			processReq: true,
 		},
+		{
+			name: "commit comment Event with /ok-to-test being ignore as GitOps command on pushed commits",
+			event: github.CommitCommentEvent{
+				Action: github.Ptr("created"),
+				Installation: &github.Installation{
+					ID: &idd,
+				},
+				Comment: &github.RepositoryComment{Body: github.Ptr("/ok-to-test")},
+			},
+			eventType:  "commit_comment",
+			isGH:       true,
+			processReq: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
invalidated ok-to-test command on pushed commits as it is not needed there.

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [x] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [x] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [x] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [x] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- If adding a provider feature, fill in the following details:

| Git Provider     | Supported |
|------------------|-----------|
| GitHub App       | ✅️        |
| GitHub Webhook   | ✅️        |
| Gitea            | ❌️        |
| GitLab           | ❌️        |
| Bitbucket Cloud  | ❌️        |
| Bitbucket Server | ❌️        |

  (update the documentation accordingly)
