### PR TITLE
fix: Expand "dynamic" variables in default values

### DIFF
--- a/test/testdata/pipeline_with_tekton_params.yaml
+++ b/test/testdata/pipeline_with_tekton_params.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: pipeline-with-tekton-params
+spec:
+  params:
+    - name: foo
+      type: string
+      default: "{{ repo_name }}"
+  tasks:
+    - name: task
+      taskSpec:
+        steps:
+          - name: task
+            image: registry.access.redhat.com/ubi9/ubi-micro
+            script: |
+              echo "Hello $(params.foo)"
+              exit 0

--- a/test/testdata/pipelinerun_with_tekton_params.yaml
+++ b/test/testdata/pipelinerun_with_tekton_params.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: "piplinerun-with-tekton-params"
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
+    pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
+spec:
+  pipelineRef:
+    name: pipeline-with-tekton-params


### PR DESCRIPTION
This commit addresses an issue where dynamic variables used as default values in pipeline parameters are not resolved correctly. Currently, when an expandable dynamic variable is added as a default value to a parameter in a Pipeline, it is not resolved, leading to errors.

For example, in the Pipeline.yaml:

- name: REPO_NAME
  default: "{{ repo_name }}"
- name: REVISION
- name: BRANCH
- name: PULL_REQUEST_NUMBER

Omitting the parameter with a default value in the PipelineRun does not resolve the parameter, resulting not being expanded in the PipelineRun.

Business value:
- Clean up pipelines by reducing the need to pass through all expandable dynamic parameters.
- Make shared pipelines easier to use and reduce the surface for mistakes.

fixes: #1397 

Jira: https://issues.redhat.com/browse/SRVKP-4070

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [X] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [X] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [X] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [ ] 📖 Document any user-facing features or changes in behavior.

- [X] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [ ] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [ ] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

| Git Provider     | Supported |
|------------------|-----------|
| GitHub App       | ✅️        |
| GitHub Webhook   | ❌️        |
| Gitea            | ❌️        |
| GitLab           | ❌️        |
| Bitbucket Cloud  | ❌️        |
| Bitbucket Server | ❌️        |

  (update the documentation accordingly)
