### PR TITLE
fix: Fixed flakiness in TestGitlabCancelInProgressOnPRClose test

### DIFF
--- a/test/gitlab_merge_request_test.go
+++ b/test/gitlab_merge_request_test.go
@@ -421,15 +421,17 @@ func TestGitlabCancelInProgressOnPRClose(t *testing.T) {
 	})
 	assert.NilError(t, err)
 
-	runcnx.Clients.Log.Infof("Sleeping for 10 seconds to let the pipelinerun to be canceled")
-	time.Sleep(10 * time.Second)
+	err = twait.UntilPipelineRunHasReason(ctx, runcnx.Clients, v1.PipelineRunReasonCancelled, waitOpts)
+	assert.NilError(t, err)
 
 	prs, err := runcnx.Clients.Tekton.TektonV1().PipelineRuns(targetNS).List(context.Background(), metav1.ListOptions{})
 	assert.NilError(t, err)
 	assert.Equal(t, len(prs.Items), 1, "should have only one pipelinerun, but we have: %d", len(prs.Items))
 	assert.Equal(t, prs.Items[0].GetStatusCondition().GetCondition(apis.ConditionSucceeded).GetReason(), "Cancelled", "should have been canceled")
 
-	repo, err := runcnx.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(targetNS).Get(ctx, targetNS, metav1.GetOptions{})
+	// failing on `true` condition because for cancelled PipelineRun we want `false` condition.
+	waitOpts.FailOnRepoCondition = corev1.ConditionTrue
+	repo, err := twait.UntilRepositoryUpdated(ctx, runcnx.Clients, waitOpts)
 	assert.NilError(t, err)
 
 	laststatus := repo.Status[len(repo.Status)-1]

--- a/test/pkg/wait/wait.go
+++ b/test/pkg/wait/wait.go
@@ -16,12 +16,13 @@ import (
 )
 
 type Opts struct {
-	RepoName        string
-	Namespace       string
-	MinNumberStatus int
-	PollTimeout     time.Duration
-	AdminNS         string
-	TargetSHA       string
+	RepoName            string
+	Namespace           string
+	MinNumberStatus     int
+	PollTimeout         time.Duration
+	AdminNS             string
+	TargetSHA           string
+	FailOnRepoCondition corev1.ConditionStatus
 }
 
 func UntilMinPRAppeared(ctx context.Context, clients clients.Clients, opts Opts, minNumber int) error {
@@ -58,7 +59,11 @@ func UntilRepositoryUpdated(ctx context.Context, clients clients.Clients, opts O
 		}
 		if len(prs.Items) > 0 {
 			prConditions := prs.Items[0].Status.Conditions
-			if len(prConditions) != 0 && prConditions[0].Status == corev1.ConditionFalse {
+			if opts.FailOnRepoCondition == "" {
+				opts.FailOnRepoCondition = corev1.ConditionFalse
+			}
+
+			if len(prConditions) != 0 && prConditions[0].Status == opts.FailOnRepoCondition {
 				return true, fmt.Errorf("pipelinerun has failed")
 			}
 		}


### PR DESCRIPTION
in TestGitlabCancelInProgressOnPRClose test repository status was sometime being gotten as Cancelled and sometime it was CancelledStatusRunFinally that's was the reason I think this test was having flakiness.

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [x] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [x] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [x] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [ ] 📖 Document any user-facing features or changes in behavior.

- [ ] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [ ] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [x] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

| Git Provider          | Supported |
|-----------------------|-----------|
| GitHub App            | ❌️        |
| GitHub Webhook        | ❌️        |
| Gitea                 | ❌️        |
| GitLab                | ✅️        |
| Bitbucket Cloud       | ❌️        |
| Bitbucket Data Center | ❌️        |

  (update the documentation accordingly)
