### PR TITLE
refactor: Use Client Function for API Call in ParsePayload

### DIFF
--- a/pkg/provider/github/parse_payload.go
+++ b/pkg/provider/github/parse_payload.go
@@ -233,7 +233,7 @@ func (v *Provider) getPullRequestsWithCommit(ctx context.Context, sha, org, repo
 
 	for {
 		// Use the "List pull requests associated with a commit" API to check if the commit is part of any open PR
-		prs, resp, err := v.ghClient.PullRequests.ListPullRequestsWithCommit(ctx, org, repo, sha, opts)
+		prs, resp, err := v.Client().PullRequests.ListPullRequestsWithCommit(ctx, org, repo, sha, opts)
 		if err != nil {
 			// Log the error for debugging purposes
 			v.Logger.Debugf("Failed to list pull requests for commit %s in %s/%s: %v", sha, org, repo, err)


### PR DESCRIPTION
This commit refactors the direct API call made using the ghClient variable in ParsePayload.go to instead use the standardized Provider.Client function. This change ensures consistency across API interactions and enables proper metrics recording for all GitHub API calls.

# Changes <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

- [x] 📝 Ensure your commit message is clear and informative. Refer to the How to write a git commit message guide. Include the commit message in the PR body rather than linking to an external site (e.g., Jira ticket).

- [x] ♽ Run make test lint before submitting a PR to avoid unnecessary CI processing. Consider installing [pre-commit](https://pre-commit.com/) and running pre-commit install in the repository root for an efficient workflow.

- [x] ✨ We use linters to maintain clean and consistent code. Run make lint before submitting a PR. Some linters offer a --fix mode, executable with make fix-linters (ensure [markdownlint](https://github.com/DavidAnson/markdownlint) and [golangci-lint](https://github.com/golangci/golangci-lint) are installed).

- If adding a provider feature, fill in the following details:

  - [x] GitHub App
  - [x] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center

  (update the provider documentation accordingly)
