### PR TITLE
🪞 [MIRRORED] Enable relative TaskRefs within remote Pipelines

### DIFF
--- a/pkg/resolve/resolve.go
+++ b/pkg/resolve/resolve.go
@@ -38,8 +38,9 @@ type FetchedResources struct {
 
 // Contains Fetched Resources for Run, with key equals to resource name from metadata.name field.
 type FetchedResourcesForRun struct {
-	Tasks    map[string]*tektonv1.Task
-	Pipeline *tektonv1.Pipeline
+	Tasks       map[string]*tektonv1.Task
+	Pipeline    *tektonv1.Pipeline
+	PipelineURL string
 }
 
 func NewTektonTypes() TektonTypes {

--- a/pkg/resolve/testdata/remote-pipeline-with-relative-tasks-1.yaml
+++ b/pkg/resolve/testdata/remote-pipeline-with-relative-tasks-1.yaml
@@ -1,0 +1,31 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    pipelinesascode.tekton.dev/pipeline: http://remote/remote-pipeline-1
+  generateName: pipelinerun-abc-
+spec:
+  pipelineSpec:
+    tasks:
+    - name: remote-task-b
+      taskSpec:
+        steps:
+        - name: step1
+          image: scratch
+          command:
+          - "true"
+    - name: remote-task-c
+      taskSpec:
+        steps:
+        - name: step1
+          image: scratch
+          command:
+          - "true"
+    - name: remote-task-d
+      taskSpec:
+        steps:
+        - name: step1
+          image: scratch
+          command:
+          - "true"
+    finally: []

--- a/pkg/resolve/testdata/remote-pipeline-with-relative-tasks.yaml
+++ b/pkg/resolve/testdata/remote-pipeline-with-relative-tasks.yaml
@@ -1,0 +1,31 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    pipelinesascode.tekton.dev/pipeline: http://remote/remote-pipeline
+  generateName: pipelinerun-abc-
+spec:
+  pipelineSpec:
+    tasks:
+    - name: remote-task-a
+      taskSpec:
+        steps:
+        - name: step1
+          image: scratch
+          command:
+          - "true"
+    - name: remote-task-b
+      taskSpec:
+        steps:
+        - name: step1
+          image: scratch
+          command:
+          - "true"
+    - name: remote-task-c
+      taskSpec:
+        steps:
+        - name: step1
+          image: scratch
+          command:
+          - "true"
+    finally: []

--- a/pkg/test/tekton/genz.go
+++ b/pkg/test/tekton/genz.go
@@ -9,6 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knativeapi "knative.dev/pkg/apis"
 	knativeduckv1 "knative.dev/pkg/apis/duck/v1"
+	"sigs.k8s.io/yaml"
 )
 
 func MakePrTrStatus(ptaskname, displayName string, completionmn int) *tektonv1.PipelineRunTaskRunStatus {
@@ -147,6 +148,14 @@ func MakeTask(name string, taskSpec tektonv1.TaskSpec) *tektonv1.Task {
 		ObjectMeta: metav1.ObjectMeta{Name: name},
 		Spec:       taskSpec,
 	}
+}
+
+func MakeTaskB(name string, taskSpec tektonv1.TaskSpec) ([]byte, error) {
+	objB, err := yaml.Marshal(MakeTask(name, taskSpec))
+	if err != nil {
+		return nil, err
+	}
+	return objB, nil
 }
 
 func MakeTaskRunCompletion(clock *clockwork.FakeClock, name, namespace, runstatus string, annotation map[string]string, taskStatus tektonv1.TaskRunStatusFields, conditions knativeduckv1.Conditions, timeshift int) *tektonv1.TaskRun {


### PR DESCRIPTION
🔄 Mirrors https://github.com/openshift-pipelines/pipelines-as-code/pull/2149 to run E2E tests. Original author: @martindbrv