### PR TITLE
feat: Add PipelineRun to create JIRA tickets via comments

### DIFF
--- a/.tekton/jira.yaml
+++ b/.tekton/jira.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: jira
+  annotations:
+    pipelinesascode.tekton.dev/pipeline: "https://raw.githubusercontent.com/chmouel/pipelinerun-jira-pullrequest/main/tekton/jira.yaml"
+    pipelinesascode.tekton.dev/on-comment: "^/jira"
+    pipelinesascode.tekton.dev/max-keep-runs: "2"
+spec:
+  pipelineRef:
+    name: create-jira-from-pr
+  params:
+    - name: PR_URL
+      value: "{{ repo_url }}/pull/{{ pull_request_number }}"
+    - name: GITHUB_TOKEN_SECRET
+      value: "{{ git_auth_secret }}"
+    - name: GITHUB_TOKEN_SECRET_KEY
+      value: "git-provider-token"
+    - name: AI_TOKEN_SECRET
+      value: "gemini"
+    - name: AI_TOKEN_SECRET_KEY
+      value: "secret"
+    - name: JIRA_ENDPOINT
+      value: "https://issues.redhat.com"
+    - name: JIRA_TOKEN_SECRET
+      value: "jira"
+    - name: JIRA_TOKEN_SECRET_KEY
+      value: "secret"
+    - name: JIRA_USER_EMAIL
+      value: "cboudjna@redhat.com"
+    - name: JIRA_PROJECT
+      # value: "TP"
+      value: "SRVKP"
+    - name: JIRA_COMPONENT
+      # value: "Internal Tools"
+      value: "Pipelines as Code"
+    - name: PR_QUERY
+      value: "{{ trigger_comment }}"
+    - name: CREATE_IN_JIRA
+      value: "true"


### PR DESCRIPTION
This pull request introduces a new Tekton PipelineRun configuration for automating Jira ticket creation from pull requests. The configuration is designed to trigger on specific comments in pull requests and integrates with both GitHub and Jira.

### New Tekton PipelineRun for Jira Integration:

* [`.tekton/jira.yaml`](diffhunk://#diff-963c723a9727501ea51bf6e44e35c417fdf9ccd145cffec977e436157e81f2e0R1-R41): Added a new `PipelineRun` definition named `jira` to automate Jira ticket creation from pull requests. It includes parameters for GitHub and Jira authentication, Jira project and component details, and a trigger mechanism based on pull request comments.- Introduced a Tekton `PipelineRun` for creating JIRA tickets.
- The pipeline is triggered by a `/jira` comment on a pull request using Pipelines-as-Code.
- This automated the creation of JIRA issues directly from GitHub, streamlining the developer workflow.
