### PR TITLE
🪞 [MIRRORED] fix(gitlab): use TargetProjectID for merge request comments

### DIFF
--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -95,7 +95,7 @@ func (v *Provider) CreateComment(_ context.Context, event *info.Event, commit, u
 
 	// List comments of the merge request
 	if updateMarker != "" {
-		comments, _, err := v.Client().Notes.ListMergeRequestNotes(v.sourceProjectID, event.PullRequestNumber, &gitlab.ListMergeRequestNotesOptions{
+		comments, _, err := v.Client().Notes.ListMergeRequestNotes(event.TargetProjectID, event.PullRequestNumber, &gitlab.ListMergeRequestNotesOptions{
 			ListOptions: gitlab.ListOptions{
 				Page:    1,
 				PerPage: 100,
@@ -108,7 +108,7 @@ func (v *Provider) CreateComment(_ context.Context, event *info.Event, commit, u
 		re := regexp.MustCompile(updateMarker)
 		for _, comment := range comments {
 			if re.MatchString(comment.Body) {
-				_, _, err := v.Client().Notes.UpdateMergeRequestNote(v.sourceProjectID, event.PullRequestNumber, comment.ID, &gitlab.UpdateMergeRequestNoteOptions{
+				_, _, err := v.Client().Notes.UpdateMergeRequestNote(event.TargetProjectID, event.PullRequestNumber, comment.ID, &gitlab.UpdateMergeRequestNoteOptions{
 					Body: &commit,
 				})
 				return err
@@ -116,7 +116,7 @@ func (v *Provider) CreateComment(_ context.Context, event *info.Event, commit, u
 		}
 	}
 
-	_, _, err := v.Client().Notes.CreateMergeRequestNote(v.sourceProjectID, event.PullRequestNumber, &gitlab.CreateMergeRequestNoteOptions{
+	_, _, err := v.Client().Notes.CreateMergeRequestNote(event.TargetProjectID, event.PullRequestNumber, &gitlab.CreateMergeRequestNoteOptions{
 		Body: &commit,
 	})
 

--- a/pkg/provider/gitlab/gitlab_test.go
+++ b/pkg/provider/gitlab/gitlab_test.go
@@ -991,7 +991,7 @@ func TestGitLabCreateComment(t *testing.T) {
 		},
 		{
 			name:         "create new comment",
-			event:        &info.Event{PullRequestNumber: 123},
+			event:        &info.Event{PullRequestNumber: 123, TargetProjectID: 666},
 			commit:       "New Comment",
 			updateMarker: "",
 			mockResponses: map[string]func(rw http.ResponseWriter, _ *http.Request){
@@ -1004,7 +1004,7 @@ func TestGitLabCreateComment(t *testing.T) {
 		},
 		{
 			name:         "update existing comment",
-			event:        &info.Event{PullRequestNumber: 123},
+			event:        &info.Event{PullRequestNumber: 123, TargetProjectID: 666},
 			commit:       "Updated Comment",
 			updateMarker: "MARKER",
 			mockResponses: map[string]func(rw http.ResponseWriter, _ *http.Request){
@@ -1023,7 +1023,7 @@ func TestGitLabCreateComment(t *testing.T) {
 		},
 		{
 			name:         "no matching comment creates new",
-			event:        &info.Event{PullRequestNumber: 123},
+			event:        &info.Event{PullRequestNumber: 123, TargetProjectID: 666},
 			commit:       "New Comment",
 			updateMarker: "MARKER",
 			mockResponses: map[string]func(rw http.ResponseWriter, _ *http.Request){


### PR DESCRIPTION
🔄 Mirrors https://github.com/openshift-pipelines/pipelines-as-code/pull/2194 to run E2E tests. Original author: @infernus01