### PR TITLE
fix: simplify PR trigger condition for e2e workflow

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -31,7 +31,7 @@ jobs:
     if: >
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request_target' && (github.actor == github.triggering_actor && (github.event.repository.permissions.write == true || github.event.repository.permissions.admin == true)))
+      (github.event_name == 'pull_request_target' && github.event.repository.permissions.write == true)
 
     concurrency:
       group: ${{ github.workflow }}-${{ matrix.provider }}-${{ github.event.pull_request.number || github.ref_name }}


### PR DESCRIPTION
* Removed unnecessary check for github.actor == github.triggering_actor
* Removed redundant permission check for admin (since write permission is sufficient)
* Streamlined condition to focus on repository write permission only
