### PR TITLE
test: add verbose flag to e2e tests in ci workflow

### DIFF
--- a/hack/gh-workflow-ci.sh
+++ b/hack/gh-workflow-ci.sh
@@ -88,7 +88,7 @@ run_e2e_tests() {
   mapfile -t tests < <(get_tests "${target}")
   echo "About to run ${#tests[@]} tests: ${tests[*]}"
   # shellcheck disable=SC2001
-  make test-e2e GO_TEST_FLAGS="-run \"$(echo "${tests[*]}" | sed 's/ /|/g')\""
+  make test-e2e GO_TEST_FLAGS="-v -run \"$(echo "${tests[*]}" | sed 's/ /|/g')\""
 }
 
 output_logs() {


### PR DESCRIPTION
* added -v flag to go_test_flags to enable verbose output for e2e tests
* this change will provide more detailed test logs, making it easier to diagnose issues in the ci pipeline
