### PR TITLE
fix(cli): tkn pac generate command when .tekton directory is not there

### DIFF
--- a/pkg/cmd/tknpac/generate/generate.go
+++ b/pkg/cmd/tknpac/generate/generate.go
@@ -197,24 +197,27 @@ func generatefileName(eventType string) string {
 // directory.
 func (o *Opts) samplePipeline(recreateTemplate bool) error {
 	cs := o.IOStreams.ColorScheme()
-	var relpath, fpath string
+	var relpath, fpath, dirPath string
 
 	if o.FileName != "" {
 		fpath = o.FileName
 		relpath = fpath
+		dirPath = filepath.Dir(fpath)
 	} else {
 		fname := generatefileName(o.Event.EventType)
 		fpath = filepath.Join(o.GitInfo.TopLevelPath, ".tekton", fname)
 		relpath, _ = filepath.Rel(o.GitInfo.TopLevelPath, fpath)
-		if _, err := os.Stat(filepath.Join(o.GitInfo.TopLevelPath, ".tekton")); os.IsNotExist(err) {
-			if err := os.MkdirAll(filepath.Join(o.GitInfo.TopLevelPath, ".tekton"), 0o755); err != nil {
-				return err
-			}
-			fmt.Fprintf(o.IOStreams.Out, "%s Directory %s has been created.\n",
-				cs.InfoIcon(),
-				cs.Bold(".tekton"),
-			)
+		dirPath = filepath.Join(o.GitInfo.TopLevelPath, ".tekton")
+	}
+
+	if _, err := os.Stat(dirPath); os.IsNotExist(err) {
+		if err := os.MkdirAll(dirPath, 0o755); err != nil {
+			return err
 		}
+		fmt.Fprintf(o.IOStreams.Out, "%s Directory %s has been created.\n",
+			cs.InfoIcon(),
+			cs.Bold(dirPath),
+		)
 	}
 
 	if _, err := os.Stat(fpath); !os.IsNotExist(err) && !o.overwrite {

--- a/pkg/cmd/tknpac/generate/generate_test.go
+++ b/pkg/cmd/tknpac/generate/generate_test.go
@@ -31,6 +31,8 @@ func TestGenerateTemplate(t *testing.T) {
 		addExtraFilesInRepo     map[string]string
 		regenerateTemplate      bool
 		useClusterTask          bool
+		fileName                string
+		overwrite               bool
 	}{
 		{
 			name: "pull request default",
@@ -167,6 +169,34 @@ func TestGenerateTemplate(t *testing.T) {
 			},
 			regenerateTemplate: false,
 		},
+		{
+			name: "create .tekton directory if it doesn't exists",
+			askStubs: func(as *prompt.AskStubber) {
+				as.StubOneDefault() // pull_request
+				as.StubOne("")      // default as main
+			},
+			checkGeneratedFile: ".tekton/another.yaml",
+			gitinfo: git.Info{
+				URL: "https://hello/moto",
+			},
+			regenerateTemplate: false,
+			fileName:           ".tekton/another.yaml",
+			overwrite:          true,
+		},
+		{
+			name: "create /tmp/foobar if it doesn't exists",
+			askStubs: func(as *prompt.AskStubber) {
+				as.StubOneDefault() // pull_request
+				as.StubOne("")      // default as main
+			},
+			checkGeneratedFile: "/tmp/foobar/remove.yaml",
+			gitinfo: git.Info{
+				URL: "https://hello/moto",
+			},
+			regenerateTemplate: false,
+			fileName:           "/tmp/foobar/remove.yaml",
+			overwrite:          true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -190,12 +220,18 @@ func TestGenerateTemplate(t *testing.T) {
 				assert.NilError(t, err, "failed to create file", key)
 			}
 
+			if tt.fileName != "" {
+				tt.fileName = newdir.Path() + "/" + tt.fileName
+			}
+
 			err := Generate(&Opts{
 				Event:                   &tt.event,
 				GitInfo:                 &tt.gitinfo,
 				IOStreams:               io,
 				CLIOpts:                 &cli.PacCliOpts{},
 				generateWithClusterTask: tt.useClusterTask,
+				FileName:                tt.fileName,
+				overwrite:               tt.overwrite,
 			}, tt.regenerateTemplate)
 			assert.NilError(t, err)
 


### PR DESCRIPTION
* Before this patch when .tekton directory is not there and if user runs `tkn pac generate -f` command then it used to return an error

* Now with this patch if .tekton directory is not there and the command is executed then directory is created and it generates the pipelinerun yaml based on the name provided by the user

Fixes: #1849 

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [x] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [x] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [ ] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [ ] 📖 Document any user-facing features or changes in behavior.

- [ ] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [ ] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [ ] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

| Git Provider     | Supported |
|------------------|-----------|
| GitHub App       | ✅️        |
| GitHub Webhook   | ❌️        |
| Gitea            | ❌️        |
| GitLab           | ❌️        |
| Bitbucket Cloud  | ❌️        |
| Bitbucket Server | ❌️        |

  (update the documentation accordingly)
