### PR TITLE
test: fix SecondPullRequestConcurrencyMultiplePR

### DIFF
--- a/test/github_pullrequest_concurrency_multiplepr_test.go
+++ b/test/github_pullrequest_concurrency_multiplepr_test.go
@@ -135,30 +135,32 @@ func TestGithubSecondPullRequestConcurrencyMultiplePR(t *testing.T) {
 		t.Errorf("we didn't get %d pipelineruns as successful, some of them are still pending or it's abnormally slow to process the Q", allPipelinesRunsCnt)
 	}
 
-	prs, err := runcnx.Clients.Tekton.TektonV1().PipelineRuns(targetNS).List(ctx, metav1.ListOptions{})
-	assert.NilError(t, err)
+	maxWaitLoopRun := 10
+	success := false
 	allPipelineRunsNamesAndStatus := []string{}
-	for _, pr := range prs.Items {
-		allPipelineRunsNamesAndStatus = append(allPipelineRunsNamesAndStatus, fmt.Sprintf("%s %s", pr.Name, pr.Status.GetConditions()))
-	}
-	// Filter out PipelineRuns that don't match our pattern
-	matchingPRs := []tektonv1.PipelineRun{}
-	for _, pr := range prs.Items {
-		if strings.HasPrefix(pr.Name, "prlongrunnning-") {
-			matchingPRs = append(matchingPRs, pr)
+	for i := range maxWaitLoopRun {
+		prs, err := runcnx.Clients.Tekton.TektonV1().PipelineRuns(targetNS).List(ctx, metav1.ListOptions{})
+		assert.NilError(t, err)
+		for _, pr := range prs.Items {
+			allPipelineRunsNamesAndStatus = append(allPipelineRunsNamesAndStatus, fmt.Sprintf("%s %s", pr.Name, pr.Status.GetConditions()))
 		}
-	}
+		// Filter out PipelineRuns that don't match our pattern
+		matchingPRs := []tektonv1.PipelineRun{}
+		for _, pr := range prs.Items {
+			if strings.HasPrefix(pr.Name, "prlongrunnning-") {
+				matchingPRs = append(matchingPRs, pr)
+			}
+		}
+		if len(matchingPRs) == allPipelinesRunAfterCleanUp {
+			runcnx.Clients.Log.Infof("we have the expected number of pipelineruns %d/%d, %d/%d", len(matchingPRs), allPipelinesRunAfterCleanUp, i, maxWaitLoopRun)
+			success = true
+			break
+		}
 
-	// NOTE(chmouel): Sometime it's 8 sometime it's 9, it's a bit flaky but we
-	// are mostly okay if its one of those. Maybe one day we will get to the
-	// bottom of it.
-	//
-	// See discussion here:
-	// https://github.com/openshift-pipelines/pipelines-as-code/pull/1978#issue-2897418926
-	if len(matchingPRs) != allPipelinesRunAfterCleanUp && len(matchingPRs) != allPipelinesRunsCnt+1 {
-		t.Fatalf("number of cleaned PR is %d we expected to have %d after the cleanup: PipelineRun and its statuses: %+v", len(matchingPRs), allPipelinesRunAfterCleanUp, allPipelineRunsNamesAndStatus)
-		return
+		runcnx.Clients.Log.Infof("we are still waiting for pipelineruns to be cleaned up, we have %d/%d, sleeping 10s, %d/%d", len(matchingPRs), allPipelinesRunsCnt, i, maxWaitLoopRun)
+		time.Sleep(10 * time.Second)
 	}
+	assert.Assert(t, success, "we didn't get %d pipelineruns as successful, some of them are still pending or it's abnormally slow to process the Q: %s", allPipelinesRunsCnt, allPipelineRunsNamesAndStatus)
 
 	if os.Getenv("TEST_NOCLEANUP") != "true" {
 		repository.NSTearDown(ctx, t, runcnx, targetNS)


### PR DESCRIPTION
* The `TestGithubSecondPullRequestConcurrencyMultiplePR` test occasionally failed due to timing issues related to PipelineRun cleanup.
* The check for the final number of PipelineRuns sometimes occurred before the cancellation/cleanup mechanism had fully processed superseded runs.
* Introduced a wait loop to allow sufficient time for PipelineRuns to be garbage collected or cleaned up by the controller.
* This ensures the assertion for the exact number of expected PipelineRuns is more reliable, reducing test flakiness.

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [ ] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [ ] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [ ] 📖 Document any user-facing features or changes in behavior.

- [ ] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [ ] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [ ] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

  - [x] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center

  (update the provider documentation accordingly)
