### PR TITLE
refactor: replace interface{} with any in codebase

### DIFF
--- a/.tekton/go.yaml
+++ b/.tekton/go.yaml
@@ -122,6 +122,8 @@ spec:
                   value: ["**go.mod", "**go.sum"]
                 - name: target
                   value: oci://image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/cache-go:{{hash}}
+                - name: fetched
+                  value: $(tasks.cached-fetch.results.fetched)
                 - name: cachePath
                   value: $(workspaces.source.path)/go-build-cache
                 - name: workingdir

--- a/pkg/action/patch.go
+++ b/pkg/action/patch.go
@@ -30,7 +30,7 @@ import (
 //
 // The function doubles the default retry parameters (steps, duration, factor, jitter) to handle conflicts more robustly.
 // If the patch operation fails after retries, the original PipelineRun is returned along with the error.
-func PatchPipelineRun(ctx context.Context, logger *zap.SugaredLogger, whatPatching string, tekton versioned.Interface, pr *tektonv1.PipelineRun, mergePatch map[string]interface{}) (*tektonv1.PipelineRun, error) {
+func PatchPipelineRun(ctx context.Context, logger *zap.SugaredLogger, whatPatching string, tekton versioned.Interface, pr *tektonv1.PipelineRun, mergePatch map[string]any) (*tektonv1.PipelineRun, error) {
 	if pr == nil {
 		return nil, nil
 	}

--- a/pkg/action/patch_test.go
+++ b/pkg/action/patch_test.go
@@ -43,9 +43,9 @@ func TestPatchPipelineRun(t *testing.T) {
 	assert.Equal(t, patchedPR.Annotations[filepath.Join(apipac.GroupName, "log-url")], "https://localhost.console/#/namespaces/namespace/pipelineruns/force-me")
 }
 
-func getLogURLMergePatch(clients clients.Clients, pr *pipelinev1.PipelineRun) map[string]interface{} {
-	return map[string]interface{}{
-		"metadata": map[string]interface{}{
+func getLogURLMergePatch(clients clients.Clients, pr *pipelinev1.PipelineRun) map[string]any {
+	return map[string]any{
+		"metadata": map[string]any{
 			"annotations": map[string]string{
 				keys.LogURL: clients.ConsoleUI().DetailURL(pr),
 			},

--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -128,7 +128,7 @@ func (l listener) handleEvent(ctx context.Context) http.HandlerFunc {
 			return
 		}
 
-		var event map[string]interface{}
+		var event map[string]any
 		if string(payload) != "" {
 			if err := json.Unmarshal(payload, &event); err != nil {
 				l.logger.Errorf("Invalid event body format format: %s", err)
@@ -232,7 +232,7 @@ func (l listener) detectProvider(req *http.Request, reqBody string) (provider.In
 	log := *l.logger
 
 	// payload validation
-	var event map[string]interface{}
+	var event map[string]any
 	if err := json.Unmarshal([]byte(reqBody), &event); err != nil {
 		return nil, &log, fmt.Errorf("invalid event body format: %w", err)
 	}

--- a/pkg/adapter/adapter_test.go
+++ b/pkg/adapter/adapter_test.go
@@ -48,10 +48,10 @@ func TestHandleEvent(t *testing.T) {
 	ctx = info.StoreNS(ctx, "default")
 
 	emptys := &unstructured.Unstructured{}
-	emptys.SetUnstructuredContent(map[string]interface{}{
+	emptys.SetUnstructuredContent(map[string]any{
 		"apiVersion": "route.openshift.io/v1",
 		"kind":       "Route",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      "not",
 			"namespace": "console",
 		},
@@ -218,7 +218,7 @@ func TestWhichProvider(t *testing.T) {
 	}
 	tests := []struct {
 		name          string
-		event         interface{}
+		event         any
 		header        http.Header
 		wantErrString string
 	}{

--- a/pkg/adapter/incoming_test.go
+++ b/pkg/adapter/incoming_test.go
@@ -898,7 +898,7 @@ func TestApplyIncomingParams(t *testing.T) {
 			contentType: "application/json",
 			payloadBody: []byte(`{"params": {"key": "value", "other": "value"}}`),
 			params:      []string{"key", "other"},
-			expected:    apincoming.Payload{Params: map[string]interface{}{"key": "value", "other": "value"}},
+			expected:    apincoming.Payload{Params: map[string]any{"key": "value", "other": "value"}},
 		},
 	}
 

--- a/pkg/apis/incoming/incoming.go
+++ b/pkg/apis/incoming/incoming.go
@@ -3,7 +3,7 @@ package incoming
 import "encoding/json"
 
 type (
-	Params  map[string]interface{}
+	Params  map[string]any
 	Payload struct {
 		Params Params `json:"params"`
 	}

--- a/pkg/apis/incoming/incoming_test.go
+++ b/pkg/apis/incoming/incoming_test.go
@@ -9,7 +9,7 @@ import (
 func TestParseIncomingPayload(t *testing.T) {
 	// Test case where payload is valid JSON
 	payload := []byte(`{"params": {"key": "value"}}`)
-	expected := Payload{map[string]interface{}{"key": "value"}}
+	expected := Payload{map[string]any{"key": "value"}}
 	actual, err := ParseIncomingPayload(payload)
 	assert.NilError(t, err)
 	assert.DeepEqual(t, expected, actual)

--- a/pkg/cli/color.go
+++ b/pkg/cli/color.go
@@ -102,7 +102,7 @@ func (c *ColorScheme) Dimmed(t string) string {
 	return dimmed(t)
 }
 
-func (c *ColorScheme) Boldf(t string, args ...interface{}) string {
+func (c *ColorScheme) Boldf(t string, args ...any) string {
 	return c.Bold(fmt.Sprintf(t, args...))
 }
 
@@ -136,7 +136,7 @@ func (c *ColorScheme) BulletSpace() string {
 	return "  "
 }
 
-func (c *ColorScheme) Redf(t string, args ...interface{}) string {
+func (c *ColorScheme) Redf(t string, args ...any) string {
 	return c.Red(fmt.Sprintf(t, args...))
 }
 
@@ -147,7 +147,7 @@ func (c *ColorScheme) Yellow(t string) string {
 	return yellow(t)
 }
 
-func (c *ColorScheme) Yellowf(t string, args ...interface{}) string {
+func (c *ColorScheme) Yellowf(t string, args ...any) string {
 	return c.Yellow(fmt.Sprintf(t, args...))
 }
 
@@ -165,7 +165,7 @@ func (c *ColorScheme) Underline(t string) string {
 	return underline(t)
 }
 
-func (c *ColorScheme) Greenf(t string, args ...interface{}) string {
+func (c *ColorScheme) Greenf(t string, args ...any) string {
 	return c.Green(fmt.Sprintf(t, args...))
 }
 
@@ -179,7 +179,7 @@ func (c *ColorScheme) Gray(t string) string {
 	return gray(t)
 }
 
-func (c *ColorScheme) Grayf(t string, args ...interface{}) string {
+func (c *ColorScheme) Grayf(t string, args ...any) string {
 	return c.Gray(fmt.Sprintf(t, args...))
 }
 
@@ -190,7 +190,7 @@ func (c *ColorScheme) Magenta(t string) string {
 	return magenta(t)
 }
 
-func (c *ColorScheme) Magentaf(t string, args ...interface{}) string {
+func (c *ColorScheme) Magentaf(t string, args ...any) string {
 	return c.Magenta(fmt.Sprintf(t, args...))
 }
 
@@ -201,7 +201,7 @@ func (c *ColorScheme) Cyan(t string) string {
 	return cyan(t)
 }
 
-func (c *ColorScheme) Cyanf(t string, args ...interface{}) string {
+func (c *ColorScheme) Cyanf(t string, args ...any) string {
 	return c.Cyan(fmt.Sprintf(t, args...))
 }
 
@@ -226,7 +226,7 @@ func (c *ColorScheme) BlueBold(t string) string {
 	return blueBold(t)
 }
 
-func (c *ColorScheme) Bluef(t string, args ...interface{}) string {
+func (c *ColorScheme) Bluef(t string, args ...any) string {
 	return c.Blue(fmt.Sprintf(t, args...))
 }
 

--- a/pkg/cli/prompt/prompt.go
+++ b/pkg/cli/prompt/prompt.go
@@ -3,11 +3,11 @@ package prompt
 import "github.com/AlecAivazis/survey/v2"
 
 // SurveyAskOne ask one question to be stubbed later.
-var SurveyAskOne = func(p survey.Prompt, response interface{}, opts ...survey.AskOpt) error {
+var SurveyAskOne = func(p survey.Prompt, response any, opts ...survey.AskOpt) error {
 	return survey.AskOne(p, response, opts...)
 }
 
 // SurveyAsk ask questions to be stubbed later.
-var SurveyAsk = func(qs []*survey.Question, response interface{}, opts ...survey.AskOpt) error {
+var SurveyAsk = func(qs []*survey.Question, response any, opts ...survey.AskOpt) error {
 	return survey.Ask(qs, response, opts...)
 }

--- a/pkg/cli/prompt/stubber.go
+++ b/pkg/cli/prompt/stubber.go
@@ -22,7 +22,7 @@ func InitAskStubber() (*AskStubber, func()) {
 	origSurveyAskOne := SurveyAskOne
 	as := AskStubber{}
 
-	SurveyAskOne = func(p survey.Prompt, response interface{}, _ ...survey.AskOpt) error {
+	SurveyAskOne = func(p survey.Prompt, response any, _ ...survey.AskOpt) error {
 		as.AskOnes = append(as.AskOnes, &p)
 		count := as.OneCount
 		as.OneCount++
@@ -49,17 +49,17 @@ func InitAskStubber() (*AskStubber, func()) {
 }
 
 type StubPrompt struct {
-	Value   interface{}
+	Value   any
 	Default bool
 }
 
 type QuestionStub struct {
 	Name    string
-	Value   interface{}
+	Value   any
 	Default bool
 }
 
-func (as *AskStubber) StubOne(value interface{}) {
+func (as *AskStubber) StubOne(value any) {
 	as.StubOnes = append(as.StubOnes, &StubPrompt{
 		Value: value,
 	})

--- a/pkg/cmd/tknpac/bootstrap/route.go
+++ b/pkg/cmd/tknpac/bootstrap/route.go
@@ -32,7 +32,7 @@ func DetectOpenShiftRoute(ctx context.Context, run *params.Run, targetNamespace 
 	}
 	route := routes.Items[0]
 
-	spec, ok := route.Object["spec"].(map[string]interface{})
+	spec, ok := route.Object["spec"].(map[string]any)
 	if !ok {
 		return "", fmt.Errorf("couldn't find spec in the PAC Controller route")
 	}

--- a/pkg/cmd/tknpac/resolve/resolve.go
+++ b/pkg/cmd/tknpac/resolve/resolve.go
@@ -203,7 +203,7 @@ func resolveFilenames(ctx context.Context, cs *params.Run, filenames []string, p
 	}
 
 	// TODO: flags
-	allTheYamls = templates.ReplacePlaceHoldersVariables(allTheYamls, params, nil, http.Header{}, map[string]interface{}{})
+	allTheYamls = templates.ReplacePlaceHoldersVariables(allTheYamls, params, nil, http.Header{}, map[string]any{})
 	// We use github here but since we don't do remotetask we would not care
 	providerintf := github.New()
 	event := info.NewEvent()

--- a/pkg/configutil/config.go
+++ b/pkg/configutil/config.go
@@ -9,7 +9,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func ValidateAndAssignValues(logger *zap.SugaredLogger, configData map[string]string, configStruct interface{}, customValidations map[string]func(string) error, logUpdates bool) error {
+func ValidateAndAssignValues(logger *zap.SugaredLogger, configData map[string]string, configStruct any, customValidations map[string]func(string) error, logUpdates bool) error {
 	structValue := reflect.ValueOf(configStruct).Elem()
 	structType := reflect.TypeOf(configStruct).Elem()
 

--- a/pkg/consoleui/interface_test.go
+++ b/pkg/consoleui/interface_test.go
@@ -16,7 +16,7 @@ func TestFallbackConsole(t *testing.T) {
 	fbc := &FallBackConsole{}
 	ctx, _ := rtesting.SetupFakeContext(t)
 	unsf := &unstructured.Unstructured{}
-	unsf.SetUnstructuredContent(map[string]interface{}{
+	unsf.SetUnstructuredContent(map[string]any{
 		"apiVersion": "foo.io/v1",
 		"kind":       "Random",
 	})

--- a/pkg/consoleui/openshift.go
+++ b/pkg/consoleui/openshift.go
@@ -62,7 +62,7 @@ func (o *OpenshiftConsole) UI(ctx context.Context, kdyn dynamic.Interface) error
 		return err
 	}
 
-	spec, ok := route.Object["spec"].(map[string]interface{})
+	spec, ok := route.Object["spec"].(map[string]any)
 	if !ok {
 		// this condition is satisfied if there's no metadata at all in the provided CR
 		return fmt.Errorf("couldn't find spec in the OpenShift Console route")

--- a/pkg/consoleui/openshift_test.go
+++ b/pkg/consoleui/openshift_test.go
@@ -14,42 +14,42 @@ import (
 
 func TestOpenshiftConsoleUI(t *testing.T) {
 	fakeroute := &unstructured.Unstructured{}
-	fakeroute.SetUnstructuredContent(map[string]interface{}{
+	fakeroute.SetUnstructuredContent(map[string]any{
 		"apiVersion": "route.openshift.io/v1",
 		"kind":       "Route",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      "console",
 			"namespace": "openshift-console",
 		},
-		"spec": map[string]interface{}{
+		"spec": map[string]any{
 			"host": "http://fakeconsole",
 		},
 	})
 	emptys := &unstructured.Unstructured{}
-	emptys.SetUnstructuredContent(map[string]interface{}{
+	emptys.SetUnstructuredContent(map[string]any{
 		"apiVersion": "route.openshift.io/v1",
 		"kind":       "Route",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      "not",
 			"namespace": "console",
 		},
 	})
 	nospeccontent := &unstructured.Unstructured{}
-	nospeccontent.SetUnstructuredContent(map[string]interface{}{
+	nospeccontent.SetUnstructuredContent(map[string]any{
 		"apiVersion": "route.openshift.io/v1",
 		"kind":       "Route",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      "console",
 			"namespace": "openshift-console",
 		},
-		"spec": map[string]interface{}{},
+		"spec": map[string]any{},
 	})
 
 	nohost := &unstructured.Unstructured{}
-	nohost.SetUnstructuredContent(map[string]interface{}{
+	nohost.SetUnstructuredContent(map[string]any{
 		"apiVersion": "route.openshift.io/v1",
 		"kind":       "Route",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      "console",
 			"namespace": "openshift-console",
 		},

--- a/pkg/consoleui/tektondashboard_test.go
+++ b/pkg/consoleui/tektondashboard_test.go
@@ -20,7 +20,7 @@ func TestTektonDashboard(t *testing.T) {
 	ctx, _ := rtesting.SetupFakeContext(t)
 
 	unsf := &unstructured.Unstructured{}
-	unsf.SetUnstructuredContent(map[string]interface{}{
+	unsf.SetUnstructuredContent(map[string]any{
 		"apiVersion": "foo.io/v1",
 		"kind":       "Random",
 	})

--- a/pkg/customparams/customparams.go
+++ b/pkg/customparams/customparams.go
@@ -62,7 +62,7 @@ func (p *CustomParams) applyIncomingParams(ret map[string]string) map[string]str
 // we let the user specify a cel filter. If false then we skip the parameters.
 // if multiple params name has a filter we pick up the first one that has
 // matched true.
-func (p *CustomParams) GetParams(ctx context.Context) (map[string]string, map[string]interface{}, error) {
+func (p *CustomParams) GetParams(ctx context.Context) (map[string]string, map[string]any, error) {
 	stdParams, changedFiles := p.makeStandardParamsFromEvent(ctx)
 	resolvedParams, mapFilters, parsedFromComment := map[string]string{}, map[string]string{}, map[string]string{}
 	if p.event.TriggerComment != "" {

--- a/pkg/customparams/customparams_test.go
+++ b/pkg/customparams/customparams_test.go
@@ -35,7 +35,7 @@ func TestApplyIncomingParams(t *testing.T) {
 				"key1": "value1",
 			},
 			payload: &incoming.Payload{
-				Params: map[string]interface{}{
+				Params: map[string]any{
 					"key2": "value2",
 				},
 			},
@@ -49,7 +49,7 @@ func TestApplyIncomingParams(t *testing.T) {
 				"key1": "value1",
 			},
 			payload: &incoming.Payload{
-				Params: map[string]interface{}{
+				Params: map[string]any{
 					"key1": "value2",
 				},
 			},
@@ -72,7 +72,7 @@ func TestApplyIncomingParams(t *testing.T) {
 				"key1": "value1",
 			},
 			payload: &incoming.Payload{
-				Params: map[string]interface{}{
+				Params: map[string]any{
 					"key2": 1,
 				},
 			},

--- a/pkg/customparams/standard.go
+++ b/pkg/customparams/standard.go
@@ -25,7 +25,7 @@ func (p *CustomParams) getChangedFiles(ctx context.Context) changedfiles.Changed
 }
 
 // makeStandardParamsFromEvent will create a map of standard params out of the event.
-func (p *CustomParams) makeStandardParamsFromEvent(ctx context.Context) (map[string]string, map[string]interface{}) {
+func (p *CustomParams) makeStandardParamsFromEvent(ctx context.Context) (map[string]string, map[string]any) {
 	repoURL := p.event.URL
 	// On bitbucket data center you are have a special url for checking it out, they
 	// seemed to fix it in 2.0 but i guess we have to live with this until then.
@@ -49,7 +49,7 @@ func (p *CustomParams) makeStandardParamsFromEvent(ctx context.Context) (map[str
 			"event_type":          opscomments.EventTypeBackwardCompat(p.eventEmitter, p.repo, p.event.EventType),
 			"trigger_comment":     triggerCommentAsSingleLine,
 			"pull_request_labels": pullRequestLabels,
-		}, map[string]interface{}{
+		}, map[string]any{
 			"all":      changedFiles.All,
 			"added":    changedFiles.Added,
 			"deleted":  changedFiles.Deleted,

--- a/pkg/generated/clientset/versioned/typed/pipelinesascode/v1alpha1/generated_expansion.go
+++ b/pkg/generated/clientset/versioned/typed/pipelinesascode/v1alpha1/generated_expansion.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 package v1alpha1
 
-type RepositoryExpansion interface{}
+type RepositoryExpansion any

--- a/pkg/generated/listers/pipelinesascode/v1alpha1/expansion_generated.go
+++ b/pkg/generated/listers/pipelinesascode/v1alpha1/expansion_generated.go
@@ -20,8 +20,8 @@ package v1alpha1
 
 // RepositoryListerExpansion allows custom methods to be added to
 // RepositoryLister.
-type RepositoryListerExpansion interface{}
+type RepositoryListerExpansion any
 
 // RepositoryNamespaceListerExpansion allows custom methods to be added to
 // RepositoryNamespaceLister.
-type RepositoryNamespaceListerExpansion interface{}
+type RepositoryNamespaceListerExpansion any

--- a/pkg/generated/listers/pipelinesascode/v1alpha1/repository.go
+++ b/pkg/generated/listers/pipelinesascode/v1alpha1/repository.go
@@ -48,7 +48,7 @@ func NewRepositoryLister(indexer cache.Indexer) RepositoryLister {
 
 // List lists all Repositories in the indexer.
 func (s *repositoryLister) List(selector labels.Selector) (ret []*v1alpha1.Repository, err error) {
-	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+	err = cache.ListAll(s.indexer, selector, func(m any) {
 		ret = append(ret, m.(*v1alpha1.Repository))
 	})
 	return ret, err
@@ -80,7 +80,7 @@ type repositoryNamespaceLister struct {
 
 // List lists all Repositories in the indexer for a given namespace.
 func (s repositoryNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.Repository, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m any) {
 		ret = append(ret, m.(*v1alpha1.Repository))
 	})
 	return ret, err

--- a/pkg/matcher/annotation_matcher_test.go
+++ b/pkg/matcher/annotation_matcher_test.go
@@ -193,7 +193,7 @@ func TestMatchPipelinerunAnnotationAndRepositories(t *testing.T) {
 					EventType:     "pull_request",
 					BaseBranch:    mainBranch,
 					HeadBranch:    "unittests",
-					Event: map[string]interface{}{
+					Event: map[string]any{
 						"foo": "bar",
 					},
 				},

--- a/pkg/params/cli.go
+++ b/pkg/params/cli.go
@@ -27,6 +27,6 @@ func NewCliOptions() *PacCliOpts {
 	}
 }
 
-func (c *PacCliOpts) Ask(qss []*survey.Question, answer interface{}) error {
+func (c *PacCliOpts) Ask(qss []*survey.Question, answer any) error {
 	return survey.Ask(qss, answer, c.AskOpts)
 }

--- a/pkg/params/config_sync.go
+++ b/pkg/params/config_sync.go
@@ -24,13 +24,13 @@ func StartConfigSync(ctx context.Context, run *Run) {
 		}))
 	informer := informerFactory.Core().V1().ConfigMaps().Informer()
 	_, _ = informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(_ interface{}) {
+		AddFunc: func(_ any) {
 			// nothing to do
 		},
-		UpdateFunc: func(_, _ interface{}) {
+		UpdateFunc: func(_, _ any) {
 			_ = run.UpdatePacConfig(ctx)
 		},
-		DeleteFunc: func(_ interface{}) {
+		DeleteFunc: func(_ any) {
 			// nothing to do
 		},
 	})

--- a/pkg/params/info/events.go
+++ b/pkg/params/info/events.go
@@ -8,7 +8,7 @@ import (
 
 type Event struct {
 	State
-	Event interface{}
+	Event any
 
 	// EventType is what coming from the provider header, i.e:
 	// GitHub -> pull_request

--- a/pkg/params/settings/convert.go
+++ b/pkg/params/settings/convert.go
@@ -42,7 +42,7 @@ func ConvertPacStructToConfigMap(settings *Settings) map[string]string {
 			// for hub catalogs map
 			if key == "" {
 				data := element.Interface().(*sync.Map)
-				data.Range(func(key, value interface{}) bool {
+				data.Range(func(key, value any) bool {
 					catalogData := value.(HubCatalog)
 					if key == "default" {
 						config[HubURLKey] = catalogData.URL

--- a/pkg/params/settings/default_test.go
+++ b/pkg/params/settings/default_test.go
@@ -126,7 +126,7 @@ func TestGetCatalogHub(t *testing.T) {
 			}
 			catalogs := getHubCatalogs(fakelogger, tt.hubCatalogs, tt.config)
 			length := 0
-			catalogs.Range(func(_, _ interface{}) bool {
+			catalogs.Range(func(_, _ any) bool {
 				length++
 				return true
 			})

--- a/pkg/pipelineascode/cancel_pipelineruns.go
+++ b/pkg/pipelineascode/cancel_pipelineruns.go
@@ -22,8 +22,8 @@ import (
 
 type matchingCond func(pr tektonv1.PipelineRun) bool
 
-var cancelMergePatch = map[string]interface{}{
-	"spec": map[string]interface{}{
+var cancelMergePatch = map[string]any{
+	"spec": map[string]any{
 		"status": tektonv1.PipelineRunSpecStatusCancelledRunFinally,
 	},
 }

--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -370,7 +370,7 @@ func changeSecret(prs []*tektonv1.PipelineRun) error {
 		name := secrets.GenerateBasicAuthSecretName()
 		processed := templates.ReplacePlaceHoldersVariables(string(b), map[string]string{
 			"git_auth_secret": name,
-		}, nil, nil, map[string]interface{}{})
+		}, nil, nil, map[string]any{})
 
 		var np *tektonv1.PipelineRun
 		err = json.Unmarshal([]byte(processed), &np)

--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -267,9 +267,9 @@ func (p *PacRun) startPR(ctx context.Context, match matcher.Match) (*tektonv1.Pi
 	return pr, nil
 }
 
-func getLogURLMergePatch(clients clients.Clients, pr *tektonv1.PipelineRun) map[string]interface{} {
-	return map[string]interface{}{
-		"metadata": map[string]interface{}{
+func getLogURLMergePatch(clients clients.Clients, pr *tektonv1.PipelineRun) map[string]any {
+	return map[string]any{
+		"metadata": map[string]any{
 			"annotations": map[string]string{
 				keys.LogURL: clients.ConsoleUI().DetailURL(pr),
 			},
@@ -277,9 +277,9 @@ func getLogURLMergePatch(clients clients.Clients, pr *tektonv1.PipelineRun) map[
 	}
 }
 
-func getExecutionOrderPatch(order string) map[string]interface{} {
-	return map[string]interface{}{
-		"metadata": map[string]interface{}{
+func getExecutionOrderPatch(order string) map[string]any {
+	return map[string]any{
+		"metadata": map[string]any{
 			"annotations": map[string]string{
 				keys.ExecutionOrder: order,
 			},

--- a/pkg/pipelineascode/pipelineascode_test.go
+++ b/pkg/pipelineascode/pipelineascode_test.go
@@ -669,7 +669,7 @@ func TestGetLogURLMergePatch(t *testing.T) {
 		},
 	}
 	result := getLogURLMergePatch(clients, pr)
-	m, ok := result["metadata"].(map[string]interface{})
+	m, ok := result["metadata"].(map[string]any)
 	assert.Assert(t, ok)
 	a, ok := m["annotations"].(map[string]string)
 	assert.Assert(t, ok)

--- a/pkg/provider/bitbucketcloud/bitbucket.go
+++ b/pkg/provider/bitbucketcloud/bitbucket.go
@@ -203,11 +203,11 @@ func (v *Provider) GetCommitInfo(_ context.Context, event *info.Event) error {
 	if err != nil {
 		return err
 	}
-	commitMap, ok := response.(map[string]interface{})
+	commitMap, ok := response.(map[string]any)
 	if !ok {
 		return fmt.Errorf("cannot convert")
 	}
-	values, ok := commitMap["values"].([]interface{})
+	values, ok := commitMap["values"].([]any)
 	if !ok {
 		return fmt.Errorf("cannot convert")
 	}

--- a/pkg/provider/bitbucketcloud/detect_test.go
+++ b/pkg/provider/bitbucketcloud/detect_test.go
@@ -17,7 +17,7 @@ func TestProvider_Detect(t *testing.T) {
 		wantErrString  string
 		isBC           bool
 		processReq     bool
-		event          interface{}
+		event          any
 		eventType      string
 		wantReason     string
 		wantLogSnippet string

--- a/pkg/provider/bitbucketcloud/parse_payload.go
+++ b/pkg/provider/bitbucketcloud/parse_payload.go
@@ -73,8 +73,8 @@ func (v *Provider) checkFromPublicCloudIPS(ctx context.Context, run *params.Run,
 			sourceIP, bitbucketCloudIPrangesList)
 }
 
-func parsePayloadType(event, rawPayload string) (interface{}, error) {
-	var payload interface{}
+func parsePayloadType(event, rawPayload string) (any, error) {
+	var payload any
 
 	var localEvent string
 	if strings.HasPrefix(event, "pullrequest:") {

--- a/pkg/provider/bitbucketcloud/parse_payload_test.go
+++ b/pkg/provider/bitbucketcloud/parse_payload_test.go
@@ -19,7 +19,7 @@ import (
 func TestParsePayload(t *testing.T) {
 	tests := []struct {
 		name                      string
-		payloadEvent              interface{}
+		payloadEvent              any
 		wantErr                   bool
 		expectedSender            string
 		expectedEventType         string

--- a/pkg/provider/bitbucketdatacenter/acl.go
+++ b/pkg/provider/bitbucketdatacenter/acl.go
@@ -47,7 +47,7 @@ func (v *Provider) IsAllowedOwnersFile(ctx context.Context, event *info.Event) (
 
 func (v *Provider) checkOkToTestCommentFromApprovedMember(ctx context.Context, event *info.Event) (bool, error) {
 	allPages, err := paginate(func(nextPage int) (*bbv1.APIResponse, error) {
-		localVarOptionals := map[string]interface{}{
+		localVarOptionals := map[string]any{
 			"fromType": "COMMENT",
 		}
 		if nextPage > 0 {
@@ -94,7 +94,7 @@ func (v *Provider) checkOkToTestCommentFromApprovedMember(ctx context.Context, e
 	return false, nil
 }
 
-func (v *Provider) checkMemberShipResults(results []interface{}, event *info.Event) (bool, error) {
+func (v *Provider) checkMemberShipResults(results []any, event *info.Event) (bool, error) {
 	accountintid, err := strconv.Atoi(event.AccountID)
 	if err != nil {
 		return false, err
@@ -116,7 +116,7 @@ func (v *Provider) checkMemberShipResults(results []interface{}, event *info.Eve
 func (v *Provider) checkMemberShip(ctx context.Context, event *info.Event) (bool, error) {
 	// Get permissions from project
 	allValues, err := paginate(func(nextPage int) (*bbv1.APIResponse, error) {
-		localVarOptionals := map[string]interface{}{}
+		localVarOptionals := map[string]any{}
 		if nextPage > 0 {
 			localVarOptionals["start"] = int(nextPage)
 		}
@@ -135,7 +135,7 @@ func (v *Provider) checkMemberShip(ctx context.Context, event *info.Event) (bool
 
 	// Get permissions from repo
 	allValues, err = paginate(func(nextPage int) (*bbv1.APIResponse, error) {
-		localVarOptionals := map[string]interface{}{}
+		localVarOptionals := map[string]any{}
 		if nextPage > 0 {
 			localVarOptionals["start"] = int(nextPage)
 		}

--- a/pkg/provider/bitbucketdatacenter/bitbucketdatacenter.go
+++ b/pkg/provider/bitbucketdatacenter/bitbucketdatacenter.go
@@ -315,7 +315,7 @@ func (v *Provider) SetClient(ctx context.Context, run *params.Run, event *info.E
 }
 
 func (v *Provider) GetCommitInfo(_ context.Context, event *info.Event) error {
-	localVarOptionals := map[string]interface{}{}
+	localVarOptionals := map[string]any{}
 	resp, err := v.Client.DefaultApi.GetCommit(v.projectKey, event.Repository, event.SHA, localVarOptionals)
 	if err != nil {
 		return err

--- a/pkg/provider/bitbucketdatacenter/detect_test.go
+++ b/pkg/provider/bitbucketdatacenter/detect_test.go
@@ -18,7 +18,7 @@ func TestProvider_Detect(t *testing.T) {
 		wantErrString string
 		isBS          bool
 		processReq    bool
-		event         interface{}
+		event         any
 		eventType     string
 		wantReason    string
 	}{

--- a/pkg/provider/bitbucketdatacenter/pagination.go
+++ b/pkg/provider/bitbucketdatacenter/pagination.go
@@ -9,10 +9,10 @@ import (
 type apiResultfunc func(int) (*bbv1.APIResponse, error)
 
 // paginate go over an API call and fetch next results.
-func paginate(apiResultfunc apiResultfunc) ([]interface{}, error) {
+func paginate(apiResultfunc apiResultfunc) ([]any, error) {
 	var nextPageStart int
 
-	allValues := []interface{}{}
+	allValues := []any{}
 	for {
 		result, err := apiResultfunc(nextPageStart)
 		if err != nil {
@@ -27,7 +27,7 @@ func paginate(apiResultfunc apiResultfunc) ([]interface{}, error) {
 			if result.Values["values"] == nil {
 				return nil, fmt.Errorf("key \"values\" not found in result")
 			}
-			values, ok := result.Values["values"].([]interface{})
+			values, ok := result.Values["values"].([]any)
 			if !ok {
 				return nil, fmt.Errorf("key \"values\" is not an array")
 			}

--- a/pkg/provider/bitbucketdatacenter/parse_payload.go
+++ b/pkg/provider/bitbucketdatacenter/parse_payload.go
@@ -193,7 +193,7 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 	return processedEvent, nil
 }
 
-func parsePayloadType(event string) (interface{}, error) {
+func parsePayloadType(event string) (any, error) {
 	// bitbucket data center event type has `pr:` prefix for pull request
 	// but in case of push event it is `repo:` prefix for both bitbucket data center
 	// and cloud, so we check the event name directly
@@ -209,7 +209,7 @@ func parsePayloadType(event string) (interface{}, error) {
 		localEvent = "push"
 	}
 
-	var intfType interface{}
+	var intfType any
 	switch localEvent {
 	case triggertype.PullRequest.String():
 		intfType = &types.PullRequestEvent{}

--- a/pkg/provider/bitbucketdatacenter/parse_payload_test.go
+++ b/pkg/provider/bitbucketdatacenter/parse_payload_test.go
@@ -568,7 +568,7 @@ func TestParsePayload(t *testing.T) {
 
 	tests := []struct {
 		name                    string
-		payloadEvent            interface{}
+		payloadEvent            any
 		expEvent                *info.Event
 		eventType               string
 		wantErrSubstr           string

--- a/pkg/provider/bitbucketdatacenter/test/test.go
+++ b/pkg/provider/bitbucketdatacenter/test/test.go
@@ -191,7 +191,7 @@ func MuxListDir(t *testing.T, mux *http.ServeMux, event *info.Event, path string
 
 		// as pagination of jenkins-x/go-scm is not like previous one
 		// it doesn't work as it did with previous lib.
-		resp := map[string]interface{}{
+		resp := map[string]any{
 			"start":         0,
 			"isLastPage":    true,
 			"values":        files,
@@ -230,7 +230,7 @@ func MuxProjectMemberShip(t *testing.T, mux *http.ServeMux, event *info.Event, u
 		if userperms == nil {
 			fmt.Fprintf(rw, "{\"values\": []}")
 		}
-		resp := map[string]interface{}{
+		resp := map[string]any{
 			"values": userperms,
 		}
 		b, err := json.Marshal(resp)
@@ -246,7 +246,7 @@ func MuxRepoMemberShip(t *testing.T, mux *http.ServeMux, event *info.Event, user
 		if userperms == nil {
 			fmt.Fprintf(rw, "{\"values\": []}")
 		}
-		resp := map[string]interface{}{
+		resp := map[string]any{
 			"values": userperms,
 		}
 		b, err := json.Marshal(resp)
@@ -258,7 +258,7 @@ func MuxRepoMemberShip(t *testing.T, mux *http.ServeMux, event *info.Event, user
 func MuxPullRequestActivities(t *testing.T, mux *http.ServeMux, event *info.Event, prNumber int, activities []*bbv1.Activity) {
 	path := fmt.Sprintf("/projects/%s/repos/%s/pull-requests/%d/activities", event.Organization, event.Repository, prNumber)
 	mux.HandleFunc(path, func(rw http.ResponseWriter, _ *http.Request) {
-		resp := map[string]interface{}{
+		resp := map[string]any{
 			"values": activities,
 		}
 		b, err := json.Marshal(resp)

--- a/pkg/provider/gitea/webhook.go
+++ b/pkg/provider/gitea/webhook.go
@@ -32,7 +32,7 @@ const (
 	EventTypePullRequestSync     whEventType = "pull_request_sync"
 )
 
-func parseWebhook(eventType whEventType, payload []byte) (event interface{}, err error) {
+func parseWebhook(eventType whEventType, payload []byte) (event any, err error) {
 	switch eventType {
 	case EventTypePush:
 		event = &giteaStructs.PushPayload{}

--- a/pkg/provider/github/detect_test.go
+++ b/pkg/provider/github/detect_test.go
@@ -18,7 +18,7 @@ func TestProvider_Detect(t *testing.T) {
 		wantErrString string
 		isGH          bool
 		processReq    bool
-		event         interface{}
+		event         any
 		eventType     string
 		wantReason    string
 	}{

--- a/pkg/provider/github/parse_payload.go
+++ b/pkg/provider/github/parse_payload.go
@@ -208,7 +208,7 @@ func (v *Provider) ParsePayload(ctx context.Context, run *params.Run, request *h
 	return processedEvent, nil
 }
 
-func (v *Provider) processEvent(ctx context.Context, event *info.Event, eventInt interface{}) (*info.Event, error) {
+func (v *Provider) processEvent(ctx context.Context, event *info.Event, eventInt any) (*info.Event, error) {
 	var processedEvent *info.Event
 	var err error
 

--- a/pkg/provider/github/parse_payload_test.go
+++ b/pkg/provider/github/parse_payload_test.go
@@ -97,11 +97,11 @@ func TestParsePayLoad(t *testing.T) {
 		name                       string
 		wantErrString              string
 		eventType                  string
-		payloadEventStruct         interface{}
+		payloadEventStruct         any
 		jeez                       string
 		triggerTarget              string
 		githubClient               bool
-		muxReplies                 map[string]interface{}
+		muxReplies                 map[string]any
 		shaRet                     string
 		targetPipelinerun          string
 		targetCancelPipelinerun    string
@@ -219,7 +219,7 @@ func TestParsePayLoad(t *testing.T) {
 					},
 				},
 			},
-			muxReplies: map[string]interface{}{"/repos/owner/reponame/pulls/54321": samplePR},
+			muxReplies: map[string]any{"/repos/owner/reponame/pulls/54321": samplePR},
 			shaRet:     "samplePRsha",
 		},
 		// all checks in a check_suite
@@ -235,7 +235,7 @@ func TestParsePayLoad(t *testing.T) {
 					PullRequests: []*github.PullRequest{&samplePR},
 				},
 			},
-			muxReplies: map[string]interface{}{"/repos/owner/reponame/pulls/54321": samplePR},
+			muxReplies: map[string]any{"/repos/owner/reponame/pulls/54321": samplePR},
 			shaRet:     "samplePRsha",
 		},
 		{
@@ -275,7 +275,7 @@ func TestParsePayLoad(t *testing.T) {
 				},
 				Repo: sampleRepo,
 			},
-			muxReplies: map[string]interface{}{"/repos/owner/reponame/pulls/666": samplePR},
+			muxReplies: map[string]any{"/repos/owner/reponame/pulls/666": samplePR},
 			shaRet:     "samplePRsha",
 		},
 		{
@@ -322,7 +322,7 @@ func TestParsePayLoad(t *testing.T) {
 					Body: github.Ptr("/retest dummy"),
 				},
 			},
-			muxReplies:        map[string]interface{}{"/repos/owner/reponame/pulls/777": samplePR},
+			muxReplies:        map[string]any{"/repos/owner/reponame/pulls/777": samplePR},
 			shaRet:            "samplePRsha",
 			targetPipelinerun: "dummy",
 		},
@@ -343,7 +343,7 @@ func TestParsePayLoad(t *testing.T) {
 					Body: github.Ptr("/cancel"),
 				},
 			},
-			muxReplies: map[string]interface{}{"/repos/owner/reponame/pulls/999": samplePR},
+			muxReplies: map[string]any{"/repos/owner/reponame/pulls/999": samplePR},
 			shaRet:     "samplePRsha",
 		},
 		{
@@ -363,7 +363,7 @@ func TestParsePayLoad(t *testing.T) {
 					Body: github.Ptr("/cancel dummy"),
 				},
 			},
-			muxReplies:              map[string]interface{}{"/repos/owner/reponame/pulls/888": samplePR},
+			muxReplies:              map[string]any{"/repos/owner/reponame/pulls/888": samplePR},
 			shaRet:                  "samplePRsha",
 			targetCancelPipelinerun: "dummy",
 		},
@@ -396,7 +396,7 @@ func TestParsePayLoad(t *testing.T) {
 					Body:     github.Ptr("/test dummy rbanch:test"), // rbanch is wrong word for branch 🙂
 				},
 			},
-			muxReplies:        map[string]interface{}{"/repos/owner/reponame/pulls/777": samplePR},
+			muxReplies:        map[string]any{"/repos/owner/reponame/pulls/777": samplePR},
 			shaRet:            "samplePRsha",
 			targetPipelinerun: "dummy",
 			wantedBranchName:  "main",
@@ -414,7 +414,7 @@ func TestParsePayLoad(t *testing.T) {
 					Body:     github.Ptr("/retest dummy"),
 				},
 			},
-			muxReplies:        map[string]interface{}{"/repos/owner/reponame/pulls/777": samplePR},
+			muxReplies:        map[string]any{"/repos/owner/reponame/pulls/777": samplePR},
 			shaRet:            "samplePRsha",
 			targetPipelinerun: "dummy",
 			wantedBranchName:  "main",
@@ -432,7 +432,7 @@ func TestParsePayLoad(t *testing.T) {
 					Body:     github.Ptr("/retest"),
 				},
 			},
-			muxReplies:       map[string]interface{}{"/repos/owner/reponame/pulls/777": samplePR},
+			muxReplies:       map[string]any{"/repos/owner/reponame/pulls/777": samplePR},
 			shaRet:           "samplePRsha",
 			wantedBranchName: "main",
 		},
@@ -449,7 +449,7 @@ func TestParsePayLoad(t *testing.T) {
 					Body:     github.Ptr("/cancel"),
 				},
 			},
-			muxReplies:                 map[string]interface{}{"/repos/owner/reponame/pulls/999": samplePR},
+			muxReplies:                 map[string]any{"/repos/owner/reponame/pulls/999": samplePR},
 			shaRet:                     "samplePRsha",
 			wantedBranchName:           "main",
 			isCancelPipelineRunEnabled: true,
@@ -467,7 +467,7 @@ func TestParsePayLoad(t *testing.T) {
 					Body:     github.Ptr("/cancel dummy"),
 				},
 			},
-			muxReplies:                 map[string]interface{}{"/repos/owner/reponame/pulls/888": samplePR},
+			muxReplies:                 map[string]any{"/repos/owner/reponame/pulls/888": samplePR},
 			shaRet:                     "samplePRsha",
 			targetCancelPipelinerun:    "dummy",
 			wantedBranchName:           "main",
@@ -486,7 +486,7 @@ func TestParsePayLoad(t *testing.T) {
 					Body:     github.Ptr("/retest dummy branch:test1"),
 				},
 			},
-			muxReplies:                 map[string]interface{}{"/repos/owner/reponame/pulls/7771": samplePR},
+			muxReplies:                 map[string]any{"/repos/owner/reponame/pulls/7771": samplePR},
 			shaRet:                     "samplePRsha",
 			targetPipelinerun:          "dummy",
 			wantedBranchName:           "test1",
@@ -505,7 +505,7 @@ func TestParsePayLoad(t *testing.T) {
 					Body:     github.Ptr("/cancel branch:test1"),
 				},
 			},
-			muxReplies:                 map[string]interface{}{"/repos/owner/reponame/pulls/9991": samplePR},
+			muxReplies:                 map[string]any{"/repos/owner/reponame/pulls/9991": samplePR},
 			shaRet:                     "samplePRsha",
 			wantedBranchName:           "test1",
 			isCancelPipelineRunEnabled: true,
@@ -523,7 +523,7 @@ func TestParsePayLoad(t *testing.T) {
 					Body:     github.Ptr("/cancel dummy branch:test1"),
 				},
 			},
-			muxReplies:                 map[string]interface{}{"/repos/owner/reponame/pulls/8881": samplePR},
+			muxReplies:                 map[string]any{"/repos/owner/reponame/pulls/8881": samplePR},
 			shaRet:                     "samplePRsha",
 			targetCancelPipelinerun:    "dummy",
 			wantedBranchName:           "test1",
@@ -542,7 +542,7 @@ func TestParsePayLoad(t *testing.T) {
 					Body:     github.Ptr("/cancel dummy branch:test2"),
 				},
 			},
-			muxReplies:                 map[string]interface{}{"/repos/owner/reponame/pulls/8881": samplePR},
+			muxReplies:                 map[string]any{"/repos/owner/reponame/pulls/8881": samplePR},
 			shaRet:                     "samplePRsha",
 			targetCancelPipelinerun:    "dummy",
 			wantedBranchName:           "test2",
@@ -562,7 +562,7 @@ func TestParsePayLoad(t *testing.T) {
 					Body:     github.Ptr("/retest dummy"),
 				},
 			},
-			muxReplies:        map[string]interface{}{"/repos/owner/reponame/pulls/777": samplePRAnother},
+			muxReplies:        map[string]any{"/repos/owner/reponame/pulls/777": samplePRAnother},
 			shaRet:            "samplePRshanew",
 			targetPipelinerun: "dummy",
 			wantedBranchName:  "main",

--- a/pkg/provider/github/repository.go
+++ b/pkg/provider/github/repository.go
@@ -114,5 +114,5 @@ func generateNamespaceName(nsTemplate string, gitEvent *github.RepositoryEvent) 
 		"repo_owner": repoOwner,
 		"repo_name":  repoName,
 	}
-	return templates.ReplacePlaceHoldersVariables(nsTemplate, maptemplate, nil, http.Header{}, map[string]interface{}{}), nil
+	return templates.ReplacePlaceHoldersVariables(nsTemplate, maptemplate, nil, http.Header{}, map[string]any{}), nil
 }

--- a/pkg/provider/github/status.go
+++ b/pkg/provider/github/status.go
@@ -284,9 +284,9 @@ func isPipelineRunCancelledOrStopped(run *tektonv1.PipelineRun) bool {
 	return false
 }
 
-func metadataPatch(checkRunID *int64, logURL string) map[string]interface{} {
-	return map[string]interface{}{
-		"metadata": map[string]interface{}{
+func metadataPatch(checkRunID *int64, logURL string) map[string]any {
+	return map[string]any{
+		"metadata": map[string]any{
 			"labels": map[string]string{
 				keys.CheckRunID: strconv.FormatInt(*checkRunID, 10),
 			},

--- a/pkg/reconciler/controller.go
+++ b/pkg/reconciler/controller.go
@@ -73,8 +73,8 @@ func NewController() func(context.Context, configmap.Watcher) *controller.Impl {
 
 // enqueue only the pipelineruns which are in `started` state
 // pipelinerun will have a label `pipelinesascode.tekton.dev/state` to describe the state.
-func checkStateAndEnqueue(impl *controller.Impl) func(obj interface{}) {
-	return func(obj interface{}) {
+func checkStateAndEnqueue(impl *controller.Impl) func(obj any) {
+	return func(obj any) {
 		object, err := kmeta.DeletionHandlingAccessor(obj)
 		if err == nil {
 			_, exist := object.GetAnnotations()[keys.State]
@@ -89,7 +89,7 @@ func ctrlOpts() func(impl *controller.Impl) controller.Options {
 	return func(_ *controller.Impl) controller.Options {
 		return controller.Options{
 			FinalizerName: pipelinesascode.GroupName,
-			PromoteFilterFunc: func(obj interface{}) bool {
+			PromoteFilterFunc: func(obj any) bool {
 				_, exist := obj.(*tektonv1.PipelineRun).GetAnnotations()[keys.State]
 				return exist
 			},

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -302,8 +302,8 @@ func (r *Reconciler) updatePipelineRunToInProgress(ctx context.Context, logger *
 }
 
 func (r *Reconciler) updatePipelineRunState(ctx context.Context, logger *zap.SugaredLogger, pr *tektonv1.PipelineRun, state string) (*tektonv1.PipelineRun, error) {
-	mergePatch := map[string]interface{}{
-		"metadata": map[string]interface{}{
+	mergePatch := map[string]any{
+		"metadata": map[string]any{
 			"labels": map[string]string{
 				keys.State: state,
 			},
@@ -314,7 +314,7 @@ func (r *Reconciler) updatePipelineRunState(ctx context.Context, logger *zap.Sug
 	}
 	// if state is started then remove pipelineRun pending status
 	if state == kubeinteraction.StateStarted {
-		mergePatch["spec"] = map[string]interface{}{
+		mergePatch["spec"] = map[string]any{
 			"status": "",
 		}
 	}

--- a/pkg/sync/priority_queue.go
+++ b/pkg/sync/priority_queue.go
@@ -61,7 +61,7 @@ func (pq priorityQueue) Swap(i, j int) {
 	pq.items[j].index = j
 }
 
-func (pq *priorityQueue) Push(x interface{}) {
+func (pq *priorityQueue) Push(x any) {
 	n := len(pq.items)
 	item, _ := x.(*item)
 	item.index = n
@@ -69,7 +69,7 @@ func (pq *priorityQueue) Push(x interface{}) {
 	pq.itemByKey[item.key] = item
 }
 
-func (pq *priorityQueue) Pop() interface{} {
+func (pq *priorityQueue) Pop() any {
 	old := pq.items
 	n := len(old)
 	item := old[n-1]

--- a/pkg/templates/templating.go
+++ b/pkg/templates/templating.go
@@ -45,10 +45,10 @@ var (
 //     placeholders with keys that have a prefix of "body", "headers", or "files".
 //   - headers (http.Header): The HTTP headers that may be used to retrieve
 //     values for placeholders with keys that have a prefix of "headers".
-//   - changedFiles (map[string]interface{}): A map of changed files that may be
+//   - changedFiles (map[string]any): A map of changed files that may be
 //     used to retrieve values for placeholders with keys that have a prefix of
 //     "files".
-func ReplacePlaceHoldersVariables(template string, dico map[string]string, rawEvent any, headers http.Header, changedFiles map[string]interface{}) string {
+func ReplacePlaceHoldersVariables(template string, dico map[string]string, rawEvent any, headers http.Header, changedFiles map[string]any) string {
 	return keys.ParamsRe.ReplaceAllStringFunc(template, func(s string) string {
 		parts := keys.ParamsRe.FindStringSubmatch(s)
 		key := strings.TrimSpace(parts[1])
@@ -63,7 +63,7 @@ func ReplacePlaceHoldersVariables(template string, dico map[string]string, rawEv
 				if err != nil {
 					return s
 				}
-				var raw interface{}
+				var raw any
 				var b []byte
 
 				switch val.(type) {

--- a/pkg/templates/templating_test.go
+++ b/pkg/templates/templating_test.go
@@ -14,7 +14,7 @@ func TestReplacePlaceHoldersVariables(t *testing.T) {
 		expected     string
 		dicto        map[string]string
 		headers      http.Header
-		changedFiles map[string]interface{}
+		changedFiles map[string]any
 		rawEvent     any
 	}{
 		{
@@ -25,14 +25,14 @@ func TestReplacePlaceHoldersVariables(t *testing.T) {
 				"revision": "master",
 				"url":      "https://chmouel.com",
 			},
-			changedFiles: map[string]interface{}{},
+			changedFiles: map[string]any{},
 		},
 		{
 			name:         "Test Replace with CEL body",
 			template:     `hello: {{ body.hello }}`,
 			expected:     `hello: world`,
 			dicto:        map[string]string{},
-			changedFiles: map[string]interface{}{},
+			changedFiles: map[string]any{},
 			headers:      http.Header{},
 			rawEvent: map[string]string{
 				"hello": "world",
@@ -43,7 +43,7 @@ func TestReplacePlaceHoldersVariables(t *testing.T) {
 			template:     `Is this {{ body.hello == 'world' }}`,
 			expected:     `Is this true`,
 			dicto:        map[string]string{},
-			changedFiles: map[string]interface{}{},
+			changedFiles: map[string]any{},
 			headers:      http.Header{},
 			rawEvent: map[string]string{
 				"hello": "world",
@@ -54,7 +54,7 @@ func TestReplacePlaceHoldersVariables(t *testing.T) {
 			template:     `header: {{ headers["X-Hello"] }}`,
 			expected:     `header: World`,
 			dicto:        map[string]string{},
-			changedFiles: map[string]interface{}{},
+			changedFiles: map[string]any{},
 			headers: http.Header{
 				"X-Hello": []string{"World"},
 			},
@@ -65,7 +65,7 @@ func TestReplacePlaceHoldersVariables(t *testing.T) {
 			template: `changed: {{ files.all[0] }}`,
 			expected: `changed: changed.txt`,
 			dicto:    map[string]string{},
-			changedFiles: map[string]interface{}{
+			changedFiles: map[string]any{
 				"all": []string{"changed.txt"},
 			},
 			headers:  http.Header{},

--- a/test/pkg/payload/send.go
+++ b/test/pkg/payload/send.go
@@ -20,7 +20,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 )
 
-func Send(ctx context.Context, cs *params.Run, elURL, elWebHookSecret, githubURL, installationID string, event interface{}, eventType string) error {
+func Send(ctx context.Context, cs *params.Run, elURL, elWebHookSecret, githubURL, installationID string, event any, eventType string) error {
 	jeez, err := json.Marshal(event)
 	if err != nil {
 		return err


### PR DESCRIPTION

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

This commit refactors the codebase by replacing instances of interface{}
with the new any type introduced in Go 1.18. This change improves code
readability and aligns with modern Go practices.

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
