### PR TITLE
docs: add CEL filter example for non-code changes

### DIFF
--- a/docs/content/docs/guide/matchingevents.md
+++ b/docs/content/docs/guide/matchingevents.md
@@ -383,7 +383,7 @@ This example demonstrates how to filter `pull_request` events to exclude changes
 pipelinesascode.tekton.dev/on-cel-expression: |
   event == "pull_request"
   && target_branch == "main"
-  && !files.all.all(x, x.matches('^docs/|\\.md$|^(?:.*/)?(\.gitignore|OWNERS|PROJECT|LICENSE)$'))
+  && !files.all.all(x, x.matches('^docs/') || x.matches('\\.md$') || x.matches('(\\.gitignore|OWNERS|PROJECT|LICENSE)$'))
 ```
 
 This expression will:
@@ -391,10 +391,14 @@ This expression will:
 * Only match `pull_request` events targeting the `main` branch
 * **Exclude** the PipelineRun if all changed files match any of the following patterns:
   * Files in the `docs/` directory (`^docs/`)
-  * Markdown files (`.md$`)
-  * Common repository metadata files (`.gitignore`, `OWNERS`, `PROJECT`, `LICENSE`)
+  * Markdown files (`\\.md$`)
+  * Common repository metadata files (`\\.gitignore`, `OWNERS`, `PROJECT`, `LICENSE`)
 
-The `!files.all.all(x, x.matches('pattern'))` syntax means "not all files match the pattern", which effectively means "trigger only if at least one file doesn't match the exclusion pattern" (i.e., there are meaningful code changes).
+The `!files.all.all(x, x.matches('pattern1') || x.matches('pattern2') || ...)` syntax means "not all files match any of these patterns", which effectively means "trigger only if at least one file doesn't match the exclusion patterns" (i.e., there are meaningful code changes).
+
+{{< hint warning >}}
+**Important**: When using regex patterns in CEL expressions, remember to properly escape special characters. The backslash (`\`) needs to be doubled (`\\`) to escape properly within the CEL string context. Using logical OR (`||`) operators within the `matches()` function is more reliable than combining patterns with pipe (`|`) characters in a single regex.
+{{< /hint >}}
 
 ### Matching PipelineRun to an event (commit, pull_request) title
 

--- a/docs/content/docs/guide/matchingevents.md
+++ b/docs/content/docs/guide/matchingevents.md
@@ -375,6 +375,27 @@ This example will match modified files with the name of test.go:
       files.modified.exists(x, x.matches('test.go'))
 ```
 
+### Filtering PipelineRuns to exclude non-code changes
+
+This example demonstrates how to filter `pull_request` events to exclude changes that only affect documentation, configuration files, or other non-code files. This is useful when you want to run tests only when actual code changes occur:
+
+```yaml
+pipelinesascode.tekton.dev/on-cel-expression: |
+  event == "pull_request"
+  && target_branch == "main"
+  && !files.all.all(x, x.matches('^docs/|\\.md$|^(?:.*/)?(\.gitignore|OWNERS|PROJECT|LICENSE)$'))
+```
+
+This expression will:
+
+* Only match `pull_request` events targeting the `main` branch
+* **Exclude** the PipelineRun if all changed files match any of the following patterns:
+  * Files in the `docs/` directory (`^docs/`)
+  * Markdown files (`.md$`)
+  * Common repository metadata files (`.gitignore`, `OWNERS`, `PROJECT`, `LICENSE`)
+
+The `!files.all.all(x, x.matches('pattern'))` syntax means "not all files match the pattern", which effectively means "trigger only if at least one file doesn't match the exclusion pattern" (i.e., there are meaningful code changes).
+
 ### Matching PipelineRun to an event (commit, pull_request) title
 
 This example will match all pull requests starting with the title `[DOWNSTREAM]`:


### PR DESCRIPTION
Add comprehensive example showing how to use CEL expressions to filter PipelineRuns and exclude changes that only affect documentation, configuration files, or metadata files. This addresses user feedback about needing precise examples for crafting CEL regex expressions.

The example demonstrates the !files.all.all() syntax to exclude PRs when all changes match patterns for docs/, .md files, and common metadata files like .gitignore, OWNERS, PROJECT, and LICENSE.

## 📝 Description of the Change

<!--- Take all comments into account and provide a detailed description of the change. -->

## 🔗 Linked GitHub Issue

Fixes #

## 👨🏻‍ Linked Jira

https://issues.redhat.com/browse/SRVKP-4602

## 🚀 Type of Change

- [ ] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [X] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

<!-- (update the title of the Pull Request accordingly) -->

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## ✅ Submitter Checklist

- [ ] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [ ] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [ ] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
