### PR TITLE
Enhance `hack/mirror-pr.sh` with PR Management Features (Update, List/Close, Dry Run)

### DIFF
--- a/.tekton/linter.yaml
+++ b/.tekton/linter.yaml
@@ -75,20 +75,29 @@ spec:
                 fi
 
                 git config --global --add safe.directory $(workspaces.source.path)
+                git config --global user.name "Pipelines as Code"
+                git config --global user.email "email@email.org"
                 git log -1 --format=format:%s |grep -E -q '^Merge branch' && exit 0
                 pip3 install gitlint
 
                 # Check all commits between base_sha and HEAD
                 base_sha="{{ body.pull_request.base.sha }}"
-                failed=0
+                failed=()
                 while read -r commit_hash; do
                   echo "Checking commit: $commit_hash"
-                  if ! gitlint --commit "$commit_hash" --ignore "Merge branch"; then
-                    failed=1
+                  if ! git log -1 --pretty=format:%B "$commit_hash" | gitlint --staged; then
+                    echo "Gitlint failed for commit: $commit_hash"
+                    failed+=("$commit_hash")
                   fi
                 done < <(git log "${base_sha}..HEAD" --format=format:%H --no-merges)
 
-                exit $failed
+                if [ "${#failed[@]}" -ne 0 ]; then
+                  echo "Failed commits: ${failed[@]}"
+                  exit 1
+                else
+                  echo "Gitlint completed. All commits passed."
+                  exit 0
+                fi
 
             - name: check-generated-schemas
               displayName: "Check generated OpenAPI schemas"


### PR DESCRIPTION
This pull request introduces significant enhancements to the `hack/mirror-pr.sh` script, improving the workflow for managing mirrored pull requests
used for testing external contributions.

Key features and improvements include:

* **Mirrored PR Listing and Conditional Closing (`-c`):** Added a new option (`-c`) to list all mirrored pull requests in the repository. The script

![image](https://github.com/user-attachments/assets/36072490-f423-4201-b22e-33bfcffed29d)

now fetches the state of the original PR and interactively prompts the user to close the mirrored PR if the original has been merged or closed.
* **Updating Existing Mirrored PRs (`-u`):** Introduced an update mode (`-u`) that allows selecting an existing mirrored pull request via `fzf` and
updating it with the latest changes from the original contributor's branch.
* **Dry Run Mode (`-t`):** Added a dry run option (`-t`) to the script, enabling users to preview the commands that would be executed without making
any actual changes. This enhances safety and debuggability.

* fix: Improve Tekton gitlint step to list all failing commits


