### PR TITLE
chore: remove redundant checkout reference in e2e workflow

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -62,9 +62,6 @@ jobs:
       TEST_BITBUCKET_SERVER_E2E_REPOSITORY: PAC/pac-e2e-tests
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.sha }}
-
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"


### PR DESCRIPTION
- Removed explicit SHA reference in actions/checkout step
- The default behavior of checkout already uses the triggering commit
- Simplified workflow configuration by removing unnecessary parameters
