### PR TITLE
[DNM] docs(profiling): update guide for OTel migration

### DIFF
--- a/docs/content/docs/operations/profiling.md
+++ b/docs/content/docs/operations/profiling.md
@@ -31,14 +31,31 @@ When profiling is disabled the server still listens but returns `404` for every 
 
 ## Enabling Profiling
 
-### Watcher
+All components read profiling configuration from the same ConfigMap:
 
-The **watcher** (`pipelines-as-code-watcher`) uses Knative's `sharedmain` framework,
-which watches the `config-observability` ConfigMap and toggles profiling **without a
-restart**.
+```bash
+# Enable
+kubectl patch configmap pipelines-as-code-config-observability \
+  -n pipelines-as-code \
+  --type merge \
+  -p '{"data":{"runtime-profiling":"enabled"}}'
 
-**`PAC_DISABLE_HEALTH_PROBE=true` must be set on the watcher, otherwise a port conflict
-on 8080 will cause the profiling server to shut down:**
+# Disable
+kubectl patch configmap pipelines-as-code-config-observability \
+  -n pipelines-as-code \
+  --type merge \
+  -p '{"data":{"runtime-profiling":"disabled"}}'
+```
+
+### Component-specific prerequisites
+
+| Component | Extra step required |
+| --- | --- |
+| **watcher** | Set `PAC_DISABLE_HEALTH_PROBE=true` — otherwise a port conflict on 8080 causes the profiling server to shut down (see below). The watcher picks up ConfigMap changes without a restart. |
+| **webhook** | Set `CONFIG_OBSERVABILITY_NAME=pipelines-as-code-config-observability` — the webhook Deployment does not set this by default and falls back to `config-observability`, which does not exist in the PAC namespace. The webhook picks up ConfigMap changes without a restart. |
+| **controller** | **Profiling is not currently supported.** The eventing adapter framework used by the controller creates the pprof server but never starts it (`ListenAndServe` is never called), so port 8008 never opens. |
+
+For the watcher:
 
 ```bash
 kubectl set env deployment/pipelines-as-code-watcher \
@@ -46,35 +63,7 @@ kubectl set env deployment/pipelines-as-code-watcher \
   PAC_DISABLE_HEALTH_PROBE=true
 ```
 
-Then enable profiling via the ConfigMap:
-
-```bash
-kubectl patch configmap pipelines-as-code-config-observability \
-  -n pipelines-as-code \
-  --type merge \
-  -p '{"data":{"profiling.enable":"true"}}'
-```
-
-To disable profiling:
-
-```bash
-kubectl patch configmap pipelines-as-code-config-observability \
-  -n pipelines-as-code \
-  --type merge \
-  -p '{"data":{"profiling.enable":"false"}}'
-```
-
-The watcher picks up the ConfigMap change immediately without a restart.
-
-### Webhook
-
-The **webhook** (`pipelines-as-code-webhook`) also uses `sharedmain` and supports
-dynamic toggling via the same ConfigMap. Unlike the watcher, the webhook does not run
-its own health probe server, so `PAC_DISABLE_HEALTH_PROBE` is not required.
-
-The webhook deployment does not set `CONFIG_OBSERVABILITY_NAME` by default, so it
-falls back to looking for a ConfigMap named `config-observability`, which does not
-exist in the PAC namespace. Set the environment variable first:
+For the webhook:
 
 ```bash
 kubectl set env deployment/pipelines-as-code-webhook \
@@ -82,47 +71,28 @@ kubectl set env deployment/pipelines-as-code-webhook \
   CONFIG_OBSERVABILITY_NAME=pipelines-as-code-config-observability
 ```
 
-Then use the same `kubectl patch` on the ConfigMap above to enable or disable profiling.
-
-### Controller
-
-The **controller** (`pipelines-as-code-controller`) uses the Knative eventing adapter
-framework. Profiling is configured at startup from the `K_METRICS_CONFIG` environment
-variable and is **not** dynamically reloaded; a pod restart is required after any change.
-
-The `K_METRICS_CONFIG` variable contains a JSON object whose `ConfigMap` field holds
-inline key/value configuration data. To enable profiling, add `"profiling.enable":"true"`
-inside that `ConfigMap` object:
-
-```bash
-# Read the current value first
-kubectl get deployment pipelines-as-code-controller \
-  -n pipelines-as-code \
-  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="K_METRICS_CONFIG")].value}'
-```
-
-Then patch the Deployment with `profiling.enable` added to the `ConfigMap` field, for example:
-
-```bash
-kubectl set env deployment/pipelines-as-code-controller \
-  -n pipelines-as-code \
-  'K_METRICS_CONFIG={"Domain":"pipelinesascode.tekton.dev/controller","Component":"pac_controller","PrometheusPort":9090,"ConfigMap":{"name":"pipelines-as-code-config-observability","profiling.enable":"true"}}'
-```
-
-This triggers a rolling restart of the controller pod. Remove `"profiling.enable":"true"`
-(or set it to `"false"`) and re-apply to disable.
-
 ## Accessing Profiles
 
-Port 8008 is not declared in the container spec by default. To make it reachable, patch
-the target Deployment(s) to add the port:
+The profiling server listens on port **8008** by default. If that conflicts with another
+service, set `PROFILING_PORT` on the relevant Deployment(s) before proceeding:
 
 ```bash
-for deploy in pipelines-as-code-watcher pipelines-as-code-controller pipelines-as-code-webhook; do
+kubectl set env deployment/pipelines-as-code-watcher \
+  deployment/pipelines-as-code-webhook \
+  -n pipelines-as-code \
+  PROFILING_PORT=8090
+```
+
+Port 8008 (or your chosen port) is not declared in the container spec by default. Patch
+the target Deployment(s) to expose it — substituting the port number if you changed it:
+
+```bash
+PROFILING_PORT=8008  # change if you set a custom port above
+for deploy in pipelines-as-code-watcher pipelines-as-code-webhook; do
   kubectl patch deployment "$deploy" \
     -n pipelines-as-code \
     --type json \
-    -p '[{"op":"add","path":"/spec/template/spec/containers/0/ports/-","value":{"name":"profiling","containerPort":8008,"protocol":"TCP"}}]'
+    -p "[{\"op\":\"add\",\"path\":\"/spec/template/spec/containers/0/ports/-\",\"value\":{\"name\":\"profiling\",\"containerPort\":${PROFILING_PORT},\"protocol\":\"TCP\"}}]"
 done
 ```
 
@@ -144,37 +114,19 @@ export POD_NAME=$(kubectl get pods -n pipelines-as-code \
   -l app.kubernetes.io/name=watcher \
   -o jsonpath='{.items[0].metadata.name}')
 
-# Controller
-export POD_NAME=$(kubectl get pods -n pipelines-as-code \
-  -l app.kubernetes.io/name=controller \
-  -o jsonpath='{.items[0].metadata.name}')
-
 # Webhook
 export POD_NAME=$(kubectl get pods -n pipelines-as-code \
   -l app.kubernetes.io/name=webhook \
   -o jsonpath='{.items[0].metadata.name}')
 ```
 
-Then, forward a local port to the pod's profiling port:
+Then, forward a local port to the pod's profiling port (adjust if you changed `PROFILING_PORT`):
 
 ```bash
 kubectl port-forward -n pipelines-as-code $POD_NAME 8008:8008
 ```
 
 The pprof index is now available at `http://localhost:8008/debug/pprof/`.
-
-### Changing the profiling port
-
-If port 8008 conflicts with another service, set the `PROFILING_PORT` environment
-variable on the Deployment to use a different port:
-
-```bash
-kubectl set env deployment/pipelines-as-code-watcher \
-  -n pipelines-as-code \
-  PROFILING_PORT=8090
-```
-
-Update the `containerPort` in the patch above and your port-forward command to match.
 
 ### Capturing profiles with `go tool pprof`
 
@@ -214,4 +166,4 @@ in the container spec by default, access requires an explicit Deployment patch, 
 it to users with `deployments/patch` permission in the `pipelines-as-code` namespace.
 
 Do not expose port 8008 via a Service or Ingress in production environments. Disable
-profiling (`profiling.enable: "false"`) when not actively investigating an issue.
+profiling (`runtime-profiling: "disabled"`) when not actively investigating an issue.


### PR DESCRIPTION
## 📝 Description of the Change
Replace the old profiling.enable configmap key with runtime-profiling, remove the obsolete K_METRICS_CONFIG controller instructions, and note that controller profiling is broken in the eventing adapter framework as ListenAndServe is never called.

## 🔗 Linked GitHub Issue
N/A

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [x] Not Applicable

## 🤖 AI Assistance

AI assistance can be used for various tasks, such as code generation,
documentation, or testing.

Please indicate whether you have used AI assistance
for this PR and provide details if applicable.

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

> [!IMPORTANT]
>
> **Slop will be simply rejected**, if you are using AI assistance you need to make sure you
> understand the code generated and that it meets the project's standards. you
> need at least know how to run the code and deploy it (if needed). See
> [startpaac](https://github.com/openshift-pipelines/startpaac) to make it easy
> to deploy and test your code changes.
>
> If the **majority of the code** in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Claude <noreply@anthropic.com>

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [x] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
