### PR TITLE
fix: Cancel PipelineRuns on MR change in Gitlab

### DIFF
--- a/pkg/pipelineascode/cancel_pipelineruns.go
+++ b/pkg/pipelineascode/cancel_pipelineruns.go
@@ -88,7 +88,8 @@ func (p *PacRun) cancelInProgressMatchingPR(ctx context.Context, matchPR *tekton
 	}
 	labelSelector := getLabelSelector(labelMap)
 	if p.event.TriggerTarget == triggertype.PullRequest {
-		labelSelector += fmt.Sprintf(",%s in (pull_request, %s)", keys.EventType, opscomments.AnyOpsKubeLabelInSelector())
+		// "Merge_Request" included since EventType is not normalized to "Pull Request" like TriggerTarget
+		labelSelector += fmt.Sprintf(",%s in (pull_request, Merge_Request, %s)", keys.EventType, opscomments.AnyOpsKubeLabelInSelector())
 	}
 	p.run.Clients.Log.Infof("cancel-in-progress: selecting pipelineRuns to cancel with labels: %v", labelSelector)
 	prs, err := p.run.Clients.Tekton.TektonV1().PipelineRuns(matchPR.GetNamespace()).List(ctx, metav1.ListOptions{

--- a/test/gitlab_merge_request_test.go
+++ b/test/gitlab_merge_request_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/scm"
 	twait "github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/names"
 	clientGitlab "gitlab.com/gitlab-org/api/client-go"
 	"gotest.tools/v3/assert"
@@ -275,6 +276,91 @@ func TestGitlabOnComment(t *testing.T) {
 
 	err = twait.RegexpMatchingInPodLog(context.Background(), runcnx, targetNS, fmt.Sprintf("tekton.dev/pipelineRun=%s", lastPrName), "step-task", *regexp.MustCompile(triggerComment), "", 2)
 	assert.NilError(t, err)
+}
+
+func TestGitlabCancelInProgressOnChange(t *testing.T) {
+	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
+	ctx := context.Background()
+	runcnx, opts, glprovider, err := tgitlab.Setup(ctx)
+	assert.NilError(t, err)
+	ctx, err = cctx.GetControllerCtxInfo(ctx, runcnx)
+	assert.NilError(t, err)
+	runcnx.Clients.Log.Info("Testing Gitlab cancel in progress on pr close")
+	projectinfo, resp, err := glprovider.Client.Projects.GetProject(opts.ProjectID, nil)
+	assert.NilError(t, err)
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
+	}
+
+	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, targetNS, nil)
+	assert.NilError(t, err)
+
+	entries, err := payload.GetEntries(map[string]string{
+		".tekton/in-progress.yaml": "testdata/pipelinerun-cancel-in-progress.yaml",
+	}, targetNS, projectinfo.DefaultBranch,
+		triggertype.PullRequest.String(), map[string]string{})
+	assert.NilError(t, err)
+	targetRefName := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test")
+
+	gitCloneURL, err := scm.MakeGitCloneURL(projectinfo.WebURL, opts.UserName, opts.Password)
+	assert.NilError(t, err)
+	mrTitle := "TestCancelInProgress initial commit - " + targetRefName
+	scmOpts := &scm.Opts{
+		GitURL:        gitCloneURL,
+		Log:           runcnx.Clients.Log,
+		WebURL:        projectinfo.WebURL,
+		TargetRefName: targetRefName,
+		BaseRefName:   projectinfo.DefaultBranch,
+		CommitTitle:   mrTitle,
+	}
+
+	oldSha := scm.PushFilesToRefGit(t, scmOpts, entries)
+	runcnx.Clients.Log.Infof("Branch %s has been created and pushed with files", targetRefName)
+	mrID, err := tgitlab.CreateMR(glprovider.Client, opts.ProjectID, targetRefName, projectinfo.DefaultBranch, mrTitle)
+	assert.NilError(t, err)
+	runcnx.Clients.Log.Infof("MergeRequest %s/-/merge_requests/%d has been created", projectinfo.WebURL, mrID)
+	defer tgitlab.TearDown(ctx, t, runcnx, glprovider, mrID, targetRefName, targetNS, opts.ProjectID)
+
+	runcnx.Clients.Log.Infof("Waiting for the pipelinerun to be created")
+	originalPipelineWaitOpts := twait.Opts{
+		RepoName:        targetNS,
+		Namespace:       targetNS,
+		MinNumberStatus: 1,
+		PollTimeout:     twait.DefaultTimeout,
+		TargetSHA:       oldSha,
+	}
+	err = twait.UntilPipelineRunCreated(ctx, runcnx.Clients, originalPipelineWaitOpts)
+	assert.NilError(t, err)
+
+	newEntries := map[string]string{
+		"new-file.txt": "plz work",
+	}
+
+	changeTitle := "TestCancelInProgress second commit - " + targetRefName
+	scmOpts = &scm.Opts{
+		GitURL:        gitCloneURL,
+		Log:           runcnx.Clients.Log,
+		WebURL:        projectinfo.WebURL,
+		TargetRefName: targetRefName,
+		BaseRefName:   targetRefName,
+		CommitTitle:   changeTitle,
+	}
+	newSha := scm.PushFilesToRefGit(t, scmOpts, newEntries)
+
+	runcnx.Clients.Log.Infof("Waiting for new pipeline to be created")
+	newPipelineWaitOpts := twait.Opts{
+		RepoName:        targetNS,
+		Namespace:       targetNS,
+		MinNumberStatus: 1,
+		PollTimeout:     twait.DefaultTimeout,
+		TargetSHA:       newSha,
+	}
+	err = twait.UntilPipelineRunCreated(ctx, runcnx.Clients, newPipelineWaitOpts)
+	assert.NilError(t, err)
+
+	runcnx.Clients.Log.Infof("Waiting for old pipelinerun to be canceled")
+	cancelledErr := twait.UntilPipelineRunHasReason(ctx, runcnx.Clients, v1.PipelineRunReasonCancelled, originalPipelineWaitOpts)
+	assert.NilError(t, cancelledErr)
 }
 
 func TestGitlabCancelInProgressOnPRClose(t *testing.T) {


### PR DESCRIPTION
# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Add support for cancelling in-progress PipelineRuns when a Gitlab MergeRequest is updated

When a Merge Request in Gitlab triggers a PipelineRun, the TriggerTarget is updated to "pull_request" but the EventType label intentionally remains as "Merge Request", unchanged from the event. This appears to be done intentionally. As a result, when querying for PipelineRuns related to an event with a PullRequest Trigger type using the EventType label, we have to include 'Merge_Request' as a possible label value

Note: 'Merge_Request' is used instead of the event's raw string 'Merge Request' because <space> is an illegal character in labels and is sanitized in labels.AddLabelsAndAnnotations using formatting.CleanValueKubernetes

https://issues.redhat.com/browse/SRVKP-7148

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [x] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [x] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [x] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [x] 📖 Document any user-facing features or changes in behavior.

- [ ] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [x] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [x] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

| Git Provider          | Supported |
|-----------------------|-----------|
| GitHub App            | ✅️        |
| GitHub Webhook        | ❌️        |
| Gitea                 | ❌️        |
| GitLab                | ✅️        |
| Bitbucket Cloud       | ❌️        |
| Bitbucket Data Center | ❌️        |

  (update the documentation accordingly)
