### PR TITLE
chore: Updated PAC Deployments for KUBERNETES_MIN_VERSION Env

### DIFF
--- a/config/400-controller.yaml
+++ b/config/400-controller.yaml
@@ -101,6 +101,8 @@ spec:
               value: "pipelines-as-code-secret"
             - name: PAC_CONTROLLER_CONFIGMAP
               value: "pipelines-as-code"
+            - name: KUBERNETES_MIN_VERSION
+              value: "v1.28.0"
           volumeMounts:
             - mountPath: "/etc/pipelines-as-code/tls"
               readOnly: true

--- a/config/500-watcher.yaml
+++ b/config/500-watcher.yaml
@@ -60,6 +60,8 @@ spec:
             value: pipelines-as-code-config-observability
           - name: CONFIG_LEADERELECTION_NAME
             value: pac-watcher-config-leader-election
+          - name: KUBERNETES_MIN_VERSION
+            value: "v1.28.0"
           ports:
           - name: probes
             containerPort: 8080

--- a/config/600-webhook.yaml
+++ b/config/600-webhook.yaml
@@ -60,6 +60,8 @@ spec:
               value: tekton.dev/pipelinesascode
             - name: CONFIG_LEADERELECTION_NAME
               value: pac-webhook-config-leader-election
+            - name: KUBERNETES_MIN_VERSION
+              value: "v1.28.0"
           ports:
             - name: https-webhook
               containerPort: 8443


### PR DESCRIPTION
added KUBERNETES_MIN_VERSION env in controller, watcher, and webhook to support v1.28.0.

