### PR TITLE
fix: Check source project access for GitLab PRs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/google/cel-go v0.26.1
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-github/scrape v0.0.0-20250818135035-f137c94931a7
+	github.com/google/go-github/v72 v72.0.0
 	github.com/google/go-github/v74 v74.0.0
 	github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b
 	github.com/jenkins-x/go-scm v1.15.16
@@ -69,7 +70,6 @@ require (
 	github.com/go-openapi/swag/stringutils v0.24.0 // indirect
 	github.com/go-openapi/swag/typeutils v0.24.0 // indirect
 	github.com/go-openapi/swag/yamlutils v0.24.0 // indirect
-	github.com/google/go-github/v72 v72.0.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/rickb777/plural v1.4.4 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -195,9 +195,11 @@ func (v *Provider) SetClient(_ context.Context, run *params.Run, runevent *info.
 	}
 	v.apiURL = apiURL
 
-	v.gitlabClient, err = gitlab.NewClient(runevent.Provider.Token, gitlab.WithBaseURL(apiURL))
-	if err != nil {
-		return err
+	if v.gitlabClient == nil {
+		v.gitlabClient, err = gitlab.NewClient(runevent.Provider.Token, gitlab.WithBaseURL(apiURL))
+		if err != nil {
+			return err
+		}
 	}
 	v.Token = &runevent.Provider.Token
 
@@ -209,6 +211,19 @@ func (v *Provider) SetClient(_ context.Context, run *params.Run, runevent *info.
 	// the ID from runevent.SourceProjectID when v.sourceProject is 0 (nil).
 	if v.sourceProjectID == 0 && runevent.SourceProjectID > 0 {
 		v.sourceProjectID = runevent.SourceProjectID
+	}
+
+	// check that we have access to the source project if it's a private repo, this should only occur on Merge Requests
+	if runevent.TriggerTarget == triggertype.PullRequest {
+		_, resp, err := v.Client().Projects.GetProject(runevent.SourceProjectID, &gitlab.GetProjectOptions{})
+		errmsg := fmt.Sprintf("failed to access GitLab source repository ID %d: please ensure token has 'read_repository' scope on that repository",
+			runevent.SourceProjectID)
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("%s", errmsg)
+		}
+		if err != nil {
+			return fmt.Errorf("%s: %w", errmsg, err)
+		}
 	}
 
 	// if we don't have sourceProjectID (ie: incoming-webhook) then try to set
@@ -280,27 +295,35 @@ func (v *Provider) CreateStatus(_ context.Context, event *info.Event, statusOpts
 		Context:     gitlab.Ptr(contextName),
 	}
 
-	// setCommitStatus attempts to set the commit status for a given SHA, handling GitLab's permission model.
-	// First tries the source project (fork), then falls back to the target project (upstream repo).
-	// This fallback is necessary because:
-	// - In fork/MR scenarios, the GitLab token may not have write access to the contributor's fork
-	// - This ensures commit status can be displayed somewhere useful regardless
-	// of permission differences
-	// Returns nil if status is set on either project, logs error if both attempts fail.
+	// In case we have access, set the status. Typically, on a Merge Request (MR)
+	// from a fork in an upstream repository, the token needs to have write access
+	// to the fork repository in order to create a status. However, the token set on the
+	// Repository CR usually doesn't have such broad access, preventing from creating
+	// a status comment on it.
+	// This would work on a push or an MR from a branch within the same repo.
+	// Ignoring errors because of the write access issues,
 	_, _, err := v.Client().Commits.SetCommitStatus(event.SourceProjectID, event.SHA, opt)
-	if err == nil {
-		v.Logger.Debugf("created commit status on source project ID %d", event.SourceProjectID)
+	if err != nil {
+		v.Logger.Debugf("cannot set status with the GitLab token on the source project: %v", err)
+	} else {
+		// we managed to set the status on the source repo, all good we are done
+		v.Logger.Debugf("created commit status on source project ID %d", event.TargetProjectID)
 		return nil
 	}
 	if _, _, err2 := v.Client().Commits.SetCommitStatus(event.TargetProjectID, event.SHA, opt); err2 == nil {
 		v.Logger.Debugf("created commit status on target project ID %d", event.TargetProjectID)
+		// we managed to set the status on the target repo, all good we are done
 		return nil
 	}
-	v.Logger.Debugf(
-		"Failed to create commit status: source project ID %d, target project ID %d. "+
-			"If you want Gitlab Pipeline Status update, ensure your GitLab token has access "+
-			"to the source repository. Error: %v",
-		event.SourceProjectID, event.TargetProjectID, err)
+	v.Logger.Debugf("cannot set status with the GitLab token on the target project: %v", err)
+	// we only show the first error as it's likely something the user has more control to fix
+	// the second err is cryptic as it needs a dummy gitlab pipeline to start
+	// with and will only give more confusion in the event namespace
+	v.eventEmitter.EmitMessage(v.repo, zap.InfoLevel, "FailedToSetCommitStatus",
+		fmt.Sprintf("failed to create commit status: source project ID %d, target project ID %d. "+
+			"If you want Gitlab Pipeline Status update, ensure your GitLab token giving it access "+
+			"to the source repository. %v",
+			event.SourceProjectID, event.TargetProjectID, err))
 
 	eventType := triggertype.IsPullRequestType(event.EventType)
 	// When a GitOps command is sent on a pushed commit, it mistakenly treats it as a pull_request


### PR DESCRIPTION
## 📝 Description of the Change

- Added a check to ensure the GitLab token has read access to the source repository when processing pull requests.
- This addresses an issue where builds could fail if the token lacked the necessary scope to access private source repositories.

<!--- Take all comments into account and provide a detailed description of the change. -->

## 🔗 Linked GitHub Issue


## 👨🏻‍ Linked Jira

https://issues.redhat.com/browse/SRVKP-8902
https://issues.redhat.com/browse/SRVKP-8910

## 🚀 Type of Change

- [ ] 🐛 Bug fix (`fix:`)
- [ ] ✨ New feature (`feat:`)
- [ ] 💥 Breaking change (`feat!:`, `fix!:`)
- [ ] 📚 Documentation update (`docs:`)
- [ ] ⚙️ Chore (`chore:`)
- [ ] 💅 Refactor (`refactor:`)
- [X] 🔧 Enhancement (`enhance:`)
- [ ] 📦 Dependency update (`deps:`)

<!-- (update the title of the Pull Request accordingly) -->

## 🧪 Testing Strategy

- [X] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## ✅ Submitter Checklist

- [ ] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [ ] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [ ] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
