### PR TITLE
fix: /ok-to-test /retest pipelineruns should not be created if last sha successful

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -35,7 +35,7 @@ tracking using a Git workflow.
 
 <--->
 
-- Pull-request "*GitOps*" actions through comments with  `/retest`, `/test <pipeline-name>` and so on.
+- Pull-request "*GitOps*" actions through comments with `/retest` (reruns failed pipelines), `/test <pipeline-name>` (force rerun specific pipeline) and so on.
 
 - Automatic Task resolution in Pipelines (local Tasks, Artifact Hub, and remote URLs)
 

--- a/docs/content/docs/guide/policy.md
+++ b/docs/content/docs/guide/policy.md
@@ -23,7 +23,7 @@ or other supported Git providers (currently GitHub and Gitea).
   to trigger the CI for a pull request by commenting `/ok-to-test`. This enables
   CI to run on pull requests submitted by contributors who are not collaborators
   of the repository or organization. It also applies to `/test` and `/retest`
-  commands. This action takes precedence over the `pull_request` action.
+  commands. Note that `/retest` will only trigger failed PipelineRuns. This action takes precedence over the `pull_request` action.
 
 ## Configuring Policies in the Repository CR
 

--- a/hack/gh-workflow-ci.sh
+++ b/hack/gh-workflow-ci.sh
@@ -75,7 +75,7 @@ get_tests() {
   ghglabre="Github|Gitlab|Bitbucket"
   if [[ ${target} == "providers" ]]; then
     grep -hioP "^func Test.*(${ghglabre})(\w+)\(" "${testfiles[@]}" | sed -e 's/func[ ]*//' -e 's/($//'
-  elif [[ ${target} == "gitea_others" ]]; then
+    elif [[ ${target} == "gitea_others" ]]; then
     grep -hioP '^func Test(\w+)\(' "${testfiles[@]}" | grep -iPv "(${ghglabre})" | sed -e 's/func[ ]*//' -e 's/($//'
   else
     echo "Invalid target: ${target}"

--- a/test/gitea_params_test.go
+++ b/test/gitea_params_test.go
@@ -314,7 +314,15 @@ func TestGiteaParamsOnRepoCR(t *testing.T) {
 	_, f := tgitea.TestPR(t, topts)
 	defer f()
 
-	repo, err := topts.ParamsRun.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(topts.TargetNS).Get(context.Background(), topts.TargetNS, metav1.GetOptions{})
+	// Wait for Repository status to be updated
+	waitOpts := twait.Opts{
+		RepoName:        topts.TargetNS,
+		Namespace:       topts.TargetNS,
+		MinNumberStatus: 1,
+		PollTimeout:     twait.DefaultTimeout,
+		TargetSHA:       "",
+	}
+	repo, err := twait.UntilRepositoryUpdated(context.Background(), topts.ParamsRun.Clients, waitOpts)
 	assert.NilError(t, err)
 	assert.Assert(t, len(repo.Status) != 0)
 	assert.NilError(t,

--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -454,7 +454,7 @@ func TestGiteaConfigMaxKeepRun(t *testing.T) {
 	}
 	_, f := tgitea.TestPR(t, topts)
 	defer f()
-	tgitea.PostCommentOnPullRequest(t, topts, "/retest")
+	tgitea.PostCommentOnPullRequest(t, topts, "/test")
 	tgitea.WaitForStatus(t, topts, "heads/"+topts.TargetRefName, "", false)
 
 	waitOpts := twait.Opts{
@@ -496,8 +496,8 @@ func TestGiteaConfigCancelInProgress(t *testing.T) {
 
 	time.Sleep(3 * time.Second) // “Evil does not sleep. It waits.” - Galadriel
 
-	// wait a bit that the pipelinerun had created
-	tgitea.PostCommentOnPullRequest(t, topts, "/retest")
+	// wait a bit that the pipelinerun had created, then trigger a new run to test cancel-in-progress
+	tgitea.PostCommentOnPullRequest(t, topts, "/test")
 
 	time.Sleep(2 * time.Second) // “Evil does not sleep. It waits.” - Galadriel
 
@@ -539,11 +539,11 @@ func TestGiteaConfigCancelInProgress(t *testing.T) {
 	}
 	assert.Equal(t, cancelledPr, 1, "only one pr should have been canceled")
 
-	// Test that cancelling works with /retest
-	tgitea.PostCommentOnPullRequest(t, topts, "/retest")
+	// Test that cancelling works with /retest - use specific PipelineRun name to bypass success check
+	tgitea.PostCommentOnPullRequest(t, topts, "/retest pr-cancel-in-progress")
 	topts.ParamsRun.Clients.Log.Info("Waiting 10 seconds before a new retest")
-	time.Sleep(10 * time.Second) // “Evil does not sleep. It waits.” - Galadriel
-	tgitea.PostCommentOnPullRequest(t, topts, "/retest")
+	time.Sleep(10 * time.Second) // "Evil does not sleep. It waits." - Galadriel
+	tgitea.PostCommentOnPullRequest(t, topts, "/retest pr-cancel-in-progress")
 	tgitea.WaitForStatus(t, topts, "heads/"+targetRef, "", false)
 
 	for _, pr := range prs.Items {

--- a/test/github_config_maxkeepruns_test.go
+++ b/test/github_config_maxkeepruns_test.go
@@ -26,9 +26,9 @@ func TestGithubMaxKeepRuns(t *testing.T) {
 	g.RunPullRequest(ctx, t)
 	defer g.TearDown(ctx, t)
 
-	g.Cnx.Clients.Log.Infof("Creating /retest in PullRequest")
+	g.Cnx.Clients.Log.Infof("Creating /test in PullRequest to create a second run")
 	_, _, err := g.Provider.Client().Issues.CreateComment(ctx, g.Options.Organization, g.Options.Repo, g.PRNumber,
-		&ghlib.IssueComment{Body: ghlib.Ptr("/retest")})
+		&ghlib.IssueComment{Body: ghlib.Ptr("/test")})
 	assert.NilError(t, err)
 
 	g.Cnx.Clients.Log.Infof("Wait for the second repository update to be updated")

--- a/test/github_pullrequest_test.go
+++ b/test/github_pullrequest_test.go
@@ -323,9 +323,9 @@ func TestGithubSecondCancelInProgress(t *testing.T) {
 	assert.NilError(t, err)
 	time.Sleep(10 * time.Second)
 
-	g.Cnx.Clients.Log.Infof("Creating /retest on PullRequest")
+	g.Cnx.Clients.Log.Infof("Creating /test on PullRequest to create a second run")
 	_, _, err = g.Provider.Client().Issues.CreateComment(ctx, g.Options.Organization, g.Options.Repo, g.PRNumber,
-		&github.IssueComment{Body: github.Ptr("/retest")})
+		&github.IssueComment{Body: github.Ptr("/test")})
 	assert.NilError(t, err)
 
 	g.Cnx.Clients.Log.Infof("Waiting for the two pipelinerun to be created")
@@ -529,7 +529,7 @@ func TestGithubCancelInProgressSettingFromConfigMapOnPR(t *testing.T) {
 	_, _, err = g.Provider.Client().Issues.CreateComment(ctx,
 		g.Options.Organization,
 		g.Options.Repo, g.PRNumber,
-		&github.IssueComment{Body: github.Ptr("/retest")})
+		&github.IssueComment{Body: github.Ptr("/test")})
 	assert.NilError(t, err)
 
 	g.Cnx.Clients.Log.Infof("Waiting for the two pipelinerun to be created")

--- a/test/gitlab_incoming_webhook_test.go
+++ b/test/gitlab_incoming_webhook_test.go
@@ -24,10 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var (
-	incomingSecreteValue = "shhhh-secrete"
-	incomingSecretName   = "incoming-webhook-secret"
-)
+// Constants moved to test/github_incoming_test.go to avoid redeclaration
 
 func TestGitlabIncomingWebhookLegacy(t *testing.T) {
 	testGitlabIncomingWebhook(t, true)

--- a/test/gitlab_merge_request_test.go
+++ b/test/gitlab_merge_request_test.go
@@ -104,15 +104,15 @@ func TestGitlabMergeRequest(t *testing.T) {
 		assert.Equal(t, "Merge Request", prsNew.Items[i].Annotations[keys.EventType])
 	}
 
-	runcnx.Clients.Log.Infof("Sending /retest comment on MergeRequest %s/-/merge_requests/%d", projectinfo.WebURL, mrID)
+	runcnx.Clients.Log.Infof("Sending /test comment on MergeRequest %s/-/merge_requests/%d", projectinfo.WebURL, mrID)
 	_, _, err = glprovider.Client().Notes.CreateMergeRequestNote(opts.ProjectID, mrID, &clientGitlab.CreateMergeRequestNoteOptions{
-		Body: clientGitlab.Ptr("/retest"),
+		Body: clientGitlab.Ptr("/test"),
 	})
 	assert.NilError(t, err)
 
 	sopt = twait.SuccessOpt{
 		Title:           commitTitle,
-		OnEvent:         opscomments.RetestAllCommentEventType.String(),
+		OnEvent:         opscomments.TestAllCommentEventType.String(),
 		TargetNS:        targetNS,
 		NumberofPRMatch: 5, // this is the max we get in repos status
 		SHA:             "",
@@ -128,7 +128,7 @@ func TestGitlabMergeRequest(t *testing.T) {
 			successCommentsPost++
 		}
 	}
-	// we get 2 PRS initially, 2 prs from the push update and 2 prs from the /retest == 6
+	// we get 2 PRS initially, 2 prs from the push update and 2 prs from the /test == 6
 	assert.Equal(t, 6, successCommentsPost)
 }
 
@@ -577,7 +577,7 @@ func TestGitlabDisableCommentsOnMR(t *testing.T) {
 	// no comments will be posted related to pipelineruns
 	assert.Equal(t, 0, successCommentsPost)
 
-	// Update the repo setting to nil, and comment /retest to restart the pipelinerun
+	// Update the repo setting to nil, and comment /test to restart the pipelinerun
 	// and now comments will be added on the MR
 	waitOpts := twait.Opts{
 		RepoName:  targetNS,
@@ -589,15 +589,15 @@ func TestGitlabDisableCommentsOnMR(t *testing.T) {
 	err = repository.UpdateRepo(ctx, waitOpts.Namespace, waitOpts.RepoName, runcnx.Clients)
 	assert.NilError(t, err)
 
-	runcnx.Clients.Log.Infof("Sending /retest comment on MergeRequest %s/-/merge_requests/%d", projectinfo.WebURL, mrID)
+	runcnx.Clients.Log.Infof("Sending /test comment on MergeRequest %s/-/merge_requests/%d", projectinfo.WebURL, mrID)
 	_, _, err = glprovider.Client().Notes.CreateMergeRequestNote(opts.ProjectID, mrID, &clientGitlab.CreateMergeRequestNoteOptions{
-		Body: clientGitlab.Ptr("/retest"),
+		Body: clientGitlab.Ptr("/test"),
 	})
 	assert.NilError(t, err)
 
 	sopt = twait.SuccessOpt{
 		Title:           commitTitle,
-		OnEvent:         opscomments.RetestAllCommentEventType.String(),
+		OnEvent:         opscomments.TestAllCommentEventType.String(),
 		TargetNS:        targetNS,
 		NumberofPRMatch: 2, // this is the max we get in repos status
 		SHA:             "",


### PR DESCRIPTION
# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
 
/retest and /ok-to-test should only restart failed pipelines; the
changes in the PR ensure that we do not match successful pipelineruns
during invocation of these gitops commands. The tests have also been
updated to use /test instead wherever /retest is being used to restart
successful pipelines

fixes https://github.com/openshift-pipelines/pipelines-as-code/issues/1959
Jira: https://issues.redhat.com/browse/SRVKP-7236

# Submitter Checklist

- [x] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [x] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [x] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [ ] 📖 Document any user-facing features or changes in behavior.

- [ ] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [ ] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [ ] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center

  (update the provider documentation accordingly)
