### PR TITLE
Enable relative TaskRefs within remote Pipelines

### DIFF
--- a/pkg/resolve/resolve.go
+++ b/pkg/resolve/resolve.go
@@ -38,8 +38,9 @@ type FetchedResources struct {
 
 // Contains Fetched Resources for Run, with key equals to resource name from metadata.name field.
 type FetchedResourcesForRun struct {
-	Tasks    map[string]*tektonv1.Task
-	Pipeline *tektonv1.Pipeline
+	Tasks       map[string]*tektonv1.Task
+	Pipeline    *tektonv1.Pipeline
+	PipelineURL string
 }
 
 func NewTektonTypes() TektonTypes {

--- a/pkg/resolve/testdata/remote-pipeline-with-relative-tasks-1.yaml
+++ b/pkg/resolve/testdata/remote-pipeline-with-relative-tasks-1.yaml
@@ -1,0 +1,31 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    pipelinesascode.tekton.dev/pipeline: http://remote/remote-pipeline-1
+  generateName: pipelinerun-abc-
+spec:
+  pipelineSpec:
+    tasks:
+    - name: remote-task-b
+      taskSpec:
+        steps:
+        - name: step1
+          image: scratch
+          command:
+          - "true"
+    - name: remote-task-c
+      taskSpec:
+        steps:
+        - name: step1
+          image: scratch
+          command:
+          - "true"
+    - name: remote-task-d
+      taskSpec:
+        steps:
+        - name: step1
+          image: scratch
+          command:
+          - "true"
+    finally: []

--- a/pkg/resolve/testdata/remote-pipeline-with-relative-tasks.yaml
+++ b/pkg/resolve/testdata/remote-pipeline-with-relative-tasks.yaml
@@ -1,0 +1,31 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    pipelinesascode.tekton.dev/pipeline: http://remote/remote-pipeline
+  generateName: pipelinerun-abc-
+spec:
+  pipelineSpec:
+    tasks:
+    - name: remote-task-a
+      taskSpec:
+        steps:
+        - name: step1
+          image: scratch
+          command:
+          - "true"
+    - name: remote-task-b
+      taskSpec:
+        steps:
+        - name: step1
+          image: scratch
+          command:
+          - "true"
+    - name: remote-task-c
+      taskSpec:
+        steps:
+        - name: step1
+          image: scratch
+          command:
+          - "true"
+    finally: []

--- a/pkg/test/tekton/genz.go
+++ b/pkg/test/tekton/genz.go
@@ -9,6 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knativeapi "knative.dev/pkg/apis"
 	knativeduckv1 "knative.dev/pkg/apis/duck/v1"
+	"sigs.k8s.io/yaml"
 )
 
 func MakePrTrStatus(ptaskname, displayName string, completionmn int) *tektonv1.PipelineRunTaskRunStatus {
@@ -147,6 +148,14 @@ func MakeTask(name string, taskSpec tektonv1.TaskSpec) *tektonv1.Task {
 		ObjectMeta: metav1.ObjectMeta{Name: name},
 		Spec:       taskSpec,
 	}
+}
+
+func MakeTaskB(name string, taskSpec tektonv1.TaskSpec) ([]byte, error) {
+	objB, err := yaml.Marshal(MakeTask(name, taskSpec))
+	if err != nil {
+		return nil, err
+	}
+	return objB, nil
 }
 
 func MakeTaskRunCompletion(clock *clockwork.FakeClock, name, namespace, runstatus string, annotation map[string]string, taskStatus tektonv1.TaskRunStatusFields, conditions knativeduckv1.Conditions, timeshift int) *tektonv1.TaskRun {


### PR DESCRIPTION
# Description

The current implementation doesn't allow to reference tasks relative to a remote pipeline (e.g., the task definition is in the same remote location as the pipeline). The issue is described here:

https://issues.redhat.com/browse/SRVKP-4332

# Changes

This PR includes a simple function that makes use of the [task overriding functionality](https://pipelinesascode.com/docs/guide/resolver/#overriding-tasks-from-a-remote-pipeline-on-a-pipelinerun) (see the relative path example).
Previously, only relative overrides for tasks within the triggering event's `.tekton` folder were supported. Now, it simply checks if there is a `pipelinesascode.tekton.dev/task` with a relative path value in the remote pipeline's definition and then assembles the tasks's FQDN based on the remote pipeline's location. 

Consider the following scenario:

*Repository A*, contains:
- `.tekton/pipelinerun.yaml`

```yaml
apiVersion: tekton.dev/v1
kind: PipelineRun
metadata:
  name: hello-world
  annotations:
    pipelinesascode.tekton.dev/on-target-branch: "[main]"
    pipelinesascode.tekton.dev/on-event: "[push]"
    pipelinesascode.tekton.dev/pipeline: "https://github.com/user/repositoryb/blob/main/pipeline.yaml"
spec:
  pipelineRef:
    name: hello-world
```

*Repository B*, contains:
- `pipeline.yaml`

```yaml
apiVersion: tekton.dev/v1beta1
kind: Pipeline
metadata:
  name: hello-world
  annotations:
    pipelinesascode.tekton.dev/task: "./task.yaml"
spec:
  tasks:
    - name: say-hello
      taskRef:
        name: hello
```

- `task.yaml`

```yaml
apiVersion: tekton.dev/v1beta1
kind: Task
metadata:
  name: hello
spec:
  steps:
    - name: echo
      image: alpine
      script: |
        #!/bin/sh
        echo "Hello, World!"
```

Previously, you had to specify the *FQDN* of the task either within the *PipelineRun* or the *Pipeline*. Now, you can still do that but you can also use relative references as shown above in the `hello-world` pipeline.

> [!NOTE]
> I will modify the docs to include info about the new functionality. I will also write some additional tests.
> Just wanted to get some initial feedback before doing these things.

# Submitter Checklist

- [X] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [X] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [X] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- [X] 📖 Document any user-facing features or changes in behavior.

- [X] 🧪 While 100% coverage isn't required, we encourage unit tests for code changes where possible.

- [ ] 🎁 If feasible, add an end-to-end test. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for details.

- [ ] 🔎 Address any CI test flakiness before merging, or provide a valid reason to bypass it (e.g., token rate limitations).

- If adding a provider feature, fill in the following details:

  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
