### PR TITLE
fix(github): use provided target ref in GetFileInsideRepo

### DIFF
--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -505,7 +505,7 @@ func (v *Provider) GetCommitInfo(ctx context.Context, runevent *info.Event) erro
 func (v *Provider) GetFileInsideRepo(ctx context.Context, runevent *info.Event, path, target string) (string, error) {
 	ref := runevent.SHA
 	if target != "" {
-		ref = runevent.BaseBranch
+		ref = target
 	} else if v.provenance == "default_branch" {
 		ref = runevent.DefaultBranch
 	}

--- a/pkg/provider/github/github_test.go
+++ b/pkg/provider/github/github_test.go
@@ -728,6 +728,79 @@ func TestGetFileInsideRepo(t *testing.T) {
 	}
 }
 
+func TestGetFileInsideRepoRefSelection(t *testing.T) {
+	fileContent := base64.StdEncoding.EncodeToString([]byte("valid owners file"))
+	tests := []struct {
+		name        string
+		event       *info.Event
+		target      string
+		provenance  string
+		expectedRef string
+	}{
+		{
+			name: "uses SHA when target is empty",
+			event: &info.Event{
+				Organization:  "org",
+				Repository:    "repo",
+				SHA:           "sha123",
+				BaseBranch:    "main",
+				DefaultBranch: "main",
+			},
+			target:      "",
+			expectedRef: "sha123",
+		},
+		{
+			name: "uses target ref when target is provided",
+			event: &info.Event{
+				Organization:  "org",
+				Repository:    "repo",
+				SHA:           "sha123",
+				BaseBranch:    "main",
+				DefaultBranch: "main",
+			},
+			target:      "refs/heads/release-1.0",
+			expectedRef: "refs/heads/release-1.0",
+		},
+		{
+			name: "uses DefaultBranch when target is empty and provenance is default_branch",
+			event: &info.Event{
+				Organization:  "org",
+				Repository:    "repo",
+				SHA:           "sha123",
+				BaseBranch:    "develop",
+				DefaultBranch: "main",
+			},
+			target:      "",
+			provenance:  "default_branch",
+			expectedRef: "main",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			fakeclient, mux, _, teardown := ghtesthelper.SetupGH()
+			defer teardown()
+			gvcs := Provider{
+				ghClient:   fakeclient,
+				provenance: tt.provenance,
+			}
+
+			mux.HandleFunc("/repos/org/repo/contents/OWNERS", func(w http.ResponseWriter, r *http.Request) {
+				gotRef := r.URL.Query().Get("ref")
+				assert.Equal(t, gotRef, tt.expectedRef)
+				fmt.Fprintf(w, `{"name": "OWNERS", "path": "OWNERS", "sha": "ownersha"}`)
+			})
+			mux.HandleFunc("/repos/org/repo/git/blobs/ownersha", func(w http.ResponseWriter, _ *http.Request) {
+				fmt.Fprintf(w, `{"content": %q, "sha": "ownersha"}`, fileContent)
+			})
+
+			got, err := gvcs.GetFileInsideRepo(ctx, tt.event, "OWNERS", tt.target)
+			assert.NilError(t, err)
+			assert.Equal(t, got, "valid owners file")
+		})
+	}
+}
+
 func TestCheckSenderOrgMembership(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION


## 📝 Description of the Change
GetFileInsideRepo ignored the caller-supplied target ref and substituted runevent.BaseBranch. This caused OWNERS ACL checks to read from the wrong branch when a PR targets a non-default branch, and remote task fetches to resolve against the PR base instead of the specified ref.

## 🔗 Linked GitHub Issue
N/A

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [x] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

AI assistance can be used for various tasks, such as code generation,
documentation, or testing.

Please indicate whether you have used AI assistance
for this PR and provide details if applicable.

- [x] I have not used any AI assistance for this PR.
- [ ] I have used AI assistance for this PR.

> [!IMPORTANT]
>
> **Slop will be simply rejected**, if you are using AI assistance you need to make sure you
> understand the code generated and that it meets the project's standards. you
> need at least know how to run the code and deploy it (if needed). See
> [startpaac](https://github.com/openshift-pipelines/startpaac) to make it easy
> to deploy and test your code changes.
>
> If the **majority of the code** in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Claude <noreply@anthropic.com>

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
