### PR TITLE
fix: Restrict E2E workflow on PR target to privileged users

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -16,7 +16,6 @@ on:
         required: false
   pull_request_target:
     types:
-      - labeled
       - opened
       - reopened
       - synchronize
@@ -27,11 +26,12 @@ on:
 
 jobs:
   e2e-tests:
-    # Only run if it's a scheduled run, manual dispatch, or has e2e label
+    # Run on schedule, unconditional workflow_dispatch,
+    # or pull_request_target if the actor has write/admin permissions.
     if: >
-      github.event_name == 'schedule' || 
-      github.event_name == 'workflow_dispatch' || 
-      (github.event_name == 'pull_request_target' && (github.event.label.name == 'e2e' || contains(github.event.pull_request.labels.*.name, 'e2e')))
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request_target' && (github.actor == github.triggering_actor && (github.event.repository.permissions.write == true || github.event.repository.permissions.admin == true)))
 
     concurrency:
       group: ${{ github.workflow }}-${{ matrix.provider }}-${{ github.event.pull_request.number || github.ref_name }}
@@ -122,8 +122,11 @@ jobs:
         run: |
           ./hack/gh-workflow-ci.sh create_second_github_app_controller_on_ghe
 
+      # Adjusted step-level conditions based on the new job-level logic
       - name: Run E2E Tests
-        if: ${{ github.event_name != 'schedule' || github.event.label.name == 'e2e' || contains(github.event.pull_request.labels.*.name, 'e2e') }}
+        # This step runs for schedule, PR target (if job started), or workflow_dispatch (if job started)
+        # Remove the old label check which is no longer relevant for triggering.
+        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request_target' }}
         env:
           TEST_PROVIDER: ${{ matrix.provider }}
           TEST_BITBUCKET_CLOUD_TOKEN: ${{ secrets.BITBUCKET_CLOUD_TOKEN }}
@@ -140,6 +143,7 @@ jobs:
           ./hack/gh-workflow-ci.sh run_e2e_tests
 
       - name: Run E2E Tests on nightly
+        # This step still runs specifically for schedule or workflow_dispatch
         if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
         env:
           NIGHTLY_E2E_TEST: "true"

--- a/.tekton/e2e-label.yaml
+++ b/.tekton/e2e-label.yaml
@@ -5,10 +5,7 @@ metadata:
   name: e2e-label.yaml
   annotations:
     pipelinesascode.tekton.dev/max-keep-runs: "2"
-    pipelinesascode.tekton.dev/cancel-in-progress: "true"
-    pipelinesascode.tekton.dev/on-event: "pull_request"
-    pipelinesascode.tekton.dev/on-target-branch: "main"
-    pipelinesascode.tekton.dev/on-path-change: "[**/*.go, .github/workflows/*l, test/**]"
+    pipelinesascode.tekton.dev/on-comment: "^/e2e"
 spec:
   pipelineSpec:
     tasks:


### PR DESCRIPTION
- Removed the `labeled` event type from `pull_request_target` triggers for the E2E workflow.
- The E2E workflow will now run on `pull_request_target` events (opened, reopened, synchronize) only if the actor who triggered the event possessed write or admin permissions to the repository.
- This replaced the previous mechanism where an 'e2e' label on a pull request would trigger the workflow.
- The primary goal was to enhance security for `pull_request_target` workflows, preventing untrusted users from running them with potentially elevated permissions via labels.
- Adjusted conditional logic in E2E test execution steps to align with these new permission-based job triggers, removing obsolete label checks.

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [ ] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [ ] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [ ] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [ ] 📖 Document any user-facing features or changes in behavior.

- [ ] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [ ] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [ ] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center

  (update the provider documentation accordingly)
