### PR TITLE
(chore) ADD LLM Development Rules for PAC

### DIFF
--- a/.cursor/rules/architecture.mdc
+++ b/.cursor/rules/architecture.mdc
@@ -1,0 +1,9 @@
+---
+description: Architecture and Targets
+alwaysApply: false
+---
+# Architecture and Targets
+
+- The project targets both arm64 and amd64 architectures
+- Use `ko` for building container images in development
+- The project uses Tekton pipelines and integrates with multiple Git providers (GitHub, GitLab, Bitbucket, Gitea)

--- a/.cursor/rules/code-formatting.mdc
+++ b/.cursor/rules/code-formatting.mdc
@@ -1,0 +1,11 @@
+---
+description: Code formatting rules for the project.
+alwaysApply: false
+---
+# Code Quality and Formatting
+
+- Always run `make fumpt` after writing Go code to ensure proper formatting
+- Use `make fix-linters` to automatically fix most linting issues
+- Run `make check` to verify both linting and tests pass before committing
+- For markdown files, use `make fix-markdownlint` to fix formatting issues
+- Use `make fix-trailing-spaces` to clean up trailing whitespace in markdown and yaml files

--- a/.cursor/rules/dependencies.mdc
+++ b/.cursor/rules/dependencies.mdc
@@ -1,0 +1,10 @@
+---
+description: Dependencies and Modules
+alwaysApply: false
+---
+# Dependencies and Modules
+
+- Always run `make vendor` after adding new dependencies
+- Check for and remove unnecessary `replace` clauses in go.mod
+- Update Go version to match the latest RHEL version when needed
+- Use `go mod tidy -go=1.20` (or appropriate version) to update Go version

--- a/.cursor/rules/documentation.mdc
+++ b/.cursor/rules/documentation.mdc
@@ -1,0 +1,10 @@
+---
+description: Writting documentation
+alwaysApply: false
+---
+# Documentation
+
+- Use `make dev-docs` to preview documentation changes locally at <http://localhost:1313>
+- Documentation uses Hugo with the hugo-book theme
+- Use the custom shortcodes like `tech_preview` and `support_matrix` for feature documentation
+- Follow the documentation guidelines in the developer docs

--- a/.cursor/rules/e2e-testing.mdc
+++ b/.cursor/rules/e2e-testing.mdc
@@ -1,0 +1,9 @@
+---
+description: E2E testing rules
+alwaysApply: false
+---
+# E2E Testing
+
+- Always ask the user to run the e2e tests manually and copy the output. Since
+  E2E tests require specific setup and environment variables
+- Gitea tests are the most comprehensive and self-contained

--- a/.cursor/rules/git-commit-format.mdc
+++ b/.cursor/rules/git-commit-format.mdc
@@ -1,0 +1,153 @@
+---
+description: Git commit message formatting rules, for use when generating commit messages
+alwaysApply: false
+---
+# Commit Message Formatting Rules
+
+**When to apply**: When generating commit messages or discussing commit practices
+
+**Description**: Rules for formatting commit messages with conventional commits and Jira issue integration
+
+## Commit Message Format
+
+Use conventional commits format:
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+Signed-off-by: <name> <email>
+Assisted-by: <model-name> (via Cursor)
+```
+
+## Line Length Requirements
+
+Follow conventional commit line length standards:
+
+- **Subject line**: Maximum 50 characters (hard limit: 72 characters)
+- **Body**: Wrap at 72 characters per line
+- **Blank line**: Always include blank line between subject and body
+- **Footer**: Each footer on separate line
+
+## Scope Rules
+
+1. **For branches with Jira issues** (pattern: `SRVKP-XXX-description` or `OCP-XXX-description`):
+   - Extract Jira issue number using regex: `[A-Z]{2,}-[0-9]+`
+   - Use as scope: `feat(SRVKP-123): description`
+
+2. **For main/master branches or non-Jira branches**:
+   - Ask user for Jira issue number
+   - Look up issue on issues.redhat.com using web search
+   - Use component name as fallback: `feat(webhook)`, `fix(controller)`, `docs(README)`
+
+## Commit Types
+
+- **feat**: New features
+- **fix**: Bug fixes  
+- **docs**: Documentation changes
+- **style**: Code style changes
+- **refactor**: Code refactoring
+- **test**: Adding/updating tests
+- **chore**: Maintenance tasks
+- **build**: Build system or dependencies
+- **ci**: CI/CD changes
+- **perf**: Performance improvements
+- **revert**: Revert previous commit
+
+## Required Footers
+
+### Signed-off-by
+
+- Always include: `Signed-off-by: <name> <email>`
+- Get name and email using this priority order:
+  1. Environment variables: `$GIT_AUTHOR_NAME` and `$GIT_AUTHOR_EMAIL`
+  2. Git config: `git config user.name` and `git config user.email`
+  3. If neither configured, ask user to provide details
+- Common in dev containers: environment variables are preferred method
+
+### Assisted-by
+
+- Always include: `Assisted-by: <model-name> (via Cursor)`
+- Format examples:
+  - `Assisted-by: Claude-3.5-Sonnet (via Cursor)`
+  - `Assisted-by: Gemini (via Cursor)`
+- Use the actual model name being used for the commit message generation
+
+## Examples
+
+```bash
+feat(SRVKP-123): Add webhook controller for GitHub integration
+
+Signed-off-by: Developer Name <developer@redhat.com>
+Assisted-by: Claude-3.5-Sonnet (via Cursor)
+```
+
+```bash
+fix(controller): Update pipeline reconciliation logic
+
+Resolves issue with concurrent pipeline runs
+
+Signed-off-by: Developer Name <developer@redhat.com>
+Assisted-by: Claude-3.5-Sonnet (via Cursor)
+```
+
+## Auto-Detection Rules
+
+When generating commit messages:
+
+1. Check current branch name for Jira issue pattern
+2. If no Jira issue in branch, ask user for issue number
+3. Look up issue details on issues.redhat.com if provided
+4. Analyze staged files to determine commit type
+5. Generate appropriate scope and description
+6. Detect author info from environment variables ($GIT_AUTHOR_NAME, $GIT_AUTHOR_EMAIL) or git config
+7. Ensure subject line is ≤50 characters (max 72 characters)
+8. Wrap body text at 72 characters per line
+9. Add required footers (Signed-off-by and Assisted-by)
+10. Format according to conventional commits standard
+
+## Commit Process
+
+**IMPORTANT**: Always ask for user confirmation before executing `git commit`:
+
+1. **Generate** the commit message following the rules above
+2. **Display** the generated commit message to the user
+3. **Ask for confirmation**: "Should I commit with this message? (y/n)"
+4. **Wait for user response** before running `git commit`
+5. **Only commit** if user confirms with "yes", "y", or similar affirmative response
+
+**Example interaction:**
+
+```
+Generated commit message:
+---
+feat(SRVKP-456): ensure webhook logs output to stdout
+
+Configure webhook controller to direct all logs to stdout for container compatibility
+
+Signed-off-by: Developer Name <developer@redhat.com>
+Assisted-by: Claude-3.5-Sonnet (via Cursor)
+---
+
+Should I commit with this message? (y/n)
+```
+
+## Jira Issue Lookup Process
+
+When no Jira issue is found in branch name:
+
+1. Ask user: "What Jira issue number should I use for this commit?"
+2. If provided, search issues.redhat.com for issue details
+3. Use issue summary and description to enhance commit message
+4. Suggest creating a new branch if desired
+
+## Gitlint Integration
+
+- The project uses gitlint to enforce commit message format
+- Ensure all commit messages pass gitlint validation
+- Common gitlint rules to follow:
+  - Conventional commit format
+  - Proper line length limits
+  - Required footers
+  - No trailing whitespace

--- a/.cursor/rules/pre-commit.mdc
+++ b/.cursor/rules/pre-commit.mdc
@@ -1,0 +1,9 @@
+---
+description: Pre-commit and Quality Gates
+alwaysApply: false
+---
+- Install pre-commit hooks with `pre-commit install` to ensure code quality
+- The project uses multiple linters: golangci-lint, yamllint, markdownlint, ruff, shellcheck, vale, codespell
+- Pre-commit hooks run automatically on push, but can be skipped with `git push --no-verify`
+- Use `SKIP=hook-name git push` to skip specific hooks
+

--- a/.cursor/rules/testing-quality.mdc
+++ b/.cursor/rules/testing-quality.mdc
@@ -1,0 +1,14 @@
+---
+description: Testing and Quality Assurance
+alwaysApply: false
+---
+
+- if you need to run test, run the test with `make test`
+- if you need to run the linter, run the linter with `make lint`
+- every time you write go code, make sure to run `make fumpt` to reformat the code
+- every time you write markdown make sure to do a `make fix-markdownlint` to fix the markdown
+- if you need to add a dependency, use `go get -u dependency` and make sure to run `make vendor` afterwards or it would not work.
+- do not try to run the e2e tests in tests/ there is a bunch of pre-requisites
+that need to be set up. Ask the user to run the e2e tests manually and copy the
+output.
+- When writing unit tests, always use `gotest.tools/v3` and never use other libraries like testify

--- a/.cursor/rules/useful-commands.mdc
+++ b/.cursor/rules/useful-commands.mdc
@@ -1,0 +1,18 @@
+---
+description: Useful commands for building and testing the project.
+alwaysApply: false
+---
+
+- `make help` - Show all available make targets
+- `make all` - Build all binaries, run tests and lint
+- `make html-coverage` - Generate HTML test coverage report
+- `make test-no-cache` - Run tests without caching
+- `make clean` - Clean build artifacts
+
+# Useful Commands
+
+- `make help` - Show all available make targets
+- `make all` - Build all binaries, run tests and lint
+- `make html-coverage` - Generate HTML test coverage report
+- `make test-no-cache` - Run tests without caching
+- `make clean` - Clean build artifacts

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,8 +1,9 @@
 {
-    "line-length": false,
-    "first-header-h1": false,
-    "no-inline-html": false,
-    "MD013": false,
-    "MD025": false,
-    "descriptive-link-text": false
+  "line-length": false,
+  "first-header-h1": false,
+  "first-line-h1": false,
+  "no-inline-html": false,
+  "MD013": false,
+  "MD025": false,
+  "descriptive-link-text": false
 }

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+@file .cursor/rules/*


### PR DESCRIPTION
This pull request introduces a comprehensive set of rules and guidelines for various aspects of the project, including architecture, code formatting, dependencies, documentation, testing, commit message formatting, pre-commit hooks, and useful commands. These changes aim to standardize practices, improve code quality, and streamline development workflows. Below is a summary of the most important changes grouped by theme.

### Architecture and Build Guidelines
* Added architecture rules targeting both `arm64` and `amd64`, and specified the use of `ko` for building container images in development. Integrated Tekton pipelines with multiple Git providers. (`.cursor/rules/architecture.mdc`, [.cursor/rules/architecture.mdcR1-R9](diffhunk://#diff-0b3f9e5f87f7d84205bb8db1e12736fd22601e4e227a7a058a03f4c7d2a06f36R1-R9))

### Code Quality and Formatting
* Introduced rules for Go code formatting (`make fumpt`), linting (`make fix-linters`), and markdown formatting (`make fix-markdownlint`). Ensured quality checks with `make check` before committing. (`.cursor/rules/code-formatting.mdc`, [.cursor/rules/code-formatting.mdcR1-R11](diffhunk://#diff-f40821eea979f2bcf66a8216560876836926ec6463f3112c8634f87d27fe9226R1-R11))

### Dependencies Management
* Established guidelines for managing Go dependencies, including running `make vendor` after adding dependencies and using `go mod tidy` to update Go versions. (`.cursor/rules/dependencies.mdc`, [.cursor/rules/dependencies.mdcR1-R10](diffhunk://#diff-c3a9f5eb5e253926375c8b3b03f3e7fdfee9b08205d91c8c1924cb45425c05f1R1-R10))

### Commit Message Standards
* Defined comprehensive commit message formatting rules using conventional commits and Jira issue integration. Included guidelines for scopes, types, and required footers like `Signed-off-by` and `Assisted-by`. (`.cursor/rules/git-commit-format.mdc`, [.cursor/rules/git-commit-format.mdcR1-R153](diffhunk://#diff-1d09bacf532fe7f6f767aea7974bbe751bc82d2f3e00975114f53b137418d194R1-R153))

### Testing and Quality Assurance
* Added rules for running unit tests with `gotest.tools/v3`, handling e2e tests manually due to prerequisites, and using `make test` and `make lint` for testing and linting. (`.cursor/rules/testing-quality.mdc`, [.cursor/rules/testing-quality.mdcR1-R14](diffhunk://#diff-15ad6c1b043653b2689a8dd108f39c7fdd0b83a01fa87c12bd479a9481a9ee5cR1-R14))