### PR TITLE
chore: ensure tmp dir for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ test-clean:  ## Clean testcache
 .PHONY: test test-unit
 test-no-cache: test-clean test-unit ## Run test-unit without caching
 test-unit: ## Run unit tests
+	@mkdir -p tmp/
 	@echo "Running unit tests..."
 	$(GO) test $(DEFAULT_GO_TEST_FLAGS) $(GO_TEST_FLAGS) -timeout $(TIMEOUT_UNIT) ./pkg/...
 


### PR DESCRIPTION
- **fix: Refine PipelineRun patching retry logic for conflicts**
  *   Moved JSON marshaling call outside the retry loop.
  *   Updated retry backoff strategy by only doubling steps and duration to avoid
  overly long backoff times.
  *   Changed retry mechanism to explicitly retry only on conflict errors.
  *   Refined logging within the retry loop to distinguish conflict retries from
  other patch failures.
  *   Corrected placeholder order in a returned error message.
  
  Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
  

- **fix: Create tmp directory for unit tests**
  * Created `tmp/` directory before running unit tests.
  * Ensured the directory exists to prevent potential test execution failures.
  
  If we don't create them we get:
  
   Running unit tests...
   go test -race -failfast  -timeout 20m ./pkg/...
   go: creating work dir: stat
   /Users/chmouel/git/pac/trees/update-gitlab-commit-status/tmp: no such
   file or directory
   make: *** [Makefile:63: test-unit] Error 1
  
  Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
  