### PR TITLE
fix(ci): golangci-lint revive var-naming error in linters

### DIFF
--- a/pkg/provider/bitbucketcloud/types/types.go
+++ b/pkg/provider/bitbucketcloud/types/types.go
@@ -1,3 +1,4 @@
+//revive:disable-next-line:var-naming
 package types
 
 type Workspace struct {

--- a/pkg/provider/bitbucketdatacenter/types/types.go
+++ b/pkg/provider/bitbucketdatacenter/types/types.go
@@ -1,3 +1,4 @@
+//revive:disable-next-line:var-naming
 package types
 
 type UserWithMetadata struct {

--- a/pkg/secrets/types/types.go
+++ b/pkg/secrets/types/types.go
@@ -1,3 +1,4 @@
+//revive:disable-next-line:var-naming
 package types
 
 type SecretValue struct {


### PR DESCRIPTION
fixed golangci-lint revive var-naming error in linters. this might be happening due new fix release of golangci-lint hours before https://github.com/golangci/golangci-lint/pull/5904

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [x] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [x] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [x] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).
