### PR TITLE
chore: Add PipelineRun status in logs when creating PipelineRun

### DIFF
--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -213,8 +213,8 @@ func (p *PacRun) startPR(ctx context.Context, match matcher.Match) (*tektonv1.Pi
 	}
 
 	// Create status with the log url
-	p.logger.Infof("pipelinerun %s has been created in namespace %s for SHA: %s Target Branch: %s",
-		pr.GetName(), match.Repo.GetNamespace(), p.event.SHA, p.event.BaseBranch)
+	p.logger.Infof("PipelineRun %s has been created in namespace %s with status %s for SHA: %s Target Branch: %s",
+		pr.GetName(), match.Repo.GetNamespace(), pr.Spec.Status, p.event.SHA, p.event.BaseBranch)
 
 	consoleURL := p.run.Clients.ConsoleUI().DetailURL(pr)
 	mt := formatting.MessageTemplate{


### PR DESCRIPTION
## 📝 Description of the Change

When PipelineRun is created, PaC logs a message about it but it lacks PipelineRun status that in which state the PipelineRun has been so it would be nice to have that info as well right there in logs.

<!--- Take all comments into account and provide a detailed description of the change. -->

## 🔗 Linked GitHub Issue

Fixes #

## 👨🏻‍ Linked Jira

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

- [ ] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [x] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)

<!-- (update the title of the Pull Request accordingly) -->

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
