### PR TITLE
fix: Improve error messaging during repository/event validation

### DIFF
--- a/pkg/acl/owners.go
+++ b/pkg/acl/owners.go
@@ -1,6 +1,8 @@
 package acl
 
 import (
+	"fmt"
+
 	"sigs.k8s.io/yaml"
 )
 
@@ -28,15 +30,15 @@ func UserInOwnerFile(ownersContent, ownersAliasesContent, sender string) (bool, 
 	ac := aliasesConfig{}
 	err := yaml.Unmarshal([]byte(ownersContent), &sc)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("cannot parse OWNERS file Approvers and Reviewers: %w", err)
 	}
 	err = yaml.Unmarshal([]byte(ownersContent), &fc)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("cannot parse OWNERS file Filters: %w", err)
 	}
 	err = yaml.Unmarshal([]byte(ownersAliasesContent), &ac)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("cannot parse OWNERS_ALIASES: %w", err)
 	}
 
 	var approvers, reviewers []string

--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -47,7 +47,7 @@ func (p *PacRun) verifyRepoAndUser(ctx context.Context) (*v1alpha1.Repository, e
 	// Match the Event URL to a Repository URL,
 	repo, err := matcher.MatchEventURLRepo(ctx, p.run, p.event, "")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error matching Repository for event: %w", err)
 	}
 
 	if repo == nil {
@@ -405,7 +405,7 @@ func (p *PacRun) checkNeedUpdate(_ string) (string, bool) {
 func (p *PacRun) checkAccessOrErrror(ctx context.Context, repo *v1alpha1.Repository, status provider.StatusOpts, viamsg string) (bool, error) {
 	allowed, err := p.vcx.IsAllowed(ctx, p.event)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("unable to verify event authorization: %w", err)
 	}
 	if allowed {
 		return true, nil


### PR DESCRIPTION
Since errors returned from `PacRun.matchRepoPR` are emitted as an event to end-users, the error messaging is important to enable users to self-service when possible.

This improves error messaging by wrapping certain errors with additional context. E.g. parsing the owners file previously may have errored with the message: `error unmarshaling JSON: error decoding JSON: ...` After this change, the error is wrapped with a more helpful message: `Cannot parse OWNERS file Approvers and Reviewers: error unmarshaling JSON: ...`

Addresses https://issues.redhat.com/browse/SRVKP-7322

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [ ] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [ ] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [ ] 📖 Document any user-facing features or changes in behavior.

- [ ] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [ ] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [ ] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

| Git Provider          | Supported |
|-----------------------|-----------|
| GitHub App            | ✅️        |
| GitHub Webhook        | ❌️        |
| Gitea                 | ❌️        |
| GitLab                | ❌️        |
| Bitbucket Cloud       | ❌️        |
| Bitbucket Data Center | ❌️        |

  (update the documentation accordingly)
