### PR TITLE
Disable GitLab comments for pipeline start/end events to reduce MR noise

### DIFF
--- a/config/300-repositories.yaml
+++ b/config/300-repositories.yaml
@@ -84,6 +84,11 @@ spec:
                           items:
                             description: list of teams allowed to have ci run on pull/merge requests.
                             type: string
+                    gitlab:
+                      type: object
+                      properties:
+                        comment_strategy:
+                          type: string
                     github_app_token_scope_repos:
                       type: array
                       items:

--- a/docs/content/docs/guide/repositorycrd.md
+++ b/docs/content/docs/guide/repositorycrd.md
@@ -121,6 +121,18 @@ right to merge commits to the default branch can change the PipelineRun and have
 access to the infrastructure.
 {{< /hint >}}
 
+## Disabling all comments for Pipelineruns on GitLab MR
+
+`comment_strategy` allows you to disable the comments on GitLab MR for a Repository
+
+```yaml
+spec:
+  gitlab:
+    comment_strategy: "disable_all"
+```
+
+When you set the value of `comment_strategy` to `disable_all` it will not add any comment on the merge request for the start and the end of pipelinerun
+
 ## Concurrency
 
 `concurrency_limit` allows you to define the maximum number of PipelineRuns running at any time for a Repository.

--- a/pkg/apis/pipelinesascode/v1alpha1/types.go
+++ b/pkg/apis/pipelinesascode/v1alpha1/types.go
@@ -101,9 +101,14 @@ func (r *RepositorySpec) Merge(newRepo RepositorySpec) {
 }
 
 type Settings struct {
-	GithubAppTokenScopeRepos []string `json:"github_app_token_scope_repos,omitempty"`
-	PipelineRunProvenance    string   `json:"pipelinerun_provenance,omitempty"`
-	Policy                   *Policy  `json:"policy,omitempty"`
+	GithubAppTokenScopeRepos []string        `json:"github_app_token_scope_repos,omitempty"`
+	PipelineRunProvenance    string          `json:"pipelinerun_provenance,omitempty"`
+	Policy                   *Policy         `json:"policy,omitempty"`
+	Gitlab                   *GitlabSettings `json:"gitlab,omitempty"`
+}
+
+type GitlabSettings struct {
+	CommentStrategy string `json:"comment_strategy,omitempty"`
 }
 
 func (s *Settings) Merge(newSettings *Settings) {

--- a/pkg/reconciler/status_test.go
+++ b/pkg/reconciler/status_test.go
@@ -70,6 +70,7 @@ func TestPostFinalStatus(t *testing.T) {
 			ErrorLogSnippet: false,
 		},
 	}
+
 	_, err := r.postFinalStatus(ctx, fakelogger, pacInfo, vcx, info.NewEvent(), pr1)
 	assert.NilError(t, err)
 }

--- a/test/gitlab_delete_tag_event_test.go
+++ b/test/gitlab_delete_tag_event_test.go
@@ -33,7 +33,7 @@ func TestGitlabDeleteTagEvent(t *testing.T) {
 	}
 	defer tgitlab.TearDown(ctx, t, runcnx, glprovider, -1, "", targetNS, opts.ProjectID)
 
-	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, targetNS, nil)
+	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, opts, targetNS, nil)
 	assert.NilError(t, err)
 
 	tagName := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("v1.0")

--- a/test/gitlab_incoming_webhook_test.go
+++ b/test/gitlab_incoming_webhook_test.go
@@ -53,7 +53,7 @@ func TestGitlabIncomingWebhook(t *testing.T) {
 		},
 	}
 
-	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, randomedString, incoming)
+	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, opts, randomedString, incoming)
 	assert.NilError(t, err)
 
 	err = secret.Create(ctx, runcnx, map[string]string{"incoming": incomingSecreteValue}, randomedString, incomingSecretName)

--- a/test/gitlab_push_gitops_command_test.go
+++ b/test/gitlab_push_gitops_command_test.go
@@ -37,7 +37,7 @@ func TestGitlabGitOpsCommandTestOnPush(t *testing.T) {
 		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
 	}
 
-	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, targetNs, nil)
+	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, opts, targetNs, nil)
 	assert.NilError(t, err)
 
 	entries, err := payload.GetEntries(map[string]string{
@@ -107,7 +107,7 @@ func TestGitlabGitOpsCommandCancelOnPush(t *testing.T) {
 		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
 	}
 
-	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, targetNs, nil)
+	err = tgitlab.CreateCRD(ctx, projectinfo, runcnx, opts, targetNs, nil)
 	assert.NilError(t, err)
 
 	entries, err := payload.GetEntries(map[string]string{

--- a/test/pkg/gitlab/crd.go
+++ b/test/pkg/gitlab/crd.go
@@ -6,13 +6,14 @@ import (
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
 	pacrepo "github.com/openshift-pipelines/pipelines-as-code/test/pkg/repository"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/secret"
 	gitlab "gitlab.com/gitlab-org/api/client-go"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func CreateCRD(ctx context.Context, projectinfo *gitlab.Project, run *params.Run, targetNS string, incomings *[]v1alpha1.Incoming) error {
+func CreateCRD(ctx context.Context, projectinfo *gitlab.Project, run *params.Run, opts options.E2E, targetNS string, incomings *[]v1alpha1.Incoming) error {
 	if err := pacrepo.CreateNS(ctx, targetNS, run); err != nil {
 		return err
 	}
@@ -31,7 +32,8 @@ func CreateCRD(ctx context.Context, projectinfo *gitlab.Project, run *params.Run
 			Name: targetNS,
 		},
 		Spec: v1alpha1.RepositorySpec{
-			URL: projectinfo.WebURL,
+			Settings: &opts.Settings,
+			URL:      projectinfo.WebURL,
 			GitProvider: &v1alpha1.GitProvider{
 				Type:          "gitlab",
 				URL:           apiURL,

--- a/test/pkg/options/options.go
+++ b/test/pkg/options/options.go
@@ -1,5 +1,7 @@
 package options
 
+import "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+
 type E2E struct {
 	Repo, Organization string
 	DirectWebhook      bool
@@ -8,6 +10,7 @@ type E2E struct {
 	Concurrency        int
 	UserName           string
 	Password           string
+	Settings           v1alpha1.Settings
 }
 
 var (

--- a/test/pkg/repository/update.go
+++ b/test/pkg/repository/update.go
@@ -1,0 +1,22 @@
+package repository
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
+)
+
+func UpdateRepo(ctx context.Context, repoName, targetNs string, clients clients.Clients) error {
+	repo, err := clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(targetNs).Get(ctx, repoName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	repo.Spec.Settings = nil
+	if _, err := clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(targetNs).Update(ctx, repo, metav1.UpdateOptions{}); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
* The GitLab integration was previously generating a comment on every pipeline start and end filling merge requests with redundant updates

* Hence this patch introduces a new setting to completely disable comment creation

* By using `comment_strategy: disable_all`, no comments will be added for either pipeline start or completion

* Also includes e2e tests to validate the new behavior

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [x] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [x] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [x] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [x] 📖 Document any user-facing features or changes in behavior.

- [x] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [x] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- If adding a provider feature, fill in the following details:

  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [x] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center

  (update the provider documentation accordingly)
