### PR TITLE
docs: Remove /rest suffix from Bitbucket DC url

### DIFF
--- a/docs/content/docs/install/bitbucket_datacenter.md
+++ b/docs/content/docs/install/bitbucket_datacenter.md
@@ -71,8 +71,8 @@ recreate it.
     url: "https://bitbucket.com/workspace/repo"
     git_provider:
       # make sure you have the right bitbucket data center api url without the
-      # /api/v1.0 usually the # default install will have a /rest suffix
-      url: "https://bitbucket.datacenter.api.url/rest"
+      # The base URL of your Bitbucket Data Center instance. Do not include the /rest suffix.
+      url: "https://bitbucket.datacenter.api.url"
       user: "your-bitbucket-username"
       secret:
         name: "bitbucket-datacenter-webhook-config"


### PR DESCRIPTION
Corrected the setup documentation for Bitbucket Data Center. Users should now provide only the base URL of their instance without the /rest suffix, as this is handled automatically by the rest client library (jenkins-x/go-scm).

## 📝 Description of the Change

<!--- Take all comments into account and provide a detailed description of the change. -->

## 🔗 Linked GitHub Issue

Fixes #

## 👨🏻‍ Linked Jira

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

- [ ] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [x] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)

<!-- (update the title of the Pull Request accordingly) -->

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [x] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [x] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [x] Bitbucket Data Center
