### PR TITLE
fix: Improve handling of missing .tekton directory for ok-to-test events

### DIFF
--- a/docs/content/docs/guide/gitops_commands.md
+++ b/docs/content/docs/guide/gitops_commands.md
@@ -262,8 +262,7 @@ Here are the possible event types:
 * `cancel-comment`: The event is a `/cancel <PipelineRun>` that would cancel a specific PipelineRun.
 * `ok-to-test-comment`: The event is a `/ok-to-test` that would allow running the CI for an unauthorized user.
 
-When a repository owner issues the `/ok-to-test` command on a pull request raised by an unauthorized user, and no PipelineRun exists in the .tekton directory for `pull_request` event,
-Pipelines-as-Code will create a neutral check-run status. This status serves to indicate that no PipelineRun has been matched, preventing any workflows from being blocked such as auto-merge, will proceed as expected.
+If a repository owner comments `/ok-to-test` on a pull request from an external contributor but no PipelineRun **matches** the `pull_request` event (or the repository has no `.tekton` directory), Pipelines-as-Code sets a **neutral** commit status. This indicates that no PipelineRun was matched, allowing other workflows—such as auto-merge—to proceed without being blocked.
 
 {{< hint info >}}
 

--- a/pkg/pipelineascode/errors.go
+++ b/pkg/pipelineascode/errors.go
@@ -13,11 +13,14 @@ import (
 	"go.uber.org/zap"
 )
 
-const validationErrorTemplate = `> [!CAUTION]
+const (
+	validationErrorTemplate = `> [!CAUTION]
 > There are some errors in your PipelineRun template.
 
 | PipelineRun | Error |
 |------|-------|`
+	tektonDirMissingError = ".tekton/ directory doesn't exist in repository's root directory"
+)
 
 var regexpIgnoreErrors = regexp.MustCompile(`.*no kind.*is registered for version.*in scheme.*`)
 

--- a/pkg/pipelineascode/match_test.go
+++ b/pkg/pipelineascode/match_test.go
@@ -234,6 +234,19 @@ func TestGetPipelineRunsFromRepo(t *testing.T) {
 			expectedNumberOfPruns: 0,
 			event:                 okToTestEvent,
 		},
+		{
+			name: "no .tekton dir in repository",
+			repositories: &v1alpha1.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testrepo",
+					Namespace: "test",
+				},
+				Spec: v1alpha1.RepositorySpec{},
+			},
+			tektondir:             "testdata/no_tekton_dir",
+			expectedNumberOfPruns: 0,
+			event:                 okToTestEvent,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/pipelineascode/testdata/no_tekton_dir/.gitkeep
+++ b/pkg/pipelineascode/testdata/no_tekton_dir/.gitkeep
@@ -1,0 +1,1 @@
+we need this file in order to keep no_tekton_dir folder otherwise git ignores it.


### PR DESCRIPTION
Before this, if a repository doesn't have .tekton directory and a pull request is opened by unauthorized user, PaC first creates a pending check but when admin is making `/ok-to-test` comment, the pending check wasn't clearing because  it was returned just after `GetTektonDir` call. we had added the logic to clear pending check when there is no matching PipelineRun found in [getPipelineRunsFromRepo](https://github.com/openshift-pipelines/pipelines-as-code/blob/fdd654988d9f3d8b0ce456b4721bee10ab2b642c/pkg/pipelineascode/match.go#L171) (see #1899 PR) but in this case when .tekton dir doesn't exist, it was **not** reaching [that clearing logic](https://github.com/openshift-pipelines/pipelines-as-code/blob/fdd654988d9f3d8b0ce456b4721bee10ab2b642c/pkg/pipelineascode/match.go#L282) rather it was returning just after GetTektonDir func call, leaving pending check as it is.

- Update getPipelineRunsFromRepo to create a neutral status with specific messaging when .tekton directory is missing during ok-to-test events, clarifying that the directory doesn't exist in the repository's root.

- Adjust error logging for push events to handle empty rawTemplates case without creating comments, ensuring consistent behavior across event types.

- Modify unit tests in match_test.go to cover the new missing .tekton directory scenario, including a new test case using "testdata/no_tekton_dir" and removing unnecessary status expectation fields for simplicity.

## 📝 Description of the Change

<!--- Take all comments into account and provide a detailed description of the change. -->

## 🔗 Linked GitHub Issue

Fixes #

## 👨🏻‍ Linked Jira
https://issues.redhat.com/browse/SRVKP-7680

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

- [x] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)

<!-- (update the title of the Pull Request accordingly) -->

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
