### PR TITLE
refactor github action to use env

### DIFF
--- a/.github/workflows/kind-e2e-tests.yaml
+++ b/.github/workflows/kind-e2e-tests.yaml
@@ -31,6 +31,27 @@ jobs:
       CONTROLLER_DOMAIN_URL: controller.paac-127-0-0-1.nip.io
       TEST_GITHUB_REPO_OWNER_GITHUBAPP: openshift-pipelines/pipelines-as-code-e2e-tests
       KUBECONFIG: /home/runner/.kube/config.kind
+      # Configure test environment variables
+      TEST_BITBUCKET_CLOUD_API_URL: https://api.bitbucket.org/2.0
+      TEST_BITBUCKET_CLOUD_E2E_REPOSITORY: cboudjna/pac-e2e-tests
+      TEST_BITBUCKET_CLOUD_USER: cboudjna
+      TEST_EL_URL: http://controller.paac-127-0-0-1.nip.io
+      TEST_GITEA_API_URL: http://localhost:3000
+      TEST_GITEA_USERNAME: pac
+      TEST_GITEA_PASSWORD: pac
+      TEST_GITEA_REPO_OWNER: pac/pac
+      TEST_GITHUB_API_URL: api.github.com
+      TEST_GITHUB_REPO_OWNER_WEBHOOK: openshift-pipelines/pipelines-as-code-e2e-tests-webhook
+      TEST_GITHUB_PRIVATE_TASK_URL: https://github.com/openshift-pipelines/pipelines-as-code-e2e-tests-private/blob/main/remote_task.yaml
+      TEST_GITHUB_PRIVATE_TASK_NAME: task-remote
+      TEST_GITHUB_SECOND_API_URL: ghe.pipelinesascode.com
+      TEST_GITHUB_SECOND_EL_URL: http://ghe.paac-127-0-0-1.nip.io
+      TEST_GITHUB_SECOND_REPO_OWNER_GITHUBAPP: pipelines-as-code/e2e
+      TEST_GITHUB_SECOND_REPO_INSTALLATION_ID: 1
+      TEST_GITLAB_API_URL: https://gitlab.com
+      TEST_GITLAB_PROJECT_ID: 34405323
+      TEST_BITBUCKET_SERVER_USER: pipelines
+      TEST_BITBUCKET_SERVER_E2E_REPOSITORY: PAC/pac-e2e-tests
 
     steps:
       - uses: actions/checkout@v4
@@ -66,58 +87,63 @@ jobs:
           bash -x ./hack/dev/kind/install.sh
 
       - name: Create PAC github-app-secret
+        env:
+          PAC_GITHUB_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+          PAC_GITHUB_APPLICATION_ID: ${{ secrets.APPLICATION_ID }}
+          PAC_WEBHOOK_SECRET: ${{ secrets.WEBHOOK_SECRET }}
         run: |
-          ./hack/gh-workflow-ci.sh create_pac_github_app_secret \
-             "${{ secrets.APP_PRIVATE_KEY }}" \
-             "${{ secrets.APPLICATION_ID }}" \
-             "${{secrets.WEBHOOK_SECRET }}"
+          ./hack/gh-workflow-ci.sh create_pac_github_app_secret
 
       - name: Create second Github APP Controller on GHE
+        env:
+          TEST_GITHUB_SECOND_SMEE_URL: ${{ secrets.TEST_GITHUB_SECOND_SMEE_URL }}
+          TEST_GITHUB_SECOND_PRIVATE_KEY: ${{ secrets.TEST_GITHUB_SECOND_PRIVATE_KEY }}
+          TEST_GITHUB_SECOND_WEBHOOK_SECRET: ${{ secrets.TEST_GITHUB_SECOND_WEBHOOK_SECRET }}
         run: |
-          ./hack/gh-workflow-ci.sh create_second_github_app_controller_on_ghe \
-           "${{ secrets.TEST_GITHUB_SECOND_SMEE_URL }}" \
-           "${{ secrets.TEST_GITHUB_SECOND_PRIVATE_KEY }}" \
-           "${{ secrets.TEST_GITHUB_SECOND_WEBHOOK_SECRET }}"
+          ./hack/gh-workflow-ci.sh create_second_github_app_controller_on_ghe
 
       - name: Run E2E Tests on pull_request
         if: ${{ github.event_name != 'schedule' }}
+        env:
+          TEST_PROVIDER: ${{ matrix.provider }}
+          TEST_BITBUCKET_CLOUD_TOKEN: ${{ secrets.BITBUCKET_CLOUD_TOKEN }}
+          TEST_EL_WEBHOOK_SECRET: ${{ secrets.WEBHOOK_SECRET }}
+          TEST_GITEA_SMEEURL: ${{ secrets.TEST_GITEA_SMEEURL }}
+          TEST_GITHUB_REPO_INSTALLATION_ID: ${{ secrets.INSTALLATION_ID }}
+          TEST_GITHUB_TOKEN: ${{ secrets.GH_APPS_TOKEN }}
+          TEST_GITHUB_SECOND_TOKEN: ${{ secrets.TEST_GITHUB_SECOND_TOKEN }}
+          TEST_GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+          TEST_BITBUCKET_SERVER_TOKEN: ${{ secrets.BITBUCKET_SERVER_TOKEN }}
+          TEST_BITBUCKET_SERVER_API_URL: ${{ secrets.BITBUCKET_SERVER_API_URL }}
+          TEST_BITBUCKET_SERVER_WEBHOOK_SECRET: ${{ secrets.BITBUCKET_SERVER_WEBHOOK_SECRET }}
         run: |
-          ./hack/gh-workflow-ci.sh run_e2e_tests \
-           ${{ matrix.provider }} \
-           "${{ secrets.BITBUCKET_CLOUD_TOKEN }}" \
-           "${{ secrets.WEBHOOK_SECRET }}" \
-           "${{ secrets.TEST_GITEA_SMEEURL }}" \
-           "${{ secrets.INSTALLATION_ID }}" \
-           "${{ secrets.GH_APPS_TOKEN }}" \
-           "${{ secrets.TEST_GITHUB_SECOND_TOKEN }}" \
-           "${{ secrets.GITLAB_TOKEN }}" \
-           "${{ secrets.BITBUCKET_SERVER_TOKEN }}" \
-           "${{ secrets.BITBUCKET_SERVER_API_URL }}" \
-           "${{ secrets.BITBUCKET_SERVER_WEBHOOK_SECRET }}"
+          ./hack/gh-workflow-ci.sh run_e2e_tests
 
       - name: Run E2E Tests on nightly
         if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+        env:
+          NIGHTLY_E2E_TEST: "true"
+          TEST_PROVIDER: ${{ matrix.provider }}
+          TEST_BITBUCKET_CLOUD_TOKEN: ${{ secrets.BITBUCKET_CLOUD_TOKEN }}
+          TEST_EL_WEBHOOK_SECRET: ${{ secrets.WEBHOOK_SECRET }}
+          TEST_GITEA_SMEEURL: ${{ secrets.TEST_GITEA_SMEEURL }}
+          TEST_GITHUB_REPO_INSTALLATION_ID: ${{ secrets.INSTALLATION_ID }}
+          TEST_GITHUB_TOKEN: ${{ secrets.GH_APPS_TOKEN }}
+          TEST_GITHUB_SECOND_TOKEN: ${{ secrets.TEST_GITHUB_SECOND_TOKEN }}
+          TEST_GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+          TEST_BITBUCKET_SERVER_TOKEN: ${{ secrets.BITBUCKET_SERVER_TOKEN }}
+          TEST_BITBUCKET_SERVER_API_URL: ${{ secrets.BITBUCKET_SERVER_API_URL }}
+          TEST_BITBUCKET_SERVER_WEBHOOK_SECRET: ${{ secrets.BITBUCKET_SERVER_WEBHOOK_SECRET }}
         run: |
-          export NIGHTLY_E2E_TEST="true"
-          ./hack/gh-workflow-ci.sh run_e2e_tests \
-           ${{ matrix.provider }} \
-           "${{ secrets.BITBUCKET_CLOUD_TOKEN }}" \
-           "${{ secrets.WEBHOOK_SECRET }}" \
-           "${{ secrets.TEST_GITEA_SMEEURL }}" \
-           "${{ secrets.INSTALLATION_ID }}" \
-           "${{ secrets.GH_APPS_TOKEN }}" \
-           "${{ secrets.TEST_GITHUB_SECOND_TOKEN }}" \
-           "${{ secrets.GITLAB_TOKEN }}" \
-           "${{ secrets.BITBUCKET_SERVER_TOKEN }}" \
-           "${{ secrets.BITBUCKET_SERVER_API_URL }}" \
-           "${{ secrets.BITBUCKET_SERVER_WEBHOOK_SECRET }}"
+          ./hack/gh-workflow-ci.sh run_e2e_tests
 
       - name: Collect logs
         if: ${{ always() }}
+        env:
+          TEST_GITEA_SMEEURL: ${{ secrets.TEST_GITEA_SMEEURL }}
+          TEST_GITHUB_SECOND_SMEE_URL: ${{ secrets.TEST_GITHUB_SECOND_SMEE_URL }}
         run: |
-          ./hack/gh-workflow-ci.sh collect_logs \
-          "${{ secrets.TEST_GITEA_SMEEURL }}" \
-          "${{ secrets.TEST_GITHUB_SECOND_SMEE_URL }}"
+          ./hack/gh-workflow-ci.sh collect_logs
 
       - name: Upload artifacts
         if: ${{ always() }}

--- a/pkg/formatting/age.go
+++ b/pkg/formatting/age.go
@@ -11,18 +11,14 @@ func Age(t *metav1.Time, c clockwork.Clock) string {
 	if t.IsZero() {
 		return nonAttributedStr
 	}
-
-	dur := c.Since(t.Time)
-	return durafmt.ParseShort(dur).String() + " ago"
+	return durafmt.ParseShort(c.Since(t.Time)).String() + " ago"
 }
 
 func Duration(t1, t2 *metav1.Time) string {
 	if t1.IsZero() || t2.IsZero() {
 		return nonAttributedStr
 	}
-
-	dur := t2.Sub(t1.Time)
-	return durafmt.ParseShort(dur).String()
+	return durafmt.ParseShort(t2.Sub(t1.Time)).String()
 }
 
 // PRDuration calculates the duration of a repository run, given its status.
@@ -35,11 +31,10 @@ func PRDuration(runStatus v1alpha1.RepositoryRunStatus) string {
 
 	lasttime := runStatus.CompletionTime
 	if lasttime == nil {
-		if len(runStatus.Conditions) > 0 {
-			lasttime = &runStatus.Conditions[0].LastTransitionTime.Inner
-		} else {
+		if len(runStatus.Conditions) == 0 {
 			return nonAttributedStr
 		}
+		lasttime = &runStatus.Conditions[0].LastTransitionTime.Inner
 	}
 
 	return Duration(runStatus.StartTime, lasttime)
@@ -49,6 +44,5 @@ func Timeout(t *metav1.Duration) string {
 	if t == nil {
 		return nonAttributedStr
 	}
-
 	return durafmt.Parse(t.Duration).String()
 }


### PR DESCRIPTION
- **refactor: simplify duration calculations in age.go**
  Removed redundant variable assignments in the Age and Duration functions.
  Refactored the PRDuration function to reduce nesting and improve readability.
  No functional changes were made.
  

- **chore: migrate GitHub Action workflows to use env**
  Replace command-line arguments with environment variables in the GitHub Actions
  workflow and supporting scripts. This change improves maintainability by:
  
  - Removing complex argument passing in the gh-workflow-ci.sh script
  - Using environment variables for configuration in GitHub Actions
  - Simplifying function calls in the CI workflow
  - Improving readability of the workflow files
  
  Document it to the README.md
  
  Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
  