### PR TITLE
refactor: GetCommitInfo func in Bitbucket Data Center

### DIFF
--- a/pkg/provider/bitbucketdatacenter/bitbucketdatacenter_test.go
+++ b/pkg/provider/bitbucketdatacenter/bitbucketdatacenter_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	bbtest "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketdatacenter/test"
 
-	bbv1 "github.com/gfleury/go-bitbucket-v1"
+	"github.com/jenkins-x/go-scm/scm"
 	"go.uber.org/zap"
 	zapobserver "go.uber.org/zap/zaptest/observer"
 	"gotest.tools/v3/assert"
@@ -384,7 +384,7 @@ func TestGetCommitInfo(t *testing.T) {
 	tests := []struct {
 		name          string
 		event         *info.Event
-		commit        bbv1.Commit
+		commit        scm.Commit
 		defaultBranch string
 		latestCommit  string
 	}{
@@ -396,7 +396,7 @@ func TestGetCommitInfo(t *testing.T) {
 				SHA:          "sha",
 			},
 			defaultBranch: "branchmain",
-			commit: bbv1.Commit{
+			commit: scm.Commit{
 				Message: "hello moto",
 			},
 			latestCommit: "latestcommit",
@@ -406,11 +406,11 @@ func TestGetCommitInfo(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, _ := rtesting.SetupFakeContext(t)
-			bbclient, _, mux, tearDown, tURL := bbtest.SetupBBDataCenterClient(ctx)
+			_, scmClient, mux, tearDown, tURL := bbtest.SetupBBDataCenterClient(ctx)
 			bbtest.MuxCommitInfo(t, mux, tt.event, tt.commit)
 			bbtest.MuxDefaultBranch(t, mux, tt.event, tt.defaultBranch, tt.latestCommit)
 			defer tearDown()
-			v := &Provider{Client: bbclient, baseURL: tURL, projectKey: tt.event.Organization}
+			v := &Provider{ScmClient: scmClient, baseURL: tURL, projectKey: tt.event.Organization}
 			err := v.GetCommitInfo(ctx, tt.event)
 			assert.NilError(t, err)
 			assert.Equal(t, tt.defaultBranch, tt.event.DefaultBranch)

--- a/pkg/provider/bitbucketdatacenter/test/test.go
+++ b/pkg/provider/bitbucketdatacenter/test/test.go
@@ -141,7 +141,7 @@ func MuxDirContent(t *testing.T, mux *http.ServeMux, event *info.Event, testDir,
 	MuxFiles(t, mux, event, event.HeadBranch, targetDirName, filecontents, wantFilesErr)
 }
 
-func MuxCommitInfo(t *testing.T, mux *http.ServeMux, event *info.Event, commit bbv1.Commit) {
+func MuxCommitInfo(t *testing.T, mux *http.ServeMux, event *info.Event, commit scm.Commit) {
 	path := fmt.Sprintf("/projects/%s/repos/%s/commits/%s", event.Organization, event.Repository, event.SHA)
 
 	mux.HandleFunc(path, func(rw http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
This patch refactors GetCommitInfo in Bitucket DataCenter using jenkins-x/go-scm

https://issues.redhat.com/browse/SRVKP-7292

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [x] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [x] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [x] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [x] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- If adding a provider feature, fill in the following details:

| Git Provider          | Supported |
|-----------------------|-----------|
| GitHub App            |    ❌️     |
| GitHub Webhook        | ❌️        |
| Gitea                 | ❌️        |
| GitLab                | ❌️        |
| Bitbucket Cloud       | ❌️        |
| Bitbucket Data Center | ✅️        |

  (update the documentation accordingly)
