### PR TITLE
chore: Separate CI log formatting into dedicated workflow step

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -165,6 +165,10 @@ jobs:
         run: |
           ./hack/gh-workflow-ci.sh collect_logs
 
+      - name: Show controllers/watcher logs with Snazy
+        run: |
+          ./hack/gh-workflow-ci output-logs
+
       - name: Upload artifacts
         if: ${{ always() }}
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
*   Extracted log formatting logic into a reusable `output_logs` function in
`gh-workflow-ci.sh`.
*   Added a distinct step in the e2e GitHub Actions workflow to display
formatted logs using `snazy` or a Python fallback.
*   This change aimed to improve CI log visibility directly within the GitHub
UI after log collection completed.
*   Updated script command-line handling and help text to reflect the new
function.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
