### PR TITLE
fix: Triggering PipelineRun on label addition in Github PRs

### DIFF
--- a/pkg/matcher/annotation_matcher.go
+++ b/pkg/matcher/annotation_matcher.go
@@ -226,6 +226,15 @@ func MatchPipelinerunByAnnotation(ctx context.Context, logger *zap.SugaredLogger
 		if event.EventType == opscomments.NoOpsCommentEventType.String() || event.EventType == opscomments.OnCommentEventType.String() {
 			continue
 		}
+
+		// If the event is a pull_request and the event type is label_update, but the PipelineRun
+		// does not contain an 'on-label' annotation, do not match this PipelineRun, as it is not intended for this event.
+		_, ok := prun.GetObjectMeta().GetAnnotations()[keys.OnLabel]
+		if event.TriggerTarget == triggertype.PullRequest && event.EventType == string(triggertype.LabelUpdate) && !ok {
+			logger.Infof("label update event, PipelineRun %s does not have a on-label for any of those labels: %s", prName, strings.Join(event.PullRequestLabel, "|"))
+			continue
+		}
+
 		if celExpr, ok := prun.GetObjectMeta().GetAnnotations()[keys.OnCelExpression]; ok {
 			out, err := celEvaluate(ctx, celExpr, event, vcx)
 			if err != nil {
@@ -278,9 +287,6 @@ func MatchPipelinerunByAnnotation(ctx context.Context, logger *zap.SugaredLogger
 				}
 				logger.Infof("matched PipelineRun with name: %s, annotation Label: %q", prName, key)
 				prMatch.Config["label"] = key
-			} else if event.EventType == string(triggertype.LabelUpdate) {
-				logger.Infof("label update event, PipelineRun %s does not have a on-label for any of those labels: %s", prName, strings.Join(event.PullRequestLabel, "|"))
-				continue
 			}
 
 			if key, ok := prun.GetObjectMeta().GetAnnotations()[keys.OnPathChangeIgnore]; ok {

--- a/pkg/matcher/annotation_matcher_test.go
+++ b/pkg/matcher/annotation_matcher_test.go
@@ -1641,6 +1641,37 @@ func TestMatchPipelinerunByAnnotation(t *testing.T) {
 			},
 		},
 		{
+			name: "no-on-label-annotation-on-pr",
+			args: args{
+				pruns: []*tektonv1.PipelineRun{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pipeline-label",
+							Annotations: map[string]string{
+								keys.OnEvent:        "[pull_request]",
+								keys.OnTargetBranch: "[main]",
+							},
+						},
+					},
+					pipelineGood,
+				},
+				runevent: info.Event{
+					URL:               "https://hello/moto",
+					TriggerTarget:     triggertype.PullRequest,
+					EventType:         string(triggertype.LabelUpdate),
+					HeadBranch:        "source",
+					BaseBranch:        "main",
+					PullRequestNumber: 10,
+					PullRequestLabel:  []string{"documentation"},
+				},
+			},
+			wantErr: true,
+			wantLog: []string{
+				"label update event, PipelineRun pipeline-label does not have a on-label for any of those labels: documentation",
+				"label update event, PipelineRun pipeline-good does not have a on-label for any of those labels: documentation",
+			},
+		},
+		{
 			name: "match-on-comment",
 			args: args{
 				pruns: []*tektonv1.PipelineRun{pipelineGood, pipelineOnComment},

--- a/test/testdata/pipelinerun-pr-cel-expression.yaml
+++ b/test/testdata/pipelinerun-pr-cel-expression.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: "\\ .PipelineName //"
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "\\ .TargetEvent //" && target_branch == "\\ .TargetBranch //"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: task
+        displayName: "The Task name is Task"
+        taskSpec:
+          steps:
+            - name: task
+              image: registry.access.redhat.com/ubi9/ubi-micro
+              command: ["/bin/echo", "HELLOMOTO"]


### PR DESCRIPTION
fixed an issue where PAC is triggering PipelineRuns on label addition on PRs when on-label annotation is not explicitly used and on-cel-expression is being used for matching event in PipelineRun definition.

Now, before matching annotations it is checking for label_update event type and on-label annoation and if it doesn't present then ignoring the PipelineRun with a log message and still preserving on-cel-expression precendence over on-label.

https://issues.redhat.com/browse/SRVKP-7378
https://issues.redhat.com/browse/SRVKP-7443

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [x] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [x] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [x] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [ ] 📖 Document any user-facing features or changes in behavior.

- [x] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [x] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [ ] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

| Git Provider          | Supported |
|-----------------------|-----------|
| GitHub App            | ✅️        |
| GitHub Webhook        | ❌️        |
| Gitea                 | ❌️        |
| GitLab                | ❌️        |
| Bitbucket Cloud       | ❌️        |
| Bitbucket Data Center | ❌️        |

  (update the documentation accordingly)
