### PR TITLE
fix(ci): use exec.CommandContext to satisfy `noctx` linter

### DIFF
--- a/pkg/cli/browser/browser.go
+++ b/pkg/cli/browser/browser.go
@@ -1,12 +1,13 @@
 package browser
 
 import (
+	"context"
 	"os/exec"
 	"runtime"
 )
 
 // OpenWebBrowser opens the specified URL in the default browser of the user.
-func OpenWebBrowser(url string) error {
+func OpenWebBrowser(ctx context.Context, url string) error {
 	var cmd string
 
 	args := []string{}
@@ -21,5 +22,5 @@ func OpenWebBrowser(url string) error {
 	}
 
 	args = append(args, url)
-	return exec.Command(cmd, args...).Start()
+	return exec.CommandContext(ctx, cmd, args...).Start()
 }

--- a/pkg/cmd/tknpac/bootstrap/web.go
+++ b/pkg/cmd/tknpac/bootstrap/web.go
@@ -45,7 +45,7 @@ func startWebServer(ctx context.Context, opts *bootstrapOpts, run *params.Run, j
 		url := fmt.Sprintf("http://localhost:%d", opts.webserverPort)
 		fmt.Fprintf(opts.ioStreams.Out, "🌍 Starting a web browser on %s, click on the button to create your GitHub APP\n", url)
 		//nolint:errcheck
-		go browser.OpenWebBrowser(url)
+		go browser.OpenWebBrowser(ctx, url)
 		if err := s.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.Fatal(err)
 		}

--- a/pkg/cmd/tknpac/completion/completion.go
+++ b/pkg/cmd/tknpac/completion/completion.go
@@ -1,6 +1,7 @@
 package completion
 
 import (
+	"context"
 	"os/exec"
 	"strings"
 
@@ -10,7 +11,7 @@ import (
 // GetObjectsWithKubectl return completions with kubectl, we are doing this with
 // kubectl since we have caching and without it completion is way too slow.
 func GetObjectsWithKubectl(obj string) []string {
-	out, err := exec.Command("kubectl", "get", obj, "-o=jsonpath={range .items[*]}{.metadata.name} {end}").Output()
+	out, err := exec.CommandContext(context.Background(), "kubectl", "get", obj, "-o=jsonpath={range .items[*]}{.metadata.name} {end}").Output()
 	if err != nil {
 		return nil
 	}

--- a/pkg/cmd/tknpac/logs/logs.go
+++ b/pkg/cmd/tknpac/logs/logs.go
@@ -238,12 +238,12 @@ func log(ctx context.Context, lo *logOption) error {
 	replyName := strings.Fields(replyString)[0]
 
 	if lo.webBrowser {
-		return showLogsWithWebConsole(lo, replyName)
+		return showLogsWithWebConsole(ctx, lo, replyName)
 	}
 	return showlogswithtkn(lo.tknPath, replyName, lo.cs.Info.Kube.Namespace)
 }
 
-func showLogsWithWebConsole(lo *logOption, pr string) error {
+func showLogsWithWebConsole(ctx context.Context, lo *logOption, pr string) error {
 	if os.Getenv("PAC_TEKTON_DASHBOARD_URL") != "" {
 		lo.cs.Clients.SetConsoleUI(&consoleui.TektonDashboard{BaseURL: os.Getenv("PAC_TEKTON_DASHBOARD_URL")})
 	}
@@ -254,7 +254,7 @@ func showLogsWithWebConsole(lo *logOption, pr string) error {
 			Namespace: lo.cs.Info.Kube.Namespace,
 		},
 	}
-	return browser.OpenWebBrowser(lo.cs.Clients.ConsoleUI().DetailURL(prObj))
+	return browser.OpenWebBrowser(ctx, lo.cs.Clients.ConsoleUI().DetailURL(prObj))
 }
 
 func showlogswithtkn(tknPath, pr, ns string) error {

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -24,7 +25,7 @@ func RunGit(dir string, args ...string) (string, error) {
 	// insert in args "-c", "gitcommit.gpgsign=false" at the beginning gpg sign when set in user
 	args = append([]string{"-c", "commit.gpgsign=false"}, args...)
 
-	c := exec.Command(gitPath, args...)
+	c := exec.CommandContext(context.Background(), gitPath, args...)
 	c.Env = []string{
 		"PATH=" + os.Getenv("PATH"),
 		"HOME=" + os.Getenv("HOME"),


### PR DESCRIPTION
## 📝 Description of the Change

Replaced all direct calls to exec.Command with the context-aware
exec.CommandContext across CLI utilities and helper packages.

## 🚀 Type of Change

- [x] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)

<!-- (update the title of the Pull Request accordingly) -->

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
