### PR TITLE
chore: allow users to set the REG_PORT for `make dev` using a envvar

### DIFF
--- a/docs/content/docs/dev/_index.md
+++ b/docs/content/docs/dev/_index.md
@@ -26,6 +26,16 @@ When it finishes, you will have the following installed in your kind cluster:
 - Pipelines as code deployed from your repo with ko.
 - Gitea service running locally so you can run the E2E tests against it (Gitea has the most comprehensive set of tests).
 
+### Configuring the Kind Registry Port
+
+By default, the Kind registry runs on port 5000. To use a different port, set the `REG_PORT` environment variable:
+
+```shell
+# Set a custom registry port
+export REG_PORT=5001
+make dev
+```
+
 By default, it will try to install from
 $GOPATH/src/github.com/openshift-pipelines/pipelines-as-code. To override it,
 set the `PAC_DIRS` environment variable.

--- a/hack/dev/kind/install.sh
+++ b/hack/dev/kind/install.sh
@@ -46,7 +46,7 @@ if ! builtin type -p gosmee &>/dev/null; then
 fi
 
 TMPD=$(mktemp -d /tmp/.GITXXXX)
-REG_PORT='5000'
+REG_PORT=${REG_PORT:-'5000'}
 REG_NAME='kind-registry'
 INSTALL_FROM_RELEASE=
 PAC_PASS_SECRET_FOLDER=${PAC_PASS_SECRET_FOLDER:-""}
@@ -173,7 +173,7 @@ function install_pac() {
     if [[ -n ${PAC_DEPLOY_SCRIPT:-""} ]]; then
       ${PAC_DEPLOY_SCRIPT}
     else
-      env KO_DOCKER_REPO=localhost:5000 $ko apply -f config --sbom=none -B >/dev/null
+      env KO_DOCKER_REPO=localhost:${REG_PORT} $ko apply -f config --sbom=none -B >/dev/null
     fi
     cd ${oldPwd}
   fi
@@ -243,6 +243,7 @@ main() {
   install_pac
   [[ -z ${DISABLE_GITEA} ]] && install_gitea
   echo "And we are done :): "
+  echo "Using registry on localhost:${REG_PORT}"
 }
 
 function usage() {


### PR DESCRIPTION
# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

On Apple Macs the ControlCenter listens on port 5000. 

```
# lsof without running the docker registry locally
lsof -i :5000 
                                                      
COMMAND     PID         USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
ControlCe 81715 vibhavbobade   11u  IPv4 0xf70fc252883ced3a      0t0  TCP *:commplex-main (LISTEN)
ControlCe 81715 vibhavbobade   12u  IPv6 0x13b6e0db93572d28
```

I wanted to use the 5001 port instead to avoid unauthorized errors while running `ko` builds. 

This change we ensures that the user it able to set the REG_PORT using an environment variable and then use `make dev` after which consumes the REG_PORT env var to create the kind-registry exposed on the aforementioned port.

# Submitter Checklist

- [x] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [x] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [x] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [x] 📖 Document any user-facing features or changes in behavior.

- [ ] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [ ] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [ ] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center

  (update the provider documentation accordingly)
