### PR TITLE
DNM: Release v0.35.2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -74,25 +74,26 @@ release:
 
     https://release-{{ replace .Tag "." "-" }}.pipelines-as-code.pages.dev
 
-brews:
+homebrew_casks:
   - name: tektoncd-pac
     repository:
       owner: openshift-pipelines
       name: homebrew-pipelines-as-code
     directory: Formula
     dependencies:
-      - name: tektoncd-cli
-        type: optional
-      - name: git
+      - formula: tektoncd-cli
+      - formula: git
     homepage: "https://pipelinesascode.com"
     description: tkn-pac - A command line interface for interacting with Pipelines as Code
-    install: |
-      bin.install "tkn-pac" => "tkn-pac"
-      output = Utils.popen_read("SHELL=bash #{bin}/tkn-pac completion bash")
-      (bash_completion/"tkn-pac").write output
-      output = Utils.popen_read("SHELL=zsh #{bin}/tkn-pac completion zsh")
-      (zsh_completion/"_tkn-pac").write output
-      prefix.install_metafiles
+    hooks:
+      pre:
+        install: |
+          bin.install "tkn-pac" => "tkn-pac"
+          output = Utils.popen_read("SHELL=bash #{bin}/tkn-pac completion bash")
+          (bash_completion/"tkn-pac").write output
+          output = Utils.popen_read("SHELL=zsh #{bin}/tkn-pac completion zsh")
+          (zsh_completion/"_tkn-pac").write output
+          prefix.install_metafiles
 nfpms:
   - file_name_template: >-
       tkn-pac-

--- a/.tekton/go.yaml
+++ b/.tekton/go.yaml
@@ -7,7 +7,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "2"
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/on-event: "pull_request"
-    pipelinesascode.tekton.dev/on-target-branch: "main"
+    pipelinesascode.tekton.dev/on-target-branch: "[*]"
     pipelinesascode.tekton.dev/on-path-change: "[***/*.go]"
 spec:
   params:

--- a/docs/content/docs/guide/running.md
+++ b/docs/content/docs/guide/running.md
@@ -124,12 +124,11 @@ click on it and follow the pipeline execution directly there.
 
 ## Errors When Parsing PipelineRun YAML
 
-When Pipelines-As-Code encounters an issue with the YAML formatting in the
-repository, it will log the error in the user namespace events log and
-the Pipelines-as-Code controller log.
+If Pipelines-As-Code encounters an issue with the YAML formatting of Tekton resources in the repository, it will create a comment on
+the pull request describing the error. The error will also be logged in the user namespace events log and in the Pipelines-as-Code controller log.
 
-Despite the error, Pipelines-As-Code will continue to run other correctly parsed
-and matched PipelineRuns.
+Despite validation errors, Pipelines-as-Code continues to run other correctly parsed and matched PipelineRuns.
+However, if a PipelineRun has YAML syntax error, it halts the execution of all PipelineRuns, even those that are syntactically correct.
 
 {{< support_matrix github_app="true" github_webhook="true" gitea="true" gitlab="true" bitbucket_cloud="false" bitbucket_server="false" >}}
 

--- a/pkg/action/patch_test.go
+++ b/pkg/action/patch_test.go
@@ -1,7 +1,7 @@
 package action
 
 import (
-	"path/filepath"
+	"path"
 	"testing"
 
 	apipac "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
@@ -40,7 +40,7 @@ func TestPatchPipelineRun(t *testing.T) {
 
 	patchedPR, err := PatchPipelineRun(ctx, logger, "log URL", fakeClients.Tekton, testPR, getLogURLMergePatch(fakeClients, testPR))
 	assert.NilError(t, err)
-	assert.Equal(t, patchedPR.Annotations[filepath.Join(apipac.GroupName, "log-url")], "https://localhost.console/#/namespaces/namespace/pipelineruns/force-me")
+	assert.Equal(t, patchedPR.Annotations[path.Join(apipac.GroupName, "log-url")], "https://localhost.console/#/namespaces/namespace/pipelineruns/force-me")
 }
 
 func getLogURLMergePatch(clients clients.Clients, pr *pipelinev1.PipelineRun) map[string]any {

--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -93,11 +93,13 @@ func (l *listener) Start(ctx context.Context) error {
 
 	mux.HandleFunc("/", l.handleEvent(ctx))
 
-	//nolint: gosec
 	srv := &http.Server{
 		Addr: ":" + adapterPort,
 		Handler: http.TimeoutHandler(mux,
 			httpTimeoutHandler, "Listener Timeout!\n"),
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		IdleTimeout:       30 * time.Second,
 	}
 
 	enabled, tlsCertFile, tlsKeyFile := l.isTLSEnabled()

--- a/pkg/apis/pipelinesascode/register.go
+++ b/pkg/apis/pipelinesascode/register.go
@@ -21,4 +21,5 @@ const (
 	GroupName       = "pipelinesascode.tekton.dev"
 	RepositoryKind  = "Repository"
 	V1alpha1Version = "v1alpha1"
+	FinalizerName   = "finalizer"
 )

--- a/pkg/cmd/tknpac/bootstrap/route.go
+++ b/pkg/cmd/tknpac/bootstrap/route.go
@@ -59,7 +59,9 @@ func detectSelfSignedCertificate(ctx context.Context, url string) string {
 	} else if err != nil {
 		return fmt.Sprintf("⚠️ could not connect to the route %s, make sure the pipelines-as-code controller is running", url)
 	}
-	resp.Body.Close()
+	if err := resp.Body.Close(); err != nil {
+		return fmt.Sprintf("⚠️ could not close the response body: %v", err)
+	}
 	return ""
 }
 

--- a/pkg/cmd/tknpac/bootstrap/web.go
+++ b/pkg/cmd/tknpac/bootstrap/web.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"path/filepath"
+	"time"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli/browser"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli/info"
@@ -19,7 +20,13 @@ import (
 func startWebServer(ctx context.Context, opts *bootstrapOpts, run *params.Run, jeez string) error {
 	m := http.NewServeMux()
 	//nolint: gosec
-	s := http.Server{Addr: fmt.Sprintf(":%d", opts.webserverPort), Handler: m}
+	s := http.Server{
+		Addr:              fmt.Sprintf(":%d", opts.webserverPort),
+		Handler:           m,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		IdleTimeout:       30 * time.Second,
+	}
 	codeCh := make(chan string)
 	m.HandleFunc("/", func(rw http.ResponseWriter, r *http.Request) {
 		code := r.URL.Query().Get("code")

--- a/pkg/cmd/tknpac/list/list.go
+++ b/pkg/cmd/tknpac/list/list.go
@@ -188,6 +188,5 @@ func list(ctx context.Context, cs *params.Run, opts *cli.PacCliOpts, ioStreams *
 	if err := t.Execute(w, data); err != nil {
 		return err
 	}
-	w.Flush()
-	return nil
+	return w.Flush()
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,0 +1,9 @@
+package errors
+
+type PacYamlValidations struct {
+	Name   string
+	Err    error
+	Schema string
+}
+
+const GenericBadYAMLValidation = "Generic bad YAML Validation"

--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -9,6 +9,7 @@ import (
 
 	apipac "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	pacerrors "github.com/openshift-pipelines/pipelines-as-code/pkg/errors"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/matcher"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/opscomments"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
@@ -186,7 +187,15 @@ func (p *PacRun) getPipelineRunsFromRepo(ctx context.Context, repo *v1alpha1.Rep
 		reg := regexp.MustCompile(`error unmarshalling yaml file\s([^:]*):\s*(yaml:\s*)?(.*)`)
 		matches := reg.FindStringSubmatch(err.Error())
 		if len(matches) == 4 {
-			p.reportValidationErrors(ctx, repo, map[string]string{matches[1]: matches[3]})
+			p.reportValidationErrors(ctx, repo,
+				[]*pacerrors.PacYamlValidations{
+					{
+						Name:   matches[1],
+						Err:    fmt.Errorf("yaml validation error: %s", matches[3]),
+						Schema: pacerrors.GenericBadYAMLValidation,
+					},
+				},
+			)
 			return nil, nil
 		}
 
@@ -463,12 +472,19 @@ func (p *PacRun) createNeutralStatus(ctx context.Context) error {
 // 1. Creating error messages for each validation error
 // 2. Emitting error messages to the event system
 // 3. Creating a markdown formatted comment on the repository with all errors.
-func (p *PacRun) reportValidationErrors(ctx context.Context, repo *v1alpha1.Repository, validationErrors map[string]string) {
+func (p *PacRun) reportValidationErrors(ctx context.Context, repo *v1alpha1.Repository, validationErrors []*pacerrors.PacYamlValidations) {
 	errorRows := make([]string, 0, len(validationErrors))
-	for name, err := range validationErrors {
-		errorRows = append(errorRows, fmt.Sprintf("| %s | `%s` |", name, err))
+	for _, err := range validationErrors {
+		// if the error is a TektonConversionError, we don't want to report it since it may be a file that is not a tekton resource
+		// and we don't want to report it as a validation error.
+		if strings.HasPrefix(err.Schema, tektonv1.SchemeGroupVersion.Group) || err.Schema == pacerrors.GenericBadYAMLValidation {
+			errorRows = append(errorRows, fmt.Sprintf("| %s | `%s` |", err.Name, err.Err.Error()))
+		}
 		p.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "PipelineRunValidationErrors",
-			fmt.Sprintf("cannot read the PipelineRun: %s, error: %s", name, err))
+			fmt.Sprintf("cannot read the PipelineRun: %s, error: %s", err.Name, err.Err.Error()))
+	}
+	if len(errorRows) == 0 {
+		return
 	}
 	markdownErrMessage := fmt.Sprintf(`%s
 %s`, validationErrorTemplate, strings.Join(errorRows, "\n"))

--- a/pkg/pipelineascode/pipelineascode_test.go
+++ b/pkg/pipelineascode/pipelineascode_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"path/filepath"
+	"path"
 	"regexp"
 	"strings"
 	"sync"
@@ -667,7 +667,7 @@ func TestRun(t *testing.T) {
 					if pr.GetName() == "force-me" {
 						continue
 					}
-					logURL, ok := pr.Annotations[filepath.Join(apipac.GroupName, "log-url")]
+					logURL, ok := pr.Annotations[path.Join(apipac.GroupName, "log-url")]
 					assert.Assert(t, ok, "failed to find log-url label on pipelinerun: %s/%s", pr.GetNamespace(), pr.GetGenerateName())
 					assert.Equal(t, logURL, cs.Clients.ConsoleUI().DetailURL(&pr))
 
@@ -700,5 +700,5 @@ func TestGetLogURLMergePatch(t *testing.T) {
 	assert.Assert(t, ok)
 	a, ok := m["annotations"].(map[string]string)
 	assert.Assert(t, ok)
-	assert.Equal(t, a[filepath.Join(apipac.GroupName, "log-url")], con.URL())
+	assert.Equal(t, a[path.Join(apipac.GroupName, "log-url")], con.URL())
 }

--- a/pkg/provider/bitbucketcloud/bitbucket.go
+++ b/pkg/provider/bitbucketcloud/bitbucket.go
@@ -171,7 +171,7 @@ func (v *Provider) getDir(event *info.Event, path string) ([]bitbucket.Repositor
 		revision = event.DefaultBranch
 		v.Logger.Infof("Using PipelineRun definition from default_branch: %s", event.DefaultBranch)
 	} else {
-		v.Logger.Infof("Using PipelineRun definition from source pull request SHA: %s", event.SHA)
+		v.Logger.Infof("Using PipelineRun definition from source %s commit SHA: %s", event.TriggerTarget.String(), event.SHA)
 	}
 	repoFileOpts := &bitbucket.RepositoryFilesOptions{
 		Owner:    event.Organization,

--- a/pkg/provider/bitbucketcloud/bitbucket_test.go
+++ b/pkg/provider/bitbucketcloud/bitbucket_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	bbcloudtest "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketcloud/test"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketcloud/types"
@@ -35,11 +36,18 @@ func TestGetTektonDir(t *testing.T) {
 		filterMessageSnippet string
 	}{
 		{
-			name:                 "Get Tekton Directory",
-			event:                bbcloudtest.MakeEvent(nil),
+			name:                 "Get Tekton Directory on pull request",
+			event:                bbcloudtest.MakeEvent(&info.Event{TriggerTarget: triggertype.PullRequest}),
 			testDirPath:          "../../pipelineascode/testdata/pull_request/.tekton",
 			contentContains:      "kind: PipelineRun",
-			filterMessageSnippet: "Using PipelineRun definition from source pull request SHA",
+			filterMessageSnippet: "Using PipelineRun definition from source pull_request commit SHA",
+		},
+		{
+			name:                 "Get Tekton Directory on push",
+			event:                bbcloudtest.MakeEvent(&info.Event{TriggerTarget: triggertype.Push}),
+			testDirPath:          "../../pipelineascode/testdata/pull_request/.tekton",
+			contentContains:      "kind: PipelineRun",
+			filterMessageSnippet: "Using PipelineRun definition from source push commit SHA",
 		},
 		{
 			name:                 "Get Tekton Directory Mainbranch",

--- a/pkg/provider/bitbucketcloud/types/types.go
+++ b/pkg/provider/bitbucketcloud/types/types.go
@@ -1,3 +1,4 @@
+//revive:disable-next-line:var-naming
 package types
 
 type Workspace struct {

--- a/pkg/provider/bitbucketdatacenter/bitbucketdatacenter.go
+++ b/pkg/provider/bitbucketdatacenter/bitbucketdatacenter.go
@@ -216,7 +216,7 @@ func (v *Provider) GetTektonDir(ctx context.Context, event *info.Event, path, pr
 	at := ""
 	if v.provenance == "source" {
 		at = event.SHA
-		v.Logger.Infof("Using PipelineRun definition from source pull request SHA: %s", event.SHA)
+		v.Logger.Infof("Using PipelineRun definition from source %s commit SHA: %s", event.TriggerTarget.String(), event.SHA)
 	} else {
 		v.Logger.Infof("Using PipelineRun definition from default_branch: %s", event.DefaultBranch)
 	}

--- a/pkg/provider/bitbucketdatacenter/parse_payload.go
+++ b/pkg/provider/bitbucketdatacenter/parse_payload.go
@@ -164,6 +164,10 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 			return nil, fmt.Errorf("push event contains no commits under 'changes'; cannot proceed")
 		}
 
+		if len(e.Commits) == 0 {
+			return nil, fmt.Errorf("push event contains no commits; cannot proceed")
+		}
+
 		processedEvent.SHA = e.Changes[0].ToHash
 		processedEvent.URL = e.Repository.Links.Self[0].Href
 		processedEvent.BaseBranch = e.Changes[0].RefID

--- a/pkg/provider/bitbucketdatacenter/parse_payload.go
+++ b/pkg/provider/bitbucketdatacenter/parse_payload.go
@@ -88,7 +88,7 @@ func sanitizeOwner(owner string) string {
 }
 
 // ParsePayload parses the payload from the event.
-func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.Request,
+func (v *Provider) ParsePayload(_ context.Context, run *params.Run, request *http.Request,
 	payload string,
 ) (*info.Event, error) {
 	processedEvent := info.NewEvent()
@@ -169,6 +169,27 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 		}
 
 		processedEvent.SHA = e.Changes[0].ToHash
+
+		// In Bitbucket Data Center, when a pull request is merged, it creates two commits in the repository:
+		// 1. A merge commit, which is represented by `changes[0].ToHash`.
+		// 2. The actual commit containing the changes from the source branch.
+		//
+		// However, the merge commit often does not contain any file changes itself,
+		// which can cause issues when determining whether file modifications should trigger PipelineRuns.
+		//
+		// Typically, a regular (non-merge) commit has a single parent, but a merge commit has two parents:
+		// - The first parent is the previous HEAD of the destination branch (the branch into which the PR was merged).
+		// - The second parent is the HEAD of the source branch (the branch being merged).
+		//
+		// To correctly identify the actual commit that contains the changes (i.e., the source branch's HEAD),
+		// we inspect `e.Commits[0]`, and if it has more than one parent, we take the second parent.
+		// This helps ensure we reference the correct commit.
+		if len(e.Commits) > 1 && len(e.Commits[0].Parents) > 1 {
+			processedEvent.SHA = e.Commits[0].Parents[1].ID
+			run.Clients.Log.Infof("Detected a merge commit as HEAD; "+
+				"using second parent commit SHA %s (source branch HEAD) to target push event", e.Commits[0].Parents[1].ID)
+		}
+
 		processedEvent.URL = e.Repository.Links.Self[0].Href
 		processedEvent.BaseBranch = e.Changes[0].RefID
 		processedEvent.HeadBranch = e.Changes[0].RefID

--- a/pkg/provider/bitbucketdatacenter/parse_payload_test.go
+++ b/pkg/provider/bitbucketdatacenter/parse_payload_test.go
@@ -611,15 +611,22 @@ func TestParsePayload(t *testing.T) {
 		{
 			name:         "good/push",
 			eventType:    "repo:refs_changed",
-			payloadEvent: bbv1test.MakePushEvent(ev1, []types.PushRequestEventChange{{ToHash: ev1.SHA, RefID: "base"}}),
+			payloadEvent: bbv1test.MakePushEvent(ev1, []types.PushRequestEventChange{{ToHash: ev1.SHA, RefID: "base"}}, []types.Commit{{ID: ev1.SHA}}),
 			expEvent:     ev1,
 		},
 		{
 			name:          "bad/changes are empty in push",
 			eventType:     "repo:refs_changed",
-			payloadEvent:  bbv1test.MakePushEvent(ev1, []types.PushRequestEventChange{}),
+			payloadEvent:  bbv1test.MakePushEvent(ev1, []types.PushRequestEventChange{}, []types.Commit{}),
 			expEvent:      ev1,
 			wantErrSubstr: "push event contains no commits under 'changes'; cannot proceed",
+		},
+		{
+			name:          "bad/commits are empty in push",
+			eventType:     "repo:refs_changed",
+			payloadEvent:  bbv1test.MakePushEvent(ev1, []types.PushRequestEventChange{{ToHash: ev1.SHA, RefID: "base"}}, []types.Commit{}),
+			expEvent:      ev1,
+			wantErrSubstr: "push event contains no commits; cannot proceed",
 		},
 		{
 			name:         "good/comment ok-to-test",

--- a/pkg/provider/bitbucketdatacenter/parse_payload_test.go
+++ b/pkg/provider/bitbucketdatacenter/parse_payload_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	bbv1test "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketdatacenter/test"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketdatacenter/types"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/test/logger"
 	"gotest.tools/v3/assert"
 	rtesting "knative.dev/pkg/reconciler/testing"
 )
@@ -570,6 +571,7 @@ func TestParsePayload(t *testing.T) {
 		payloadEvent            any
 		expEvent                *info.Event
 		eventType               string
+		wantSHA                 string
 		wantErrSubstr           string
 		rawStr                  string
 		targetPipelinerun       string
@@ -607,12 +609,14 @@ func TestParsePayload(t *testing.T) {
 			eventType:    "pr:opened",
 			payloadEvent: bbv1test.MakePREvent(ev1, ""),
 			expEvent:     ev1,
+			wantSHA:      "abcd",
 		},
 		{
 			name:         "good/push",
 			eventType:    "repo:refs_changed",
 			payloadEvent: bbv1test.MakePushEvent(ev1, []types.PushRequestEventChange{{ToHash: ev1.SHA, RefID: "base"}}, []types.Commit{{ID: ev1.SHA}}),
 			expEvent:     ev1,
+			wantSHA:      "abcd",
 		},
 		{
 			name:          "bad/changes are empty in push",
@@ -629,16 +633,58 @@ func TestParsePayload(t *testing.T) {
 			wantErrSubstr: "push event contains no commits; cannot proceed",
 		},
 		{
+			name:      "good/changes are empty in push",
+			eventType: "repo:refs_changed",
+			payloadEvent: bbv1test.MakePushEvent(ev1, []types.PushRequestEventChange{
+				{
+					Ref:    types.Ref{ID: "refs/heads/main"},
+					ToHash: "abcd",
+				},
+			}, []types.Commit{
+				{
+					Parents: []struct {
+						ID        string `json:"id"`
+						DisplayID string `json:"displayId"`
+					}{
+						{
+							ID:        "efghabcd",
+							DisplayID: "efgh",
+						},
+						{
+							ID:        "abcdefgh",
+							DisplayID: "abcd",
+						},
+					},
+				},
+				{
+					ID: "abcdefgh",
+					Parents: []struct {
+						ID        string `json:"id"`
+						DisplayID string `json:"displayId"`
+					}{
+						{
+							ID:        "weroiusf",
+							DisplayID: "wero",
+						},
+					},
+				},
+			}),
+			expEvent: ev1,
+			wantSHA:  "abcdefgh",
+		},
+		{
 			name:         "good/comment ok-to-test",
 			eventType:    "pr:comment:added",
 			payloadEvent: bbv1test.MakePREvent(ev1, "/ok-to-test"),
 			expEvent:     ev1,
+			wantSHA:      "abcd",
 		},
 		{
 			name:         "good/comment test",
 			eventType:    "pr:comment:added",
 			payloadEvent: bbv1test.MakePREvent(ev1, "/test"),
 			expEvent:     ev1,
+			wantSHA:      "abcd",
 		},
 		{
 			name:              "good/comment retest a pr",
@@ -646,6 +692,7 @@ func TestParsePayload(t *testing.T) {
 			payloadEvent:      bbv1test.MakePREvent(ev1, "/retest dummy"),
 			expEvent:          ev1,
 			targetPipelinerun: "dummy",
+			wantSHA:           "abcd",
 		},
 		{
 			name:                    "good/comment cancel a pr",
@@ -653,12 +700,14 @@ func TestParsePayload(t *testing.T) {
 			payloadEvent:            bbv1test.MakePREvent(ev1, "/cancel dummy"),
 			expEvent:                ev1,
 			canceltargetPipelinerun: "dummy",
+			wantSHA:                 "abcd",
 		},
 		{
 			name:         "good/comment cancel all",
 			eventType:    "pr:comment:added",
 			payloadEvent: bbv1test.MakePREvent(ev1, "/cancel"),
 			expEvent:     ev1,
+			wantSHA:      "abcd",
 		},
 	}
 	for _, tt := range tests {
@@ -672,6 +721,7 @@ func TestParsePayload(t *testing.T) {
 			run := &params.Run{
 				Info: info.Info{},
 			}
+			run.Clients.Log, _ = logger.GetLogger()
 			_b, err := json.Marshal(tt.payloadEvent)
 			assert.NilError(t, err)
 			payload := string(_b)
@@ -685,6 +735,9 @@ func TestParsePayload(t *testing.T) {
 				return
 			}
 			assert.NilError(t, err)
+
+			// assert SHA ID
+			assert.Equal(t, tt.wantSHA, got.SHA)
 
 			assert.Equal(t, got.AccountID, tt.expEvent.AccountID)
 

--- a/pkg/provider/bitbucketdatacenter/test/test.go
+++ b/pkg/provider/bitbucketdatacenter/test/test.go
@@ -338,7 +338,7 @@ func MakePREvent(event *info.Event, comment string) *types.PullRequestEvent {
 	return pr
 }
 
-func MakePushEvent(event *info.Event, changes []types.PushRequestEventChange) *types.PushRequestEvent {
+func MakePushEvent(event *info.Event, changes []types.PushRequestEventChange, commits []types.Commit) *types.PushRequestEvent {
 	iii, _ := strconv.Atoi(event.AccountID)
 
 	return &types.PushRequestEvent{
@@ -366,5 +366,6 @@ func MakePushEvent(event *info.Event, changes []types.PushRequestEventChange) *t
 			},
 		},
 		Changes: changes,
+		Commits: commits,
 	}
 }

--- a/pkg/provider/bitbucketdatacenter/types/types.go
+++ b/pkg/provider/bitbucketdatacenter/types/types.go
@@ -1,3 +1,4 @@
+//revive:disable-next-line:var-naming
 package types
 
 type UserWithMetadata struct {

--- a/pkg/provider/gitea/gitea.go
+++ b/pkg/provider/gitea/gitea.go
@@ -254,7 +254,7 @@ func (v *Provider) GetTektonDir(_ context.Context, event *info.Event, path, prov
 		revision = event.DefaultBranch
 		v.Logger.Infof("Using PipelineRun definition from default_branch: %s", event.DefaultBranch)
 	} else {
-		v.Logger.Infof("Using PipelineRun definition from source pull request SHA: %s", event.SHA)
+		v.Logger.Infof("Using PipelineRun definition from source %s commit SHA: %s", event.TriggerTarget.String(), event.SHA)
 	}
 
 	tektonDirSha := ""

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -258,7 +258,7 @@ func parseTS(headerTS string) (time.Time, error) {
 // the issue was.
 func (v *Provider) checkWebhookSecretValidity(ctx context.Context, cw clockwork.Clock) error {
 	rl, resp, err := v.Client().RateLimit.Get(ctx)
-	if resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		v.Logger.Info("skipping checking if token has expired, rate_limit api is not enabled on token")
 		return nil
 	}
@@ -266,16 +266,23 @@ func (v *Provider) checkWebhookSecretValidity(ctx context.Context, cw clockwork.
 	if err != nil {
 		return fmt.Errorf("error making request to the GitHub API checking rate limit: %w", err)
 	}
-	if resp.Header.Get("GitHub-Authentication-Token-Expiration") != "" {
+
+	if resp != nil && resp.Header.Get("GitHub-Authentication-Token-Expiration") != "" {
 		ts, err := parseTS(resp.Header.Get("GitHub-Authentication-Token-Expiration"))
 		if err != nil {
 			return fmt.Errorf("error parsing token expiration date: %w", err)
 		}
 
 		if cw.Now().After(ts) {
-			errm := fmt.Sprintf("token has expired at %s", resp.TokenExpiration.Format(time.RFC1123))
-			return fmt.Errorf("%s", errm)
+			errMsg := fmt.Sprintf("token has expired at %s", resp.TokenExpiration.Format(time.RFC1123))
+			return fmt.Errorf("%s", errMsg)
 		}
+	}
+
+	// Guard against nil rl or rl.SCIM which could lead to a panic.
+	if rl == nil || rl.SCIM == nil {
+		v.Logger.Info("skipping token expiration check, SCIM rate limit API is not available for this token")
+		return nil
 	}
 
 	if rl.SCIM.Remaining == 0 {

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -324,7 +324,11 @@ func (v *Provider) GetTektonDir(ctx context.Context, runevent *info.Event, path,
 		revision = runevent.DefaultBranch
 		v.Logger.Infof("Using PipelineRun definition from default_branch: %s", runevent.DefaultBranch)
 	} else {
-		v.Logger.Infof("Using PipelineRun definition from source pull request %s/%s#%d SHA on %s", runevent.Organization, runevent.Repository, runevent.PullRequestNumber, runevent.SHA)
+		prInfo := ""
+		if runevent.TriggerTarget == triggertype.PullRequest {
+			prInfo = fmt.Sprintf("%s/%s#%d", runevent.Organization, runevent.Repository, runevent.PullRequestNumber)
+		}
+		v.Logger.Infof("Using PipelineRun definition from source %s %s on commit SHA %s", runevent.TriggerTarget.String(), prInfo, runevent.SHA)
 	}
 
 	rootobjects, _, err := v.Client().Git.GetTree(ctx, runevent.Organization, runevent.Repository, revision, false)

--- a/pkg/provider/github/github_test.go
+++ b/pkg/provider/github/github_test.go
@@ -240,15 +240,32 @@ func TestGetTektonDir(t *testing.T) {
 		expectedGHApiCalls   int64
 	}{
 		{
-			name: "test no subtree",
+			name: "test no subtree on pull request",
 			event: &info.Event{
-				Organization: "tekton",
-				Repository:   "cat",
-				SHA:          "123",
+				Organization:  "tekton",
+				Repository:    "cat",
+				SHA:           "123",
+				TriggerTarget: triggertype.PullRequest,
 			},
 			expectedString:       "PipelineRun",
 			treepath:             "testdata/tree/simple",
-			filterMessageSnippet: "Using PipelineRun definition from source pull request tekton/cat#0",
+			filterMessageSnippet: "Using PipelineRun definition from source pull_request tekton/cat#0",
+			// 1. Get Repo root objects
+			// 2. Get Tekton Dir objects
+			// 3/4. Get object content for each object (pipelinerun.yaml, pipeline.yaml)
+			expectedGHApiCalls: 4,
+		},
+		{
+			name: "test no subtree on push",
+			event: &info.Event{
+				Organization:  "tekton",
+				Repository:    "cat",
+				SHA:           "123",
+				TriggerTarget: triggertype.Push,
+			},
+			expectedString:       "PipelineRun",
+			treepath:             "testdata/tree/simple",
+			filterMessageSnippet: "Using PipelineRun definition from source push",
 			// 1. Get Repo root objects
 			// 2. Get Tekton Dir objects
 			// 3/4. Get object content for each object (pipelinerun.yaml, pipeline.yaml)
@@ -302,13 +319,14 @@ func TestGetTektonDir(t *testing.T) {
 		{
 			name: "test no tekton directory",
 			event: &info.Event{
-				Organization: "tekton",
-				Repository:   "cat",
-				SHA:          "123",
+				Organization:  "tekton",
+				Repository:    "cat",
+				SHA:           "123",
+				TriggerTarget: triggertype.PullRequest,
 			},
 			expectedString:       "",
 			treepath:             "testdata/tree/notektondir",
-			filterMessageSnippet: "Using PipelineRun definition from source pull request tekton/cat#0",
+			filterMessageSnippet: "Using PipelineRun definition from source pull_request tekton/cat#0",
 			// 1. Get Repo root objects
 			// _. No tekton dir to fetch
 			expectedGHApiCalls: 1,

--- a/pkg/provider/github/github_test.go
+++ b/pkg/provider/github/github_test.go
@@ -914,6 +914,12 @@ func TestGetFiles(t *testing.T) {
 	}
 }
 
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
 func TestProvider_checkWebhookSecretValidity(t *testing.T) {
 	t1 := time.Date(1999, time.February, 3, 4, 5, 6, 7, time.UTC)
 	cw := clockwork.NewFakeClockAt(t1)
@@ -925,7 +931,9 @@ func TestProvider_checkWebhookSecretValidity(t *testing.T) {
 		expHeaderSet   bool
 		apiNotEnabled  bool
 		wantLogSnippet string
-		report500      bool
+		statusCode     int
+		wantNilSCIM    bool
+		wantNilResp    bool
 	}{
 		{
 			name:         "remaining scim calls",
@@ -951,6 +959,22 @@ func TestProvider_checkWebhookSecretValidity(t *testing.T) {
 			remaining: 5,
 		},
 		{
+			name:       "skipping api rate limit is not enabled",
+			remaining:  0,
+			statusCode: http.StatusNotFound,
+		},
+		{
+			name:        "skipping because scim is not available",
+			remaining:   0,
+			wantNilSCIM: true,
+		},
+		{
+			name:        "resp is nil",
+			remaining:   0,
+			wantNilResp: true,
+			wantSubErr:  "error making request to the GitHub API checking rate limit",
+		},
+		{
 			name:       "no header but no remaining scim calls",
 			remaining:  0,
 			wantSubErr: "api rate limit exceeded. Access will be restored at Mon, 01 Jan 0001 00:00:00 UTC",
@@ -958,7 +982,12 @@ func TestProvider_checkWebhookSecretValidity(t *testing.T) {
 		{
 			name:       "api error",
 			wantSubErr: "error making request to the GitHub API checking rate limit",
-			report500:  true,
+			statusCode: http.StatusInternalServerError,
+		},
+		{
+			name:           "not enabled",
+			apiNotEnabled:  true,
+			wantLogSnippet: "skipping checking",
 		},
 		{
 			name:           "not enabled",
@@ -974,14 +1003,15 @@ func TestProvider_checkWebhookSecretValidity(t *testing.T) {
 
 			if !tt.apiNotEnabled {
 				mux.HandleFunc("/rate_limit", func(rw http.ResponseWriter, _ *http.Request) {
-					if tt.report500 {
-						rw.WriteHeader(http.StatusInternalServerError)
+					if tt.statusCode != 0 {
+						rw.WriteHeader(tt.statusCode)
 						return
 					}
-					s := &github.RateLimits{
-						SCIM: &github.Rate{
+					s := &github.RateLimits{}
+					if !tt.wantNilSCIM {
+						s.SCIM = &github.Rate{
 							Remaining: tt.remaining,
-						},
+						}
 					}
 					st := new(struct {
 						Resources *github.RateLimits `json:"resources"`
@@ -996,6 +1026,16 @@ func TestProvider_checkWebhookSecretValidity(t *testing.T) {
 				})
 			}
 			defer teardown()
+
+			// create bad round tripper to make response nil and test that it handles that case.
+			if tt.wantNilResp {
+				errRT := roundTripperFunc(func(*http.Request) (*http.Response, error) {
+					return nil, fmt.Errorf("network down")
+				})
+				httpClient := &http.Client{Transport: errRT}
+				fakeclient = github.NewClient(httpClient)
+			}
+
 			v := &Provider{
 				ghClient: fakeclient,
 				Logger:   logger,

--- a/pkg/provider/gitlab/detect_test.go
+++ b/pkg/provider/gitlab/detect_test.go
@@ -73,6 +73,20 @@ func TestProvider_Detect(t *testing.T) {
 			processReq: true,
 		},
 		{
+			name:       "good/mergeRequest update Event with title",
+			event:      sample.MREventAsJSON("update", `"title": "test"`),
+			eventType:  gitlab.EventTypeMergeRequest,
+			isGL:       true,
+			processReq: false,
+		},
+		{
+			name:       "good/mergeRequest update Event with description",
+			event:      sample.MREventAsJSON("update", `"description": "test pac"`),
+			eventType:  gitlab.EventTypeMergeRequest,
+			isGL:       true,
+			processReq: false,
+		},
+		{
 			name:       "good/note event",
 			event:      sample.NoteEventAsJSON("abc"),
 			eventType:  gitlab.EventTypeNote,

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -329,7 +329,11 @@ func (v *Provider) GetTektonDir(_ context.Context, event *info.Event, path, prov
 		revision = event.DefaultBranch
 		v.Logger.Infof("Using PipelineRun definition from default_branch: %s", event.DefaultBranch)
 	} else {
-		v.Logger.Infof("Using PipelineRun definition from source merge request SHA: %s", event.SHA)
+		trigger := event.TriggerTarget.String()
+		if event.TriggerTarget == triggertype.PullRequest {
+			trigger = "merge request"
+		}
+		v.Logger.Infof("Using PipelineRun definition from source %s on commit SHA: %s", trigger, event.SHA)
 	}
 
 	opt := &gitlab.ListTreeOptions{

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -212,7 +213,7 @@ func (v *Provider) SetClient(_ context.Context, run *params.Run, runevent *info.
 	// if we don't have sourceProjectID (ie: incoming-webhook) then try to set
 	// it ASAP if we can.
 	if v.sourceProjectID == 0 && runevent.Organization != "" && runevent.Repository != "" {
-		projectSlug := filepath.Join(runevent.Organization, runevent.Repository)
+		projectSlug := path.Join(runevent.Organization, runevent.Repository)
 		projectinfo, _, err := v.Client().Projects.GetProject(projectSlug, &gitlab.GetProjectOptions{})
 		if err != nil {
 			return err

--- a/pkg/provider/gitlab/gitlab_test.go
+++ b/pkg/provider/gitlab/gitlab_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	thelp "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/gitlab/test"
 	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
@@ -460,12 +461,13 @@ func TestGetTektonDir(t *testing.T) {
 			wantErr:   "error unmarshalling yaml file pr.yaml: yaml: line 4: could not find expected ':'",
 		},
 		{
-			name:      "list tekton dir",
+			name:      "list tekton dir on pull request",
 			prcontent: string(samplePR),
 			args: args{
 				path: ".tekton",
 				event: &info.Event{
-					HeadBranch: "main",
+					HeadBranch:    "main",
+					TriggerTarget: triggertype.PullRequest,
 				},
 			},
 			fields: fields{
@@ -473,7 +475,24 @@ func TestGetTektonDir(t *testing.T) {
 			},
 			wantClient:           true,
 			wantStr:              "kind: PipelineRun",
-			filterMessageSnippet: `Using PipelineRun definition from source merge request SHA`,
+			filterMessageSnippet: `Using PipelineRun definition from source merge request on commit SHA`,
+		},
+		{
+			name:      "list tekton dir on push",
+			prcontent: string(samplePR),
+			args: args{
+				path: ".tekton",
+				event: &info.Event{
+					HeadBranch:    "main",
+					TriggerTarget: triggertype.Push,
+				},
+			},
+			fields: fields{
+				sourceProjectID: 100,
+			},
+			wantClient:           true,
+			wantStr:              "kind: PipelineRun",
+			filterMessageSnippet: `Using PipelineRun definition from source push on commit SHA`,
 		},
 		{
 			name:      "list tekton dir on default_branch",

--- a/pkg/reconciler/controller.go
+++ b/pkg/reconciler/controller.go
@@ -2,6 +2,7 @@ package reconciler
 
 import (
 	"context"
+	"path"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
@@ -88,7 +89,7 @@ func checkStateAndEnqueue(impl *controller.Impl) func(obj any) {
 func ctrlOpts() func(impl *controller.Impl) controller.Options {
 	return func(_ *controller.Impl) controller.Options {
 		return controller.Options{
-			FinalizerName: pipelinesascode.GroupName,
+			FinalizerName: path.Join(pipelinesascode.GroupName, pipelinesascode.FinalizerName),
 			PromoteFilterFunc: func(obj any) bool {
 				_, exist := obj.(*tektonv1.PipelineRun).GetAnnotations()[keys.State]
 				return exist

--- a/pkg/reconciler/controller_test.go
+++ b/pkg/reconciler/controller_test.go
@@ -2,6 +2,7 @@ package reconciler
 
 import (
 	"context"
+	"path"
 	"testing"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
@@ -63,7 +64,7 @@ func TestCtrlOpts(t *testing.T) {
 	opts := ctrlOpts()(impl)
 
 	// Assert that the finalizer name is set correctly.
-	assert.Equal(t, pipelinesascode.GroupName, opts.FinalizerName)
+	assert.Equal(t, path.Join(pipelinesascode.GroupName, pipelinesascode.FinalizerName), opts.FinalizerName)
 
 	// Create a new PipelineRun object with the "started" state label.
 	pr := &pipelinev1.PipelineRun{

--- a/pkg/secrets/types/types.go
+++ b/pkg/secrets/types/types.go
@@ -1,3 +1,4 @@
+//revive:disable-next-line:var-naming
 package types
 
 type SecretValue struct {

--- a/test/bitbucket_datacenter_pull_request_test.go
+++ b/test/bitbucket_datacenter_pull_request_test.go
@@ -9,12 +9,17 @@ import (
 	"os"
 	"testing"
 
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	tbbdc "github.com/openshift-pipelines/pipelines-as-code/test/pkg/bitbucketdatacenter"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
 
+	"github.com/jenkins-x/go-scm/scm"
 	"github.com/tektoncd/pipeline/pkg/names"
 	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestBitbucketDataCenterPullRequest(t *testing.T) {
@@ -35,9 +40,11 @@ func TestBitbucketDataCenterPullRequest(t *testing.T) {
 		files[fmt.Sprintf(".tekton/pipelinerun-%d.yaml", i)] = "testdata/pipelinerun.yaml"
 	}
 
+	files, err = payload.GetEntries(files, targetNS, options.MainBranch, triggertype.PullRequest.String(), map[string]string{})
+	assert.NilError(t, err)
+
 	pr := tbbdc.CreatePR(ctx, t, client, runcnx, opts, repo, files, bitbucketWSOwner, targetNS)
-	runcnx.Clients.Log.Infof("Pull Request with title '%s' is created", pr.Title)
-	defer tbbdc.TearDown(ctx, t, runcnx, client, pr.Number, bitbucketWSOwner, targetNS)
+	defer tbbdc.TearDown(ctx, t, runcnx, client, pr, bitbucketWSOwner, targetNS)
 
 	successOpts := wait.SuccessOpt{
 		TargetNS:        targetNS,
@@ -64,9 +71,11 @@ func TestBitbucketDataCenterCELPathChangeInPullRequest(t *testing.T) {
 		".tekton/pipelinerun.yaml": "testdata/pipelinerun-cel-path-changed.yaml",
 	}
 
+	files, err = payload.GetEntries(files, targetNS, options.MainBranch, triggertype.PullRequest.String(), map[string]string{})
+	assert.NilError(t, err)
+
 	pr := tbbdc.CreatePR(ctx, t, client, runcnx, opts, repo, files, bitbucketWSOwner, targetNS)
-	runcnx.Clients.Log.Infof("Pull Request with title '%s' is created", pr.Title)
-	defer tbbdc.TearDown(ctx, t, runcnx, client, pr.Number, bitbucketWSOwner, targetNS)
+	defer tbbdc.TearDown(ctx, t, runcnx, client, pr, bitbucketWSOwner, targetNS)
 
 	successOpts := wait.SuccessOpt{
 		TargetNS:        targetNS,
@@ -75,4 +84,65 @@ func TestBitbucketDataCenterCELPathChangeInPullRequest(t *testing.T) {
 		MinNumberStatus: 1,
 	}
 	wait.Succeeded(ctx, t, runcnx, opts, successOpts)
+}
+
+func TestBitbucketDataCenterOnPathChangeAnnotationOnPRMerge(t *testing.T) {
+	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
+	// this would be a temporary base branch for the pull request we're going to raise
+	// we need this because we're going to merge the pull request so that after test
+	// we can delete the temporary base branch and our main branch should not be affected
+	// by this merge because we run the E2E frequently.
+	tempBaseBranch := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
+
+	ctx := context.Background()
+	bitbucketWSOwner := os.Getenv("TEST_BITBUCKET_SERVER_E2E_REPOSITORY")
+
+	ctx, runcnx, opts, client, err := tbbdc.Setup(ctx)
+	assert.NilError(t, err)
+
+	repo := tbbdc.CreateCRD(ctx, t, client, runcnx, bitbucketWSOwner, targetNS)
+	runcnx.Clients.Log.Infof("Repository %s has been created", repo.Name)
+	defer tbbdc.TearDownNs(ctx, t, runcnx, targetNS)
+
+	branch, resp, err := client.Git.CreateRef(ctx, bitbucketWSOwner, tempBaseBranch, repo.Branch)
+	assert.NilError(t, err, "error creating branch: http status code: %d : %v", resp.Status, err)
+	runcnx.Clients.Log.Infof("Base branch %s has been created", branch.Name)
+
+	opts.BaseBranch = branch.Name
+
+	if os.Getenv("TEST_NOCLEANUP") != "true" {
+		defer func() {
+			_, err := client.Git.DeleteRef(ctx, bitbucketWSOwner, tempBaseBranch)
+			assert.NilError(t, err, "error deleting branch: http status code: %d : %v", resp.Status, err)
+		}()
+	}
+
+	files := map[string]string{
+		".tekton/pr.yaml":       "testdata/pipelinerun-on-path-change.yaml",
+		"doc/foo/bar/README.md": "README.md",
+	}
+
+	files, err = payload.GetEntries(files, targetNS, tempBaseBranch, triggertype.Push.String(), map[string]string{})
+	assert.NilError(t, err)
+
+	pr := tbbdc.CreatePR(ctx, t, client, runcnx, opts, repo, files, bitbucketWSOwner, targetNS)
+	defer tbbdc.TearDown(ctx, t, runcnx, client, nil, bitbucketWSOwner, targetNS)
+
+	// merge the pull request so that we can get push event.
+	_, err = client.PullRequests.Merge(ctx, bitbucketWSOwner, pr.Number, &scm.PullRequestMergeOptions{})
+	assert.NilError(t, err)
+
+	successOpts := wait.SuccessOpt{
+		TargetNS:        targetNS,
+		OnEvent:         triggertype.Push.String(),
+		NumberofPRMatch: 1,
+		MinNumberStatus: 1,
+	}
+	wait.Succeeded(ctx, t, runcnx, opts, successOpts)
+
+	pipelineRuns, err := runcnx.Clients.Tekton.TektonV1().PipelineRuns(targetNS).List(ctx, metav1.ListOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, len(pipelineRuns.Items), 1)
+	// check that pipeline run contains on-path-change annotation.
+	assert.Equal(t, pipelineRuns.Items[0].GetAnnotations()[keys.OnPathChange], "[doc/***.md]")
 }

--- a/test/bitbucket_datacenter_push_test.go
+++ b/test/bitbucket_datacenter_push_test.go
@@ -39,7 +39,7 @@ func TestBitbucketDataCenterCELPathChangeOnPush(t *testing.T) {
 	branch, resp, err := client.Git.CreateRef(ctx, bitbucketWSOwner, targetNS, mainBranchRef)
 	assert.NilError(t, err, "error creating branch: http status code: %d : %v", resp.Status, err)
 	runcnx.Clients.Log.Infof("Branch %s has been created", branch.Name)
-	defer tbbs.TearDown(ctx, t, runcnx, client, -1, bitbucketWSOwner, branch.Name)
+	defer tbbs.TearDown(ctx, t, runcnx, client, nil, bitbucketWSOwner, branch.Name)
 
 	files, err = payload.GetEntries(files, targetNS, branch.Name, triggertype.Push.String(), map[string]string{})
 	assert.NilError(t, err)

--- a/test/pkg/bitbucketdatacenter/pr.go
+++ b/test/pkg/bitbucketdatacenter/pr.go
@@ -6,9 +6,7 @@ import (
 	"testing"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
-	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/scm"
 
 	goscm "github.com/jenkins-x/go-scm/scm"
@@ -16,21 +14,24 @@ import (
 )
 
 func CreatePR(ctx context.Context, t *testing.T, client *goscm.Client, runcnx *params.Run, opts options.E2E, repo *goscm.Repository, files map[string]string, orgAndRepo, targetNS string) *goscm.PullRequest {
-	mainBranchRef := "refs/heads/main"
-	branch, resp, err := client.Git.CreateRef(ctx, orgAndRepo, targetNS, mainBranchRef)
+	baseBranchRef := repo.Branch
+	if opts.BaseBranch != "" {
+		baseBranchRef = opts.BaseBranch
+	}
+
+	branch, resp, err := client.Git.CreateRef(ctx, orgAndRepo, targetNS, baseBranchRef)
 	assert.NilError(t, err, "error creating branch: http status code: %d : %v", resp.Status, err)
 	runcnx.Clients.Log.Infof("Branch %s has been created", branch.Name)
 
-	files, err = payload.GetEntries(files, targetNS, options.MainBranch, triggertype.PullRequest.String(), map[string]string{})
-	assert.NilError(t, err)
 	gitCloneURL, err := scm.MakeGitCloneURL(repo.Clone, opts.UserName, opts.Password)
 	assert.NilError(t, err)
+
 	scmOpts := &scm.Opts{
 		GitURL:        gitCloneURL,
 		Log:           runcnx.Clients.Log,
 		WebURL:        repo.Clone,
 		TargetRefName: targetNS,
-		BaseRefName:   repo.Branch,
+		BaseRefName:   baseBranchRef,
 		CommitTitle:   fmt.Sprintf("commit %s", targetNS),
 	}
 	scm.PushFilesToRefGit(t, scmOpts, files)
@@ -41,9 +42,10 @@ func CreatePR(ctx context.Context, t *testing.T, client *goscm.Client, runcnx *p
 		Title: title,
 		Body:  "Test PAC on bitbucket data center",
 		Head:  targetNS,
-		Base:  "main",
+		Base:  baseBranchRef,
 	}
 	pr, resp, err := client.PullRequests.Create(ctx, orgAndRepo, prOpts)
 	assert.NilError(t, err, "error creating pull request: http status code: %d : %v", resp.Status, err)
+	runcnx.Clients.Log.Infof("Created Pull Request with Title '%s'. Head branch '%s' ⮕ Base Branch '%s'", pr.Title, pr.Head.Ref, pr.Base.Ref)
 	return pr
 }

--- a/test/pkg/bitbucketdatacenter/setup.go
+++ b/test/pkg/bitbucketdatacenter/setup.go
@@ -82,15 +82,16 @@ func TearDownNs(ctx context.Context, t *testing.T, runcnx *params.Run, targetNS 
 	repository.NSTearDown(ctx, t, runcnx, targetNS)
 }
 
-func TearDown(ctx context.Context, t *testing.T, runcnx *params.Run, client *scm.Client, prID int, orgAndRepo, ref string) {
+func TearDown(ctx context.Context, t *testing.T, runcnx *params.Run, client *scm.Client, pr *scm.PullRequest, orgAndRepo, ref string) {
 	if os.Getenv("TEST_NOCLEANUP") == "true" {
 		runcnx.Clients.Log.Infof("Not cleaning up and closing PR since TEST_NOCLEANUP is set")
 		return
 	}
 
-	if prID != -1 {
-		runcnx.Clients.Log.Infof("Deleting PR #%d", prID)
-		_, err := client.PullRequests.DeletePullRequest(ctx, orgAndRepo, prID)
+	// in Bitbucket Data Center, merged pull requests cannot be deleted.
+	if pr != nil && !pr.Merged {
+		runcnx.Clients.Log.Infof("Deleting PR #%d", pr.Number)
+		_, err := client.PullRequests.DeletePullRequest(ctx, orgAndRepo, pr.Number)
 		assert.NilError(t, err)
 	}
 

--- a/test/pkg/options/options.go
+++ b/test/pkg/options/options.go
@@ -4,6 +4,7 @@ import "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascod
 
 type E2E struct {
 	Repo, Organization string
+	BaseBranch         string
 	DirectWebhook      bool
 	ProjectID          int
 	ControllerURL      string

--- a/test/testdata/TestGithubSecondPullRequestBadYaml.golden
+++ b/test/testdata/TestGithubSecondPullRequestBadYaml.golden
@@ -3,4 +3,4 @@
 
 | PipelineRun | Error |
 |------|-------|
-| bad-yaml.yaml | `line 3: could not find expected ':'` |
+| bad-yaml.yaml | `yaml validation error: line 3: could not find expected ':'` |

--- a/test/testdata/randomcrd.yaml
+++ b/test/testdata/randomcrd.yaml
@@ -1,0 +1,6 @@
+apiVersion: blah.openshift.io/v1
+kind: Blahblah
+metadata:
+  name: blahblah
+spec:
+  blah: blah


### PR DESCRIPTION
# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

This Pull Request tests the v0.35.2 release.

## Includes Commits:

40beb7d03 fix(github): guard checkWebhookSecretValidity against nil response
7a8ad7660 chore: Make go-testing PipelineRun targeted by all branches
9e4dc3539 fix(ci): golangci-lint revive var-naming error in linters
cc3867487 fix: use correct event type in log in GetTektonDir func
c64cc7193 fix: migrate from brews to homebrew_casks in goreleaser
656a92b98 fix: issue in on-path-change on pr merge in bitbucket data center
68a9cc197 fix: inavlidate empty commits in push events in bitbucket dc
bf79d8255 fix: handle response body close errors
71c4390f2 fix: avoid reporting errors for non-Tekton res
4220e6d41 fix: add timeouts to HTTP server
4988cb492 fix: Split error message of yaml validation on push
1a5f4da74 fix(gitlab): trigger PipelineRun only on label change
a80121084 chore: Update controller finalizer name to include explicit part

