### PR TITLE
doc: remove plan permissions for GitHub app

### DIFF
--- a/docs/content/docs/install/github_apps.md
+++ b/docs/content/docs/install/github_apps.md
@@ -42,7 +42,6 @@ Alternatively, you could set up manually by following the steps [here](./#setup-
 
 * Select the following organization permissions:
   * **Members**: `Readonly`
-  * **Plan**: `Readonly`
 
 * Subscribe to following events:
   * Check run

--- a/pkg/cmd/tknpac/bootstrap/github.go
+++ b/pkg/cmd/tknpac/bootstrap/github.go
@@ -27,13 +27,12 @@ func generateManifest(opts *bootstrapOpts) ([]byte, error) {
 			"push",
 		},
 		DefaultPermissions: &github.InstallationPermissions{
-			Checks:           github.Ptr("write"),
-			Contents:         github.Ptr("write"),
-			Issues:           github.Ptr("write"),
-			Members:          github.Ptr("read"),
-			Metadata:         github.Ptr("read"),
-			OrganizationPlan: github.Ptr("read"),
-			PullRequests:     github.Ptr("write"),
+			Checks:       github.Ptr("write"),
+			Contents:     github.Ptr("write"),
+			Issues:       github.Ptr("write"),
+			Members:      github.Ptr("read"),
+			Metadata:     github.Ptr("read"),
+			PullRequests: github.Ptr("write"),
 		},
 	}
 	return json.Marshal(sc)

--- a/test/github_pullrequest_retest_test.go
+++ b/test/github_pullrequest_retest_test.go
@@ -18,6 +18,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// TestGithubSecondPullRequestGitopsCommentRetest will test the retest
+// functionality of a GitHub pull request.
 func TestGithubSecondPullRequestGitopsCommentRetest(t *testing.T) {
 	if os.Getenv("NIGHTLY_E2E_TEST") != "true" {
 		t.Skip("Skipping test since only enabled for nightly")


### PR DESCRIPTION
Remove plan permissions from the organization permissions as it's not
required.

This Plan permission here (as read-only)

![image](https://github.com/user-attachments/assets/73e336d9-0fe3-4aae-85c5-11584009a858)

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [ ] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [ ] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [ ] 📖 Document any user-facing features or changes in behavior.

- [ ] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [ ] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [ ] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

| Git Provider          | Supported |
|-----------------------|-----------|
| GitHub App            | ✅️        |
| GitHub Webhook        | ❌️        |
| Gitea                 | ❌️        |
| GitLab                | ❌️        |
| Bitbucket Cloud       | ❌️        |
| Bitbucket Data Center | ❌️        |

  (update the documentation accordingly)
