### PR TITLE
ci: update golangci-lint and update gha workflows

### DIFF
--- a/.github/workflows/nightly_push_dispatch.yaml
+++ b/.github/workflows/nightly_push_dispatch.yaml
@@ -10,11 +10,10 @@ on:
         description: "Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)"
         required: false
         default: false
-  pull_request_target:
-    types: [opened, synchronize, reopened]
-    paths:
-      - "**.go"
-
+      sha:
+        description: "The commit SHA to checkout"
+        required: false
+        default: "main"
 jobs:
   e2e-tests:
     concurrency:
@@ -55,7 +54,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ inputs.sha || github.sha }}
 
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/pull_request_trusted.yaml
+++ b/.github/workflows/pull_request_trusted.yaml
@@ -5,7 +5,6 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - "**.go"
-
 jobs:
   e2e-tests:
     concurrency:
@@ -90,13 +89,6 @@ jobs:
       - name: Run gosmee
         run: |
           nohup gosmee client --saveDir /tmp/gosmee-replay ${{ secrets.PYSMEE_URL }} "http://${CONTROLLER_DOMAIN_URL}" &
-
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
-        with:
-          detached: true
-          limit-access-to-actor: true
 
       - name: Start installing cluster
         run: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,132 +1,105 @@
-issues:
-  exclude-dirs:
-    - vendor
-    - pkg/provider/gitea/structs
-  exclude-rules:
-    # Exclude some linters from running on tests files.
-    - path: _test\.go
-      linters:
-        - gosec
-    # hopefully we can remove this when https://github.com/golangci/golangci-lint/issues/4697 is fixed
-    - path: pkg/resolve/resolve.go
-      text: "don't use `init` function"
+version: "2"
 run:
   build-tags:
     - e2e
-linters-settings:
-  gocritic:
-    disabled-checks:
-      - unlambda
-  errcheck:
-    exclude-functions:
-      - (*github.com/tektoncd/pipeline/vendor/go.uber.org/zap.SugaredLogger).Sync
-      - flag.Set
-      - logger.Sync
-      - fmt.Fprintf
-      - fmt.Fprintln
-      - (io.Closer).Close
-      - updateConfigMap
-  gofumpt:
-    extra-rules: true
 linters:
   enable:
     - asasalint
     - asciicheck
     - bidichk
     - bodyclose
-    #- containedctx
-    #- contextcheck
-    #- cyclop
+    - copyloopvar
     - decorder
-    #- depguard
     - dogsled
     - dupl
     - dupword
     - durationcheck
-    - errcheck
     - errchkjson
     - errname
     - errorlint
-    # - execinquery
     - exhaustive
-    #- exhaustruct
-    - copyloopvar
     - forbidigo
     - forcetypeassert
-    #- funlen
-    #- gci
     - ginkgolinter
     - gocheckcompilerdirectives
-    #- gochecknoglobals
     - gochecknoinits
     - gochecksumtype
-    #- gocognit
-    #- goconst
     - gocritic
-    #- gocyclo
     - godot
-    #- godox
-    #- goerr113
-    #- gofmt
-    - gofumpt
     - goheader
-    - goimports
-    #- gomnd
-    #- gomoddirectives
     - gomodguard
     - goprintffuncname
     - gosec
-    - gosimple
     - gosmopolitan
-    - govet
     - grouper
     - importas
-    #- inamedparam
-    #- interfacebloat
-    #- ireturn
-    #- lll
     - loggercheck
-    #- maintidx
     - makezero
     - mirror
     - misspell
-    #- musttag
     - nakedret
-    #- nestif
     - nilerr
-    #- nilnil
-    #- nlreturn
     - noctx
-    #- nolintlint
-    #- nonamedreturns
     - nosprintfhostport
-    #- paralleltest
-    #- perfsprint
     - prealloc
     - predeclared
     - promlinter
     - protogetter
     - reassign
     - revive
-    #- rowserrcheck
     - sloglint
-    #- sqlclosecheck
     - staticcheck
-    - stylecheck
     - tagalign
-    #- tagliatelle
     - testableexamples
-    # - testifylint
-    #- testpackage
-    #- thelper
     - tparallel
-    #- unconvert
     - unparam
-    - unused
     - usestdlibvars
-    #- varnamelen
-    #- wastedassign
     - whitespace
-    #- wrapcheck
-    #- wsl
     - zerologlint
+  settings:
+    errcheck:
+      exclude-functions:
+        - (*github.com/tektoncd/pipeline/vendor/go.uber.org/zap.SugaredLogger).Sync
+        - flag.Set
+        - logger.Sync
+        - fmt.Fprintf
+        - fmt.Fprintln
+        - (io.Closer).Close
+        - updateConfigMap
+    gocritic:
+      disabled-checks:
+        - unlambda
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - gosec
+        path: _test\.go
+      - path: pkg/resolve/resolve.go
+        text: don't use `init` function
+    paths:
+      - vendor
+      - pkg/provider/gitea/structs
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+  settings:
+    gofumpt:
+      extra-rules: true
+  exclusions:
+    generated: lax
+    paths:
+      - vendor
+      - pkg/provider/gitea/structs
+      - third_party$
+      - builtin$
+      - examples$

--- a/pkg/cmd/tknpac/list/list.go
+++ b/pkg/cmd/tknpac/list/list.go
@@ -123,8 +123,8 @@ func formatStatus(status *v1alpha1.RepositoryRunStatus, cs *cli.ColorScheme, c c
 	}
 
 	reason := "UNKNOWN"
-	if len(status.Status.Conditions) > 0 {
-		reason = status.Status.Conditions[0].Reason
+	if len(status.Conditions) > 0 {
+		reason = status.Conditions[0].Reason
 	}
 	return fmt.Sprintf("%s\t%s", s, cs.HyperLink(cs.ColorStatus(reason), *status.LogURL))
 }

--- a/pkg/cmd/tknpac/logs/logs.go
+++ b/pkg/cmd/tknpac/logs/logs.go
@@ -191,7 +191,7 @@ func getPipelineRunsToRepo(ctx context.Context, lopt *logOption, repoName string
 		if lopt.limit > -1 && i > lopt.limit {
 			continue
 		}
-		ret = append(ret, fmt.Sprintf("%s %s %s", run.ObjectMeta.Name, label, formatting.Age(date, lopt.cw)))
+		ret = append(ret, fmt.Sprintf("%s %s %s", run.Name, label, formatting.Age(date, lopt.cw)))
 	}
 	return ret, nil
 }

--- a/pkg/provider/bitbucketdatacenter/parse_payload_test.go
+++ b/pkg/provider/bitbucketdatacenter/parse_payload_test.go
@@ -598,9 +598,8 @@ func TestParsePayload(t *testing.T) {
 					Sender:       "sender",
 					Organization: "PROJ",
 					Repository:   "repo",
-					//nolint: stylecheck
-					URL: "💢",
-					SHA: "abcd",
+					URL:          "\x03💢\x16",
+					SHA:          "abcd",
 				}, ""),
 			wantErrSubstr: "invalid control character",
 		},

--- a/pkg/provider/gitea/gitea.go
+++ b/pkg/provider/gitea/gitea.go
@@ -318,7 +318,7 @@ func (v *Provider) GetCommitInfo(_ context.Context, runevent *info.Event) error 
 }
 
 func ShouldGetNextPage(resp *gitea.Response, currentPage int) (bool, int) {
-	val, exists := resp.Response.Header[http.CanonicalHeaderKey("x-pagecount")]
+	val, exists := resp.Header[http.CanonicalHeaderKey("x-pagecount")]
 	if !exists {
 		return false, 0
 	}

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -327,7 +327,7 @@ func (v *Provider) getObject(fname, branch string, pid int) ([]byte, *gitlab.Res
 	if err != nil {
 		return []byte{}, resp, fmt.Errorf("failed to get filename from api %s dir: %w", fname, err)
 	}
-	if resp != nil && resp.Response.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		return []byte{}, resp, nil
 	}
 	return file, resp, nil

--- a/pkg/resolve/resolve_test.go
+++ b/pkg/resolve/resolve_test.go
@@ -85,11 +85,11 @@ func TestPipelineRunPipelineMiddle(t *testing.T) {
 func TestGenerateName(t *testing.T) {
 	resolved, _, err := readTDfile(t, "pipelinerun-pipeline-task", true, true)
 	assert.NilError(t, err)
-	assert.Assert(t, resolved.ObjectMeta.GenerateName != "")
+	assert.Assert(t, resolved.GenerateName != "")
 
 	resolved, _, err = readTDfile(t, "with-generatename", true, true)
 	assert.NilError(t, err)
-	assert.Assert(t, resolved.ObjectMeta.GenerateName != "")
+	assert.Assert(t, resolved.GenerateName != "")
 }
 
 // TestPipelineBundlesSkipped effectively test conversion from beta1 to v1.

--- a/pkg/test/clients/clients.go
+++ b/pkg/test/clients/clients.go
@@ -51,7 +51,7 @@ type Data struct {
 
 // SeedTestData returns Clients and Informers populated with the
 // given Data.
-func SeedTestData(t *testing.T, ctx context.Context, d Data) (Clients, Informers) { //nolint: golint, revive
+func SeedTestData(t *testing.T, ctx context.Context, d Data) (Clients, Informers) { //nolint: revive
 	c := Clients{
 		PipelineAsCode: fakepacclient.Get(ctx),
 		Kube:           fakekubeclient.Get(ctx),

--- a/test/github_pullrequest_retest_test.go
+++ b/test/github_pullrequest_retest_test.go
@@ -125,17 +125,22 @@ func TestGithubSecondPullRequestGitopsCommentCancel(t *testing.T) {
 	// go over all pruns check that at least one is canceled and the other two are succeeded
 	canceledCount := 0
 	succeededCount := 0
+	unknownCount := 0
 	for _, prun := range pruns.Items {
 		for _, condition := range prun.Status.Conditions {
 			if condition.Type == "Succeeded" {
-				if condition.Status == corev1.ConditionFalse {
+				switch condition.Status {
+				case corev1.ConditionFalse:
 					canceledCount++
-				} else if condition.Status == corev1.ConditionTrue {
+				case corev1.ConditionTrue:
 					succeededCount++
+				case corev1.ConditionUnknown:
+					unknownCount++
 				}
 			}
 		}
 	}
 	assert.Equal(t, canceledCount, 1, "should have one canceled PipelineRun")
 	assert.Equal(t, succeededCount, 2, "should have two succeeded PipelineRuns")
+	assert.Equal(t, unknownCount, 0, "should have zero unknown PipelineRuns: %+v", pruns.Items)
 }


### PR DESCRIPTION
**Updates and Fixes:**
1. **Update golangci-lint to 2.0:**
   - Updated golangci-lint configuration with enabled linters and exclusion paths.
   - Adjusted struct field accesses from `status.Status.Conditions` to `status.Conditions`.
   - Simplified PipelineRun name references using `ObjectMeta.Name` shortcut.
   - Fixed invalid URL test data and control character handling assertions.
   - Corrected pagination header check in Gitea provider.
   - Updated test assertions for `PipelineRun` GenerateName fields.
   - Added unknown status handling in GitHub retest verification.
2. **Fix gha workflows:**
   - Removed the `pull_request_target` trigger from `nightly_push_dispatch.yaml`.
   - Added input for commit SHA with a default to the main branch.
   - Removed unnecessary tmate setup from `pull_request_trusted.yaml`.
