### PR TITLE
chore: Vale rules enforcing GitLab

### DIFF
--- a/.vale/styles/RedHat/CaseSensitiveTerms.yml
+++ b/.vale/styles/RedHat/CaseSensitiveTerms.yml
@@ -1,7 +1,7 @@
 ---
 extends: substitution
 ignorecase: false
-level: error
+level: warning
 link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/casesensitiveterms/
 message: "Use '%s' rather than '%s'."
 action:
@@ -177,7 +177,7 @@ swap:
   knowledgebase: Knowledgebase
   ksession|knowledge session: KIE session
   Kubelet(?! Stats Receiver): kubelet
-  kubernetes|k8s: Kubernetes
+  kubernetes: Kubernetes
   kvm: KVM
   Lan|lan: LAN
   Librados|LIBRADOS: librados

--- a/.vale/styles/RedHat/GitLinks.yml
+++ b/.vale/styles/RedHat/GitLinks.yml
@@ -3,10 +3,11 @@ extends: existence
 message: Do not include a link to %s unless it is explicitly approved.
 link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/gitlinks/
 ignorecase: true
+nonword: true
 level: warning
 scope: raw
 action:
   name: remove
 tokens:
-  - 'https:\/\/gitlab\.com'
+  - 'https:\/\/gitlab\.com\/\w+'
   - 'https:\/\/github\.com(?!\/openshift|\/redhat-developer)'

--- a/.vale/styles/RedHat/HeadingPunctuation.yml
+++ b/.vale/styles/RedHat/HeadingPunctuation.yml
@@ -1,11 +1,11 @@
 ---
-extends: substitution
+extends: existence
 level: warning
 link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/headingpunctuation/
 message: "Do not use end punctuation in headings."
 nonword: true
 scope: heading
 action:
-  name: replace
-swap:
-  '[.?!]$': ''
+  name: remove
+tokens:
+  - '[.?!]$'

--- a/.vale/styles/RedHat/Hyphens.yml
+++ b/.vale/styles/RedHat/Hyphens.yml
@@ -8,16 +8,18 @@ action:
   name: replace
 # swap maps tokens in the form "bad: good"
 swap:
-  "(?<!.-)addon": add-on
+  '(?<!.-)addon\b': add-on
+  "(?<!.-)addons": add-ons
   "broad cast|broad-cast": broadcast
-  "call out|call-out": callout
+  'call out\b|call-out\b': callout
+  "call outs|call-outs": callouts
   "comma delimited|commadelimited": comma-delimited
   "command driven|commanddriven": command-driven
   "meta-data|meta data": metadata
   "open-source|OpenSource|opensource": open source
   "over-ride|over ride": override
   "plug-ins|plug ins": plugins
-  "plug-in|plug in": plugin
+  'plug-in\b|plug in\b': plugin
   "super-user|super user": superuser
   "timeframe|time-frame": time frame
   "up-grade|up grade": upgrade

--- a/.vale/styles/RedHat/SimpleWords.yml
+++ b/.vale/styles/RedHat/SimpleWords.yml
@@ -7,7 +7,6 @@ message: "Use simple language. Consider using '%s' rather than '%s'."
 action:
   name: replace
 swap:
-  "(?<!an |the |IP |IPv[46] |MAC |sub-)address": discuss
   "approximate(?:ly)?": about
   "objective(?! C?)": aim|goal
   absent: none|not here

--- a/.vale/styles/RedHat/Spelling.yml
+++ b/.vale/styles/RedHat/Spelling.yml
@@ -22,15 +22,14 @@ filters:
   - "[bB]indable"
   - "[bB]oolean"
   - "[bB]ootable"
-  - "[bB]reakpoint"
-  - "[bB]reakpoints"
-  - "[cC]he"
+  - "[bB]reakpoint(s)?"
+  - '\b[cC]he\b'
   - "[cC]hrony"
   - "[cC]lassloading"
   - "[cC]lasspath"
   - "[cC]olocate"
   - "[cC]olocation"
-  - "[cC]onfig"
+  - '\b[cC]onfig\b'
   - "[cC]ontainerd"
   - "[cC]orequisite"
   - "[cC]ustomizer"
@@ -42,11 +41,9 @@ filters:
   - "[dD]ecompiler"
   - "[dD]efragmentation"
   - "[dD]eserialization"
-  - "[dD]eserialize"
-  - "[dD]eserialized"
-  - "[dD]esynchronize"
-  - "[dD]esynchronized"
-  - "[dD]ev"
+  - "[dD]eserialize(d)?"
+  - "[dD]esynchronize(d)?"
+  - '\b[dD]ev\b'
   - "[dD]ev[wW]orkspace"
   - "[dD]evfile"
   - "[dD]istro"
@@ -61,7 +58,7 @@ filters:
   - "[fF]indability"
   - "[gG]bps"
   - "[gG]ibibyte"
-  - "[gG]it"
+  - '\b[gG]it\b'
   - "[gG]lock"
   - "[gG]radle"
   - "[gG]rafana"
@@ -75,7 +72,7 @@ filters:
   - "[iI]ntrarecord"
   - "[iI]ntrasystem"
   - "[iI]nvocable"
-  - "[iI]tem"
+  - '\b[iI]tem\b'
   - "[jJ]et[bB]rains"
   - "[jJ]ournald"
   - "[jJ]ournaling"
@@ -143,7 +140,7 @@ filters:
   - "[pP]ostoperation"
   - "[pP]ostrequisite"
   - "[pP]recompile"
-  - "[pP]reconfigured"
+  - "[pP]reconfigure(d)?"
   - "[pP]reenrollment"
   - "[pP]reformatted"
   - "[pP]regenerated"
@@ -197,25 +194,17 @@ filters:
   - "[sS]ervlet"
   - "[sS]etter"
   - "[sS]harding"
-  - "[Ss]u"
-  - "[sS]ubcommand"
-  - "[sS]ubcommands"
-  - "[sS]ubmenu"
-  - "[sS]ubmenus"
-  - "[sS]ubnetwork"
-  - "[sS]ubnetworks"
-  - "[sS]ubpackage"
-  - "[sS]ubpackages"
-  - "[sS]ubpath"
-  - "[sS]ubpaths"
-  - "[sS]ubstep"
-  - "[sS]ubsteps"
-  - "[sS]ubtest"
-  - "[sS]ubtests"
-  - "[sS]ubuser"
-  - "[sS]ubusers"
-  - "[sS]ubvolume"
-  - "[sS]ubvolumes"
+  - '\b[Ss]u\b'
+  - "[sS]ubcommand(s)?"
+  - "[sS]ubmenu(s)?"
+  - "[sS]ubnet(s)?"
+  - "[sS]ubnetwork(s)?"
+  - "[sS]ubpackage(s)?"
+  - "[sS]ubpath(s)?"
+  - "[sS]ubstep(s)?"
+  - "[sS]ubtest(s)?"
+  - "[sS]ubuser(s)?"
+  - "[sS]ubvolume(s)?"
   - "[sS]ysctl"
   - "[sS]yslog"
   - "[sS]ystemd"
@@ -254,6 +243,7 @@ filters:
   - Applixware
   - Asciidoctor
   - AssertJ
+  - autoconfigure
   - autolink
   - aws
   - AWS
@@ -406,6 +396,7 @@ filters:
   - Mirantis
   - Mockito
   - MongoDB
+  - multischema
   - MySQL
   - Nagios
   - Narayana
@@ -443,8 +434,10 @@ filters:
   - Podman
   - PostgreSQL
   - PowerShell
+  - precache
   - Prometheus
   - proxied
+  - PVCs
   - Pytorch
   - qdmanage
   - qdstat
@@ -479,6 +472,10 @@ filters:
   - startx
   - STMicroelectronics
   - Stratis
+  - subaddress
+  - subcapacity
+  - subtab
+  - superobject
   - Suchow
   - SVG
   - Symfony

--- a/.vale/styles/RedHat/TermsErrors.yml
+++ b/.vale/styles/RedHat/TermsErrors.yml
@@ -12,14 +12,14 @@ swap:
   "(?<!-)pm": PM
   "(?<!-|I )am": AM
   "(?<!.)io": I/O
-  "(?<!as well )as per": according to|as|as in
+  '(?<!as well )\bas per\b': according to|as|as in
   "(?<!kernel )oops": kernel oops
   "(?<!mobile |cell )phone": "telephone|cell phone|mobile phone"
   "(?<!Mozilla )Firefox": Mozilla Firefox
   "(?<!Mozilla )Thunderbird": Mozilla Thunderbird
   "(?<!pseudo-)ops": operations
   "(?<!self-)hosted engine|hosted-engine": self-hosted engine
-  "bare metal( clusters?| compute| configuration| controls?| environments?| equipment| events?| hardware| hosts?| infrastructure| installations?| installers?| instances?| machines?| media| nodes?| provisioning| servers?| workers?)": bare-metal$1
+  "bare metal( clusters?| compute| configuration| controls?| environments?| equipment| events?| hardware| hosts?| infrastructure| installations?| installers?| instances?| machines?| media| nodes?| provisioning| servers?| workers?| networks?)": bare-metal$1
   "bare-metal(?! clusters?| compute| configuration| controls?| environments?| equipment| events?| hardware| hosts?| infrastructure| installations?| installers?| instances?| machines?| media| nodes?| provisioning| servers?| workers?)": bare metal
   "[bB]asic [aA]uth": Basic HTTP authentication|Basic authentication
   "a lot(?: of)?": many|much
@@ -103,7 +103,7 @@ swap:
   catastrophic error: unrecoverable error
   CBE: Common Base Event
   CBTS: CICS BTS|BTS
-  CD burner|burner: CD writer
+  CD burner|(?<!kube-)burner: CD writer
   centre: center
   check box: checkbox
   check list: checklist

--- a/.vale/styles/RedHat/TermsSuggestions.yml
+++ b/.vale/styles/RedHat/TermsSuggestions.yml
@@ -9,13 +9,14 @@ action:
   name: replace
 swap:
   "(?<!, | in | on | at | to | for | from | of | with | without | against )which": "that|, which"
-  ", that": "that|, which"
   "(?<!.-)jar": compress|archive
+  ", that": "that|, which"
   "[Nn]avigate": click|select|browse|go to
   "bottom(?:-)?left": lower left|lower-left
   "bottom(?:-)?right": lower right|lower-right
   "shell(?! prompt| script)": shell prompt
   "x64|x86-64|(?<!64-bit )x86": 64-bit x86|x86_64
+  '(?<!-)\bk8s\b(?!-)': Kubernetes
   '(?<!.*-|program )operator': Operator
   '(?<!.*-|program )operators': Operators
   '(?<![\.\-])(?:zip|gzip|tar)(?! file| archive)': compress
@@ -42,8 +43,8 @@ swap:
   information on: information about
   launch: start|open
   legacy: existing|traditional|established|classic|earlier|previous
-  once: after|when
   on-premise: on-site|in-house
+  once: after|when
   refer to: see
   segfault: segmentation fault
   spawn: create

--- a/.vale/styles/RedHat/TermsWarnings.yml
+++ b/.vale/styles/RedHat/TermsWarnings.yml
@@ -42,6 +42,7 @@ swap:
   execute: run|issue|start|enter
   find out: discover
   hamburger|kebab menu|kebab|vertical ellipsis: more options icon|options icon
+  hashbang: shebang|interpreter directive
   he|she: you
   host name: hostname
   illegal: invalid|not allowed|incorrect
@@ -56,6 +57,8 @@ swap:
   may: might|can
   on-premises|on-prem|on premise: on-premise|on-site|in-house
   opt into|opting into: opt in
+  police: policy
+  polices: policies
   preload: preinstall
   preloaded: preinstalled
   print out: print

--- a/.vale/styles/RedHat/Using.yml
+++ b/.vale/styles/RedHat/Using.yml
@@ -11,4 +11,4 @@ action:
     - "$1 by using" # replace
 tokens:
   - tag: NN|NNP|NNPS|NNS
-  - pattern: using
+  - pattern: \busing\b

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ lint-md: ## runs markdownlint and vale on all markdown files
 	@echo "Linting markdown files..."
 	@markdownlint $(MD_FILES)
 	@echo "Grammar check with vale of documentation..."
-	@vale docs/content *.md --minAlertLevel=error --output=line
+	@vale docs/content --output=line --glob='*.md'
 	@echo "CodeSpell on docs content"
 	@codespell docs/content
 

--- a/docs/content/docs/guide/matchingevents.md
+++ b/docs/content/docs/guide/matchingevents.md
@@ -303,10 +303,10 @@ The fields available are:
 | `source_branch`   | The branch where this pull_request comes from. (On `push`, this is the same as `target_branch`.)                                 |
 | `target_url`      | The URL of the repository we are targeting.                                                                                      |
 | `source_url`      | The URL of the repository where this pull_request comes from. (On `push`, this is the same as `target_url`.)                     |
-| `event_title`     | Matches the title of the event. For `push`, it matches the commit title. For PR, it matches the Pull/Merge Request title. (Only supported for `GitHub`, `Gitlab`, and `BitbucketCloud` providers.) |
+| `event_title`     | Matches the title of the event. For `push`, it matches the commit title. For PR, it matches the Pull/Merge Request title. (Only supported for `GitHub`, `GitLab`, and `BitbucketCloud` providers.) |
 | `body`            | The full body as passed by the Git provider. Example: `body.pull_request.number` retrieves the pull request number on GitHub.    |
 | `headers`         | The full set of headers as passed by the Git provider. Example: `headers['x-github-event']` retrieves the event type on GitHub.  |
-| `.pathChanged`    | A suffix function to a string that can be a glob of a path to check if changed. (Supported only for `GitHub` and `Gitlab` providers.) |
+| `.pathChanged`    | A suffix function to a string that can be a glob of a path to check if changed. (Supported only for `GitHub` and `GitLab` providers.) |
 | `files`           | The list of files that changed in the event (`all`, `added`, `deleted`, `modified`, and `renamed`). Example: `files.all` or `files.deleted`. For pull requests, every file belonging to the pull request will be listed. |
 
 CEL expressions let you do more complex filtering compared to the simple `on-target` annotation matching and enable more advanced scenarios.

--- a/docs/content/docs/install/kubernetes.md
+++ b/docs/content/docs/install/kubernetes.md
@@ -47,7 +47,7 @@ All three deployments should have all pods ready before moving on to ingress set
 You will need a
 [`Ingress`](https://kubernetes.io/docs/concepts/services-networking/ingress/)
 setup to point to make your pipelines-as-code controller available to `Github`,
-`Gitlab` or other `Git` providers.
+`GitLab` or other `Git` providers.
 
 The ingress configuration depends on your Kubernetes provider. See below for
 some examples.

--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -257,8 +257,8 @@ func (l listener) detectProvider(req *http.Request, reqBody string) (provider.In
 	}
 
 	gitLab := &gitlab.Provider{}
-	isGitlab, processReq, logger, reason, err := gitLab.Detect(req, reqBody, &log)
-	if isGitlab {
+	isGitLab, processReq, logger, reason, err := gitLab.Detect(req, reqBody, &log)
+	if isGitLab {
 		return l.processRes(processReq, gitLab, logger, reason, err)
 	}
 

--- a/pkg/params/info/events.go
+++ b/pkg/params/info/events.go
@@ -20,7 +20,7 @@ type Event struct {
 	// Full request
 	Request *Request
 
-	// TriggerTarget stable field across providers, ie: on Gitlab, Github and
+	// TriggerTarget stable field across providers, ie: on GitLab, Github and
 	// others it would be always be pull_request we can rely on to know if it's
 	// a push or a pull_request
 	TriggerTarget triggertype.Trigger
@@ -60,7 +60,7 @@ type Event struct {
 	CloneURL string // bitbucket data center has a different url for cloning the repo than normal public html url
 	Provider *Provider
 
-	// Gitlab
+	// GitLab
 	SourceProjectID int
 	TargetProjectID int
 }

--- a/pkg/provider/gitlab/README.md
+++ b/pkg/provider/gitlab/README.md
@@ -1,4 +1,4 @@
-# Gitlab
+# GitLab
 
 ## Supported
 

--- a/pkg/provider/gitlab/detect.go
+++ b/pkg/provider/gitlab/detect.go
@@ -20,7 +20,7 @@ func (v *Provider) Detect(req *http.Request, payload string, logger *zap.Sugared
 		return false, false, logger, "no gitlab event", nil
 	}
 
-	// it is a Gitlab event
+	// it is a GitLab event
 	isGL = true
 
 	setLoggerAndProceed := func(processEvent bool, reason string, err error) (bool, bool, *zap.SugaredLogger,

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -66,7 +66,7 @@ func (v *Provider) Client() *gitlab.Client {
 	providerMetrics.RecordAPIUsage(
 		v.Logger,
 		// URL used instead of "gitlab" to differentiate in the case of a CI cluster which
-		// serves multiple Gitlab instances
+		// serves multiple GitLab instances
 		v.apiURL,
 		v.triggerEvent,
 		v.repo,
@@ -74,7 +74,7 @@ func (v *Provider) Client() *gitlab.Client {
 	return v.gitlabClient
 }
 
-func (v *Provider) SetGitlabClient(client *gitlab.Client) {
+func (v *Provider) SetGitLabClient(client *gitlab.Client) {
 	v.gitlabClient = client
 }
 

--- a/pkg/provider/gitlab/gitlab_test.go
+++ b/pkg/provider/gitlab/gitlab_test.go
@@ -228,7 +228,7 @@ func TestCreateStatus(t *testing.T) {
 
 			if tt.wantClient {
 				client, mux, tearDown := thelp.Setup(t)
-				v.SetGitlabClient(client)
+				v.SetGitLabClient(client)
 				defer tearDown()
 				thelp.MuxNotePost(t, mux, v.targetProjectID, tt.args.event.PullRequestNumber, tt.args.postStr)
 			}
@@ -336,7 +336,7 @@ func TestSetClientDetectAPIURL(t *testing.T) {
 			expectedError:  "",
 		},
 		{
-			name:              "Success: Default URL when repoURL is public Gitlab",
+			name:              "Success: Default URL when repoURL is public GitLab",
 			providerToken:     "token",
 			providerURL:       "",
 			repoURL:           apiPublicURL + "/public/repo", // Starts with public URL, so skipped
@@ -553,7 +553,7 @@ func TestGetTektonDir(t *testing.T) {
 			}
 			if tt.wantClient {
 				client, mux, tearDown := thelp.Setup(t)
-				v.SetGitlabClient(client)
+				v.SetGitLabClient(client)
 				muxbranch := tt.args.event.HeadBranch
 				if tt.args.provenance == "default_branch" {
 					muxbranch = tt.args.event.DefaultBranch
@@ -895,7 +895,7 @@ func TestIsHeadCommitOfBranch(t *testing.T) {
 			defer teardown()
 			glProvider := &Provider{sourceProjectID: 1}
 			if tt.wantClient {
-				glProvider.SetGitlabClient(fakeclient)
+				glProvider.SetGitLabClient(fakeclient)
 				mux.HandleFunc("/projects/1/repository/branches/cool-branch",
 					func(rw http.ResponseWriter, _ *http.Request) {
 						if tt.errStatusCode != 0 {

--- a/pkg/provider/gitlab/parse_payload.go
+++ b/pkg/provider/gitlab/parse_payload.go
@@ -171,7 +171,7 @@ func (v *Provider) ParsePayload(ctx context.Context, run *params.Run, request *h
 	return processedEvent, nil
 }
 
-func (v *Provider) initGitlabClient(ctx context.Context, event *info.Event) (*info.Event, error) {
+func (v *Provider) initGitLabClient(ctx context.Context, event *info.Event) (*info.Event, error) {
 	// This is to ensure the base URL of the client is not reinitialized during tests.
 	if v.gitlabClient != nil {
 		return event, nil
@@ -284,7 +284,7 @@ func (v *Provider) handleCommitCommentEvent(ctx context.Context, event *gitlab.C
 
 	// since we're going to make an API call to ensure that the commit is HEAD of the branch
 	// therefore we need to initialize GitLab client here
-	processedEvent, err = v.initGitlabClient(ctx, processedEvent)
+	processedEvent, err = v.initGitLabClient(ctx, processedEvent)
 	if err != nil {
 		return processedEvent, err
 	}

--- a/pkg/provider/gitlab/parse_payload_test.go
+++ b/pkg/provider/gitlab/parse_payload_test.go
@@ -364,7 +364,7 @@ func TestParsePayload(t *testing.T) {
 			}
 			if tt.wantClient {
 				client, mux, tearDown := thelp.Setup(t)
-				v.SetGitlabClient(client)
+				v.SetGitLabClient(client)
 				branchName := "main"
 				if tt.wantBranch != "" {
 					branchName = tt.wantBranch

--- a/pkg/reconciler/event.go
+++ b/pkg/reconciler/event.go
@@ -91,7 +91,7 @@ func buildEventFromPipelineRun(pr *tektonv1.PipelineRun) *info.Event {
 		event.GHEURL = gheURL
 	}
 
-	// Gitlab
+	// GitLab
 	if projectID, ok := prAnno[keys.SourceProjectID]; ok {
 		event.SourceProjectID, _ = strconv.Atoi(projectID)
 	}


### PR DESCRIPTION
*   Updated numerous Red Hat Vale style rules for improved accuracy and
    coverage.
*   Adjusted severity level for `CaseSensitiveTerms` from error to warning.
*   Refined regular expressions in rules like `Hyphens`, `Spelling`,
`GitLinks`, `TermsErrors`, `Using` to reduce false positives.
*   Added new terms/filters to `Spelling` and various `Terms` rules.
*   Removed `address` rule from `SimpleWords`.
*   Refactored `HeadingPunctuation` rule implementation.
*   Standardized `GitLab` capitalization across docs, code, tests, and Vale
config.
*   Updated `Makefile` Vale command for globbing improved flexibility.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
