### PR TITLE
chore: Make go-testing PipelineRun targeted by all branches

### DIFF
--- a/.tekton/go.yaml
+++ b/.tekton/go.yaml
@@ -7,7 +7,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "2"
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/on-event: "pull_request"
-    pipelinesascode.tekton.dev/on-target-branch: "main"
+    pipelinesascode.tekton.dev/on-target-branch: "[*]"
     pipelinesascode.tekton.dev/on-path-change: "[***/*.go]"
 spec:
   params:


### PR DESCRIPTION
this commits changes value of `on-target-branch` annotation in go-testing PipelineRun to make it be triggered on pull requests when any branch is targeted in the PaC repo as [linters PipelineRun](https://github.com/openshift-pipelines/pipelines-as-code/blob/7340740b8acc4f40fdb402098d06913b0c99fa6e/.tekton/linter.yaml#L8) does. when PR #2156 is raised, go-testing wasn't triggered because target branch in the PR is release-v0.35.x.

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [x] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [x] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [x] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).