### PR TITLE
Disable Github comments for pipeline start/end events to reduce PR noise

### DIFF
--- a/config/300-repositories.yaml
+++ b/config/300-repositories.yaml
@@ -334,6 +334,18 @@ spec:
                     Settings contains the configuration settings for the repository, including
                     authorization policies, provider-specific configuration, and provenance settings.
                   properties:
+                    github:
+                      properties:
+                        comment_strategy:
+                          description: |-
+                            CommentStrategy defines how GitLab comments are handled for pipeline results.
+                            Options:
+                            - 'disable_all': Disables all comments on merge requests
+                          enum:
+                            - ""
+                            - disable_all
+                          type: string
+                      type: object
                     github_app_token_scope_repos:
                       description: |-
                         GithubAppTokenScopeRepos lists repositories that can access the GitHub App token when using the

--- a/docs/content/docs/guide/repositorycrd.md
+++ b/docs/content/docs/guide/repositorycrd.md
@@ -134,6 +134,19 @@ spec:
 
 When you set the value of `comment_strategy` to `disable_all` it will not add any comment on the merge request for the start and the end of pipelinerun
 
+## Disabling all comments for Pipelineruns in GitHub Pull Requests on GitHub Webhook Setup
+
+`comment_strategy` allows you to disable the comments on GitHub PR for a Repository
+
+```yaml
+spec:
+  settings:
+    github:
+      comment_strategy: "disable_all"
+```
+
+When `comment_strategy` is set to `disable_all` Pipelines as Code will not create any comment on the pull request for PipelineRun Status
+
 ## Concurrency
 
 `concurrency_limit` allows you to define the maximum number of PipelineRuns running at any time for a Repository.

--- a/pkg/apis/pipelinesascode/v1alpha1/types.go
+++ b/pkg/apis/pipelinesascode/v1alpha1/types.go
@@ -158,9 +158,20 @@ type Settings struct {
 	// Gitlab contains GitLab-specific settings for repositories hosted on GitLab.
 	// +optional
 	Gitlab *GitlabSettings `json:"gitlab,omitempty"`
+
+	Github *GithubSettings `json:"github,omitempty"`
 }
 
 type GitlabSettings struct {
+	// CommentStrategy defines how GitLab comments are handled for pipeline results.
+	// Options:
+	// - 'disable_all': Disables all comments on merge requests
+	// +optional
+	// +kubebuilder:validation:Enum="";disable_all
+	CommentStrategy string `json:"comment_strategy,omitempty"`
+}
+
+type GithubSettings struct {
 	// CommentStrategy defines how GitLab comments are handled for pipeline results.
 	// Options:
 	// - 'disable_all': Disables all comments on merge requests

--- a/test/pkg/github/crd.go
+++ b/test/pkg/github/crd.go
@@ -21,7 +21,8 @@ func CreateCRD(ctx context.Context, t *testing.T, repoinfo *ghlib.Repository, ru
 			Name: targetNS,
 		},
 		Spec: v1alpha1.RepositorySpec{
-			URL: repoinfo.GetHTMLURL(),
+			URL:      repoinfo.GetHTMLURL(),
+			Settings: &opts.Settings,
 		},
 	}
 

--- a/test/pkg/github/pr.go
+++ b/test/pkg/github/pr.go
@@ -137,6 +137,9 @@ func (g *PRTest) RunPullRequest(ctx context.Context, t *testing.T) {
 		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
 	}
 
+	if g.Options.Settings.Github != nil {
+		opts.Settings = g.Options.Settings
+	}
 	err = CreateCRD(ctx, t, repoinfo, runcnx, opts, targetNS)
 	assert.NilError(t, err)
 


### PR DESCRIPTION
* The Github webhook integration was previously generating a comment on every pipeline start and end filling pull requests with redundant updates

* Hence this patch introduces a new setting to completely disable comment creation

* By using `comment_strategy: disable_all`, no comments will be added for either pipeline start or completion

* Also includes e2e tests to validate the new behavior

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [x] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [x] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [x] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [x] 📖 Document any user-facing features or changes in behavior.

- [x] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [x] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- If adding a provider feature, fill in the following details:

  - [ ] GitHub App
  - [x] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center

  (update the provider documentation accordingly)
