### PR TITLE
fix: Inavlidate Empty Commits on Push Events in Bitbucket Data Center

### DIFF
--- a/pkg/provider/bitbucketdatacenter/parse_payload.go
+++ b/pkg/provider/bitbucketdatacenter/parse_payload.go
@@ -164,6 +164,10 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 			return nil, fmt.Errorf("push event contains no commits under 'changes'; cannot proceed")
 		}
 
+		if len(e.Commits) == 0 {
+			return nil, fmt.Errorf("push event contains no commits; cannot proceed")
+		}
+
 		processedEvent.SHA = e.Changes[0].ToHash
 		processedEvent.URL = e.Repository.Links.Self[0].Href
 		processedEvent.BaseBranch = e.Changes[0].RefID

--- a/pkg/provider/bitbucketdatacenter/parse_payload_test.go
+++ b/pkg/provider/bitbucketdatacenter/parse_payload_test.go
@@ -611,15 +611,22 @@ func TestParsePayload(t *testing.T) {
 		{
 			name:         "good/push",
 			eventType:    "repo:refs_changed",
-			payloadEvent: bbv1test.MakePushEvent(ev1, []types.PushRequestEventChange{{ToHash: ev1.SHA, RefID: "base"}}),
+			payloadEvent: bbv1test.MakePushEvent(ev1, []types.PushRequestEventChange{{ToHash: ev1.SHA, RefID: "base"}}, []types.Commit{{ID: ev1.SHA}}),
 			expEvent:     ev1,
 		},
 		{
 			name:          "bad/changes are empty in push",
 			eventType:     "repo:refs_changed",
-			payloadEvent:  bbv1test.MakePushEvent(ev1, []types.PushRequestEventChange{}),
+			payloadEvent:  bbv1test.MakePushEvent(ev1, []types.PushRequestEventChange{}, []types.Commit{}),
 			expEvent:      ev1,
 			wantErrSubstr: "push event contains no commits under 'changes'; cannot proceed",
+		},
+		{
+			name:          "bad/commits are empty in push",
+			eventType:     "repo:refs_changed",
+			payloadEvent:  bbv1test.MakePushEvent(ev1, []types.PushRequestEventChange{{ToHash: ev1.SHA, RefID: "base"}}, []types.Commit{}),
+			expEvent:      ev1,
+			wantErrSubstr: "push event contains no commits; cannot proceed",
 		},
 		{
 			name:         "good/comment ok-to-test",

--- a/pkg/provider/bitbucketdatacenter/test/test.go
+++ b/pkg/provider/bitbucketdatacenter/test/test.go
@@ -338,7 +338,7 @@ func MakePREvent(event *info.Event, comment string) *types.PullRequestEvent {
 	return pr
 }
 
-func MakePushEvent(event *info.Event, changes []types.PushRequestEventChange) *types.PushRequestEvent {
+func MakePushEvent(event *info.Event, changes []types.PushRequestEventChange, commits []types.Commit) *types.PushRequestEvent {
 	iii, _ := strconv.Atoi(event.AccountID)
 
 	return &types.PushRequestEvent{
@@ -366,5 +366,6 @@ func MakePushEvent(event *info.Event, changes []types.PushRequestEventChange) *t
 			},
 		},
 		Changes: changes,
+		Commits: commits,
 	}
 }


### PR DESCRIPTION
invalidated empty commits in push in bitbucket data center as we may want to check commit field for commit SHA.

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [x] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [x] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [x] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [ ] 📖 Document any user-facing features or changes in behavior.

- [x] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [ ] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [ ] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [x] Bitbucket Data Center

  (update the provider documentation accordingly)
