### PR TITLE
docs: Clarification About PipelineRun YAML Validation Error

### DIFF
--- a/docs/content/docs/guide/running.md
+++ b/docs/content/docs/guide/running.md
@@ -125,11 +125,11 @@ click on it and follow the pipeline execution directly there.
 ## Errors When Parsing PipelineRun YAML
 
 When Pipelines-As-Code encounters an issue with the YAML formatting in the
-repository, it will log the error in the user namespace events log and
+repository, it will create comment on pull request describing the error and will log the error in the user namespace events log and
 the Pipelines-as-Code controller log.
 
-Despite the error, Pipelines-As-Code will continue to run other correctly parsed
-and matched PipelineRuns.
+Despite validation errors, Pipelines-as-Code continues to run other correctly parsed and matched PipelineRuns.
+However, if a PipelineRun has YAML syntax error, it halts the execution of all PipelineRuns, even those that are syntactically correct.
 
 {{< support_matrix github_app="true" github_webhook="true" gitea="true" gitlab="true" bitbucket_cloud="false" bitbucket_server="false" >}}
 


### PR DESCRIPTION
removed a statement from docs that wrongly describing about trigerring PipelineRuns if one of the PipelineRun yaml is invalid.

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [x] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [x] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [x] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [x] 📖 Document any user-facing features or changes in behavior.