### PR TITLE
chore: trigger E2E tests only on workflows change

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -21,7 +21,7 @@ on:
       - synchronize
     paths:
       - "**.go"
-      - ".github/**"
+      - ".github/workflows/**"
       - "test/testdata/**"
 
 jobs:


### PR DESCRIPTION
changed e2e trigger path from all inside .github to only .github/workflow