### PR TITLE
feat(cel): handle Forgejo headers in CLI provider auto-detection

### DIFF
--- a/pkg/cmd/tknpac/cel/cel.go
+++ b/pkg/cmd/tknpac/cel/cel.go
@@ -458,7 +458,11 @@ func pacParamsFromEvent(event *info.Event) map[string]string {
 func detectProvider(headers map[string]string, body []byte) (string, error) {
 	// Check for GitHub provider (most common)
 	if getHeaderCaseInsensitive(headers, "X-GitHub-Event") != "" {
-		// Check if it's actually Gitea (which also sets X-GitHub-Event)
+		// Forgejo sets X-Forgejo-Event-Type, X-Gitea-Event-Type, and X-GitHub-Event
+		if getHeaderCaseInsensitive(headers, "X-Forgejo-Event-Type") != "" {
+			return "forgejo", nil
+		}
+		// Gitea sets X-Gitea-Event-Type and X-GitHub-Event (but not X-Forgejo-Event-Type)
 		if getHeaderCaseInsensitive(headers, "X-Gitea-Event-Type") != "" {
 			return "gitea", nil
 		}
@@ -491,7 +495,12 @@ func detectProvider(headers map[string]string, body []byte) (string, error) {
 		}
 	}
 
-	// Check for Gitea provider (backup check in case header is missing)
+	// Check for Forgejo provider
+	if getHeaderCaseInsensitive(headers, "X-Forgejo-Event-Type") != "" {
+		return "forgejo", nil
+	}
+
+	// Check for Gitea provider
 	if getHeaderCaseInsensitive(headers, "X-Gitea-Event-Type") != "" {
 		return "gitea", nil
 	}
@@ -546,7 +555,7 @@ func Command(ioStreams *cli.IOStreams) *cobra.Command {
 		Long: `Evaluate CEL expressions interactively with webhook payloads.
 
 The command automatically detects the git provider from the webhook headers and payload structure.
-Supported providers: GitHub, GitLab, Bitbucket Cloud, Bitbucket Data Center, and Gitea.
+Supported providers: GitHub, GitLab, Bitbucket Cloud, Bitbucket Data Center, Gitea, and Forgejo.
 
 You can provide webhook payload and headers from files to test CEL expressions
 that would be used in PipelineRun configurations.`,
@@ -636,8 +645,14 @@ that would be used in PipelineRun configurations.`,
 					return err
 				}
 				pacParams = pacParamsFromEvent(event)
-			case "gitea", "forgejo":
+			case "gitea":
 				event, err := eventFromGitea(bodyBytes, headers)
+				if err != nil {
+					return err
+				}
+				pacParams = pacParamsFromEvent(event)
+			case "forgejo":
+				event, err := eventFromForgejo(bodyBytes, headers)
 				if err != nil {
 					return err
 				}

--- a/pkg/cmd/tknpac/cel/cel_test.go
+++ b/pkg/cmd/tknpac/cel/cel_test.go
@@ -1540,6 +1540,33 @@ func TestDetectProvider(t *testing.T) {
 			expectedProvider: "gitea",
 		},
 		{
+			name: "Forgejo provider with all headers",
+			headers: map[string]string{
+				"X-GitHub-Event":       "pull_request",
+				"X-Gitea-Event-Type":   "pull_request",
+				"X-Forgejo-Event-Type": "pull_request",
+			},
+			body:             []byte(`{"repository": {"html_url": "https://forgejo.example.com/owner/repo"}}`),
+			expectedProvider: "forgejo",
+		},
+		{
+			name: "Forgejo provider with only Forgejo header",
+			headers: map[string]string{
+				"X-Forgejo-Event-Type": "pull_request",
+			},
+			body:             []byte(`{"repository": {"html_url": "https://forgejo.example.com/owner/repo"}}`),
+			expectedProvider: "forgejo",
+		},
+		{
+			name: "Forgejo provider with GitHub and Forgejo headers",
+			headers: map[string]string{
+				"X-GitHub-Event":       "pull_request",
+				"X-Forgejo-Event-Type": "pull_request",
+			},
+			body:             []byte(`{"repository": {"html_url": "https://forgejo.example.com/owner/repo"}}`),
+			expectedProvider: "forgejo",
+		},
+		{
 			name: "GitLab provider",
 			headers: map[string]string{
 				"X-Gitlab-Event": "Merge Request Hook",

--- a/pkg/cmd/tknpac/cel/gitea.go
+++ b/pkg/cmd/tknpac/cel/gitea.go
@@ -8,3 +8,8 @@ import (
 func eventFromGitea(bodyBytes []byte, headers map[string]string) (*info.Event, error) {
 	return parseWebhookForCEL(bodyBytes, headers, &GiteaParser{})
 }
+
+// eventFromForgejo parses Forgejo webhook payload for CEL evaluation.
+func eventFromForgejo(bodyBytes []byte, headers map[string]string) (*info.Event, error) {
+	return parseWebhookForCEL(bodyBytes, headers, &ForgejoParser{})
+}

--- a/pkg/cmd/tknpac/cel/parser.go
+++ b/pkg/cmd/tknpac/cel/parser.go
@@ -586,6 +586,14 @@ func (p *GiteaParser) GetEventTypeHeader() string {
 	return "X-Gitea-Event-Type"
 }
 
+type ForgejoParser struct {
+	GiteaParser
+}
+
+func (p *ForgejoParser) GetEventTypeHeader() string {
+	return "X-Forgejo-Event-Type"
+}
+
 func (p *GiteaParser) ParsePayload(eventType string, body []byte) (any, error) {
 	var eventInt any
 	switch eventType {

--- a/pkg/cmd/tknpac/cel/parser_test.go
+++ b/pkg/cmd/tknpac/cel/parser_test.go
@@ -529,3 +529,78 @@ func TestGiteaParserWithMissingFields(t *testing.T) {
 		})
 	}
 }
+
+func TestEventFromForgejo(t *testing.T) {
+	prPayload := `{
+		"action": "opened",
+		"number": 1,
+		"pull_request": {
+			"title": "Test PR",
+			"head": {"ref": "feature", "sha": "abc123",
+				"repo": {"html_url": "https://forgejo.example.com/fork/repo"}},
+			"base": {"ref": "main",
+				"repo": {"html_url": "https://forgejo.example.com/owner/repo"}}
+		},
+		"repository": {
+			"html_url": "https://forgejo.example.com/owner/repo",
+			"name": "repo",
+			"default_branch": "main",
+			"owner": {"login": "owner"}
+		},
+		"sender": {"login": "contributor"}
+	}`
+
+	tests := []struct {
+		name    string
+		headers map[string]string
+		wantErr bool
+		checks  func(t *testing.T, event *info.Event)
+	}{
+		{
+			name: "Forgejo header only",
+			headers: map[string]string{
+				"X-Forgejo-Event-Type": "pull_request",
+			},
+			checks: func(t *testing.T, event *info.Event) {
+				t.Helper()
+				assert.Equal(t, event.Organization, "owner")
+				assert.Equal(t, event.Repository, "repo")
+				assert.Equal(t, event.Sender, "contributor")
+				assert.Equal(t, event.HeadBranch, "feature")
+				assert.Equal(t, event.BaseBranch, "main")
+			},
+		},
+		{
+			name: "both Forgejo and Gitea headers",
+			headers: map[string]string{
+				"X-Forgejo-Event-Type": "pull_request",
+				"X-Gitea-Event-Type":   "pull_request",
+			},
+			checks: func(t *testing.T, event *info.Event) {
+				t.Helper()
+				assert.Equal(t, event.Organization, "owner")
+				assert.Equal(t, event.Repository, "repo")
+			},
+		},
+		{
+			name: "error when only Gitea header provided",
+			headers: map[string]string{
+				"X-Gitea-Event-Type": "pull_request",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event, err := eventFromForgejo([]byte(prPayload), tt.headers)
+			if tt.wantErr {
+				assert.Assert(t, err != nil)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Assert(t, event != nil)
+			tt.checks(t, event)
+		})
+	}
+}


### PR DESCRIPTION


## 📝 Description of the Change
The `tkn pac cel` command only checked for X-Gitea-Event-Type when auto-detecting the provider from webhook headers. Forgejo sends its own X-Forgejo-Event-Type header alongside the Gitea ones, but the CLI never looked for it that caused detection to fail:
`Error: auto-detection failed: unable to detect provider from headers or payload`

  - Add `X-Forgejo-Event-Type` header checks to `detectProvider()` so the CLI correctly identifies Forgejo webhooks (checked before Gitea since Forgejo sends both headers, but Gitea never sends Forgejo headers)
  - Add `ForgejoParser` struct that reads `X-Forgejo-Event-Type` for event type, inheriting payload parsing from `GiteaParser` (identical payload format)


## 🔗 Linked GitHub Issue

Fixes #2435

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [x] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

AI assistance can be used for various tasks, such as code generation,
documentation, or testing.

Please indicate whether you have used AI assistance
for this PR and provide details if applicable.

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

> [!IMPORTANT]
>
> **Slop will be simply rejected**, if you are using AI assistance you need to make sure you
> understand the code generated and that it meets the project's standards. you
> need at least know how to run the code and deploy it (if needed). See
> [startpaac](https://github.com/openshift-pipelines/startpaac) to make it easy
> to deploy and test your code changes.
>
> If the **majority of the code** in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Claude <noreply@anthropic.com>

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [x] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [x] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
