### PR TITLE
fix: commit status for unauthorized user in Bitbucket Data Center

### DIFF
--- a/pkg/provider/bitbucketdatacenter/bitbucketdatacenter_test.go
+++ b/pkg/provider/bitbucketdatacenter/bitbucketdatacenter_test.go
@@ -111,7 +111,6 @@ func TestCreateStatus(t *testing.T) {
 	tests := []struct {
 		name                  string
 		status                provider.StatusOpts
-		expectedDescSubstr    string
 		expectedCommentSubstr string
 		pacOpts               info.PacOpts
 		nilClient             bool
@@ -126,26 +125,28 @@ func TestCreateStatus(t *testing.T) {
 			name: "good/skipped",
 			status: provider.StatusOpts{
 				Conclusion: "skipped",
+				Text:       "Skipping",
 			},
-			expectedDescSubstr: "Skipping",
-			pacOpts:            pacopts,
+
+			pacOpts: pacopts,
 		},
 		{
 			name: "good/neutral",
 			status: provider.StatusOpts{
 				Conclusion: "neutral",
+				Text:       "stopped",
 			},
-			expectedDescSubstr: "stopped",
-			pacOpts:            pacopts,
+
+			pacOpts: pacopts,
 		},
 		{
 			name: "good/completed with comment",
 			status: provider.StatusOpts{
 				Conclusion: "success",
 				Status:     "completed",
-				Text:       "Happy as a bunny",
+				Text:       "validated",
 			},
-			expectedDescSubstr:    "validated",
+
 			expectedCommentSubstr: "Happy as a bunny",
 			pacOpts:               pacopts,
 		},
@@ -153,42 +154,57 @@ func TestCreateStatus(t *testing.T) {
 			name: "good/failed",
 			status: provider.StatusOpts{
 				Conclusion: "failure",
+				Text:       "Failed",
 			},
-			expectedDescSubstr: "Failed",
-			pacOpts:            pacopts,
+
+			pacOpts: pacopts,
 		},
 		{
 			name: "good/details url",
 			status: provider.StatusOpts{
 				Conclusion: "failure",
 				DetailsURL: "http://fail.com",
+				Text:       "Failed",
 			},
-			expectedDescSubstr: "Failed",
-			pacOpts:            pacopts,
+
+			pacOpts: pacopts,
 		},
 		{
 			name: "good/pending",
 			status: provider.StatusOpts{
 				Conclusion: "pending",
+				Text:       "started",
 			},
-			expectedDescSubstr: "started",
-			pacOpts:            pacopts,
+
+			pacOpts: pacopts,
 		},
 		{
 			name: "good/success",
 			status: provider.StatusOpts{
 				Conclusion: "success",
+				Text:       "validated",
 			},
-			expectedDescSubstr: "validated",
-			pacOpts:            pacopts,
+
+			pacOpts: pacopts,
 		},
 		{
 			name: "good/completed",
 			status: provider.StatusOpts{
 				Conclusion: "completed",
+				Text:       "Completed",
 			},
-			expectedDescSubstr: "Completed",
-			pacOpts:            pacopts,
+
+			pacOpts: pacopts,
+		},
+		{
+			name: "good/pending",
+			status: provider.StatusOpts{
+				Conclusion: "pending",
+				Status:     "queued",
+				Text:       "Pending approval, waiting for an /ok-to-test",
+			},
+
+			pacOpts: pacopts,
 		},
 	}
 	for _, tt := range tests {
@@ -210,7 +226,7 @@ func TestCreateStatus(t *testing.T) {
 				run:               &params.Run{},
 				pacInfo:           &tt.pacOpts,
 			}
-			bbtest.MuxCreateAndTestCommitStatus(t, mux, event, tt.expectedDescSubstr, tt.status)
+			bbtest.MuxCreateAndTestCommitStatus(t, mux, event, tt.status.Text, tt.status)
 			bbtest.MuxCreateComment(t, mux, event, tt.expectedCommentSubstr, pullRequestNumber)
 			err := v.CreateStatus(ctx, event, tt.status)
 			if tt.wantErrSubstr != "" {


### PR DESCRIPTION
For unauthorized users waiting for /ok-to-test approval, build status was incorrectly showing as "running" instead of "pending". This was caused by the CreateStatus function setting statusOpts.Conclusion to "UNKNOWN" when statusOpts.Status was "queued", instead of preserving the "pending" conclusion.

The fix ensures that when status is "queued" and conclusion is "pending", the pending state is preserved, resulting in the correct "pending" build status in Bitbucket Data Center while waiting for repository admin approval via /ok-to-test comment.

## 📝 Description of the Change

<!--- Take all comments into account and provide a detailed description of the change. -->

## 🔗 Linked GitHub Issue

Fixes #2148

## 👨🏻‍ Linked Jira
https://issues.redhat.com/browse/SRVKP-8269

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

- [x] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

<!-- (update the title of the Pull Request accordingly) -->

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [x] Manual testing
- [ ] Not Applicable

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [x] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [x] Bitbucket Data Center
