### PR TITLE
fix: Fixed Gitea Test `TestGiteaPullRequestPrivateRepository` Flakiness

### DIFF
--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -153,7 +153,7 @@ func TestGiteaPullRequestPrivateRepository(t *testing.T) {
 	defer f()
 	reg := regexp.MustCompile(".*fetched git-clone task")
 	maxLines := int64(20)
-	err := twait.RegexpMatchingInControllerLog(ctx, topts.ParamsRun, *reg, 10, "controller", &maxLines)
+	err := twait.RegexpMatchingInControllerLog(ctx, topts.ParamsRun, *reg, 20, "controller", &maxLines)
 	assert.NilError(t, err)
 	tgitea.WaitForSecretDeletion(t, topts, topts.TargetRefName)
 }


### PR DESCRIPTION
I've seen flakiness of this specific test `TestGiteaPullRequestPrivateRepository` of Gitea today in some PRs, increased its loop looking for logs. see example links:
https://github.com/openshift-pipelines/pipelines-as-code/actions/runs/13761677410/job/38478993398?pr=1980
https://github.com/openshift-pipelines/pipelines-as-code/actions/runs/13764671169/job/38488274177?pr=1983


| Git Provider     | Supported |
|------------------|-----------|
| GitHub App       | ❌️        |
| GitHub Webhook   | ❌️        |
| Gitea            | ✅️        |
| GitLab           | ❌️        |
| Bitbucket Cloud  | ❌️        |
| Bitbucket Server | ❌️        |

  (update the documentation accordingly)
