### PR TITLE
fix: avoid reporting errors for non-Tekton res

### DIFF
--- a/docs/content/docs/guide/running.md
+++ b/docs/content/docs/guide/running.md
@@ -124,9 +124,8 @@ click on it and follow the pipeline execution directly there.
 
 ## Errors When Parsing PipelineRun YAML
 
-When Pipelines-As-Code encounters an issue with the YAML formatting in the
-repository, it will create comment on pull request describing the error and will log the error in the user namespace events log and
-the Pipelines-as-Code controller log.
+If Pipelines-As-Code encounters an issue with the YAML formatting of Tekton resources in the repository, it will create a comment on
+the pull request describing the error. The error will also be logged in the user namespace events log and in the Pipelines-as-Code controller log.
 
 Despite validation errors, Pipelines-as-Code continues to run other correctly parsed and matched PipelineRuns.
 However, if a PipelineRun has YAML syntax error, it halts the execution of all PipelineRuns, even those that are syntactically correct.

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,0 +1,9 @@
+package errors
+
+type PacYamlValidations struct {
+	Name   string
+	Err    error
+	Schema string
+}
+
+const GenericBadYAMLValidation = "Generic bad YAML Validation"

--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -9,6 +9,7 @@ import (
 
 	apipac "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	pacerrors "github.com/openshift-pipelines/pipelines-as-code/pkg/errors"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/matcher"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/opscomments"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
@@ -186,7 +187,15 @@ func (p *PacRun) getPipelineRunsFromRepo(ctx context.Context, repo *v1alpha1.Rep
 		reg := regexp.MustCompile(`error unmarshalling yaml file\s([^:]*):\s*(yaml:\s*)?(.*)`)
 		matches := reg.FindStringSubmatch(err.Error())
 		if len(matches) == 4 {
-			p.reportValidationErrors(ctx, repo, map[string]string{matches[1]: matches[3]})
+			p.reportValidationErrors(ctx, repo,
+				[]*pacerrors.PacYamlValidations{
+					{
+						Name:   matches[1],
+						Err:    fmt.Errorf("yaml validation error: %s", matches[3]),
+						Schema: pacerrors.GenericBadYAMLValidation,
+					},
+				},
+			)
 			return nil, nil
 		}
 
@@ -463,12 +472,19 @@ func (p *PacRun) createNeutralStatus(ctx context.Context) error {
 // 1. Creating error messages for each validation error
 // 2. Emitting error messages to the event system
 // 3. Creating a markdown formatted comment on the repository with all errors.
-func (p *PacRun) reportValidationErrors(ctx context.Context, repo *v1alpha1.Repository, validationErrors map[string]string) {
+func (p *PacRun) reportValidationErrors(ctx context.Context, repo *v1alpha1.Repository, validationErrors []*pacerrors.PacYamlValidations) {
 	errorRows := make([]string, 0, len(validationErrors))
-	for name, err := range validationErrors {
-		errorRows = append(errorRows, fmt.Sprintf("| %s | `%s` |", name, err))
+	for _, err := range validationErrors {
+		// if the error is a TektonConversionError, we don't want to report it since it may be a file that is not a tekton resource
+		// and we don't want to report it as a validation error.
+		if strings.HasPrefix(err.Schema, tektonv1.SchemeGroupVersion.Group) || err.Schema == pacerrors.GenericBadYAMLValidation {
+			errorRows = append(errorRows, fmt.Sprintf("| %s | `%s` |", err.Name, err.Err.Error()))
+		}
 		p.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "PipelineRunValidationErrors",
-			fmt.Sprintf("cannot read the PipelineRun: %s, error: %s", name, err))
+			fmt.Sprintf("cannot read the PipelineRun: %s, error: %s", err.Name, err.Err.Error()))
+	}
+	if len(errorRows) == 0 {
+		return
 	}
 	markdownErrMessage := fmt.Sprintf(`%s
 %s`, validationErrorTemplate, strings.Join(errorRows, "\n"))

--- a/test/testdata/TestGithubSecondPullRequestBadYaml.golden
+++ b/test/testdata/TestGithubSecondPullRequestBadYaml.golden
@@ -3,4 +3,4 @@
 
 | PipelineRun | Error |
 |------|-------|
-| bad-yaml.yaml | `line 3: could not find expected ':'` |
+| bad-yaml.yaml | `yaml validation error: line 3: could not find expected ':'` |

--- a/test/testdata/randomcrd.yaml
+++ b/test/testdata/randomcrd.yaml
@@ -1,0 +1,6 @@
+apiVersion: blah.openshift.io/v1
+kind: Blahblah
+metadata:
+  name: blahblah
+spec:
+  blah: blah


### PR DESCRIPTION
The handling of YAML validation errors was refactored to be more intelligent and less noisy. It now only reports errors for resources that are identified as Tekton resources or are fundamentally invalid YAML.

- Refactored validation errors from a simple map to a structured type that includes the resource name, schema, and error object.
- Updated YAML parsing to extract the resource's `apiVersion` (schema) even when the document fails to decode fully as a Tekton object.
- Implemented filtering to report validation errors only for resources with a `tekton.dev` API group or for generic YAML syntax errors.
- This prevents creating error comments on pull requests for other valid, non-Tekton YAML files located in the `.tekton` directory.

Jira: https://issues.redhat.com/browse/SRVKP-7906

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [x] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [x] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [x] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [x] 📖 Document any user-facing features or changes in behavior.

- [x] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [x] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [ ] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center

  (update the provider documentation accordingly)
