### PR TITLE
fix: Improve error messaging during repository/event validation (more)

### DIFF
--- a/pkg/acl/owners.go
+++ b/pkg/acl/owners.go
@@ -3,6 +3,7 @@ package acl
 import (
 	"fmt"
 
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
 	"sigs.k8s.io/yaml"
 )
 
@@ -30,15 +31,15 @@ func UserInOwnerFile(ownersContent, ownersAliasesContent, sender string) (bool, 
 	ac := aliasesConfig{}
 	err := yaml.Unmarshal([]byte(ownersContent), &sc)
 	if err != nil {
-		return false, fmt.Errorf("cannot parse OWNERS file Approvers and Reviewers: %w", err)
+		return false, fmt.Errorf("cannot parse OWNERS file Approvers and Reviewers: %w", formatting.HumanizeJSONErr(ownersContent, err))
 	}
 	err = yaml.Unmarshal([]byte(ownersContent), &fc)
 	if err != nil {
-		return false, fmt.Errorf("cannot parse OWNERS file Filters: %w", err)
+		return false, fmt.Errorf("cannot parse OWNERS file Filters: %w", formatting.HumanizeJSONErr(ownersContent, err))
 	}
 	err = yaml.Unmarshal([]byte(ownersAliasesContent), &ac)
 	if err != nil {
-		return false, fmt.Errorf("cannot parse OWNERS_ALIASES: %w", err)
+		return false, fmt.Errorf("cannot parse OWNERS_ALIASES: %w", formatting.HumanizeJSONErr(ownersAliasesContent, err))
 	}
 
 	var approvers, reviewers []string

--- a/pkg/formatting/errors.go
+++ b/pkg/formatting/errors.go
@@ -1,0 +1,46 @@
+package formatting
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+func HumanizeJSONErr(jsonContent string, err error) error {
+	errorOffset := -1
+	var syntaxErr *json.SyntaxError
+	var typeErr *json.UnmarshalTypeError
+
+	if errors.As(err, &syntaxErr) {
+		err = fmt.Errorf("JSON syntax error: %w", err)
+		errorOffset = int(syntaxErr.Offset)
+	} else if errors.As(err, &typeErr) {
+		err = fmt.Errorf("JSON type error: %w", err)
+		errorOffset = int(typeErr.Offset)
+	}
+
+	if line, char, ok := lineAndCharacterFromOffset([]byte(jsonContent), errorOffset); ok {
+		err = fmt.Errorf("%w on line %d char %d", err, line, char)
+	}
+
+	return err
+}
+
+func lineAndCharacterFromOffset(content []byte, offset int) (int, int, bool) {
+	if len(content) < offset || offset < 1 {
+		return 0, 0, false
+	}
+	line := 1
+	lineOffset := 0
+
+	for i := 0; i < offset; i++ {
+		if content[i] == '\n' {
+			line++
+			lineOffset = 0
+		} else {
+			lineOffset++
+		}
+	}
+
+	return line, lineOffset, true
+}

--- a/pkg/formatting/errors_test.go
+++ b/pkg/formatting/errors_test.go
@@ -1,0 +1,60 @@
+package formatting
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestHumanizeJSONErr(t *testing.T) {
+	badJSONUnclosedValue := `{
+  "key": "unclosed value
+}`
+	badJSONType := `{
+  "key": 123
+}`
+
+	type NamedStruct struct {
+		Key string
+	}
+
+	data := map[string]string{}
+	tests := []struct {
+		Name            string
+		JSON            string
+		Error           error
+		ExpectedMessage string
+	}{
+		{
+			Name:            "invalid json",
+			JSON:            badJSONUnclosedValue,
+			Error:           json.Unmarshal([]byte(badJSONUnclosedValue), &data),
+			ExpectedMessage: "JSON syntax error: invalid character '\\n' in string literal on line 3 char 0",
+		},
+		{
+			Name:            "type error",
+			JSON:            badJSONType,
+			Error:           json.Unmarshal([]byte(badJSONType), &data),
+			ExpectedMessage: "JSON type error: json: cannot unmarshal number into Go value of type string on line 2 char 12",
+		},
+		{
+			Name:            "type error in named struct",
+			JSON:            badJSONType,
+			Error:           json.Unmarshal([]byte(badJSONType), &NamedStruct{}),
+			ExpectedMessage: "JSON type error: json: cannot unmarshal number into Go struct field NamedStruct.Key of type string on line 2 char 12",
+		},
+		{
+			Name:            "non-json error",
+			JSON:            "{ \"key\": \"dummy value\"}",
+			Error:           fmt.Errorf("non-json error"),
+			ExpectedMessage: "non-json error",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			assert.Equal(t, HumanizeJSONErr(tt.JSON, tt.Error).Error(), tt.ExpectedMessage)
+		})
+	}
+}


### PR DESCRIPTION
# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Add more helpful JSON parse error messaging to include type of JSON error and line+character which caused the error.

The JSON error formatting is extracted into a shared formatter `formatting.HumanizeJSONErr` which other parts of the code may use. 

# Submitter Checklist

- [ ] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [ ] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [ ] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [ ] 📖 Document any user-facing features or changes in behavior.

- [ ] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [ ] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [ ] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

| Git Provider          | Supported |
|-----------------------|-----------|
| GitHub App            | ✅️        |
| GitHub Webhook        | ❌️        |
| Gitea                 | ❌️        |
| GitLab                | ❌️        |
| Bitbucket Cloud       | ❌️        |
| Bitbucket Data Center | ❌️        |

  (update the documentation accordingly)
