### PR TITLE
fix: Gitea test TestGiteaParamsChangedFilesCEL flakiness

### DIFF
--- a/pkg/pipelineascode/cancel_pipelineruns.go
+++ b/pkg/pipelineascode/cancel_pipelineruns.go
@@ -46,7 +46,7 @@ func (p *PacRun) cancelAllInProgressBelongingToClosedPullRequest(ctx context.Con
 	if len(prs.Items) == 0 {
 		msg := fmt.Sprintf("no pipelinerun found for repository: %v and pullRequest %v",
 			p.event.Repository, p.event.PullRequestNumber)
-		p.eventEmitter.EmitMessage(repo, zap.InfoLevel, "RepositoryPipelineRun", msg)
+		p.eventEmitter.EmitMessage(repo, zap.InfoLevel, "CancelInProgress", msg)
 		return nil
 	}
 
@@ -144,7 +144,7 @@ func (p *PacRun) cancelPipelineRunsOpsComment(ctx context.Context, repo *v1alpha
 	if len(prs.Items) == 0 {
 		msg := fmt.Sprintf("no pipelinerun found for repository: %v , sha: %v and pulRequest %v",
 			p.event.Repository, p.event.SHA, p.event.PullRequestNumber)
-		p.eventEmitter.EmitMessage(repo, zap.InfoLevel, "RepositoryPipelineRun", msg)
+		p.eventEmitter.EmitMessage(repo, zap.InfoLevel, "CancelInProgress", msg)
 		return nil
 	}
 
@@ -183,7 +183,7 @@ func (p *PacRun) cancelPipelineRuns(ctx context.Context, prs *tektonv1.PipelineR
 			defer wg.Done()
 			if _, err := action.PatchPipelineRun(ctx, p.logger, "cancel patch", p.run.Clients.Tekton, &pr, cancelMergePatch); err != nil {
 				errMsg := fmt.Sprintf("failed to cancel pipelineRun %s/%s: %s", pr.GetNamespace(), pr.GetName(), err.Error())
-				p.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "RepositoryPipelineRun", errMsg)
+				p.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "CancelInProgress", errMsg)
 			}
 		}(ctx, pr)
 	}


### PR DESCRIPTION
This PR refines the event reporting for PipelineRun cancellations to provide clearer messaging and prevent test failures from
expected cancellation events.

**Changes:**  
- Updated the event reason from `RepositoryPipelineRun` to `CancelInProgress` for cancellation-related messages, making the
intent more explicit.  
- Modified end-to-end tests to ignore events with the `CancelInProgress` reason, preventing false negatives in test assertions.  
- Added a helper function (`checkEvents`) to filter out cancellation-related events during test validation.  

**Impact:**  
- Better observability for cancellation actions in logs/events.  
- More reliable test execution by excluding expected cancellation events from failure checks.  

**Testing:**  
- Existing end-to-end tests were updated to accommodate the changes.  
- Manual verification confirmed cancellation events are now properly labeled and filtered in test results.  

**Related Issues:**  
(N/A – or reference relevant issues if applicable) 