### PR TITLE
DNM: release 0.33.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,132 +1,105 @@
-issues:
-  exclude-dirs:
-    - vendor
-    - pkg/provider/gitea/structs
-  exclude-rules:
-    # Exclude some linters from running on tests files.
-    - path: _test\.go
-      linters:
-        - gosec
-    # hopefully we can remove this when https://github.com/golangci/golangci-lint/issues/4697 is fixed
-    - path: pkg/resolve/resolve.go
-      text: "don't use `init` function"
+version: "2"
 run:
   build-tags:
     - e2e
-linters-settings:
-  gocritic:
-    disabled-checks:
-      - unlambda
-  errcheck:
-    exclude-functions:
-      - (*github.com/tektoncd/pipeline/vendor/go.uber.org/zap.SugaredLogger).Sync
-      - flag.Set
-      - logger.Sync
-      - fmt.Fprintf
-      - fmt.Fprintln
-      - (io.Closer).Close
-      - updateConfigMap
-  gofumpt:
-    extra-rules: true
 linters:
   enable:
     - asasalint
     - asciicheck
     - bidichk
     - bodyclose
-    #- containedctx
-    #- contextcheck
-    #- cyclop
+    - copyloopvar
     - decorder
-    #- depguard
     - dogsled
     - dupl
     - dupword
     - durationcheck
-    - errcheck
     - errchkjson
     - errname
     - errorlint
-    # - execinquery
     - exhaustive
-    #- exhaustruct
-    - copyloopvar
     - forbidigo
     - forcetypeassert
-    #- funlen
-    #- gci
     - ginkgolinter
     - gocheckcompilerdirectives
-    #- gochecknoglobals
     - gochecknoinits
     - gochecksumtype
-    #- gocognit
-    #- goconst
     - gocritic
-    #- gocyclo
     - godot
-    #- godox
-    #- goerr113
-    #- gofmt
-    - gofumpt
     - goheader
-    - goimports
-    #- gomnd
-    #- gomoddirectives
     - gomodguard
     - goprintffuncname
     - gosec
-    - gosimple
     - gosmopolitan
-    - govet
     - grouper
     - importas
-    #- inamedparam
-    #- interfacebloat
-    #- ireturn
-    #- lll
     - loggercheck
-    #- maintidx
     - makezero
     - mirror
     - misspell
-    #- musttag
     - nakedret
-    #- nestif
     - nilerr
-    #- nilnil
-    #- nlreturn
     - noctx
-    #- nolintlint
-    #- nonamedreturns
     - nosprintfhostport
-    #- paralleltest
-    #- perfsprint
     - prealloc
     - predeclared
     - promlinter
     - protogetter
     - reassign
     - revive
-    #- rowserrcheck
     - sloglint
-    #- sqlclosecheck
     - staticcheck
-    - stylecheck
     - tagalign
-    #- tagliatelle
     - testableexamples
-    # - testifylint
-    #- testpackage
-    #- thelper
     - tparallel
-    #- unconvert
     - unparam
-    - unused
     - usestdlibvars
-    #- varnamelen
-    #- wastedassign
     - whitespace
-    #- wrapcheck
-    #- wsl
     - zerologlint
+  settings:
+    errcheck:
+      exclude-functions:
+        - (*github.com/tektoncd/pipeline/vendor/go.uber.org/zap.SugaredLogger).Sync
+        - flag.Set
+        - logger.Sync
+        - fmt.Fprintf
+        - fmt.Fprintln
+        - (io.Closer).Close
+        - updateConfigMap
+    gocritic:
+      disabled-checks:
+        - unlambda
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - gosec
+        path: _test\.go
+      - path: pkg/resolve/resolve.go
+        text: don't use `init` function
+    paths:
+      - vendor
+      - pkg/provider/gitea/structs
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+  settings:
+    gofumpt:
+      extra-rules: true
+  exclusions:
+    generated: lax
+    paths:
+      - vendor
+      - pkg/provider/gitea/structs
+      - third_party$
+      - builtin$
+      - examples$

--- a/.tekton/boussole.yaml
+++ b/.tekton/boussole.yaml
@@ -23,29 +23,5 @@ spec:
       value: "{{ git_auth_secret }}"
     - name: comment_sender
       value: "{{ sender }}"
-    #
-    # Optional parameters (value is the default):
-    #
-    # The key in git_auth_secret that contains the token (default: git-provider-token)
-    # - name: git_auth_secret_key
-    #   value: git-provider-token
-    #
-    # The /lgtm threshold needed of approvers for a PR to be approved (default: 1)
-    # - name: lgtm_threshold
-    #   value: "1"
-    #
-    # The permissionms the user need to trigger a lgtm
-    # - name: lgtm_permissions
-    #   value: "admin,write"
-    #
-    # The review event  when lgtm is triggered, can be APPROVE,
-    # REQUEST_CHANGES, or COMMENT if setting to empty string it will be set as
-    # PENDING
-    # - name: lgtm_review_event
-    #   value: "APPROVE"
-    #
-    # The merge method to use. Can be one of: merge, squash, rebase
-    # - name: merge_method
-    #   value: "rebase"
   pipelineRef:
     name: boussole

--- a/docs/content/docs/guide/incoming_webhook.md
+++ b/docs/content/docs/guide/incoming_webhook.md
@@ -65,7 +65,7 @@ A PipelineRun is then annotated to target the incoming event and the main branch
 apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
-  name: target_pipelinerun
+  name: target-pipelinerun
   annotations:
     pipelinesascode.tekton.dev/on-event: "[incoming]"
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
@@ -95,7 +95,7 @@ You can use the `generateName` field as the PipelineRun name but you will need t
 As an example here is a curl snippet starting the PipelineRun:
 
 ```shell
-curl -X POST 'https://control.pac.url/incoming?secret=very-secure-shared-secret&repository=repo&branch=main&pipelinerun=target_pipelinerun'
+curl -X POST 'https://control.pac.url/incoming?secret=very-secure-shared-secret&repository=repo&branch=main&pipelinerun=target-pipelinerun'
 ```
 
 in this snippet, note two things the `"/incoming"` path to the controller URL
@@ -144,7 +144,7 @@ spec:
 and here is a curl snippet passing the `pull_request_number` value:
 
 ```shell
-curl -H "Content-Type: application/json" -X POST "https://control.pac.url/incoming?repository=repo&branch=main&secret=very-secure-shared-secret&pipelinerun=target_pipelinerun" -d '{"params": {"pull_request_number": "12345"}}'
+curl -H "Content-Type: application/json" -X POST "https://control.pac.url/incoming?repository=repo&branch=main&secret=very-secure-shared-secret&pipelinerun=target-pipelinerun" -d '{"params": {"pull_request_number": "12345"}}'
 ```
 
 The parameter value of `pull_request_number` will be set to `12345` when using the variable `{{pull_request_number}}` in your PipelineRun.
@@ -156,7 +156,7 @@ specify the `X-GitHub-Enterprise-Host` header when making the incoming webhook
 request. For example when using curl:
 
 ```shell
-curl -H "X-GitHub-Enterprise-Host: github.example.com" -X POST "https://control.pac.url/incoming?repository=repo&branch=main&secret=very-secure-shared-secret&pipelinerun=target_pipelinerun"
+curl -H "X-GitHub-Enterprise-Host: github.example.com" -X POST "https://control.pac.url/incoming?repository=repo&branch=main&secret=very-secure-shared-secret&pipelinerun=target-pipelinerun"
 ```
 
 ### Using incoming webhook with webhook based providers

--- a/pkg/cmd/tknpac/list/list.go
+++ b/pkg/cmd/tknpac/list/list.go
@@ -123,8 +123,8 @@ func formatStatus(status *v1alpha1.RepositoryRunStatus, cs *cli.ColorScheme, c c
 	}
 
 	reason := "UNKNOWN"
-	if len(status.Status.Conditions) > 0 {
-		reason = status.Status.Conditions[0].Reason
+	if len(status.Conditions) > 0 {
+		reason = status.Conditions[0].Reason
 	}
 	return fmt.Sprintf("%s\t%s", s, cs.HyperLink(cs.ColorStatus(reason), *status.LogURL))
 }

--- a/pkg/cmd/tknpac/logs/logs.go
+++ b/pkg/cmd/tknpac/logs/logs.go
@@ -191,7 +191,7 @@ func getPipelineRunsToRepo(ctx context.Context, lopt *logOption, repoName string
 		if lopt.limit > -1 && i > lopt.limit {
 			continue
 		}
-		ret = append(ret, fmt.Sprintf("%s %s %s", run.ObjectMeta.Name, label, formatting.Age(date, lopt.cw)))
+		ret = append(ret, fmt.Sprintf("%s %s %s", run.Name, label, formatting.Age(date, lopt.cw)))
 	}
 	return ret, nil
 }

--- a/pkg/kubeinteraction/labels.go
+++ b/pkg/kubeinteraction/labels.go
@@ -83,6 +83,10 @@ func AddLabelsAndAnnotations(event *info.Event, pipelineRun *tektonv1.PipelineRu
 		annotations[keys.TargetProjectID] = strconv.Itoa(event.TargetProjectID)
 	}
 
+	if value, ok := pipelineRun.GetObjectMeta().GetAnnotations()[keys.CancelInProgress]; ok {
+		labels[keys.CancelInProgress] = value
+	}
+
 	for k, v := range labels {
 		pipelineRun.Labels[k] = v
 	}

--- a/pkg/kubeinteraction/labels_test.go
+++ b/pkg/kubeinteraction/labels_test.go
@@ -41,8 +41,10 @@ func TestAddLabelsAndAnnotations(t *testing.T) {
 				event: event,
 				pipelineRun: &tektonv1.PipelineRun{
 					ObjectMeta: metav1.ObjectMeta{
-						Labels:      map[string]string{},
-						Annotations: map[string]string{},
+						Labels: map[string]string{},
+						Annotations: map[string]string{
+							keys.CancelInProgress: "true",
+						},
 					},
 				},
 				repo: &apipac.Repository{
@@ -70,6 +72,8 @@ func TestAddLabelsAndAnnotations(t *testing.T) {
 			assert.NilError(t, err)
 			assert.Equal(t, tt.args.pipelineRun.Labels[keys.URLOrg], tt.args.event.Organization, "'%s' != %s",
 				tt.args.pipelineRun.Labels[keys.URLOrg], tt.args.event.Organization)
+			assert.Equal(t, tt.args.pipelineRun.Labels[keys.CancelInProgress], tt.args.pipelineRun.Annotations[keys.CancelInProgress], "'%s' != %s",
+				tt.args.pipelineRun.Labels[keys.CancelInProgress], tt.args.pipelineRun.Annotations[keys.CancelInProgress])
 			assert.Equal(t, tt.args.pipelineRun.Annotations[keys.URLOrg], tt.args.event.Organization, "'%s' != %s",
 				tt.args.pipelineRun.Annotations[keys.URLOrg], tt.args.event.Organization)
 			assert.Equal(t, tt.args.pipelineRun.Annotations[keys.ShaURL], tt.args.event.SHAURL)

--- a/pkg/matcher/annotation_matcher.go
+++ b/pkg/matcher/annotation_matcher.go
@@ -218,6 +218,15 @@ func MatchPipelinerunByAnnotation(ctx context.Context, logger *zap.SugaredLogger
 		if event.EventType == opscomments.NoOpsCommentEventType.String() || event.EventType == opscomments.OnCommentEventType.String() {
 			continue
 		}
+
+		// If the event is a pull_request and the event type is label_update, but the PipelineRun
+		// does not contain an 'on-label' annotation, do not match this PipelineRun, as it is not intended for this event.
+		_, ok := prun.GetObjectMeta().GetAnnotations()[keys.OnLabel]
+		if event.TriggerTarget == triggertype.PullRequest && event.EventType == string(triggertype.LabelUpdate) && !ok {
+			logger.Infof("label update event, PipelineRun %s does not have a on-label for any of those labels: %s", prName, strings.Join(event.PullRequestLabel, "|"))
+			continue
+		}
+
 		if celExpr, ok := prun.GetObjectMeta().GetAnnotations()[keys.OnCelExpression]; ok {
 			out, err := celEvaluate(ctx, celExpr, event, vcx)
 			if err != nil {
@@ -270,9 +279,6 @@ func MatchPipelinerunByAnnotation(ctx context.Context, logger *zap.SugaredLogger
 				}
 				logger.Infof("matched PipelineRun with name: %s, annotation Label: %q", prName, key)
 				prMatch.Config["label"] = key
-			} else if event.EventType == string(triggertype.LabelUpdate) {
-				logger.Infof("label update event, PipelineRun %s does not have a on-label for any of those labels: %s", prName, strings.Join(event.PullRequestLabel, "|"))
-				continue
 			}
 
 			if key, ok := prun.GetObjectMeta().GetAnnotations()[keys.OnPathChangeIgnore]; ok {

--- a/pkg/matcher/annotation_matcher_test.go
+++ b/pkg/matcher/annotation_matcher_test.go
@@ -1686,6 +1686,37 @@ func TestMatchPipelinerunByAnnotation(t *testing.T) {
 			},
 		},
 		{
+			name: "no-on-label-annotation-on-pr",
+			args: args{
+				pruns: []*tektonv1.PipelineRun{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pipeline-label",
+							Annotations: map[string]string{
+								keys.OnEvent:        "[pull_request]",
+								keys.OnTargetBranch: "[main]",
+							},
+						},
+					},
+					pipelineGood,
+				},
+				runevent: info.Event{
+					URL:               "https://hello/moto",
+					TriggerTarget:     triggertype.PullRequest,
+					EventType:         string(triggertype.LabelUpdate),
+					HeadBranch:        "source",
+					BaseBranch:        "main",
+					PullRequestNumber: 10,
+					PullRequestLabel:  []string{"documentation"},
+				},
+			},
+			wantErr: true,
+			wantLog: []string{
+				"label update event, PipelineRun pipeline-label does not have a on-label for any of those labels: documentation",
+				"label update event, PipelineRun pipeline-good does not have a on-label for any of those labels: documentation",
+			},
+		},
+		{
 			name: "match-on-comment",
 			args: args{
 				pruns: []*tektonv1.PipelineRun{pipelineGood, pipelineOnComment},

--- a/pkg/pipelineascode/cancel_pipelineruns.go
+++ b/pkg/pipelineascode/cancel_pipelineruns.go
@@ -28,9 +28,9 @@ var cancelMergePatch = map[string]interface{}{
 	},
 }
 
-// cancelAllInProgressBelongingToPullRequest cancels all in-progress PipelineRuns
+// cancelAllInProgressBelongingToClosedPullRequest cancels all in-progress PipelineRuns
 // that belong to a specific pull request in the given repository.
-func (p *PacRun) cancelAllInProgressBelongingToPullRequest(ctx context.Context, repo *v1alpha1.Repository) error {
+func (p *PacRun) cancelAllInProgressBelongingToClosedPullRequest(ctx context.Context, repo *v1alpha1.Repository) error {
 	labelSelector := getLabelSelector(map[string]string{
 		keys.URLRepository: formatting.CleanValueKubernetes(p.event.Repository),
 		keys.PullRequest:   strconv.Itoa(int(p.event.PullRequestNumber)),
@@ -70,7 +70,9 @@ func (p *PacRun) cancelInProgressMatchingPR(ctx context.Context, matchPR *tekton
 		return nil
 	}
 
-	prName, ok := matchPR.GetAnnotations()[keys.OriginalPRName]
+	// As PipelineRuns are filtered by name, OriginalPRName should be taken from
+	// labels instead of annotations because of constraints imposed by kube API.
+	prName, ok := matchPR.GetLabels()[keys.OriginalPRName]
 	if !ok {
 		return nil
 	}

--- a/pkg/pipelineascode/cancel_pipelineruns.go
+++ b/pkg/pipelineascode/cancel_pipelineruns.go
@@ -46,7 +46,7 @@ func (p *PacRun) cancelAllInProgressBelongingToClosedPullRequest(ctx context.Con
 	if len(prs.Items) == 0 {
 		msg := fmt.Sprintf("no pipelinerun found for repository: %v and pullRequest %v",
 			p.event.Repository, p.event.PullRequestNumber)
-		p.eventEmitter.EmitMessage(repo, zap.InfoLevel, "RepositoryPipelineRun", msg)
+		p.eventEmitter.EmitMessage(repo, zap.InfoLevel, "CancelInProgress", msg)
 		return nil
 	}
 
@@ -143,7 +143,7 @@ func (p *PacRun) cancelPipelineRunsOpsComment(ctx context.Context, repo *v1alpha
 	if len(prs.Items) == 0 {
 		msg := fmt.Sprintf("no pipelinerun found for repository: %v , sha: %v and pulRequest %v",
 			p.event.Repository, p.event.SHA, p.event.PullRequestNumber)
-		p.eventEmitter.EmitMessage(repo, zap.InfoLevel, "RepositoryPipelineRun", msg)
+		p.eventEmitter.EmitMessage(repo, zap.InfoLevel, "CancelInProgress", msg)
 		return nil
 	}
 
@@ -182,7 +182,7 @@ func (p *PacRun) cancelPipelineRuns(ctx context.Context, prs *tektonv1.PipelineR
 			defer wg.Done()
 			if _, err := action.PatchPipelineRun(ctx, p.logger, "cancel patch", p.run.Clients.Tekton, &pr, cancelMergePatch); err != nil {
 				errMsg := fmt.Sprintf("failed to cancel pipelineRun %s/%s: %s", pr.GetNamespace(), pr.GetName(), err.Error())
-				p.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "RepositoryPipelineRun", errMsg)
+				p.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "CancelInProgress", errMsg)
 			}
 		}(ctx, pr)
 	}

--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -58,7 +58,7 @@ func NewPacs(event *info.Event, vcx provider.Interface, run *params.Run, pacInfo
 func (p *PacRun) Run(ctx context.Context) error {
 	matchedPRs, repo, err := p.matchRepoPR(ctx)
 	if repo != nil && p.event.TriggerTarget == triggertype.PullRequestClosed {
-		if err := p.cancelAllInProgressBelongingToPullRequest(ctx, repo); err != nil {
+		if err := p.cancelAllInProgressBelongingToClosedPullRequest(ctx, repo); err != nil {
 			return fmt.Errorf("error cancelling in progress pipelineRuns belonging to pull request %d: %w", p.event.PullRequestNumber, err)
 		}
 		return nil

--- a/pkg/provider/bitbucketserver/parse_payload_test.go
+++ b/pkg/provider/bitbucketserver/parse_payload_test.go
@@ -598,9 +598,8 @@ func TestParsePayload(t *testing.T) {
 					Sender:       "sender",
 					Organization: "PROJ",
 					Repository:   "repo",
-					//nolint: stylecheck
-					URL: "💢",
-					SHA: "abcd",
+					URL:          "\x03💢\x16",
+					SHA:          "abcd",
 				}, ""),
 			wantErrSubstr: "invalid control character",
 		},

--- a/pkg/provider/gitea/gitea.go
+++ b/pkg/provider/gitea/gitea.go
@@ -318,7 +318,7 @@ func (v *Provider) GetCommitInfo(_ context.Context, runevent *info.Event) error 
 }
 
 func ShouldGetNextPage(resp *gitea.Response, currentPage int) (bool, int) {
-	val, exists := resp.Response.Header[http.CanonicalHeaderKey("x-pagecount")]
+	val, exists := resp.Header[http.CanonicalHeaderKey("x-pagecount")]
 	if !exists {
 		return false, 0
 	}

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -329,7 +329,7 @@ func (v *Provider) getObject(fname, branch string, pid int) ([]byte, *gitlab.Res
 	if err != nil {
 		return []byte{}, resp, fmt.Errorf("failed to get filename from api %s dir: %w", fname, err)
 	}
-	if resp != nil && resp.Response.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		return []byte{}, resp, nil
 	}
 	return file, resp, nil

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -130,6 +130,10 @@ func (v *Provider) SetClient(_ context.Context, run *params.Run, runevent *info.
 		// this really should not happen but let's just hope this is it
 		apiURL = apiPublicURL
 	}
+	_, err = url.Parse(apiURL)
+	if err != nil {
+		return fmt.Errorf("failed to parse api url %s: %w", apiURL, err)
+	}
 	v.apiURL = apiURL
 
 	v.Client, err = gitlab.NewClient(runevent.Provider.Token, gitlab.WithBaseURL(apiURL))

--- a/pkg/provider/gitlab/gitlab_test.go
+++ b/pkg/provider/gitlab/gitlab_test.go
@@ -244,33 +244,140 @@ func TestSetClient(t *testing.T) {
 }
 
 func TestSetClientDetectAPIURL(t *testing.T) {
-	fakehost := "https://fakehost.com"
 	ctx, _ := rtesting.SetupFakeContext(t)
-	client, _, tearDown := thelp.Setup(t)
+	mockClient, _, tearDown := thelp.Setup(t)
 	defer tearDown()
-	v := &Provider{Client: client}
-	event := info.NewEvent()
-	err := v.SetClient(ctx, nil, event, nil, nil)
-	assert.ErrorContains(t, err, "no git_provider.secret has been set")
 
-	event.Provider.Token = "hello"
-	event.TargetProjectID = 10
-	event.SourceProjectID = 10
+	// Define test cases
+	tests := []struct {
+		name              string
+		providerToken     string
+		providerURL       string // input: event.Provider.URL
+		repoURL           string // input: v.repoURL
+		pathWithNamespace string // input: v.pathWithNamespace (needed if repoURL is used)
+		eventURL          string // input: event.URL
+		// Define expected outcomes
+		expectedAPIURL string
+		expectedError  string // Substring expected in the error message, "" for no error
+	}{
+		{
+			name:          "Error: No token provided",
+			providerToken: "",
+			expectedError: "no git_provider.secret has been set",
+		},
+		{
+			name:              "Success: API URL from event.Provider.URL (highest precedence)",
+			providerToken:     "token",
+			providerURL:       "https://provider.example.com",
+			repoURL:           "https://repo.example.com/foo/bar", // Should be ignored
+			pathWithNamespace: "foo/bar",
+			eventURL:          "https://event.example.com/foo/bar", // Should be ignored
+			expectedAPIURL:    "https://provider.example.com",
+			expectedError:     "",
+		},
+		{
+			name:              "Success: API URL from v.repoURL (non-public)",
+			providerToken:     "token",
+			providerURL:       "", // This must be empty to test the next case
+			repoURL:           "https://private-gitlab.com/my/repo",
+			pathWithNamespace: "my/repo",
+			eventURL:          "https://event.example.com/my/repo", // Should be ignored
+			expectedAPIURL:    "https://private-gitlab.com/",
+			expectedError:     "",
+		},
+		{
+			name:           "Success: API URL from event.URL",
+			providerToken:  "token",
+			providerURL:    "", // This must be empty
+			repoURL:        "", // This must be empty
+			eventURL:       "https://event-url.com/org/project",
+			expectedAPIURL: "https://event-url.com",
+			expectedError:  "",
+		},
+		{
+			name:           "Success: Fallback to default public API URL",
+			providerToken:  "token",
+			providerURL:    "",
+			repoURL:        "",
+			eventURL:       "",
+			expectedAPIURL: apiPublicURL, // Default case
+			expectedError:  "",
+		},
+		{
+			name:              "Success: Default URL when repoURL is public Gitlab",
+			providerToken:     "token",
+			providerURL:       "",
+			repoURL:           apiPublicURL + "/public/repo", // Starts with public URL, so skipped
+			pathWithNamespace: "public/repo",
+			eventURL:          "", // Falls through to default
+			expectedAPIURL:    apiPublicURL,
+			expectedError:     "",
+		},
+		{
+			name:          "Error: Invalid URL from event.URL",
+			providerToken: "token",
+			providerURL:   "",
+			repoURL:       "",
+			eventURL:      "://bad-schema",
+			expectedError: "parse \"://bad-schema\": missing protocol scheme", // Specific error from url.Parse
+		},
+		{
+			name:          "Error: Invalid URL from event.Provider.URL (final parse)",
+			providerToken: "token",
+			providerURL:   "ht tp://invalid host", // Invalid URL format
+			repoURL:       "",
+			eventURL:      "",
+			expectedError: "failed to parse api url", // Wrapper error message
+		},
+		{
+			name:              "Error: Invalid URL from v.repoURL (final parse)",
+			providerToken:     "token",
+			providerURL:       "",
+			repoURL:           "ht tp://invalid.repo.url/foo/bar", // Invalid format
+			pathWithNamespace: "foo/bar",
+			eventURL:          "",
+			// Note: The calculated apiURL would be "ht tp://invalid.repo.url" before parsing
+			expectedError: "failed to parse api url",
+		},
+	}
 
-	v.repoURL, event.URL, event.Provider.URL = "", "", ""
-	event.URL = fmt.Sprintf("%s/hello-this-is-me-ze/project", fakehost)
-	err = v.SetClient(ctx, nil, event, nil, nil)
-	assert.NilError(t, err)
-	assert.Equal(t, fakehost, v.apiURL)
+	// Run test cases
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup specific to this test case
+			v := &Provider{
+				Client:            mockClient, // Use the shared mock client
+				repoURL:           tc.repoURL,
+				pathWithNamespace: tc.pathWithNamespace,
+			}
+			event := info.NewEvent()
+			event.Provider.Token = tc.providerToken
+			event.Provider.URL = tc.providerURL
+			event.URL = tc.eventURL
+			// Set some default IDs to avoid potential nil pointer issues or side effects
+			// if the GetProject part of SetClient is reached unexpectedly.
+			event.TargetProjectID = 1
+			event.SourceProjectID = 1
 
-	v.repoURL, event.URL, event.Provider.URL = "", "", ""
-	event.Provider.URL = fmt.Sprintf("%s/hello-this-is-me-ze/anotherproject", fakehost)
-	assert.Equal(t, fakehost, v.apiURL)
+			// Execute the function under test
+			// Using placeholder nil values for arguments not directly related to URL detection
+			err := v.SetClient(ctx, nil, event, nil, nil)
 
-	v.repoURL = fmt.Sprintf("%s/hello-this-is-me-ze/anotherproject", fakehost)
-	v.pathWithNamespace = "hello-this-is-me-ze/anotherproject"
-	event.URL, event.Provider.URL = "", ""
-	assert.Equal(t, fakehost, v.apiURL)
+			// Assertions
+			if tc.expectedError != "" {
+				assert.ErrorContains(t, err, tc.expectedError)
+				// If an error is expected, we usually don't check the apiURL state,
+				// as it might be indeterminate or irrelevant.
+			} else {
+				assert.NilError(t, err)
+				// Only check the resulting apiURL if no error was expected
+				assert.Equal(t, tc.expectedAPIURL, v.apiURL)
+				// Optionally, check if the client was actually set (if no error)
+				assert.Assert(t, v.Client != nil)
+				assert.Assert(t, v.Token != nil && *v.Token == tc.providerToken)
+			}
+		})
+	}
 }
 
 func TestGetTektonDir(t *testing.T) {

--- a/pkg/resolve/resolve_test.go
+++ b/pkg/resolve/resolve_test.go
@@ -85,11 +85,11 @@ func TestPipelineRunPipelineMiddle(t *testing.T) {
 func TestGenerateName(t *testing.T) {
 	resolved, _, err := readTDfile(t, "pipelinerun-pipeline-task", true, true)
 	assert.NilError(t, err)
-	assert.Assert(t, resolved.ObjectMeta.GenerateName != "")
+	assert.Assert(t, resolved.GenerateName != "")
 
 	resolved, _, err = readTDfile(t, "with-generatename", true, true)
 	assert.NilError(t, err)
-	assert.Assert(t, resolved.ObjectMeta.GenerateName != "")
+	assert.Assert(t, resolved.GenerateName != "")
 }
 
 // TestPipelineBundlesSkipped effectively test conversion from beta1 to v1.

--- a/pkg/test/clients/clients.go
+++ b/pkg/test/clients/clients.go
@@ -51,7 +51,7 @@ type Data struct {
 
 // SeedTestData returns Clients and Informers populated with the
 // given Data.
-func SeedTestData(t *testing.T, ctx context.Context, d Data) (Clients, Informers) { //nolint: golint, revive
+func SeedTestData(t *testing.T, ctx context.Context, d Data) (Clients, Informers) { //nolint: revive
 	c := Clients{
 		PipelineAsCode: fakepacclient.Get(ctx),
 		Kube:           fakekubeclient.Get(ctx),

--- a/test/github_pullrequest_retest_test.go
+++ b/test/github_pullrequest_retest_test.go
@@ -86,14 +86,54 @@ func TestGithubPullRequestGitOpsComments(t *testing.T) {
 			prNum:   4,
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			waitOpts := twait.Opts{
-				RepoName:        g.TargetNamespace,
-				Namespace:       g.TargetNamespace,
-				MinNumberStatus: tt.prNum,
-				PollTimeout:     twait.DefaultTimeout,
-				TargetSHA:       g.SHA,
+	assert.NilError(t, err)
+	err = twait.UntilPipelineRunCreated(ctx, g.Cnx.Clients, waitOpts)
+	assert.NilError(t, err)
+
+	g.Cnx.Clients.Log.Infof("/cancel pr-gitops-comment on Pull Request")
+	_, _, err = g.Provider.Client.Issues.CreateComment(ctx,
+		g.Options.Organization,
+		g.Options.Repo, g.PRNumber,
+		&github.IssueComment{Body: github.Ptr("/cancel pr-gitops-comment")})
+	assert.NilError(t, err)
+
+	waitOpts = twait.Opts{
+		RepoName:        g.TargetNamespace,
+		Namespace:       g.TargetNamespace,
+		MinNumberStatus: 3,
+		PollTimeout:     twait.DefaultTimeout,
+		TargetSHA:       g.SHA,
+	}
+	g.Cnx.Clients.Log.Info("Waiting for Repository to be updated")
+	_, err = twait.UntilRepositoryUpdated(ctx, g.Cnx.Clients, waitOpts)
+	assert.NilError(t, err)
+
+	g.Cnx.Clients.Log.Infof("Check if we have the repository set as succeeded")
+	repo, err := g.Cnx.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(g.TargetNamespace).Get(ctx, g.TargetNamespace, metav1.GetOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, repo.Status[len(repo.Status)-1].Conditions[0].Status, corev1.ConditionFalse)
+
+	pruns, err = g.Cnx.Clients.Tekton.TektonV1().PipelineRuns(g.TargetNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", keys.SHA, g.SHA),
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, len(pruns.Items), 3)
+
+	// go over all pruns check that at least one is canceled and the other two are succeeded
+	canceledCount := 0
+	succeededCount := 0
+	unknownCount := 0
+	for _, prun := range pruns.Items {
+		for _, condition := range prun.Status.Conditions {
+			if condition.Type == "Succeeded" {
+				switch condition.Status {
+				case corev1.ConditionFalse:
+					canceledCount++
+				case corev1.ConditionTrue:
+					succeededCount++
+				case corev1.ConditionUnknown:
+					unknownCount++
+				}
 			}
 			if tt.comment == "/cancel pr-gitops-comment" {
 				g.Cnx.Clients.Log.Info("/test pr-gitops-comment on Pull Request before canceling")
@@ -132,4 +172,7 @@ func TestGithubPullRequestGitOpsComments(t *testing.T) {
 			assert.Equal(t, len(pruns.Items), tt.prNum)
 		})
 	}
+	assert.Equal(t, canceledCount, 1, "should have one canceled PipelineRun")
+	assert.Equal(t, succeededCount, 2, "should have two succeeded PipelineRuns")
+	assert.Equal(t, unknownCount, 0, "should have zero unknown PipelineRuns: %+v", pruns.Items)
 }

--- a/test/github_pullrequest_test.go
+++ b/test/github_pullrequest_test.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 package test
 
 import (
@@ -13,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/go-github/v68/github"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/golden"
@@ -419,6 +417,65 @@ func TestGithubPullRequestNoOnLabelAnnotation(t *testing.T) {
 		assert.Equal(t, len(prs.Items), 1)
 		time.Sleep(1 * time.Second)
 	}
+}
+
+func TestGithubPullRequestNoPipelineRunCancelledOnPRClosed(t *testing.T) {
+	ctx := context.Background()
+	g := &tgithub.PRTest{
+		Label:         "Github PullRequest",
+		YamlFiles:     []string{"testdata/pipelinerun-gitops.yaml"},
+		NoStatusCheck: true,
+	}
+	g.RunPullRequest(ctx, t)
+	defer g.TearDown(ctx, t)
+
+	g.Cnx.Clients.Log.Infof("Waiting for the two pipelinerun to be created")
+	waitOpts := twait.Opts{
+		RepoName:        g.TargetNamespace,
+		Namespace:       g.TargetNamespace,
+		MinNumberStatus: 1,
+		PollTimeout:     twait.DefaultTimeout,
+		TargetSHA:       g.SHA,
+	}
+	err := twait.UntilPipelineRunCreated(ctx, g.Cnx.Clients, waitOpts)
+	assert.NilError(t, err)
+
+	g.Cnx.Clients.Log.Infof("Closing the PullRequest")
+	_, _, err = g.Provider.Client.PullRequests.Edit(ctx, g.Options.Organization, g.Options.Repo, g.PRNumber, &github.PullRequest{
+		State: github.Ptr("closed"),
+	})
+	assert.NilError(t, err)
+
+	isCancelled := false
+	var prReason string
+
+	for range 10 {
+		prs, err := g.Cnx.Clients.Tekton.TektonV1().PipelineRuns(g.TargetNamespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			t.Logf("failed to list PipelineRuns: %v", err)
+			time.Sleep(1 * time.Second)
+			continue // try again
+		}
+		if len(prs.Items) != 1 {
+			t.Logf("expected 1 PipelineRun, got %d", len(prs.Items))
+			time.Sleep(1 * time.Second)
+			continue // try again
+		}
+		// Check all conditions, get the right one
+		conditions := prs.Items[0].Status.GetConditions()
+		for _, c := range conditions {
+			if c.Type == apis.ConditionSucceeded {
+				prReason = c.Reason
+				if prReason != string(tektonv1.PipelineRunReasonRunning) {
+					isCancelled = true
+					t.Logf("expected PipelineRun `Running`, got %s", prReason)
+					break
+				}
+			}
+		}
+		time.Sleep(1 * time.Second)
+	}
+	assert.Equal(t, false, isCancelled, fmt.Sprintf("PipelineRun got cancelled while we wanted it `Running`, last reason: %v", prReason))
 }
 
 // Local Variables:

--- a/test/gitlab_merge_request_test.go
+++ b/test/gitlab_merge_request_test.go
@@ -335,17 +335,15 @@ func TestGitlabCancelInProgressOnPRClose(t *testing.T) {
 	})
 	assert.NilError(t, err)
 
-	err = twait.UntilPipelineRunHasReason(ctx, runcnx.Clients, v1.PipelineRunReasonCancelled, waitOpts)
-	assert.NilError(t, err)
+	runcnx.Clients.Log.Infof("Sleeping for 10 seconds to let the pipelinerun to be canceled")
+	time.Sleep(10 * time.Second)
 
 	prs, err := runcnx.Clients.Tekton.TektonV1().PipelineRuns(targetNS).List(context.Background(), metav1.ListOptions{})
 	assert.NilError(t, err)
 	assert.Equal(t, len(prs.Items), 1, "should have only one pipelinerun, but we have: %d", len(prs.Items))
 	assert.Equal(t, prs.Items[0].GetStatusCondition().GetCondition(apis.ConditionSucceeded).GetReason(), "Cancelled", "should have been canceled")
 
-	// failing on `true` condition because for cancelled PipelineRun we want `false` condition.
-	waitOpts.FailOnRepoCondition = corev1.ConditionTrue
-	repo, err := twait.UntilRepositoryUpdated(ctx, runcnx.Clients, waitOpts)
+	repo, err := runcnx.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(targetNS).Get(ctx, targetNS, metav1.GetOptions{})
 	assert.NilError(t, err)
 
 	laststatus := repo.Status[len(repo.Status)-1]

--- a/test/pkg/wait/wait.go
+++ b/test/pkg/wait/wait.go
@@ -14,12 +14,13 @@ import (
 )
 
 type Opts struct {
-	RepoName        string
-	Namespace       string
-	MinNumberStatus int
-	PollTimeout     time.Duration
-	AdminNS         string
-	TargetSHA       string
+	RepoName            string
+	Namespace           string
+	MinNumberStatus     int
+	PollTimeout         time.Duration
+	AdminNS             string
+	TargetSHA           string
+	FailOnRepoCondition corev1.ConditionStatus
 }
 
 func UntilMinPRAppeared(ctx context.Context, clients clients.Clients, opts Opts, minNumber int) error {
@@ -56,7 +57,11 @@ func UntilRepositoryUpdated(ctx context.Context, clients clients.Clients, opts O
 		}
 		if len(prs.Items) > 0 {
 			prConditions := prs.Items[0].Status.Conditions
-			if len(prConditions) != 0 && prConditions[0].Status == corev1.ConditionFalse {
+			if opts.FailOnRepoCondition == "" {
+				opts.FailOnRepoCondition = corev1.ConditionFalse
+			}
+
+			if len(prConditions) != 0 && prConditions[0].Status == opts.FailOnRepoCondition {
 				return true, fmt.Errorf("pipelinerun has failed")
 			}
 		}

--- a/test/testdata/pipelinerun-pr-cel-expression.yaml
+++ b/test/testdata/pipelinerun-pr-cel-expression.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: "\\ .PipelineName //"
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "\\ .TargetEvent //" && target_branch == "\\ .TargetBranch //"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: task
+        displayName: "The Task name is Task"
+        taskSpec:
+          steps:
+            - name: task
+              image: registry.access.redhat.com/ubi9/ubi-micro
+              command: ["/bin/echo", "HELLOMOTO"]


### PR DESCRIPTION
# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

release 0.33.1 test

# Submitter Checklist

- [ ] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [ ] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [ ] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [ ] 📖 Document any user-facing features or changes in behavior.

- [ ] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [ ] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [ ] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center

  (update the provider documentation accordingly)
fixed an issue where PAC is triggering PipelineRuns on label
addition on PRs when on-label annotation is not explicitly
used and on-cel-expression is being used for matching event
in PipelineRun definition.

Now, before matching annotations it is checking for label_update
event type and on-label annoation and if it doesn't present then
ignoring the PipelineRun with a log message and still preserving
on-cel-expression precendence over on-label.

https://issues.redhat.com/browse/SRVKP-7378
https://issues.redhat.com/browse/SRVKP-7443

Signed-off-by: Zaki Shaikh <zashaikh@redhat.com>