### PR TITLE
feat: add distributed tracing for webhook handling and PipelineRun timing

### DIFF
--- a/config/302-pac-configmap.yaml
+++ b/config/302-pac-configmap.yaml
@@ -173,6 +173,12 @@ data:
   # Default: true
   skip-push-event-for-pr-commits: "true"
 
+  # PipelineRun label names PaC reads to populate tracing span attributes.
+  # Empty disables emission of the corresponding attribute.
+  tracing-label-action: "delivery.tekton.dev/action"
+  tracing-label-application: "delivery.tekton.dev/application"
+  tracing-label-component: "delivery.tekton.dev/component"
+
   # Configure a custom console here, the driver support custom parameters from
   # Repo CR along a few other template variable, see documentation for more
   # details

--- a/config/305-config-observability.yaml
+++ b/config/305-config-observability.yaml
@@ -51,3 +51,17 @@ data:
     # metrics-export-interval specifies how often metrics are exported.
     # Only applicable for grpc and http/protobuf protocols.
     # metrics-export-interval: "30s"
+
+    # tracing-protocol specifies the trace export protocol.
+    # Supported values: "grpc", "http/protobuf", "none".
+    # Default is "none" (tracing disabled).
+    # tracing-protocol: "none"
+
+    # tracing-endpoint specifies the OTLP collector endpoint.
+    # Required when tracing-protocol is "grpc" or "http/protobuf".
+    # The OTEL_EXPORTER_OTLP_ENDPOINT env var takes precedence if set.
+    # tracing-endpoint: "http://otel-collector.observability.svc.cluster.local:4317"
+
+    # tracing-sampling-rate controls the fraction of traces sampled.
+    # 0.0 = none, 1.0 = all. Default is 0 (none).
+    # tracing-sampling-rate: "1.0"

--- a/docs/content/docs/operations/tracing.md
+++ b/docs/content/docs/operations/tracing.md
@@ -1,0 +1,117 @@
+---
+title: Distributed Tracing
+weight: 5
+---
+
+This page describes how to enable OpenTelemetry distributed tracing for Pipelines-as-Code. When enabled, PaC emits trace spans for webhook event processing and PipelineRun lifecycle timing.
+
+## Enabling tracing
+
+The ConfigMap `pipelines-as-code-config-observability` controls tracing configuration. It must exist in the same namespace as the Pipelines-as-Code controller and watcher deployments. See [config/305-config-observability.yaml](https://github.com/tektoncd/pipelines-as-code/blob/main/config/305-config-observability.yaml) for the full example.
+
+It contains the following tracing fields:
+
+* `tracing-protocol`: Export protocol. Supported values: `grpc`, `http/protobuf`, `none`. Default is `none` (tracing disabled).
+* `tracing-endpoint`: OTLP collector endpoint. Required when protocol is not `none`. The `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable takes precedence if set.
+* `tracing-sampling-rate`: Fraction of traces to sample. `0.0` = none, `1.0` = all. Default is `0`.
+
+### Example
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pipelines-as-code-config-observability
+  namespace: pipelines-as-code
+data:
+  tracing-protocol: grpc
+  tracing-endpoint: "http://otel-collector.observability.svc.cluster.local:4317"
+  tracing-sampling-rate: "1.0"
+```
+
+Changes to `tracing-protocol`, `tracing-endpoint`, and `tracing-sampling-rate` require restarting the controller and watcher pods. The trace exporter is created once at startup from the ConfigMap values at that time. Set `tracing-protocol` to `none` or remove the tracing keys to disable tracing.
+
+The controller and watcher locate this ConfigMap by name via the `CONFIG_OBSERVABILITY_NAME` environment variable set in their deployment manifests. Operator-based installations may manage this differently; consult the operator documentation for details.
+
+## Emitted spans
+
+The controller emits a `PipelinesAsCode:ProcessEvent` span for each webhook event. The watcher emits `waitDuration` and `executeDuration` spans for completed PipelineRuns.
+
+### Webhook event span (`PipelinesAsCode:ProcessEvent`)
+
+[OTel VCS semantic conventions](https://opentelemetry.io/docs/specs/semconv/attributes-registry/vcs/):
+
+| Attribute | Source |
+| --- | --- |
+| `vcs.provider.name` | Git provider name |
+| `vcs.repository.url.full` | Repository URL |
+| `vcs.ref.head.revision` | Head commit SHA |
+
+PaC-specific:
+
+| Attribute | Source |
+| --- | --- |
+| `pipelinesascode.tekton.dev.event_type` | Webhook event type |
+
+### PipelineRun timing spans (`waitDuration`, `executeDuration`)
+
+Tekton-compatible bare keys (match Tekton's own reconciler spans for correlation):
+
+| Attribute | Source |
+| --- | --- |
+| `namespace` | PipelineRun namespace |
+| `pipelinerun` | PipelineRun name |
+
+Cross-service delivery attributes (`delivery.tekton.dev.*`):
+
+| Attribute | Source |
+| --- | --- |
+| `delivery.tekton.dev.pipelinerun_uid` | PipelineRun UID |
+| `delivery.tekton.dev.result_message` | First failing TaskRun message; omitted on success; truncated to 1024 bytes |
+
+Additional `delivery.tekton.dev.*` attributes are sourced from [configurable PipelineRun labels](#configuring-label-sourced-attributes).
+
+[OTel CI/CD semantic conventions](https://opentelemetry.io/docs/specs/semconv/attributes-registry/cicd/) (`executeDuration` only):
+
+| Attribute | Source |
+| --- | --- |
+| `cicd.pipeline.result` | Outcome enum (see below) |
+
+### `cicd.pipeline.result` enum
+
+| Condition | Value |
+| --- | --- |
+| `Status=True` | `success` |
+| `Status=False`, reason `Failed` | `failure` |
+| `Status=False`, reason `PipelineRunTimeout` | `timeout` |
+| `Status=False`, reason `Cancelled` or `CancelledRunningFinally` | `cancellation` |
+| `Status=False`, any other reason | `error` |
+
+## Configuring label-sourced attributes
+
+Some span attributes are read from PipelineRun labels. The label names are configurable via the main `pipelines-as-code` ConfigMap so deployments can point at their existing labels without rewriting producers:
+
+| ConfigMap key | PipelineRun label read (default) | Span attribute emitted |
+| --- | --- | --- |
+| `tracing-label-action` | `delivery.tekton.dev/action` | `cicd.pipeline.action.name` |
+| `tracing-label-application` | `delivery.tekton.dev/application` | `delivery.tekton.dev.application` |
+| `tracing-label-component` | `delivery.tekton.dev/component` | `delivery.tekton.dev.component` |
+
+Setting a ConfigMap key to the empty string disables emission of that label-sourced attribute. Only label-sourced attributes are affected; all other span attributes are always emitted. The emitted span attribute keys are fixed regardless of which labels are read, so cross-service queries work uniformly.
+
+Unlike the observability ConfigMap above (which requires a pod restart), changes to these label mappings are picked up automatically without restarting pods.
+
+## Trace context propagation
+
+When Pipelines-as-Code creates a PipelineRun, it sets the `tekton.dev/pipelinerunSpanContext` annotation with a JSON-encoded OTel TextMapCarrier containing the W3C `traceparent`. PaC tracing works independently — you get PaC spans regardless of whether Tekton Pipelines has tracing enabled.
+
+If Tekton Pipelines is also configured with tracing pointing at the same collector, its reconciler spans appear as children of the PaC span, providing a single end-to-end trace from webhook receipt through task execution. See the [Tekton Pipelines tracing documentation](https://github.com/tektoncd/pipeline/blob/main/docs/developers/tracing.md) for Tekton's independent tracing setup.
+
+## Deploying a trace collector
+
+Pipelines-as-Code exports traces using the standard OpenTelemetry Protocol (OTLP). You need a running OTLP-compatible collector for the `tracing-endpoint` to point to. Common options include:
+
+* [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) -- the vendor-neutral reference collector
+* [Jaeger](https://www.jaegertracing.io/docs/latest/getting-started/) -- supports OTLP ingestion natively since v1.35
+
+Deploying and operating a collector is outside the scope of Pipelines-as-Code. Refer to your organization's observability infrastructure or the links above for setup instructions.

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,9 @@ require (
 	gitlab.com/gitlab-org/api/client-go v1.46.0
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0
+	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
+	go.opentelemetry.io/otel/trace v1.43.0
 	go.uber.org/zap v1.27.1
 	golang.org/x/exp v0.0.0-20260312153236-7ab1446f8b90
 	golang.org/x/oauth2 v0.36.0
@@ -91,8 +93,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.65.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.43.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.43.0 // indirect
-	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect

--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -23,6 +23,10 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/gitea"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/github"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/gitlab"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/tracing"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/eventing/pkg/adapter/v2"
@@ -191,6 +195,13 @@ func (l listener) handleEvent(ctx context.Context) http.HandlerFunc {
 		}
 		gitProvider.SetPacInfo(&pacInfo)
 
+		tracedCtx := otel.GetTextMapPropagator().Extract(ctx, propagation.HeaderCarrier(request.Header))
+
+		tracer := otel.Tracer(tracing.TracerName)
+		tracedCtx, span := tracer.Start(tracedCtx, "PipelinesAsCode:ProcessEvent",
+			trace.WithSpanKind(trace.SpanKindServer),
+		)
+
 		s := sinker{
 			run:        l.run,
 			vcx:        gitProvider,
@@ -206,8 +217,10 @@ func (l listener) handleEvent(ctx context.Context) http.HandlerFunc {
 		localRequest := request.Clone(request.Context())
 
 		go func() {
-			err := s.processEvent(ctx, localRequest)
+			defer span.End()
+			err := s.processEvent(tracedCtx, localRequest)
 			if err != nil {
+				span.RecordError(err)
 				logger.Errorf("an error occurred: %v", err)
 			}
 		}()

--- a/pkg/adapter/sinker.go
+++ b/pkg/adapter/sinker.go
@@ -14,6 +14,9 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/pipelineascode"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/status"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/tracing"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 )
 
@@ -117,6 +120,10 @@ func (s *sinker) processEvent(ctx context.Context, request *http.Request) error 
 		}
 	}
 
+	// Enrich span with VCS attributes — for incoming events these are
+	// pre-populated; for webhook events ParsePayload filled them in.
+	setVCSSpanAttributes(ctx, s.event)
+
 	p := pipelineascode.NewPacs(s.event, s.vcx, s.run, s.pacInfo, s.kint, s.logger, s.globalRepo)
 	return p.Run(ctx)
 }
@@ -173,4 +180,18 @@ func (s *sinker) createSkipCIStatus(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func setVCSSpanAttributes(ctx context.Context, event *info.Event) {
+	span := trace.SpanFromContext(ctx)
+	if !span.IsRecording() {
+		return
+	}
+	span.SetAttributes(tracing.PACEventTypeKey.String(event.EventType))
+	if event.URL != "" {
+		span.SetAttributes(semconv.VCSRepositoryURLFullKey.String(event.URL))
+	}
+	if event.SHA != "" {
+		span.SetAttributes(semconv.VCSRefHeadRevisionKey.String(event.SHA))
+	}
 }

--- a/pkg/adapter/sinker_tracing_test.go
+++ b/pkg/adapter/sinker_tracing_test.go
@@ -1,0 +1,143 @@
+package adapter
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	testtracing "github.com/openshift-pipelines/pipelines-as-code/pkg/test/tracing"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/tracing"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
+	"go.opentelemetry.io/otel/trace"
+	"gotest.tools/v3/assert"
+)
+
+func TestSetVCSSpanAttributes(t *testing.T) {
+	t.Parallel()
+
+	eventTypeKey := string(tracing.PACEventTypeKey)
+	repoURLKey := string(semconv.VCSRepositoryURLFullKey)
+	headRevKey := string(semconv.VCSRefHeadRevisionKey)
+
+	tests := []struct {
+		name  string
+		event *info.Event
+		want  map[string]string
+	}{
+		{
+			name: "full event",
+			event: &info.Event{
+				EventType: "pull_request",
+				URL:       "https://github.com/test/repo",
+				SHA:       "abc123",
+			},
+			want: map[string]string{
+				eventTypeKey: "pull_request",
+				repoURLKey:   "https://github.com/test/repo",
+				headRevKey:   "abc123",
+			},
+		},
+		{
+			name: "event type only",
+			event: &info.Event{
+				EventType: "push",
+			},
+			want: map[string]string{
+				eventTypeKey: "push",
+			},
+		},
+		{
+			name: "url without sha",
+			event: &info.Event{
+				EventType: "issue_comment",
+				URL:       "https://github.com/test/repo",
+			},
+			want: map[string]string{
+				eventTypeKey: "issue_comment",
+				repoURLKey:   "https://github.com/test/repo",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			exporter := &testtracing.RecordingExporter{}
+			tp := sdktrace.NewTracerProvider(
+				sdktrace.WithSampler(sdktrace.AlwaysSample()),
+				sdktrace.WithSyncer(exporter),
+			)
+			defer func() { _ = tp.Shutdown(context.Background()) }()
+
+			ctx, span := tp.Tracer("test").Start(context.Background(), "test-span")
+			setVCSSpanAttributes(ctx, tt.event)
+			span.End()
+
+			spans := exporter.GetSpans()
+			assert.Equal(t, len(spans), 1)
+			got := map[string]string{}
+			for _, a := range spans[0].Attributes() {
+				got[string(a.Key)] = a.Value.AsString()
+			}
+			assert.DeepEqual(t, got, tt.want)
+		})
+	}
+}
+
+func TestProcessEventSpanHonorsIncomingTraceContext(t *testing.T) {
+	exporter := testtracing.SetupTracer(t)
+
+	// Simulate an external system sending a webhook with a traceparent header.
+	// Create a parent span to generate a valid trace context.
+	parentCtx, parentSpan := otel.Tracer("external-system").Start(context.Background(), "external-root")
+	expectedTraceID := parentSpan.SpanContext().TraceID()
+	parentSpan.End()
+
+	// Inject the parent context into HTTP headers (what the webhook sender would do).
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://localhost", nil)
+	otel.GetTextMapPropagator().Inject(parentCtx, propagation.HeaderCarrier(req.Header))
+
+	// This is the exact extract → start sequence from handleEvent.
+	tracedCtx := otel.GetTextMapPropagator().Extract(context.Background(), propagation.HeaderCarrier(req.Header))
+	_, span := otel.Tracer(tracing.TracerName).Start(tracedCtx, "PipelinesAsCode:ProcessEvent",
+		trace.WithSpanKind(trace.SpanKindServer),
+	)
+	span.End()
+
+	spans := exporter.GetSpans()
+	var processSpan sdktrace.ReadOnlySpan
+	for _, s := range spans {
+		if s.Name() == "PipelinesAsCode:ProcessEvent" {
+			processSpan = s
+		}
+	}
+	assert.Assert(t, processSpan != nil, "ProcessEvent span not found")
+	assert.Equal(t, processSpan.Parent().TraceID(), expectedTraceID,
+		"ProcessEvent span should be parented under the incoming trace context, not a new root")
+	assert.Assert(t, processSpan.Parent().IsValid(),
+		"ProcessEvent span should have a valid remote parent")
+}
+
+func TestProcessEventSpanCreatesRootWithoutIncomingContext(t *testing.T) {
+	exporter := testtracing.SetupTracer(t)
+
+	// Webhook with no traceparent header.
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://localhost", nil)
+
+	tracedCtx := otel.GetTextMapPropagator().Extract(context.Background(), propagation.HeaderCarrier(req.Header))
+	_, span := otel.Tracer(tracing.TracerName).Start(tracedCtx, "PipelinesAsCode:ProcessEvent",
+		trace.WithSpanKind(trace.SpanKindServer),
+	)
+	span.End()
+
+	spans := exporter.GetSpans()
+	processSpan := testtracing.FindSpan(spans, "PipelinesAsCode:ProcessEvent")
+	assert.Assert(t, processSpan != nil)
+	assert.Assert(t, !processSpan.Parent().IsValid(),
+		"ProcessEvent span should be a root when no incoming trace context is present")
+}

--- a/pkg/apis/pipelinesascode/keys/keys.go
+++ b/pkg/apis/pipelinesascode/keys/keys.go
@@ -68,6 +68,8 @@ const (
 	GithubApplicationID  = "github-application-id"
 	GithubPrivateKey     = "github-private-key"
 	ResultsRecordSummary = "results.tekton.dev/recordSummaryAnnotations"
+
+	SpanContextAnnotation = "tekton.dev/pipelinerunSpanContext"
 )
 
 var ParamsRe = regexp.MustCompile(`{{([^}]{2,})}}`)

--- a/pkg/kubeinteraction/labels.go
+++ b/pkg/kubeinteraction/labels.go
@@ -1,6 +1,8 @@
 package kubeinteraction
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"strconv"
 
@@ -12,6 +14,9 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/versiondata"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	"knative.dev/pkg/logging"
 )
 
 const (
@@ -21,11 +26,14 @@ const (
 	StateFailed    = "failed"
 )
 
-func AddLabelsAndAnnotations(event *info.Event, pipelineRun *tektonv1.PipelineRun, repo *apipac.Repository, providerConfig *info.ProviderConfig, paramsRun *params.Run) error {
+func AddLabelsAndAnnotations(ctx context.Context, event *info.Event, pipelineRun *tektonv1.PipelineRun, repo *apipac.Repository, providerConfig *info.ProviderConfig, paramsRun *params.Run) error {
 	if event == nil {
 		return fmt.Errorf("event should not be nil")
 	}
 	paramsinfo := paramsRun.Info
+
+	carrier := propagation.MapCarrier{}
+	otel.GetTextMapPropagator().Inject(ctx, carrier)
 	// Add labels on the soon-to-be created pipelinerun so UI/CLI can easily
 	// query them.
 	labels := map[string]string{
@@ -58,6 +66,17 @@ func AddLabelsAndAnnotations(event *info.Event, pipelineRun *tektonv1.PipelineRu
 		keys.SecretCreated: "false",
 		keys.ControllerInfo: fmt.Sprintf(`{"name":"%s","configmap":"%s","secret":"%s", "gRepo": "%s"}`,
 			paramsinfo.Controller.Name, paramsinfo.Controller.Configmap, paramsinfo.Controller.Secret, paramsinfo.Controller.GlobalRepository),
+	}
+
+	if len(carrier) > 0 {
+		if jsonBytes, err := json.Marshal(carrier); err != nil {
+			logging.FromContext(ctx).Errorf("failed to marshal span context carrier: %v", err)
+		} else {
+			if existing := pipelineRun.GetAnnotations()[keys.SpanContextAnnotation]; existing != "" {
+				logging.FromContext(ctx).Warnf("overwriting pre-existing %s annotation on PipelineRun template; honoring initiating event trace context", keys.SpanContextAnnotation)
+			}
+			annotations[keys.SpanContextAnnotation] = string(jsonBytes)
+		}
 	}
 
 	if event.PullRequestNumber != 0 {

--- a/pkg/kubeinteraction/labels_test.go
+++ b/pkg/kubeinteraction/labels_test.go
@@ -1,6 +1,8 @@
 package kubeinteraction
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -8,7 +10,9 @@ import (
 	apipac "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	testtracing "github.com/openshift-pipelines/pipelines-as-code/pkg/test/tracing"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"go.opentelemetry.io/otel"
 	"gotest.tools/v3/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -69,8 +73,11 @@ func TestAddLabelsAndAnnotations(t *testing.T) {
 					Controller: tt.args.controllerInfo,
 				},
 			}
-			err := AddLabelsAndAnnotations(tt.args.event, tt.args.pipelineRun, tt.args.repo, &info.ProviderConfig{}, paramsRun)
+			err := AddLabelsAndAnnotations(context.Background(), tt.args.event, tt.args.pipelineRun, tt.args.repo, &info.ProviderConfig{}, paramsRun)
 			assert.NilError(t, err)
+			// No active span in context.Background() — annotation should be absent
+			_, hasSpanCtx := tt.args.pipelineRun.Annotations[keys.SpanContextAnnotation]
+			assert.Assert(t, !hasSpanCtx, "span context annotation should not be set without an active span")
 			assert.Equal(t, tt.args.pipelineRun.Labels[keys.URLOrg], tt.args.event.Organization, "'%s' != %s",
 				tt.args.pipelineRun.Labels[keys.URLOrg], tt.args.event.Organization)
 			assert.Equal(t, tt.args.pipelineRun.Labels[keys.CancelInProgress], tt.args.pipelineRun.Annotations[keys.CancelInProgress], "'%s' != %s",
@@ -85,4 +92,52 @@ func TestAddLabelsAndAnnotations(t *testing.T) {
 			assert.Equal(t, tt.args.pipelineRun.Annotations[keys.CloneURL], tt.args.event.CloneURL)
 		})
 	}
+}
+
+func TestAddLabelsAndAnnotationsSpanContext(t *testing.T) {
+	testtracing.SetupTracer(t)
+
+	ctx, span := otel.Tracer("test").Start(context.Background(), "test-span")
+	defer span.End()
+
+	pr := &tektonv1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{},
+			Annotations: map[string]string{
+				keys.SpanContextAnnotation: `{"old":"data"}`,
+			},
+		},
+	}
+	event := info.NewEvent()
+	event.Organization = "org"
+	event.Repository = "repo"
+	event.SHA = "sha"
+	event.Sender = "sender"
+	event.EventType = "push"
+	event.BaseBranch = "main"
+
+	paramsRun := &params.Run{
+		Info: info.Info{
+			Controller: &info.ControllerInfo{
+				Name:             "controller",
+				Configmap:        "configmap",
+				Secret:           "secret",
+				GlobalRepository: "repo",
+			},
+		},
+	}
+
+	err := AddLabelsAndAnnotations(ctx, event, pr, &apipac.Repository{
+		ObjectMeta: metav1.ObjectMeta{Name: "repo"},
+	}, &info.ProviderConfig{}, paramsRun)
+	assert.NilError(t, err)
+
+	raw, ok := pr.Annotations[keys.SpanContextAnnotation]
+	assert.Assert(t, ok, "span context annotation should be set when context carries a span")
+
+	var carrier map[string]string
+	assert.NilError(t, json.Unmarshal([]byte(raw), &carrier))
+	tp0 := carrier["traceparent"]
+	assert.Assert(t, tp0 != "", "traceparent should be present in carrier")
+	assert.Assert(t, len(tp0) == 55, "traceparent should be a valid W3C trace context (got %q)", tp0)
 }

--- a/pkg/params/settings/config.go
+++ b/pkg/params/settings/config.go
@@ -82,6 +82,11 @@ type Settings struct {
 
 	RememberOKToTest   bool `json:"remember-ok-to-test"`
 	RequireOkToTestSHA bool `json:"require-ok-to-test-sha"`
+
+	// Tracing label names. Defaults in config/302-pac-configmap.yaml.
+	TracingLabelAction      string `json:"tracing-label-action"`
+	TracingLabelApplication string `json:"tracing-label-application"`
+	TracingLabelComponent   string `json:"tracing-label-component"`
 }
 
 func (s *Settings) DeepCopy(out *Settings) {

--- a/pkg/pipelineascode/client_setup.go
+++ b/pkg/pipelineascode/client_setup.go
@@ -12,6 +12,8 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/github"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 )
 
@@ -83,8 +85,14 @@ is that what you want? make sure you use -n when generating the secret, eg: echo
 		}
 	}
 	// Set up the authenticated client
-	if err := vcx.SetClient(ctx, run, event, repo, eventEmitter); err != nil {
-		return fmt.Errorf("failed to set client: %w", err)
+	clientErr := vcx.SetClient(ctx, run, event, repo, eventEmitter)
+	if name := vcx.GetConfig().Name; name != "" {
+		if span := trace.SpanFromContext(ctx); span.IsRecording() {
+			span.SetAttributes(semconv.VCSProviderNameKey.String(name))
+		}
+	}
+	if clientErr != nil {
+		return fmt.Errorf("failed to set client: %w", clientErr)
 	}
 	logger.Debugf("setupAuthenticatedClient: provider client initialized")
 

--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -216,7 +216,7 @@ func (p *PacRun) startPR(ctx context.Context, match matcher.Match) (*tektonv1.Pi
 	)
 
 	// Add labels and annotations to pipelinerun
-	err := kubeinteraction.AddLabelsAndAnnotations(p.event, match.PipelineRun, match.Repo, p.vcx.GetConfig(), p.run)
+	err := kubeinteraction.AddLabelsAndAnnotations(ctx, p.event, match.PipelineRun, match.Repo, p.vcx.GetConfig(), p.run)
 	if err != nil {
 		p.logger.Errorf("Error adding labels/annotations to PipelineRun '%s' in namespace '%s': %v", match.PipelineRun.GetName(), match.Repo.GetNamespace(), err)
 	} else {

--- a/pkg/reconciler/emit_traces.go
+++ b/pkg/reconciler/emit_traces.go
@@ -1,0 +1,147 @@
+package reconciler
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/tracing"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/propagation"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+)
+
+func extractSpanContext(logger *zap.SugaredLogger, pr *tektonv1.PipelineRun) (context.Context, bool) {
+	raw, ok := pr.GetAnnotations()[keys.SpanContextAnnotation]
+	if !ok || raw == "" {
+		return nil, false
+	}
+	var carrierMap map[string]string
+	if err := json.Unmarshal([]byte(raw), &carrierMap); err != nil {
+		logger.Warnf("ignoring malformed %s annotation on %s/%s: %v", keys.SpanContextAnnotation, pr.GetNamespace(), pr.GetName(), err)
+		return nil, false
+	}
+	carrier := propagation.MapCarrier(carrierMap)
+	ctx := otel.GetTextMapPropagator().Extract(context.Background(), carrier)
+	sc := trace.SpanContextFromContext(ctx)
+	if !sc.IsValid() {
+		return nil, false
+	}
+	return ctx, true
+}
+
+func emitTimingSpans(logger *zap.SugaredLogger, pr *tektonv1.PipelineRun, cfg *settings.Settings, trStatus map[string]*tektonv1.PipelineRunTaskRunStatus) {
+	parentCtx, ok := extractSpanContext(logger, pr)
+	if !ok {
+		return
+	}
+
+	tracer := otel.Tracer(tracing.TracerName)
+	commonAttrs := buildCommonAttributes(pr, cfg)
+
+	if pr.Status.StartTime != nil {
+		_, waitSpan := tracer.Start(parentCtx, tracing.SpanWaitDuration,
+			trace.WithTimestamp(pr.CreationTimestamp.Time),
+			trace.WithAttributes(commonAttrs...),
+		)
+		waitSpan.End(trace.WithTimestamp(pr.Status.StartTime.Time))
+	}
+
+	if pr.Status.StartTime != nil && pr.Status.CompletionTime != nil {
+		extra := buildExecuteAttributes(pr, trStatus)
+		execAttrs := make([]attribute.KeyValue, 0, len(commonAttrs)+len(extra))
+		execAttrs = append(execAttrs, commonAttrs...)
+		execAttrs = append(execAttrs, extra...)
+		_, execSpan := tracer.Start(parentCtx, tracing.SpanExecuteDuration,
+			trace.WithTimestamp(pr.Status.StartTime.Time),
+			trace.WithAttributes(execAttrs...),
+		)
+		execSpan.End(trace.WithTimestamp(pr.Status.CompletionTime.Time))
+	}
+}
+
+func buildCommonAttributes(pr *tektonv1.PipelineRun, cfg *settings.Settings) []attribute.KeyValue {
+	attrs := make([]attribute.KeyValue, 0, 6)
+	attrs = append(attrs,
+		tracing.NamespaceKey.String(pr.GetNamespace()),
+		tracing.PipelineRunKey.String(pr.GetName()),
+		tracing.DeliveryPipelineRunUIDKey.String(string(pr.GetUID())),
+	)
+
+	if cfg == nil {
+		return attrs
+	}
+	labels := pr.GetLabels()
+	labelAttrs := []struct {
+		labelName string
+		key       attribute.Key
+	}{
+		{cfg.TracingLabelAction, semconv.CICDPipelineActionNameKey},
+		{cfg.TracingLabelApplication, tracing.DeliveryApplicationKey},
+		{cfg.TracingLabelComponent, tracing.DeliveryComponentKey},
+	}
+	for _, m := range labelAttrs {
+		if m.labelName == "" {
+			continue
+		}
+		if v := labels[m.labelName]; v != "" {
+			attrs = append(attrs, m.key.String(v))
+		}
+	}
+	return attrs
+}
+
+func buildExecuteAttributes(pr *tektonv1.PipelineRun, trStatus map[string]*tektonv1.PipelineRunTaskRunStatus) []attribute.KeyValue {
+	cond := pr.Status.GetCondition(apis.ConditionSucceeded)
+	if cond == nil {
+		return nil
+	}
+	attrs := []attribute.KeyValue{tracing.ResultEnum(cond)}
+	if cond.Status == corev1.ConditionFalse {
+		if msg := failureMessage(cond, trStatus); msg != "" {
+			attrs = append(attrs, tracing.DeliveryResultMessageKey.String(tracing.TruncateResultMessage(msg)))
+		}
+	}
+	return attrs
+}
+
+// failureMessage returns the most diagnostic error text available for a
+// failed PipelineRun. It prefers the earliest failing TaskRun's condition
+// message (the err.Error() Tekton wrote via MarkResourceFailed) and falls
+// back to the PipelineRun's own condition message for early-stage failures
+// that never produced TaskRuns.
+func failureMessage(prCond *apis.Condition, trStatus map[string]*tektonv1.PipelineRunTaskRunStatus) string {
+	if msg := earliestFailingTaskRunMessage(trStatus); msg != "" {
+		return msg
+	}
+	return prCond.Message
+}
+
+func earliestFailingTaskRunMessage(trStatus map[string]*tektonv1.PipelineRunTaskRunStatus) string {
+	var (
+		earliestTime *metav1.Time
+		earliestMsg  string
+	)
+	for _, ts := range trStatus {
+		if ts == nil || ts.Status == nil || ts.Status.CompletionTime == nil {
+			continue
+		}
+		cond := ts.Status.GetCondition(apis.ConditionSucceeded)
+		if cond == nil || cond.Status != corev1.ConditionFalse {
+			continue
+		}
+		if earliestTime == nil || ts.Status.CompletionTime.Before(earliestTime) {
+			earliestTime = ts.Status.CompletionTime
+			earliestMsg = cond.Message
+		}
+	}
+	return earliestMsg
+}

--- a/pkg/reconciler/emit_traces_test.go
+++ b/pkg/reconciler/emit_traces_test.go
@@ -1,0 +1,663 @@
+package reconciler
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
+	testtracing "github.com/openshift-pipelines/pipelines-as-code/pkg/test/tracing"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/tracing"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+)
+
+const (
+	testActionLabel      = tracing.AttrNamespace + "/action"
+	testApplicationLabel = tracing.AttrNamespace + "/application"
+	testComponentLabel   = tracing.AttrNamespace + "/component"
+)
+
+func testSettings() *settings.Settings {
+	return &settings.Settings{
+		TracingLabelAction:      testActionLabel,
+		TracingLabelApplication: testApplicationLabel,
+		TracingLabelComponent:   testComponentLabel,
+	}
+}
+
+func makeSpanContextAnnotation(t *testing.T) (string, trace.TraceID) {
+	t.Helper()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSampler(sdktrace.AlwaysSample()))
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+
+	ctx, span := tp.Tracer("test").Start(context.Background(), "test-root")
+	traceID := span.SpanContext().TraceID()
+	span.End()
+
+	carrier := propagation.MapCarrier{}
+	propagation.TraceContext{}.Inject(ctx, carrier)
+	jsonBytes, err := json.Marshal(map[string]string(carrier))
+	assert.NilError(t, err)
+	return string(jsonBytes), traceID
+}
+
+func TestEmitTimingSpans(t *testing.T) {
+	creationTime := time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC)
+	startTime := metav1.NewTime(creationTime.Add(30 * time.Second))
+	completionTime := metav1.NewTime(creationTime.Add(5 * time.Minute))
+
+	tests := []struct {
+		name               string
+		annotations        map[string]string
+		labels             map[string]string
+		uid                types.UID
+		namespace          string
+		prName             string
+		startTime          *metav1.Time
+		completionTime     *metav1.Time
+		conditionStatus    corev1.ConditionStatus
+		conditionReason    string
+		conditionMessage   string
+		taskFailureMessage string // populated → trStatus contains a failing TaskRun with this message
+		skipSpanContext    bool
+		wantSpanCount      int
+		wantWaitSpan       bool
+		wantExecSpan       bool
+		wantResult         attribute.KeyValue
+		wantMessage        string // empty → result_message attribute must NOT be present
+		wantAction         string
+		wantApplication    string
+		wantComponent      string
+		wantComponentAttr  bool
+	}{
+		{
+			name: "successful PipelineRun emits both spans without result_message",
+			labels: map[string]string{
+				testActionLabel:      "build",
+				testApplicationLabel: "my-app",
+				testComponentLabel:   "my-component",
+			},
+			uid:               "test-uid-123",
+			namespace:         "test-ns",
+			prName:            "test-pr",
+			startTime:         &startTime,
+			completionTime:    &completionTime,
+			conditionStatus:   corev1.ConditionTrue,
+			conditionReason:   tektonv1.PipelineRunReasonSuccessful.String(),
+			wantSpanCount:     2,
+			wantWaitSpan:      true,
+			wantExecSpan:      true,
+			wantResult:        semconv.CICDPipelineResultSuccess,
+			wantAction:        "build",
+			wantApplication:   "my-app",
+			wantComponent:     "my-component",
+			wantComponentAttr: true,
+		},
+		{
+			name: "failed PipelineRun carries failing TaskRun message",
+			labels: map[string]string{
+				testActionLabel:      "build",
+				testApplicationLabel: "my-app",
+			},
+			uid:                "uid-fail",
+			namespace:          "ns-fail",
+			prName:             "pr-fail",
+			startTime:          &startTime,
+			completionTime:     &completionTime,
+			conditionStatus:    corev1.ConditionFalse,
+			conditionReason:    tektonv1.PipelineRunReasonFailed.String(),
+			taskFailureMessage: `step "step-build" exited with code 1`,
+			wantSpanCount:      2,
+			wantWaitSpan:       true,
+			wantExecSpan:       true,
+			wantResult:         semconv.CICDPipelineResultFailure,
+			wantMessage:        `step "step-build" exited with code 1`,
+			wantAction:         "build",
+			wantApplication:    "my-app",
+		},
+		{
+			name: "cancelled PipelineRun maps to cancellation",
+			labels: map[string]string{
+				testApplicationLabel: "my-app",
+			},
+			uid:                "uid-cancel",
+			namespace:          "ns-cancel",
+			prName:             "pr-cancel",
+			startTime:          &startTime,
+			completionTime:     &completionTime,
+			conditionStatus:    corev1.ConditionFalse,
+			conditionReason:    tektonv1.PipelineRunReasonCancelled.String(),
+			taskFailureMessage: "TaskRun cancelled by user",
+			wantSpanCount:      2,
+			wantWaitSpan:       true,
+			wantExecSpan:       true,
+			wantResult:         semconv.CICDPipelineResultCancellation,
+			wantMessage:        "TaskRun cancelled by user",
+			wantApplication:    "my-app",
+		},
+		{
+			name: "timed-out PipelineRun maps to timeout",
+			labels: map[string]string{
+				testApplicationLabel: "my-app",
+			},
+			uid:                "uid-timeout",
+			namespace:          "ns-timeout",
+			prName:             "pr-timeout",
+			startTime:          &startTime,
+			completionTime:     &completionTime,
+			conditionStatus:    corev1.ConditionFalse,
+			conditionReason:    tektonv1.PipelineRunReasonTimedOut.String(),
+			taskFailureMessage: "TaskRun \"build\" failed to finish within timeout",
+			wantSpanCount:      2,
+			wantWaitSpan:       true,
+			wantExecSpan:       true,
+			wantResult:         semconv.CICDPipelineResultTimeout,
+			wantMessage:        "TaskRun \"build\" failed to finish within timeout",
+			wantApplication:    "my-app",
+		},
+		{
+			name: "validation-error PipelineRun falls back to PR condition message",
+			labels: map[string]string{
+				testApplicationLabel: "my-app",
+			},
+			uid:              "uid-error",
+			namespace:        "ns-error",
+			prName:           "pr-error",
+			startTime:        &startTime,
+			completionTime:   &completionTime,
+			conditionStatus:  corev1.ConditionFalse,
+			conditionReason:  tektonv1.PipelineRunReasonFailedValidation.String(),
+			conditionMessage: `Pipeline ns-error/pipeline-foo can't be Run; couldn't retrieve referenced task "missing-task"`,
+			wantSpanCount:    2,
+			wantWaitSpan:     true,
+			wantExecSpan:     true,
+			wantResult:       semconv.CICDPipelineResultError,
+			wantMessage:      `Pipeline ns-error/pipeline-foo can't be Run; couldn't retrieve referenced task "missing-task"`,
+			wantApplication:  "my-app",
+		},
+		{
+			name: "completed with skipped tasks maps to success without result_message",
+			labels: map[string]string{
+				testApplicationLabel: "my-app",
+			},
+			uid:             "uid-completed",
+			namespace:       "ns-completed",
+			prName:          "pr-completed",
+			startTime:       &startTime,
+			completionTime:  &completionTime,
+			conditionStatus: corev1.ConditionTrue,
+			conditionReason: tektonv1.PipelineRunReasonCompleted.String(),
+			wantSpanCount:   2,
+			wantWaitSpan:    true,
+			wantExecSpan:    true,
+			wantResult:      semconv.CICDPipelineResultSuccess,
+			wantApplication: "my-app",
+		},
+		{
+			name:            "missing annotation emits no spans",
+			annotations:     map[string]string{},
+			labels:          map[string]string{},
+			skipSpanContext: true,
+			wantSpanCount:   0,
+		},
+		{
+			name:           "missing startTime emits no spans",
+			labels:         map[string]string{},
+			startTime:      nil,
+			completionTime: &completionTime,
+			wantSpanCount:  0,
+		},
+		{
+			name: "missing completionTime emits only waitDuration",
+			labels: map[string]string{
+				testApplicationLabel: "my-app",
+			},
+			uid:             "uid-nocomp",
+			namespace:       "ns-nocomp",
+			prName:          "pr-nocomp",
+			startTime:       &startTime,
+			completionTime:  nil,
+			wantSpanCount:   1,
+			wantWaitSpan:    true,
+			wantExecSpan:    false,
+			wantApplication: "my-app",
+		},
+		{
+			name:            "no application/component labels emits neither",
+			labels:          map[string]string{},
+			uid:             "uid-nolabels",
+			namespace:       "ns-nolabels",
+			prName:          "pr-nolabels",
+			startTime:       &startTime,
+			completionTime:  &completionTime,
+			conditionStatus: corev1.ConditionTrue,
+			conditionReason: tektonv1.PipelineRunReasonSuccessful.String(),
+			wantSpanCount:   2,
+			wantWaitSpan:    true,
+			wantExecSpan:    true,
+			wantResult:      semconv.CICDPipelineResultSuccess,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exporter := testtracing.SetupTracer(t)
+
+			annotations := tt.annotations
+			if annotations == nil {
+				annotations = map[string]string{}
+			}
+			if !tt.skipSpanContext {
+				annValue, _ := makeSpanContextAnnotation(t)
+				annotations[keys.SpanContextAnnotation] = annValue
+			}
+
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              tt.prName,
+					Namespace:         tt.namespace,
+					UID:               tt.uid,
+					CreationTimestamp: metav1.NewTime(creationTime),
+					Annotations:       annotations,
+					Labels:            tt.labels,
+				},
+				Status: tektonv1.PipelineRunStatus{
+					PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+						StartTime:      tt.startTime,
+						CompletionTime: tt.completionTime,
+					},
+				},
+			}
+
+			if tt.conditionReason != "" {
+				pr.Status.Status = duckv1.Status{
+					Conditions: []apis.Condition{{
+						Type:    apis.ConditionSucceeded,
+						Status:  tt.conditionStatus,
+						Reason:  tt.conditionReason,
+						Message: tt.conditionMessage,
+					}},
+				}
+			}
+
+			var trStatus map[string]*tektonv1.PipelineRunTaskRunStatus
+			if tt.taskFailureMessage != "" {
+				trStatus = map[string]*tektonv1.PipelineRunTaskRunStatus{
+					"tr-1": {
+						PipelineTaskName: "build",
+						Status: &tektonv1.TaskRunStatus{
+							Status: duckv1.Status{Conditions: []apis.Condition{{
+								Type:    apis.ConditionSucceeded,
+								Status:  corev1.ConditionFalse,
+								Reason:  tektonv1.TaskRunReasonFailed.String(),
+								Message: tt.taskFailureMessage,
+							}}},
+							TaskRunStatusFields: tektonv1.TaskRunStatusFields{
+								CompletionTime: tt.completionTime,
+							},
+						},
+					},
+				}
+			}
+
+			emitTimingSpans(zap.NewNop().Sugar(), pr, testSettings(), trStatus)
+
+			spans := exporter.GetSpans()
+			assert.Equal(t, len(spans), tt.wantSpanCount, "unexpected span count for %s", tt.name)
+
+			if tt.wantWaitSpan {
+				ws := testtracing.FindSpan(spans, tracing.SpanWaitDuration)
+				assert.Assert(t, ws != nil, "expected waitDuration span")
+				assert.Equal(t, ws.StartTime(), creationTime)
+				assert.Equal(t, ws.EndTime(), tt.startTime.Time)
+				assert.Equal(t, testtracing.SpanAttr(ws, string(tracing.NamespaceKey)), tt.namespace)
+				assert.Equal(t, testtracing.SpanAttr(ws, string(tracing.PipelineRunKey)), tt.prName)
+				assert.Equal(t, testtracing.SpanAttr(ws, string(tracing.DeliveryPipelineRunUIDKey)), string(tt.uid))
+				if tt.wantAction != "" {
+					assert.Equal(t, testtracing.SpanAttr(ws, string(semconv.CICDPipelineActionNameKey)), tt.wantAction)
+				} else {
+					assert.Assert(t, !testtracing.HasAttr(ws, string(semconv.CICDPipelineActionNameKey)), "unexpected action attribute")
+				}
+				if tt.wantApplication != "" {
+					assert.Equal(t, testtracing.SpanAttr(ws, string(tracing.DeliveryApplicationKey)), tt.wantApplication)
+				} else {
+					assert.Assert(t, !testtracing.HasAttr(ws, string(tracing.DeliveryApplicationKey)), "unexpected application attribute")
+				}
+				if tt.wantComponentAttr {
+					assert.Equal(t, testtracing.SpanAttr(ws, string(tracing.DeliveryComponentKey)), tt.wantComponent)
+				} else {
+					assert.Assert(t, !testtracing.HasAttr(ws, string(tracing.DeliveryComponentKey)), "unexpected component attribute")
+				}
+			}
+
+			if tt.wantExecSpan {
+				es := testtracing.FindSpan(spans, tracing.SpanExecuteDuration)
+				assert.Assert(t, es != nil, "expected executeDuration span")
+				assert.Equal(t, es.StartTime(), tt.startTime.Time)
+				assert.Equal(t, es.EndTime(), tt.completionTime.Time)
+				assert.Equal(t, testtracing.SpanAttr(es, string(tracing.NamespaceKey)), tt.namespace)
+				assert.Equal(t, testtracing.SpanAttr(es, string(tracing.PipelineRunKey)), tt.prName)
+				assert.Equal(t, testtracing.SpanAttr(es, string(tracing.DeliveryPipelineRunUIDKey)), string(tt.uid))
+				assert.Equal(t, testtracing.SpanAttr(es, string(semconv.CICDPipelineResultKey)), tt.wantResult.Value.AsString())
+				if tt.wantMessage != "" {
+					assert.Equal(t, testtracing.SpanAttr(es, string(tracing.DeliveryResultMessageKey)), tt.wantMessage)
+				} else {
+					assert.Assert(t, !testtracing.HasAttr(es, string(tracing.DeliveryResultMessageKey)), "unexpected result_message attribute")
+				}
+			}
+		})
+	}
+}
+
+func TestExtractSpanContext(t *testing.T) {
+	testtracing.SetupTracer(t)
+	validAnnotation, _ := makeSpanContextAnnotation(t)
+	ptr := func(s string) *string { return &s }
+
+	tests := []struct {
+		name       string
+		annotation *string
+		wantOK     bool
+	}{
+		{
+			name:       "valid annotation",
+			annotation: ptr(validAnnotation),
+			wantOK:     true,
+		},
+		{
+			name:   "missing annotation",
+			wantOK: false,
+		},
+		{
+			name:       "empty value",
+			annotation: ptr(""),
+			wantOK:     false,
+		},
+		{
+			name:       "invalid JSON",
+			annotation: ptr("not-json"),
+			wantOK:     false,
+		},
+		{
+			name:       "valid JSON but invalid traceparent",
+			annotation: ptr(`{"traceparent":"invalid"}`),
+			wantOK:     false,
+		},
+		{
+			name:       "empty JSON object",
+			annotation: ptr(`{}`),
+			wantOK:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			annotations := map[string]string{}
+			if tt.annotation != nil {
+				annotations[keys.SpanContextAnnotation] = *tt.annotation
+			}
+
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: annotations,
+				},
+			}
+
+			ctx, ok := extractSpanContext(zap.NewNop().Sugar(), pr)
+			assert.Equal(t, ok, tt.wantOK)
+			if tt.wantOK {
+				assert.Assert(t, ctx != nil)
+				sc := trace.SpanContextFromContext(ctx)
+				assert.Assert(t, sc.IsValid())
+			}
+		})
+	}
+}
+
+func TestExtractSpanContextLogsMalformedJSON(t *testing.T) {
+	core, logs := observer.New(zapcore.WarnLevel)
+	logger := zap.New(core).Sugar()
+
+	pr := &tektonv1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test-ns",
+			Name:      "test-pr",
+			Annotations: map[string]string{
+				keys.SpanContextAnnotation: "not-json",
+			},
+		},
+	}
+
+	_, ok := extractSpanContext(logger, pr)
+	assert.Assert(t, !ok)
+	assert.Equal(t, logs.Len(), 1)
+	assert.Assert(t, logs.All()[0].Level == zapcore.WarnLevel)
+	assert.Assert(t, logs.FilterMessageSnippet("malformed").Len() > 0,
+		"expected warning about malformed annotation, got: %v", logs.All())
+}
+
+func TestEmitTimingSpansTraceParentage(t *testing.T) {
+	exporter := testtracing.SetupTracer(t)
+
+	annValue, traceID := makeSpanContextAnnotation(t)
+	startTime := metav1.NewTime(time.Now().Add(-5 * time.Minute))
+	completionTime := metav1.NewTime(time.Now())
+
+	pr := &tektonv1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-pr",
+			Namespace:         "test-ns",
+			UID:               "test-uid",
+			CreationTimestamp: metav1.NewTime(startTime.Add(-30 * time.Second)),
+			Annotations: map[string]string{
+				keys.SpanContextAnnotation: annValue,
+			},
+			Labels: map[string]string{
+				testApplicationLabel: "my-app",
+			},
+		},
+		Status: tektonv1.PipelineRunStatus{
+			Status: duckv1.Status{Conditions: []apis.Condition{{
+				Type:   apis.ConditionSucceeded,
+				Status: corev1.ConditionTrue,
+				Reason: tektonv1.PipelineRunReasonSuccessful.String(),
+			}}},
+			PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+				StartTime:      &startTime,
+				CompletionTime: &completionTime,
+			},
+		},
+	}
+
+	emitTimingSpans(zap.NewNop().Sugar(), pr, testSettings(), nil)
+
+	spans := exporter.GetSpans()
+	assert.Equal(t, len(spans), 2)
+
+	for _, s := range spans {
+		assert.Equal(t, s.Parent().TraceID(), traceID,
+			"span %s should have the same trace ID as the parent", s.Name())
+		assert.Assert(t, s.Parent().IsValid(),
+			"span %s should have a valid parent span context", s.Name())
+	}
+}
+
+func TestBuildCommonAttributes(t *testing.T) {
+	pr := &tektonv1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-pr",
+			Namespace: "my-ns",
+			UID:       "my-uid",
+			Labels: map[string]string{
+				testActionLabel:      "build",
+				testApplicationLabel: "my-app",
+				testComponentLabel:   "my-comp",
+			},
+		},
+	}
+
+	attrs := buildCommonAttributes(pr, testSettings())
+	attrMap := make(map[string]attribute.Value)
+	for _, a := range attrs {
+		attrMap[string(a.Key)] = a.Value
+	}
+
+	assert.Equal(t, attrMap[string(tracing.NamespaceKey)].AsString(), "my-ns")
+	assert.Equal(t, attrMap[string(tracing.PipelineRunKey)].AsString(), "my-pr")
+	assert.Equal(t, attrMap[string(tracing.DeliveryPipelineRunUIDKey)].AsString(), "my-uid")
+	assert.Equal(t, attrMap[string(semconv.CICDPipelineActionNameKey)].AsString(), "build")
+	assert.Equal(t, attrMap[string(tracing.DeliveryApplicationKey)].AsString(), "my-app")
+	assert.Equal(t, attrMap[string(tracing.DeliveryComponentKey)].AsString(), "my-comp")
+}
+
+func TestBuildCommonAttributesNilSettings(t *testing.T) {
+	pr := &tektonv1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-pr",
+			Namespace: "my-ns",
+			UID:       "my-uid",
+			Labels: map[string]string{
+				testApplicationLabel: "my-app",
+			},
+		},
+	}
+
+	attrs := buildCommonAttributes(pr, nil)
+	attrMap := make(map[string]attribute.Value)
+	for _, a := range attrs {
+		attrMap[string(a.Key)] = a.Value
+	}
+
+	assert.Equal(t, attrMap[string(tracing.NamespaceKey)].AsString(), "my-ns")
+	assert.Equal(t, attrMap[string(tracing.PipelineRunKey)].AsString(), "my-pr")
+	assert.Equal(t, attrMap[string(tracing.DeliveryPipelineRunUIDKey)].AsString(), "my-uid")
+	_, hasApp := attrMap[string(tracing.DeliveryApplicationKey)]
+	assert.Assert(t, !hasApp, "no workload attributes when settings is nil")
+}
+
+func TestBuildExecuteAttributesSuccess(t *testing.T) {
+	pr := &tektonv1.PipelineRun{
+		Status: tektonv1.PipelineRunStatus{
+			Status: duckv1.Status{Conditions: []apis.Condition{{
+				Type:   apis.ConditionSucceeded,
+				Status: corev1.ConditionTrue,
+				Reason: tektonv1.PipelineRunReasonSuccessful.String(),
+			}}},
+		},
+	}
+
+	attrs := buildExecuteAttributes(pr, nil)
+	attrMap := make(map[string]attribute.Value)
+	for _, a := range attrs {
+		attrMap[string(a.Key)] = a.Value
+	}
+
+	assert.Equal(t, attrMap[string(semconv.CICDPipelineResultKey)].AsString(), semconv.CICDPipelineResultSuccess.Value.AsString())
+	_, hasMsg := attrMap[string(tracing.DeliveryResultMessageKey)]
+	assert.Assert(t, !hasMsg, "result_message must not be emitted on success")
+}
+
+func TestBuildExecuteAttributesNilCondition(t *testing.T) {
+	pr := &tektonv1.PipelineRun{}
+	attrs := buildExecuteAttributes(pr, nil)
+	assert.Assert(t, attrs == nil, "expected nil attrs when Succeeded condition is absent")
+}
+
+func TestEarliestFailingTaskRunMessage(t *testing.T) {
+	earlier := metav1.NewTime(time.Date(2025, 3, 1, 10, 1, 0, 0, time.UTC))
+	later := metav1.NewTime(time.Date(2025, 3, 1, 10, 5, 0, 0, time.UTC))
+
+	tests := []struct {
+		name     string
+		trStatus map[string]*tektonv1.PipelineRunTaskRunStatus
+		want     string
+	}{
+		{
+			name:     "nil map",
+			trStatus: nil,
+			want:     "",
+		},
+		{
+			name:     "empty map",
+			trStatus: map[string]*tektonv1.PipelineRunTaskRunStatus{},
+			want:     "",
+		},
+		{
+			name: "all succeeded",
+			trStatus: map[string]*tektonv1.PipelineRunTaskRunStatus{
+				"tr-1": newTRStatus(corev1.ConditionTrue, string(tektonv1.TaskRunReasonSuccessful), "All Steps have completed executing", &earlier),
+			},
+			want: "",
+		},
+		{
+			name: "single failure",
+			trStatus: map[string]*tektonv1.PipelineRunTaskRunStatus{
+				"tr-1": newTRStatus(corev1.ConditionFalse, string(tektonv1.TaskRunReasonFailed), "step-build exited 1", &earlier),
+			},
+			want: "step-build exited 1",
+		},
+		{
+			name: "two failures picks earliest by completion time",
+			trStatus: map[string]*tektonv1.PipelineRunTaskRunStatus{
+				"tr-late":  newTRStatus(corev1.ConditionFalse, string(tektonv1.TaskRunReasonFailed), "downstream failure", &later),
+				"tr-early": newTRStatus(corev1.ConditionFalse, string(tektonv1.TaskRunReasonFailed), "root cause failure", &earlier),
+			},
+			want: "root cause failure",
+		},
+		{
+			name: "mixed statuses ignores succeeded",
+			trStatus: map[string]*tektonv1.PipelineRunTaskRunStatus{
+				"tr-ok":   newTRStatus(corev1.ConditionTrue, string(tektonv1.TaskRunReasonSuccessful), "All Steps have completed executing", &earlier),
+				"tr-fail": newTRStatus(corev1.ConditionFalse, string(tektonv1.TaskRunReasonFailed), "the actual error", &later),
+			},
+			want: "the actual error",
+		},
+		{
+			name: "skips entries without completion time",
+			trStatus: map[string]*tektonv1.PipelineRunTaskRunStatus{
+				"tr-incomplete": newTRStatus(corev1.ConditionFalse, string(tektonv1.TaskRunReasonFailed), "still running", nil),
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := earliestFailingTaskRunMessage(tt.trStatus)
+			assert.Equal(t, got, tt.want)
+		})
+	}
+}
+
+func newTRStatus(status corev1.ConditionStatus, reason, message string, completion *metav1.Time) *tektonv1.PipelineRunTaskRunStatus {
+	return &tektonv1.PipelineRunTaskRunStatus{
+		PipelineTaskName: "build",
+		Status: &tektonv1.TaskRunStatus{
+			Status: duckv1.Status{Conditions: []apis.Condition{{
+				Type:    apis.ConditionSucceeded,
+				Status:  status,
+				Reason:  reason,
+				Message: message,
+			}}},
+			TaskRunStatusFields: tektonv1.TaskRunStatusFields{
+				CompletionTime: completion,
+			},
+		},
+	}
+}

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -311,7 +311,7 @@ func (r *Reconciler) reportFinalStatus(ctx context.Context, logger *zap.SugaredL
 	}
 
 	finalState := kubeinteraction.StateCompleted
-	newPr, err := r.postFinalStatus(ctx, logger, pacInfo, provider, event, pr)
+	newPr, trStatus, err := r.postFinalStatus(ctx, logger, pacInfo, provider, event, pr)
 	if err != nil {
 		logger.Errorf("failed to post final status, moving on: %v", err)
 		finalState = kubeinteraction.StateFailed
@@ -337,6 +337,8 @@ func (r *Reconciler) reportFinalStatus(ctx context.Context, logger *zap.SugaredL
 	if err := r.emitMetrics(ctx, pr); err != nil {
 		logger.Error("failed to emit metrics: ", err)
 	}
+
+	emitTimingSpans(logger, pr, &pacInfo.Settings, trStatus)
 
 	// remove pipelineRun from Queue and start the next one
 	for {

--- a/pkg/reconciler/status.go
+++ b/pkg/reconciler/status.go
@@ -102,12 +102,12 @@ func (r *Reconciler) getFailureSnippet(ctx context.Context, pr *tektonv1.Pipelin
 	return fmt.Sprintf("task <b>%s</b> has the status <b>\"%s\"</b>:\n<pre>%s</pre>", name, sortedTaskInfos[0].Reason, text)
 }
 
-func (r *Reconciler) postFinalStatus(ctx context.Context, logger *zap.SugaredLogger, pacInfo *info.PacOpts, vcx provider.Interface, event *info.Event, createdPR *tektonv1.PipelineRun) (*tektonv1.PipelineRun, error) {
+func (r *Reconciler) postFinalStatus(ctx context.Context, logger *zap.SugaredLogger, pacInfo *info.PacOpts, vcx provider.Interface, event *info.Event, createdPR *tektonv1.PipelineRun) (*tektonv1.PipelineRun, map[string]*tektonv1.PipelineRunTaskRunStatus, error) {
 	pr, err := r.run.Clients.Tekton.TektonV1().PipelineRuns(createdPR.GetNamespace()).Get(
 		ctx, createdPR.GetName(), metav1.GetOptions{},
 	)
 	if err != nil {
-		return pr, err
+		return pr, nil, err
 	}
 
 	trStatus := kstatus.GetStatusFromTaskStatusOrFromAsking(ctx, pr, r.run)
@@ -116,7 +116,7 @@ func (r *Reconciler) postFinalStatus(ctx context.Context, logger *zap.SugaredLog
 		var err error
 		taskStatusText, err = sort.TaskStatusTmpl(pr, trStatus, r.run, vcx.GetConfig())
 		if err != nil {
-			return pr, err
+			return pr, trStatus, err
 		}
 	} else {
 		taskStatusText = pr.Status.GetCondition(apis.ConditionSucceeded).Message
@@ -144,7 +144,7 @@ func (r *Reconciler) postFinalStatus(ctx context.Context, logger *zap.SugaredLog
 	}
 	var tmplStatusText string
 	if tmplStatusText, err = mt.MakeTemplate(vcx.GetTemplate(provider.PipelineRunStatusType)); err != nil {
-		return nil, fmt.Errorf("cannot create message template: %w", err)
+		return nil, trStatus, fmt.Errorf("cannot create message template: %w", err)
 	}
 
 	status := status.StatusOpts{
@@ -159,7 +159,7 @@ func (r *Reconciler) postFinalStatus(ctx context.Context, logger *zap.SugaredLog
 
 	err = createStatusWithRetry(ctx, logger, vcx, event, status)
 	logger.Infof("pipelinerun %s has a status of '%s'", pr.Name, status.Conclusion)
-	return pr, err
+	return pr, trStatus, err
 }
 
 func createStatusWithRetry(ctx context.Context, logger *zap.SugaredLogger, vcx provider.Interface, event *info.Event, statusOpts status.StatusOpts) error {

--- a/pkg/reconciler/status_test.go
+++ b/pkg/reconciler/status_test.go
@@ -77,6 +77,6 @@ func TestPostFinalStatus(t *testing.T) {
 		},
 	}
 
-	_, err := r.postFinalStatus(ctx, fakelogger, pacInfo, vcx, info.NewEvent(), pr1)
+	_, _, err := r.postFinalStatus(ctx, fakelogger, pacInfo, vcx, info.NewEvent(), pr1)
 	assert.NilError(t, err)
 }

--- a/pkg/test/tracing/tracing.go
+++ b/pkg/test/tracing/tracing.go
@@ -1,0 +1,79 @@
+package tracing
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+)
+
+// RecordingExporter collects exported spans for test assertions.
+type RecordingExporter struct {
+	mu    sync.Mutex
+	spans []sdktrace.ReadOnlySpan
+}
+
+func (e *RecordingExporter) ExportSpans(_ context.Context, spans []sdktrace.ReadOnlySpan) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.spans = append(e.spans, spans...)
+	return nil
+}
+
+func (e *RecordingExporter) Shutdown(_ context.Context) error { return nil }
+
+func (e *RecordingExporter) GetSpans() []sdktrace.ReadOnlySpan {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return append([]sdktrace.ReadOnlySpan{}, e.spans...)
+}
+
+// SetupTracer installs a test TracerProvider that records spans into the
+// returned exporter. The global provider is reset to noop on test cleanup.
+func SetupTracer(t *testing.T) *RecordingExporter {
+	t.Helper()
+	exporter := &RecordingExporter{}
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSyncer(exporter),
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+	)
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+		otel.SetTracerProvider(noop.NewTracerProvider())
+		otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator())
+	})
+	return exporter
+}
+
+func SpanAttr(s sdktrace.ReadOnlySpan, key string) string {
+	for _, attr := range s.Attributes() {
+		if string(attr.Key) == key {
+			return attr.Value.Emit()
+		}
+	}
+	return ""
+}
+
+func HasAttr(s sdktrace.ReadOnlySpan, key string) bool {
+	for _, attr := range s.Attributes() {
+		if string(attr.Key) == key {
+			return true
+		}
+	}
+	return false
+}
+
+func FindSpan(spans []sdktrace.ReadOnlySpan, name string) sdktrace.ReadOnlySpan {
+	for _, s := range spans {
+		if s.Name() == name {
+			return s
+		}
+	}
+	return nil
+}

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -1,0 +1,80 @@
+package tracing
+
+import (
+	"unicode/utf8"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
+	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/apis"
+)
+
+const TracerName = "pipelines-as-code"
+
+const AttrNamespace = "delivery.tekton.dev"
+
+const (
+	SpanWaitDuration    = "waitDuration"
+	SpanExecuteDuration = "executeDuration"
+)
+
+const MaxResultMessageLen = 1024
+
+const truncatedSuffix = "...[truncated]"
+
+// See docs/content/docs/operations/tracing.md for the full attribute schema.
+var (
+	NamespaceKey   = attribute.Key("namespace")
+	PipelineRunKey = attribute.Key("pipelinerun")
+
+	DeliveryApplicationKey    = attribute.Key(AttrNamespace + ".application")
+	DeliveryComponentKey      = attribute.Key(AttrNamespace + ".component")
+	DeliveryResultMessageKey  = attribute.Key(AttrNamespace + ".result_message")
+	DeliveryPipelineRunUIDKey = attribute.Key(AttrNamespace + ".pipelinerun_uid")
+
+	PACEventTypeKey = attribute.Key(pipelinesascode.GroupName + ".event_type")
+)
+
+// ResultEnum maps a PipelineRun Succeeded condition to a semconv
+// cicd.pipeline.result enum value. Unknown reasons fall back to
+// CICDPipelineResultError so that forward-compatible Tekton reasons are
+// never silently dropped.
+func ResultEnum(cond *apis.Condition) attribute.KeyValue {
+	if cond.Status == corev1.ConditionTrue {
+		return semconv.CICDPipelineResultSuccess
+	}
+	switch cond.Reason {
+	case tektonv1.PipelineRunReasonCancelled.String(),
+		tektonv1.PipelineRunReasonCancelledRunningFinally.String():
+		return semconv.CICDPipelineResultCancellation
+	case tektonv1.PipelineRunReasonTimedOut.String():
+		return semconv.CICDPipelineResultTimeout
+	case tektonv1.PipelineRunReasonFailed.String():
+		return semconv.CICDPipelineResultFailure
+	}
+	return semconv.CICDPipelineResultError
+}
+
+// TruncateResultMessage caps msg at MaxResultMessageLen bytes, appending a
+// marker when truncation occurs. The cut is walked back to a UTF-8 rune
+// boundary so the result is always valid UTF-8.
+func TruncateResultMessage(msg string) string {
+	if len(msg) <= MaxResultMessageLen {
+		return msg
+	}
+	keep := MaxResultMessageLen - len(truncatedSuffix)
+	if keep < 0 {
+		keep = 0
+	}
+	head := msg[:keep]
+	for len(head) > 0 {
+		r, size := utf8.DecodeLastRuneInString(head)
+		if r != utf8.RuneError || size > 1 {
+			break
+		}
+		head = head[:len(head)-size]
+	}
+	return head + truncatedSuffix
+}

--- a/pkg/tracing/tracing_test.go
+++ b/pkg/tracing/tracing_test.go
@@ -1,0 +1,192 @@
+package tracing
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/apis"
+)
+
+func TestAttributeKeyComposition(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"application", string(DeliveryApplicationKey), AttrNamespace + ".application"},
+		{"component", string(DeliveryComponentKey), AttrNamespace + ".component"},
+		{"result message", string(DeliveryResultMessageKey), AttrNamespace + ".result_message"},
+		{"pipelinerun uid", string(DeliveryPipelineRunUIDKey), AttrNamespace + ".pipelinerun_uid"},
+		{"namespace bare", string(NamespaceKey), "namespace"},
+		{"pipelinerun bare", string(PipelineRunKey), "pipelinerun"},
+		{"pac event type", string(PACEventTypeKey), pipelinesascode.GroupName + ".event_type"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.got, tt.want)
+		})
+	}
+}
+
+func TestResultEnum(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		status corev1.ConditionStatus
+		reason string
+		want   attribute.KeyValue
+	}{
+		{
+			name:   "successful",
+			status: corev1.ConditionTrue,
+			reason: tektonv1.PipelineRunReasonSuccessful.String(),
+			want:   semconv.CICDPipelineResultSuccess,
+		},
+		{
+			name:   "completed with skipped tasks",
+			status: corev1.ConditionTrue,
+			reason: tektonv1.PipelineRunReasonCompleted.String(),
+			want:   semconv.CICDPipelineResultSuccess,
+		},
+		{
+			name:   "failed",
+			status: corev1.ConditionFalse,
+			reason: tektonv1.PipelineRunReasonFailed.String(),
+			want:   semconv.CICDPipelineResultFailure,
+		},
+		{
+			name:   "timed out",
+			status: corev1.ConditionFalse,
+			reason: tektonv1.PipelineRunReasonTimedOut.String(),
+			want:   semconv.CICDPipelineResultTimeout,
+		},
+		{
+			name:   "cancelled",
+			status: corev1.ConditionFalse,
+			reason: tektonv1.PipelineRunReasonCancelled.String(),
+			want:   semconv.CICDPipelineResultCancellation,
+		},
+		{
+			name:   "cancelled running finally",
+			status: corev1.ConditionFalse,
+			reason: tektonv1.PipelineRunReasonCancelledRunningFinally.String(),
+			want:   semconv.CICDPipelineResultCancellation,
+		},
+		{
+			name:   "validation failed",
+			status: corev1.ConditionFalse,
+			reason: tektonv1.PipelineRunReasonFailedValidation.String(),
+			want:   semconv.CICDPipelineResultError,
+		},
+		{
+			name:   "couldn't get pipeline",
+			status: corev1.ConditionFalse,
+			reason: tektonv1.PipelineRunReasonCouldntGetPipeline.String(),
+			want:   semconv.CICDPipelineResultError,
+		},
+		{
+			name:   "couldn't get task",
+			status: corev1.ConditionFalse,
+			reason: tektonv1.PipelineRunReasonCouldntGetTask.String(),
+			want:   semconv.CICDPipelineResultError,
+		},
+		{
+			name:   "invalid graph",
+			status: corev1.ConditionFalse,
+			reason: tektonv1.PipelineRunReasonInvalidGraph.String(),
+			want:   semconv.CICDPipelineResultError,
+		},
+		{
+			name:   "parameter missing",
+			status: corev1.ConditionFalse,
+			reason: tektonv1.PipelineRunReasonParameterMissing.String(),
+			want:   semconv.CICDPipelineResultError,
+		},
+		{
+			name:   "parameter type mismatch",
+			status: corev1.ConditionFalse,
+			reason: tektonv1.PipelineRunReasonParameterTypeMismatch.String(),
+			want:   semconv.CICDPipelineResultError,
+		},
+		{
+			name:   "invalid workspace binding",
+			status: corev1.ConditionFalse,
+			reason: tektonv1.PipelineRunReasonInvalidWorkspaceBinding.String(),
+			want:   semconv.CICDPipelineResultError,
+		},
+		{
+			name:   "create run failed",
+			status: corev1.ConditionFalse,
+			reason: tektonv1.PipelineRunReasonCreateRunFailed.String(),
+			want:   semconv.CICDPipelineResultError,
+		},
+		{
+			name:   "resource verification failed",
+			status: corev1.ConditionFalse,
+			reason: tektonv1.PipelineRunReasonResourceVerificationFailed.String(),
+			want:   semconv.CICDPipelineResultError,
+		},
+		{
+			name:   "future reason from upstream",
+			status: corev1.ConditionFalse,
+			reason: "SomeFutureReasonNotYetMapped",
+			want:   semconv.CICDPipelineResultError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cond := &apis.Condition{Type: apis.ConditionSucceeded, Status: tt.status, Reason: tt.reason}
+			got := ResultEnum(cond)
+			assert.Equal(t, got, tt.want)
+		})
+	}
+}
+
+func TestTruncateResultMessage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty", in: "", want: ""},
+		{name: "short stays untouched", in: "step-build exited 1", want: "step-build exited 1"},
+		{name: "exact limit stays untouched", in: strings.Repeat("a", MaxResultMessageLen), want: strings.Repeat("a", MaxResultMessageLen)},
+		{
+			name: "over limit is truncated with marker",
+			in:   strings.Repeat("a", MaxResultMessageLen+50),
+			want: strings.Repeat("a", MaxResultMessageLen-len("...[truncated]")) + "...[truncated]",
+		},
+		{
+			// Multi-byte rune (é = 0xC3 0xA9) straddling the cut must not survive
+			// as a partial sequence. The keep boundary is shifted back to the
+			// previous valid rune, then padded with 1 byte by the suffix, so the
+			// final length is MaxResultMessageLen - 1.
+			name: "multi-byte rune at boundary is walked back to a valid boundary",
+			in:   strings.Repeat("a", MaxResultMessageLen-len("...[truncated]")-1) + "é" + strings.Repeat("a", 50),
+			want: strings.Repeat("a", MaxResultMessageLen-len("...[truncated]")-1) + "...[truncated]",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := TruncateResultMessage(tt.in)
+			assert.Equal(t, got, tt.want)
+			assert.Assert(t, len(got) <= MaxResultMessageLen, "truncated length must not exceed limit")
+			assert.Assert(t, utf8.ValidString(got), "truncated string must be valid UTF-8")
+		})
+	}
+}


### PR DESCRIPTION
## Description

Add OpenTelemetry distributed tracing to Pipelines-as-Code. When tracing is
enabled via the `pipelines-as-code-config-observability` ConfigMap, PaC emits
trace spans for webhook event processing and PipelineRun lifecycle timing.

**Controller:** Emits a `PipelinesAsCode:ProcessEvent` span for each webhook
event. Extracts W3C trace context from inbound webhook headers when present,
otherwise creates a new root span. Propagates the span context onto created
PipelineRuns via the `tekton.dev/pipelinerunSpanContext` annotation, enabling
end-to-end traces when downstream controllers also have tracing enabled.

**Watcher:** Emits `waitDuration` (creation → start) and `executeDuration`
(start → completion) timing spans for completed PipelineRuns, using resource
timestamps for accurate wall-clock timing.

### Configuration

Tracing uses two ConfigMaps (both already exist in the PaC deployment manifests):

1. **`pipelines-as-code-config-observability`** — tracing protocol, endpoint, and
   sampling rate. The controller and watcher locate this ConfigMap via the
   `CONFIG_OBSERVABILITY_NAME` environment variable already set in their deployment
   YAMLs. **Changes require a pod restart** — the trace exporter is created once at
   startup.

2. **`pipelines-as-code`** — three new keys (`tracing-label-action`,
   `tracing-label-application`, `tracing-label-component`) configure which
   PipelineRun labels are read for span attributes. Changes are picked up
   automatically without restart.

See `docs/content/docs/operations/tracing.md` for the full schema, attribute
tables, and deployment guidance.

### Testing tracing on a cluster

The default `config/305-config-observability.yaml` ships with tracing disabled.
To enable it, add `tracing-protocol`, `tracing-endpoint`, and
`tracing-sampling-rate` to the observability ConfigMap and restart the controller
and watcher pods. Note that `ko apply -f config/` will overwrite the
observability ConfigMap with defaults — re-apply tracing fields afterward.

## Linked Issue


## Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [x] Manual testing

Unit tests cover span attribute emission, trace context injection/extraction,
W3C parentage (incoming context honored vs. new root created), malformed
annotation handling, result enum mapping, and message truncation. Manually
verified end-to-end on a local cluster with Jaeger.

## AI Assistance

- [x] I have used AI assistance for this PR.

Co-authored-by trailers are on each commit.

## Submitter Checklist

- [x] Commit messages follow the project guide
- [x] `make test` and `make lint` pass locally
- [x] Documentation updated for user-facing changes
- [x] Unit tests added for code changes