### PR TITLE
cleanup: Removed TODO message and IsCancelComment func from opscomment package

### DIFF
--- a/pkg/opscomments/comments.go
+++ b/pkg/opscomments/comments.go
@@ -88,10 +88,6 @@ func IsOkToTestComment(comment string) bool {
 	return oktotestRegex.MatchString(comment)
 }
 
-func IsCancelComment(comment string) bool {
-	return cancelAllRegex.MatchString(comment) || cancelSingleRegex.MatchString(comment)
-}
-
 // EventTypeBackwardCompat handle the backward compatibility we need to keep until
 // we have done the deprecated notice
 //

--- a/pkg/opscomments/comments_test.go
+++ b/pkg/opscomments/comments_test.go
@@ -320,57 +320,6 @@ func TestIsOkToTestComment(t *testing.T) {
 	}
 }
 
-func TestCancelComment(t *testing.T) {
-	tests := []struct {
-		name    string
-		comment string
-		want    bool
-	}{
-		{
-			name:    "valid",
-			comment: "/cancel",
-			want:    true,
-		},
-		{
-			name:    "valid with some string before",
-			comment: "/lgtm \n/cancel",
-			want:    true,
-		},
-		{
-			name:    "valid with some string before and after",
-			comment: "hi, trigger the ci \n/cancel \n then report the status back",
-			want:    true,
-		},
-		{
-			name:    "valid comments",
-			comment: "/lgtm \n/cancel \n/approve",
-			want:    true,
-		},
-		{
-			name:    "invalid",
-			comment: "/ok",
-			want:    false,
-		},
-		{
-			name:    "invalid comment",
-			comment: "/ok-to-test abc",
-			want:    false,
-		},
-		{
-			name:    "cancel single pr",
-			comment: "/cancel abc",
-			want:    true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := IsCancelComment(tt.comment)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}
-
 func TestIsTestRetestComment(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/pkg/provider/github/parse_payload.go
+++ b/pkg/provider/github/parse_payload.go
@@ -525,7 +525,6 @@ func (v *Provider) handleCommitCommentEvent(ctx context.Context, event *github.C
 		err        error
 	)
 
-	// TODO: reuse the code from opscomments
 	// If it is a /test or /retest comment with pipelinerun name figure out the pipelinerun name
 	if provider.IsTestRetestComment(event.GetComment().GetBody()) {
 		prName, branchName, err = provider.GetPipelineRunAndBranchNameFromTestComment(event.GetComment().GetBody())


### PR DESCRIPTION
# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
commit 1: The task associated with the TODO was completed in a previous commit. This removes the obsolete comment to keep the codebase clean.

commit 2: The local `IsCancelComment` function duplicates functionality already available in the 'provider' package. This commit removes the local implementation in favor of the one from the provider to eliminate code redundancy and removed tests.


<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [x] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [x] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [x] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [ ] 📖 Document any user-facing features or changes in behavior.

- [ ] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [ ] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [ ] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:
