### PR TITLE
[MIRRORED] DO NOT MERGE: fix(bitbucketdatacenter): ignore branch deletion events in ParsePayload

### DIFF
--- a/pkg/provider/bitbucketdatacenter/parse_payload.go
+++ b/pkg/provider/bitbucketdatacenter/parse_payload.go
@@ -164,6 +164,13 @@ func (v *Provider) ParsePayload(_ context.Context, run *params.Run, request *htt
 			return nil, fmt.Errorf("push event contains no commits under 'changes'; cannot proceed")
 		}
 
+		// Check for branch deletion - if any change is a DELETE type with zero hash, skip processing
+		for _, change := range e.Changes {
+			if provider.IsZeroSHA(change.ToHash) && change.Type == "DELETE" {
+				return nil, fmt.Errorf("branch delete event is not supported; cannot proceed")
+			}
+		}
+
 		if len(e.Commits) == 0 {
 			return nil, fmt.Errorf("push event contains no commits; cannot proceed")
 		}


### PR DESCRIPTION
Mirrors https://github.com/openshift-pipelines/pipelines-as-code/pull/2126 to run E2E tests. Original author: @infernus01