### PR TITLE
fix: Fixed PipelineRun cancelling on PR closed

### DIFF
--- a/pkg/kubeinteraction/labels.go
+++ b/pkg/kubeinteraction/labels.go
@@ -83,6 +83,10 @@ func AddLabelsAndAnnotations(event *info.Event, pipelineRun *tektonv1.PipelineRu
 		annotations[keys.TargetProjectID] = strconv.Itoa(event.TargetProjectID)
 	}
 
+	if value, ok := pipelineRun.GetObjectMeta().GetAnnotations()[keys.CancelInProgress]; ok {
+		labels[keys.CancelInProgress] = value
+	}
+
 	for k, v := range labels {
 		pipelineRun.Labels[k] = v
 	}

--- a/pkg/kubeinteraction/labels_test.go
+++ b/pkg/kubeinteraction/labels_test.go
@@ -41,8 +41,10 @@ func TestAddLabelsAndAnnotations(t *testing.T) {
 				event: event,
 				pipelineRun: &tektonv1.PipelineRun{
 					ObjectMeta: metav1.ObjectMeta{
-						Labels:      map[string]string{},
-						Annotations: map[string]string{},
+						Labels: map[string]string{},
+						Annotations: map[string]string{
+							keys.CancelInProgress: "true",
+						},
 					},
 				},
 				repo: &apipac.Repository{
@@ -70,6 +72,8 @@ func TestAddLabelsAndAnnotations(t *testing.T) {
 			assert.NilError(t, err)
 			assert.Equal(t, tt.args.pipelineRun.Labels[keys.URLOrg], tt.args.event.Organization, "'%s' != %s",
 				tt.args.pipelineRun.Labels[keys.URLOrg], tt.args.event.Organization)
+			assert.Equal(t, tt.args.pipelineRun.Labels[keys.CancelInProgress], tt.args.pipelineRun.Annotations[keys.CancelInProgress], "'%s' != %s",
+				tt.args.pipelineRun.Labels[keys.CancelInProgress], tt.args.pipelineRun.Annotations[keys.CancelInProgress])
 			assert.Equal(t, tt.args.pipelineRun.Annotations[keys.URLOrg], tt.args.event.Organization, "'%s' != %s",
 				tt.args.pipelineRun.Annotations[keys.URLOrg], tt.args.event.Organization)
 			assert.Equal(t, tt.args.pipelineRun.Annotations[keys.ShaURL], tt.args.event.SHAURL)

--- a/pkg/pipelineascode/cancel_pipelineruns.go
+++ b/pkg/pipelineascode/cancel_pipelineruns.go
@@ -32,8 +32,9 @@ var cancelMergePatch = map[string]any{
 // that belong to a specific pull request in the given repository.
 func (p *PacRun) cancelAllInProgressBelongingToClosedPullRequest(ctx context.Context, repo *v1alpha1.Repository) error {
 	labelSelector := getLabelSelector(map[string]string{
-		keys.URLRepository: formatting.CleanValueKubernetes(p.event.Repository),
-		keys.PullRequest:   strconv.Itoa(int(p.event.PullRequestNumber)),
+		keys.URLRepository:    formatting.CleanValueKubernetes(p.event.Repository),
+		keys.PullRequest:      strconv.Itoa(p.event.PullRequestNumber),
+		keys.CancelInProgress: "true",
 	})
 	prs, err := p.run.Clients.Tekton.TektonV1().PipelineRuns(repo.Namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: labelSelector,
@@ -174,10 +175,6 @@ func (p *PacRun) cancelPipelineRuns(ctx context.Context, prs *tektonv1.PipelineR
 		if pr.IsDone() {
 			p.logger.Infof("cancel-in-progress: skipping cancelling pipelinerun %v/%v, already done", pr.GetNamespace(), pr.GetName())
 			continue
-		}
-
-		if pr.IsPending() {
-			p.logger.Infof("cancel-in-progress: skipping cancelling pipelinerun %v/%v in pending state", pr.GetNamespace(), pr.GetName())
 		}
 
 		p.logger.Infof("cancel-in-progress: cancelling pipelinerun %v/%v", pr.GetNamespace(), pr.GetName())


### PR DESCRIPTION
issue: when a PipelineRun is running on PR and it doesn't have cancel-in-progress annotation specified, on the PR close PAC is cancelling the PipelinRun.

solution: in code on PR close, it wasn't checked before that a PipelineRun has cancel-in-progress annotation or not and PAC just cancel PipelineRuns regardless of feature enabled. Now cancel-in-progress annotation is added to PipelineRun labels so that it can be filtered using labelSelector.

https://issues.redhat.com/browse/SRVKP-7456

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [x] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [x] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [x] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [ ] 📖 Document any user-facing features or changes in behavior.

- [x] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [x] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [ ] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

  - [x] GitHub App
  - [x] GitHub Webhook
  - [x] Gitea/Forgejo
  - [x] GitLab
  - [x] Bitbucket Cloud
  - [ ] Bitbucket Data Center

  (update the provider documentation accordingly)
