### PR TITLE
Revert on-path-change on pr merge in bitbucket

### DIFF
--- a/test/bitbucket_datacenter_pull_request_test.go
+++ b/test/bitbucket_datacenter_pull_request_test.go
@@ -9,17 +9,12 @@ import (
 	"os"
 	"testing"
 
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	tbbdc "github.com/openshift-pipelines/pipelines-as-code/test/pkg/bitbucketdatacenter"
-	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
-	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
 
-	"github.com/jenkins-x/go-scm/scm"
 	"github.com/tektoncd/pipeline/pkg/names"
 	"gotest.tools/v3/assert"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestBitbucketDataCenterPullRequest(t *testing.T) {
@@ -40,11 +35,9 @@ func TestBitbucketDataCenterPullRequest(t *testing.T) {
 		files[fmt.Sprintf(".tekton/pipelinerun-%d.yaml", i)] = "testdata/pipelinerun.yaml"
 	}
 
-	files, err = payload.GetEntries(files, targetNS, options.MainBranch, triggertype.PullRequest.String(), map[string]string{})
-	assert.NilError(t, err)
-
 	pr := tbbdc.CreatePR(ctx, t, client, runcnx, opts, repo, files, bitbucketWSOwner, targetNS)
-	defer tbbdc.TearDown(ctx, t, runcnx, client, pr, bitbucketWSOwner, targetNS)
+	runcnx.Clients.Log.Infof("Pull Request with title '%s' is created", pr.Title)
+	defer tbbdc.TearDown(ctx, t, runcnx, client, pr.Number, bitbucketWSOwner, targetNS)
 
 	successOpts := wait.SuccessOpt{
 		TargetNS:        targetNS,
@@ -71,11 +64,9 @@ func TestBitbucketDataCenterCELPathChangeInPullRequest(t *testing.T) {
 		".tekton/pipelinerun.yaml": "testdata/pipelinerun-cel-path-changed.yaml",
 	}
 
-	files, err = payload.GetEntries(files, targetNS, options.MainBranch, triggertype.PullRequest.String(), map[string]string{})
-	assert.NilError(t, err)
-
 	pr := tbbdc.CreatePR(ctx, t, client, runcnx, opts, repo, files, bitbucketWSOwner, targetNS)
-	defer tbbdc.TearDown(ctx, t, runcnx, client, pr, bitbucketWSOwner, targetNS)
+	runcnx.Clients.Log.Infof("Pull Request with title '%s' is created", pr.Title)
+	defer tbbdc.TearDown(ctx, t, runcnx, client, pr.Number, bitbucketWSOwner, targetNS)
 
 	successOpts := wait.SuccessOpt{
 		TargetNS:        targetNS,
@@ -84,65 +75,4 @@ func TestBitbucketDataCenterCELPathChangeInPullRequest(t *testing.T) {
 		MinNumberStatus: 1,
 	}
 	wait.Succeeded(ctx, t, runcnx, opts, successOpts)
-}
-
-func TestBitbucketDataCenterOnPathChangeAnnotationOnPRMerge(t *testing.T) {
-	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
-	// this would be a temporary base branch for the pull request we're going to raise
-	// we need this because we're going to merge the pull request so that after test
-	// we can delete the temporary base branch and our main branch should not be affected
-	// by this merge because we run the E2E frequently.
-	tempBaseBranch := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
-
-	ctx := context.Background()
-	bitbucketWSOwner := os.Getenv("TEST_BITBUCKET_SERVER_E2E_REPOSITORY")
-
-	ctx, runcnx, opts, client, err := tbbdc.Setup(ctx)
-	assert.NilError(t, err)
-
-	repo := tbbdc.CreateCRD(ctx, t, client, runcnx, bitbucketWSOwner, targetNS)
-	runcnx.Clients.Log.Infof("Repository %s has been created", repo.Name)
-	defer tbbdc.TearDownNs(ctx, t, runcnx, targetNS)
-
-	branch, resp, err := client.Git.CreateRef(ctx, bitbucketWSOwner, tempBaseBranch, repo.Branch)
-	assert.NilError(t, err, "error creating branch: http status code: %d : %v", resp.Status, err)
-	runcnx.Clients.Log.Infof("Base branch %s has been created", branch.Name)
-
-	opts.BaseBranch = branch.Name
-
-	if os.Getenv("TEST_NOCLEANUP") != "true" {
-		defer func() {
-			_, err := client.Git.DeleteRef(ctx, bitbucketWSOwner, tempBaseBranch)
-			assert.NilError(t, err, "error deleting branch: http status code: %d : %v", resp.Status, err)
-		}()
-	}
-
-	files := map[string]string{
-		".tekton/pr.yaml":       "testdata/pipelinerun-on-path-change.yaml",
-		"doc/foo/bar/README.md": "README.md",
-	}
-
-	files, err = payload.GetEntries(files, targetNS, tempBaseBranch, triggertype.Push.String(), map[string]string{})
-	assert.NilError(t, err)
-
-	pr := tbbdc.CreatePR(ctx, t, client, runcnx, opts, repo, files, bitbucketWSOwner, targetNS)
-	defer tbbdc.TearDown(ctx, t, runcnx, client, nil, bitbucketWSOwner, targetNS)
-
-	// merge the pull request so that we can get push event.
-	_, err = client.PullRequests.Merge(ctx, bitbucketWSOwner, pr.Number, &scm.PullRequestMergeOptions{})
-	assert.NilError(t, err)
-
-	successOpts := wait.SuccessOpt{
-		TargetNS:        targetNS,
-		OnEvent:         triggertype.Push.String(),
-		NumberofPRMatch: 1,
-		MinNumberStatus: 1,
-	}
-	wait.Succeeded(ctx, t, runcnx, opts, successOpts)
-
-	pipelineRuns, err := runcnx.Clients.Tekton.TektonV1().PipelineRuns(targetNS).List(ctx, metav1.ListOptions{})
-	assert.NilError(t, err)
-	assert.Equal(t, len(pipelineRuns.Items), 1)
-	// check that pipeline run contains on-path-change annotation.
-	assert.Equal(t, pipelineRuns.Items[0].GetAnnotations()[keys.OnPathChange], "[doc/***.md]")
 }

--- a/test/bitbucket_datacenter_push_test.go
+++ b/test/bitbucket_datacenter_push_test.go
@@ -39,7 +39,7 @@ func TestBitbucketDataCenterCELPathChangeOnPush(t *testing.T) {
 	branch, resp, err := client.Git.CreateRef(ctx, bitbucketWSOwner, targetNS, mainBranchRef)
 	assert.NilError(t, err, "error creating branch: http status code: %d : %v", resp.Status, err)
 	runcnx.Clients.Log.Infof("Branch %s has been created", branch.Name)
-	defer tbbs.TearDown(ctx, t, runcnx, client, nil, bitbucketWSOwner, branch.Name)
+	defer tbbs.TearDown(ctx, t, runcnx, client, -1, bitbucketWSOwner, branch.Name)
 
 	files, err = payload.GetEntries(files, targetNS, branch.Name, triggertype.Push.String(), map[string]string{})
 	assert.NilError(t, err)

--- a/test/pkg/bitbucketdatacenter/pr.go
+++ b/test/pkg/bitbucketdatacenter/pr.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/scm"
 
 	goscm "github.com/jenkins-x/go-scm/scm"
@@ -14,24 +16,21 @@ import (
 )
 
 func CreatePR(ctx context.Context, t *testing.T, client *goscm.Client, runcnx *params.Run, opts options.E2E, repo *goscm.Repository, files map[string]string, orgAndRepo, targetNS string) *goscm.PullRequest {
-	baseBranchRef := repo.Branch
-	if opts.BaseBranch != "" {
-		baseBranchRef = opts.BaseBranch
-	}
-
-	branch, resp, err := client.Git.CreateRef(ctx, orgAndRepo, targetNS, baseBranchRef)
+	mainBranchRef := "refs/heads/main"
+	branch, resp, err := client.Git.CreateRef(ctx, orgAndRepo, targetNS, mainBranchRef)
 	assert.NilError(t, err, "error creating branch: http status code: %d : %v", resp.Status, err)
 	runcnx.Clients.Log.Infof("Branch %s has been created", branch.Name)
 
+	files, err = payload.GetEntries(files, targetNS, options.MainBranch, triggertype.PullRequest.String(), map[string]string{})
+	assert.NilError(t, err)
 	gitCloneURL, err := scm.MakeGitCloneURL(repo.Clone, opts.UserName, opts.Password)
 	assert.NilError(t, err)
-
 	scmOpts := &scm.Opts{
 		GitURL:        gitCloneURL,
 		Log:           runcnx.Clients.Log,
 		WebURL:        repo.Clone,
 		TargetRefName: targetNS,
-		BaseRefName:   baseBranchRef,
+		BaseRefName:   repo.Branch,
 		CommitTitle:   fmt.Sprintf("commit %s", targetNS),
 	}
 	scm.PushFilesToRefGit(t, scmOpts, files)
@@ -42,10 +41,9 @@ func CreatePR(ctx context.Context, t *testing.T, client *goscm.Client, runcnx *p
 		Title: title,
 		Body:  "Test PAC on bitbucket data center",
 		Head:  targetNS,
-		Base:  baseBranchRef,
+		Base:  "main",
 	}
 	pr, resp, err := client.PullRequests.Create(ctx, orgAndRepo, prOpts)
 	assert.NilError(t, err, "error creating pull request: http status code: %d : %v", resp.Status, err)
-	runcnx.Clients.Log.Infof("Created Pull Request with Title '%s'. Head branch '%s' ⮕ Base Branch '%s'", pr.Title, pr.Head.Ref, pr.Base.Ref)
 	return pr
 }

--- a/test/pkg/bitbucketdatacenter/setup.go
+++ b/test/pkg/bitbucketdatacenter/setup.go
@@ -82,16 +82,15 @@ func TearDownNs(ctx context.Context, t *testing.T, runcnx *params.Run, targetNS 
 	repository.NSTearDown(ctx, t, runcnx, targetNS)
 }
 
-func TearDown(ctx context.Context, t *testing.T, runcnx *params.Run, client *scm.Client, pr *scm.PullRequest, orgAndRepo, ref string) {
+func TearDown(ctx context.Context, t *testing.T, runcnx *params.Run, client *scm.Client, prID int, orgAndRepo, ref string) {
 	if os.Getenv("TEST_NOCLEANUP") == "true" {
 		runcnx.Clients.Log.Infof("Not cleaning up and closing PR since TEST_NOCLEANUP is set")
 		return
 	}
 
-	// in Bitbucket Data Center, merged pull requests cannot be deleted.
-	if pr != nil && !pr.Merged {
-		runcnx.Clients.Log.Infof("Deleting PR #%d", pr.Number)
-		_, err := client.PullRequests.DeletePullRequest(ctx, orgAndRepo, pr.Number)
+	if prID != -1 {
+		runcnx.Clients.Log.Infof("Deleting PR #%d", prID)
+		_, err := client.PullRequests.DeletePullRequest(ctx, orgAndRepo, prID)
 		assert.NilError(t, err)
 	}
 

--- a/test/pkg/options/options.go
+++ b/test/pkg/options/options.go
@@ -4,7 +4,6 @@ import "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascod
 
 type E2E struct {
 	Repo, Organization string
-	BaseBranch         string
 	DirectWebhook      bool
 	ProjectID          int
 	ControllerURL      string


### PR DESCRIPTION
#### Description of the Change

This pull request **reverts** the changes made in a previous fix for Bitbucket Data Center (commit `f9fd3f3f7ba68db845ec2a0b723798ed812f4a1e`). The original change aimed to fix an issue where **on-path-change** annotations were not working on merge commits, but it introduced a new, critical regression.

The primary issue with the previous fix is that the **`{{ revision }}`** dynamic variable no longer correctly fetches the ID of the newest **merge commit** when a pull request is merged on Bitbucket Data Center. Instead, it was incorrectly fetching the commit ID of the source branch's HEAD. This behavior is a **blocker** for a customer who relies on the merge-commit ID for their workflows and cannot change their existing git strategies.

By reverting the change, we restore the expected behavior of the `{{ revision }}` variable, allowing customers to upgrade to the latest versions. The underlying problem of `on-path-change` not working with Bitbucket merge commits (SRVKP-7432) is a separate issue that will be addressed in a future, more comprehensive fix.

#### Linked Jira Tickets

  * **Fixes:** https://issues.redhat.com/browse/SRVKP-8616 - After upgrading to Openshift-Pipelines v1.19 PAC dynamic variable `revision` not fetch to newest commit
  * **Related:**
      * https://issues.redhat.com/browse/SRVKP-7432 - OpenShift Pipelines As Code is not working with on-path-change in Bitbucket Data Center
      * https://issues.redhat.com/browse/SRVKP-8620 - Bitbucket: Add an annotation to opt-in for Bitbucket merge commit handling

#### Type of Change

  - 🐛 Bug fix
  - 💥 Breaking change (Reverting a previous breaking change to restore expected behavior)

#### Testing Strategy

  - Unit tests
  - End-to-end tests (Reverting the previous test changes to ensure proper behavior is restored)

#### Reviewer Checklist

  - [ ] The change has been reviewed and approved.
  - [ ] The commit message is clear and includes a reason for the revert and links to the relevant Jira tickets.
  - [ ] The PR description accurately explains the change and its impact.
## 📝 Description of the Change

<!--- Take all comments into account and provide a detailed description of the change. -->

## 🔗 Linked GitHub Issue

Fixes #

## 👨🏻‍ Linked Jira

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->
## 🚀 Type of Change

- [x] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [ ] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

<!-- (update the title of the Pull Request accordingly) -->

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [x] Not Applicable

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [x] Bitbucket Data Center
