### PR TITLE
cleanup: removes unsupported enum values for Gitlab comment_strategy

### DIFF
--- a/config/300-repositories.yaml
+++ b/config/300-repositories.yaml
@@ -349,12 +349,9 @@ spec:
                           description: |-
                             CommentStrategy defines how GitLab comments are handled for pipeline results.
                             Options:
-                            - 'status-comment': Posts a single comment and updates it with pipeline results
-                            - 'pipeline-runs-comment': Creates a new comment for each PipelineRun
                             - 'disable_all': Disables all comments on merge requests
                           enum:
-                            - status-comment
-                            - pipeline-runs-comment
+                            - ""
                             - disable_all
                           type: string
                       type: object

--- a/pkg/apis/pipelinesascode/v1alpha1/types.go
+++ b/pkg/apis/pipelinesascode/v1alpha1/types.go
@@ -163,11 +163,9 @@ type Settings struct {
 type GitlabSettings struct {
 	// CommentStrategy defines how GitLab comments are handled for pipeline results.
 	// Options:
-	// - 'status-comment': Posts a single comment and updates it with pipeline results
-	// - 'pipeline-runs-comment': Creates a new comment for each PipelineRun
 	// - 'disable_all': Disables all comments on merge requests
 	// +optional
-	// +kubebuilder:validation:Enum=status-comment;pipeline-runs-comment;disable_all
+	// +kubebuilder:validation:Enum="";disable_all
 	CommentStrategy string `json:"comment_strategy,omitempty"`
 }
 


### PR DESCRIPTION
* Removed two unsupported enum values from the GitLab comment_strategy field in the CRD definition and associated structs.

* These values were not handled by the current implementation. Hence this change ensures that only supported options are exposed.

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [x] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [x] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [x] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- If adding a provider feature, fill in the following details:

  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [x] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center

  (update the provider documentation accordingly)
