### PR TITLE
docs: correct GitLab token scope from `admin:repo_hook` to `api`

### DIFF
--- a/docs/content/docs/install/gitlab.md
+++ b/docs/content/docs/install/gitlab.md
@@ -30,7 +30,7 @@ There are two ways to create the `Repository` and configure the webhook:
 * Use the [`tkn pac create repo`](/docs/guide/cli) command to
 configure a webhook and create the `Repository` CR.
 
-  You need to have a personal access token created with `admin:repo_hook` scope. `tkn pac` will use this token to configure the webhook, and add it in a secret
+  You need to have a personal access token created with `api` scope. `tkn pac` will use this token to configure the webhook, and add it in a secret
 in the cluster which will be used by Pipelines-As-Code controller for accessing the `Repository`.
 
 Below is the sample format for `tkn pac create repo`


### PR DESCRIPTION
* The documentation previously instructed users to create a GitLab personal access token with the `admin:repo_hook` scope, which is incorrect.

* Hence this patch updates the instructions to avoid confusion and ensure proper setup.

![image](https://github.com/user-attachments/assets/8392da5c-8736-4e14-9a58-44a6d4fdfb1c)

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [x] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [x] 📖 Document any user-facing features or changes in behavior.

- If adding a provider feature, fill in the following details:

  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [x] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center

  (update the provider documentation accordingly)
