### PR TITLE
feat(security): Adding logs whenever client uses token which is security best practice

### DIFF
--- a/pkg/provider/bitbucketcloud/bitbucket.go
+++ b/pkg/provider/bitbucketcloud/bitbucket.go
@@ -203,6 +203,10 @@ func (v *Provider) SetClient(_ context.Context, run *params.Run, event *info.Eve
 		return fmt.Errorf("no git_provider.user has been in repo crd")
 	}
 	v.bbClient = bitbucket.NewBasicAuth(event.Provider.User, event.Provider.Token)
+
+	// Added log for security audit purposes to log client access when a token is used
+	run.Clients.Log.Infof("bitbucket-cloud: initialized client with provided token for user=%s", event.Provider.User)
+
 	v.Token = &event.Provider.Token
 	v.Username = &event.Provider.User
 	v.run = run

--- a/pkg/provider/bitbucketdatacenter/bitbucketdatacenter.go
+++ b/pkg/provider/bitbucketdatacenter/bitbucketdatacenter.go
@@ -307,6 +307,9 @@ func (v *Provider) SetClient(ctx context.Context, run *params.Run, event *info.E
 			},
 		}
 		v.client = client
+
+		// Added for security audit purposes to log client access when a token is used
+		run.Clients.Log.Infof("bitbucket-datacenter: initialized client with provided token for user=%s providerURL=%s", event.Provider.User, event.Provider.URL)
 	}
 	v.run = run
 	v.repo = repo

--- a/pkg/provider/bitbucketdatacenter/bitbucketdatacenter_test.go
+++ b/pkg/provider/bitbucketdatacenter/bitbucketdatacenter_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
@@ -362,6 +363,13 @@ func TestSetClient(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			observer, _ := zapobserver.New(zap.InfoLevel)
+			testLog := zap.New(observer).Sugar()
+			fakeRun := &params.Run{
+				Clients: clients.Clients{
+					Log: testLog,
+				},
+			}
 			ctx, _ := rtesting.SetupFakeContext(t)
 			client, mux, tearDown, tURL := bbtest.SetupBBDataCenterClient()
 			defer tearDown()
@@ -369,7 +377,7 @@ func TestSetClient(t *testing.T) {
 				mux.HandleFunc("/users/foo", tt.muxUser)
 			}
 			v := &Provider{client: client, baseURL: tURL}
-			err := v.SetClient(ctx, nil, tt.opts, nil, nil)
+			err := v.SetClient(ctx, fakeRun, tt.opts, nil, nil)
 			if tt.wantErrSubstr != "" {
 				assert.ErrorContains(t, err, tt.wantErrSubstr)
 				return

--- a/pkg/provider/gitea/gitea.go
+++ b/pkg/provider/gitea/gitea.go
@@ -159,6 +159,10 @@ func (v *Provider) SetClient(_ context.Context, run *params.Run, runevent *info.
 	if err != nil {
 		return err
 	}
+
+	// Added log for security audit purposes to log client access when a token is used
+	run.Clients.Log.Infof("gitea: initialized API client with provided credentials user=%s providerURL=%s", runevent.Provider.User, apiURL)
+
 	v.giteaInstanceURL = runevent.Provider.URL
 	v.eventEmitter = emitter
 	v.repo = repo

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -301,6 +301,13 @@ func (v *Provider) SetClient(ctx context.Context, run *params.Run, event *info.E
 		return fmt.Errorf("no github client has been initialized")
 	}
 
+	// Added log for security audit purposes to log client access when a token is used
+	integration := "github-webhook"
+	if event.InstallationID != 0 {
+		integration = "github-app"
+	}
+	run.Clients.Log.Infof(integration+": initialized OAuth2 client for providerName=%s providerURL=%s", v.providerName, event.Provider.URL)
+
 	v.APIURL = apiURL
 
 	if event.Provider.WebhookSecretFromRepo {

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -201,6 +201,7 @@ func (v *Provider) SetClient(_ context.Context, run *params.Run, runevent *info.
 	}
 	v.Token = &runevent.Provider.Token
 
+	run.Clients.Log.Infof("gitlab: initialized for client with token for apiURL=%s, org=%s, repo=%s", apiURL, runevent.Organization, runevent.Repository)
 	// In a scenario where the source repository is forked and a merge request (MR) is created on the upstream
 	// repository, runevent.SourceProjectID will not be 0 when SetClient is called from the pac-watcher code.
 	// This is because, in the controller, SourceProjectID is set in the annotation of the pull request,

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -173,6 +173,9 @@ func (r *Reconciler) reportFinalStatus(ctx context.Context, logger *zap.SugaredL
 		}
 	}
 
+	if r.run.Clients.Log == nil {
+		r.run.Clients.Log = logger
+	}
 	err = provider.SetClient(ctx, r.run, event, repo, r.eventEmitter)
 	if err != nil {
 		return repo, fmt.Errorf("cannot set client: %w", err)

--- a/test/pkg/bitbucketcloud/setup.go
+++ b/test/pkg/bitbucketcloud/setup.go
@@ -49,7 +49,7 @@ func Setup(ctx context.Context) (*params.Run, options.E2E, bitbucketcloud.Provid
 		URL:   bitbucketCloudAPIURL,
 		User:  bitbucketCloudUser,
 	}
-	if err := bbc.SetClient(ctx, nil, event, nil, nil); err != nil {
+	if err := bbc.SetClient(ctx, run, event, nil, nil); err != nil {
 		return nil, options.E2E{}, bitbucketcloud.Provider{}, err
 	}
 	return run, e2eoptions, bbc, nil

--- a/test/pkg/gitea/setup.go
+++ b/test/pkg/gitea/setup.go
@@ -32,7 +32,7 @@ func CreateProvider(ctx context.Context, giteaURL, user, password string) (gitea
 		User:  user,
 		Token: password,
 	}
-	if err := gprovider.SetClient(ctx, nil, event, nil, nil); err != nil {
+	if err := gprovider.SetClient(ctx, run, event, nil, nil); err != nil {
 		return gitea.Provider{}, fmt.Errorf("cannot set client: %w", err)
 	}
 	return gprovider, nil

--- a/test/pkg/github/setup.go
+++ b/test/pkg/github/setup.go
@@ -100,7 +100,7 @@ func Setup(ctx context.Context, onSecondController, viaDirectWebhook bool) (cont
 	}
 	gprovider.Token = &githubToken
 	// TODO: before PR
-	if err := gprovider.SetClient(ctx, nil, event, nil, nil); err != nil {
+	if err := gprovider.SetClient(ctx, run, event, nil, nil); err != nil {
 		return ctx, nil, options.E2E{}, github.New(), err
 	}
 

--- a/test/pkg/gitlab/setup.go
+++ b/test/pkg/gitlab/setup.go
@@ -49,7 +49,7 @@ func Setup(ctx context.Context) (*params.Run, options.E2E, gitlab.Provider, erro
 		Password:      gitlabToken,
 	}
 	glprovider := gitlab.Provider{}
-	err = glprovider.SetClient(ctx, nil, &info.Event{
+	err = glprovider.SetClient(ctx, run, &info.Event{
 		Provider: &info.Provider{
 			Token: gitlabToken,
 			URL:   gitlabURL,


### PR DESCRIPTION
# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

As a part of security best practices, one of the asks is "Log all access and activity using access tokens and allow users to review those logs." So adding log messages for the clients as token is involved in this.

# Submitter Checklist

- [ ] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [ ] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [ ] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [ ] 📖 Document any user-facing features or changes in behavior.

- [ ] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [ ] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [ ] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center

  (update the provider documentation accordingly)
