### PR TITLE
feat: support PipelineRun running status reporting with Kueue

### DIFF
--- a/docs/content/docs/guide/repositorycrd.md
+++ b/docs/content/docs/guide/repositorycrd.md
@@ -169,6 +169,14 @@ of the pipelineruns will be executed in alphabetical order, one after the
 other. At any given time, only one pipeline run will be in the running state,
 while the rest will be queued.
 
+### Kueue - Kubernetes-native Job Queueing
+
+Pipelines-as-Code now accommodates [Kueue](https://kueue.sigs.k8s.io/) as an alternative, Kubernetes-native solution for queuing PipelineRun.
+To get started, you can deploy the experimental integration provided by the [konflux-ci/tekton-kueue](https://github.com/konflux-ci/tekton-kueue) project. This allows you to schedule PipelineRuns through Kueue's queuing mechanism.
+
+Note: The [konflux-ci/tekton-kueue](https://github.com/konflux-ci/tekton-kueue) project and the Pipelines-as-Code integration is only intended for testing
+It is only meant for experimentation and should not be used in production environments.
+
 ## Scoping GitHub token to a list of private and public repositories within and outside namespaces
 
 By default, the GitHub token that Pipelines-as-Code generates is scoped only to the repository where the payload comes from.

--- a/pkg/pipelineascode/pipelineascode_test.go
+++ b/pkg/pipelineascode/pipelineascode_test.go
@@ -497,6 +497,49 @@ func TestRun(t *testing.T) {
 			finalStatusText:              "User fantasio is not allowed to trigger CI by GitOps comment on push commit in this repo.",
 			skipReplyingOrgPublicMembers: true,
 		},
+		{
+			name: "pull request/pipelinerun created in pending state (state changed by other controller)",
+			runevent: info.Event{
+				Event: &github.PullRequestEvent{
+					PullRequest: &github.PullRequest{
+						Number: github.Ptr(666),
+					},
+				},
+				SHA:               "fromwebhook",
+				Organization:      "owner",
+				Sender:            "owner",
+				Repository:        "repo",
+				URL:               "https://service/documentation",
+				HeadBranch:        "press",
+				BaseBranch:        "main",
+				EventType:         "pull_request",
+				TriggerTarget:     "pull_request",
+				PullRequestNumber: 666,
+				InstallationID:    1234,
+			},
+			tektondir: "testdata/pending_pipelinerun",
+		},
+		{
+			name: "pull request/pipelinerun created in pending state without installationID (state changed by other controller)",
+			runevent: info.Event{
+				Event: &github.PullRequestEvent{
+					PullRequest: &github.PullRequest{
+						Number: github.Ptr(666),
+					},
+				},
+				SHA:               "fromwebhook",
+				Organization:      "owner",
+				Sender:            "owner",
+				Repository:        "repo",
+				URL:               "https://service/documentation",
+				HeadBranch:        "press",
+				BaseBranch:        "main",
+				EventType:         "pull_request",
+				TriggerTarget:     "pull_request",
+				PullRequestNumber: 666,
+			},
+			tektondir: "testdata/pending_pipelinerun",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -675,10 +718,10 @@ func TestRun(t *testing.T) {
 						secretName, ok := pr.GetAnnotations()[keys.GitAuthSecret]
 						assert.Assert(t, ok, "Cannot find secret %s on annotations", secretName)
 					}
-					if tt.concurrencyLimit > 0 {
-						concurrencyLimit, ok := pr.GetAnnotations()[keys.State]
-						assert.Assert(t, ok, "State hasn't been set on PR", concurrencyLimit)
-						assert.Equal(t, concurrencyLimit, kubeinteraction.StateQueued)
+					if tt.concurrencyLimit > 0 || pr.Spec.Status == pipelinev1.PipelineRunSpecStatusPending {
+						state, ok := pr.GetAnnotations()[keys.State]
+						assert.Assert(t, ok, "State hasn't been set on PR", state)
+						assert.Equal(t, state, kubeinteraction.StateQueued)
 					}
 				}
 			}
@@ -690,12 +733,8 @@ func TestGetLogURLMergePatch(t *testing.T) {
 	con := consoleui.FallBackConsole{}
 	clients := clients.Clients{}
 	clients.SetConsoleUI(con)
-	pr := &pipelinev1.PipelineRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-pipeline-run",
-		},
-	}
-	result := getLogURLMergePatch(clients, pr)
+	ann := map[string]string{keys.LogURL: con.URL()}
+	result := getMergePatch(ann, map[string]string{})
 	m, ok := result["metadata"].(map[string]any)
 	assert.Assert(t, ok)
 	a, ok := m["annotations"].(map[string]string)

--- a/pkg/pipelineascode/testdata/pending_pipelinerun/.tekton/run.yaml
+++ b/pkg/pipelineascode/testdata/pending_pipelinerun/.tekton/run.yaml
@@ -1,0 +1,17 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: pull_request-test1
+  annotations:
+    pipelinesascode.tekton.dev/on-target-branch: "[main]"
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+spec:
+  status: PipelineRunPending
+  pipelineSpec:
+    tasks:
+      - name: max
+        taskSpec:
+          steps:
+            - name: success
+              image: registry.access.redhat.com/ubi9/ubi-minimal
+              script: 'exit 0'

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -60,6 +60,24 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, pr *tektonv1.PipelineRun
 		return nil
 	}
 
+	reason := ""
+	if len(pr.Status.GetConditions()) > 0 {
+		reason = pr.Status.GetConditions()[0].GetReason()
+	}
+	// This condition handles cases where the PipelineRun has entered a "Running" state,
+	// but its status in the Git provider remains "queued" (e.g., due to updates made by
+	// another controller outside PaC). To maintain consistency between the PipelineRun
+	// status and the Git provider status, we update both the PipelineRun resource and
+	// the corresponding status on the Git provider here.
+	if reason == string(tektonv1.PipelineRunReasonRunning) && state == kubeinteraction.StateQueued {
+		repoName := pr.GetAnnotations()[keys.Repository]
+		repo, err := r.repoLister.Repositories(pr.Namespace).Get(repoName)
+		if err != nil {
+			return fmt.Errorf("failed to get repository CR: %w", err)
+		}
+		return r.updatePipelineRunToInProgress(ctx, logger, repo, pr)
+	}
+
 	// if its a GitHub App pipelineRun PR then process only if check run id is added otherwise wait
 	if _, ok := pr.Annotations[keys.InstallationID]; ok {
 		if _, ok := pr.Annotations[keys.CheckRunID]; !ok {


### PR DESCRIPTION
This adds support running status of the PipelineRun when PipelineRuns are managed by Kueue.

https://issues.redhat.com/browse/SRVKP-7738

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [x] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [x] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [x] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [ ] 📖 Document any user-facing features or changes in behavior.

- [ ] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [ ] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [ ] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

  - [x] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center

  (update the provider documentation accordingly)
