### PR TITLE
fix: scope GitHub App token and deep-copy cached remote resources

### DIFF
--- a/pkg/adapter/incoming.go
+++ b/pkg/adapter/incoming.go
@@ -222,24 +222,27 @@ func (l *listener) processIncoming(event *info.Event, targetRepo *v1alpha1.Repos
 	event.Organization = org
 	event.Repository = repo
 
+	providerType := ""
+	if targetRepo.Spec.GitProvider != nil {
+		providerType = targetRepo.Spec.GitProvider.Type
+	}
+
 	var provider provider.Interface
-	if targetRepo.Spec.GitProvider == nil || targetRepo.Spec.GitProvider.Type == "" {
-		provider = github.New()
-	} else {
-		switch targetRepo.Spec.GitProvider.Type {
-		case "github":
-			provider = github.New()
-		case "gitlab":
-			provider = &gitlab.Provider{}
-		case "gitea", "forgejo":
-			provider = &gitea.Provider{}
-		case "bitbucket-cloud":
-			provider = &bitbucketcloud.Provider{}
-		case "bitbucket-datacenter":
-			provider = &bitbucketdatacenter.Provider{}
-		default:
-			return l.processRes(false, nil, l.logger.With("namespace", targetRepo.Namespace), "", fmt.Errorf("no supported Git provider has been detected"))
-		}
+	switch providerType {
+	case "", "github":
+		gh := github.New()
+		gh.RepositoryNames = []string{repo}
+		provider = gh
+	case "gitlab":
+		provider = &gitlab.Provider{}
+	case "gitea", "forgejo":
+		provider = &gitea.Provider{}
+	case "bitbucket-cloud":
+		provider = &bitbucketcloud.Provider{}
+	case "bitbucket-datacenter":
+		provider = &bitbucketdatacenter.Provider{}
+	default:
+		return l.processRes(false, nil, l.logger.With("namespace", targetRepo.Namespace), "", fmt.Errorf("no supported Git provider has been detected"))
 	}
 
 	return l.processRes(true, provider, l.logger.With("provider", "incoming", "namespace", targetRepo.Namespace), "", nil)

--- a/pkg/adapter/incoming_test.go
+++ b/pkg/adapter/incoming_test.go
@@ -2,7 +2,9 @@ package adapter
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -12,6 +14,8 @@ import (
 
 	apincoming "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/incoming"
 
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/gitclient"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	"go.uber.org/zap"
 	zapobserver "go.uber.org/zap/zaptest/observer"
@@ -31,6 +35,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/github"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/gitlab"
 	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
+	ghtesthelper "github.com/openshift-pipelines/pipelines-as-code/pkg/test/github"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/test/kubernetestint"
 )
 
@@ -855,18 +860,20 @@ func TestListenerDetectIncoming(t *testing.T) {
 
 func TestListenerProcessIncoming(t *testing.T) {
 	tests := []struct {
-		name       string
-		want       provider.Interface
-		wantErr    bool
-		targetRepo *v1alpha1.Repository
-		wantOrg    string
-		wantRepo   string
+		name          string
+		want          provider.Interface
+		wantErr       bool
+		targetRepo    *v1alpha1.Repository
+		wantOrg       string
+		wantRepo      string
+		wantRepoNames []string
 	}{
 		{
-			name:     "process/github",
-			want:     github.New(),
-			wantOrg:  "owner",
-			wantRepo: "repo",
+			name:          "process/github",
+			want:          github.New(),
+			wantOrg:       "owner",
+			wantRepo:      "repo",
+			wantRepoNames: []string{"repo"},
 			targetRepo: &v1alpha1.Repository{
 				Spec: v1alpha1.RepositorySpec{
 					URL: "https://forge/owner/repo",
@@ -977,10 +984,11 @@ func TestListenerProcessIncoming(t *testing.T) {
 			},
 		},
 		{
-			name:     "No GitProvider is provided",
-			want:     github.New(),
-			wantOrg:  "owner",
-			wantRepo: "repo",
+			name:          "No GitProvider is provided",
+			want:          github.New(),
+			wantOrg:       "owner",
+			wantRepo:      "repo",
+			wantRepoNames: []string{"repo"},
 			targetRepo: &v1alpha1.Repository{
 				Spec: v1alpha1.RepositorySpec{
 					URL:         "https://forge/owner/repo",
@@ -989,10 +997,11 @@ func TestListenerProcessIncoming(t *testing.T) {
 			},
 		},
 		{
-			name:     "No GitProvider type is provided",
-			want:     github.New(),
-			wantOrg:  "owner",
-			wantRepo: "repo",
+			name:          "No GitProvider type is provided",
+			want:          github.New(),
+			wantOrg:       "owner",
+			wantRepo:      "repo",
+			wantRepoNames: []string{"repo"},
 			targetRepo: &v1alpha1.Repository{
 				Spec: v1alpha1.RepositorySpec{
 					URL:         "https://forge/owner/repo",
@@ -1021,8 +1030,108 @@ func TestListenerProcessIncoming(t *testing.T) {
 			assert.Assert(t, reflect.TypeOf(pintf).Elem() == reflect.TypeOf(tt.want).Elem())
 			assert.Assert(t, event.Organization == tt.wantOrg)
 			assert.Assert(t, event.Repository == tt.wantRepo)
+			if len(tt.wantRepoNames) > 0 {
+				gh, ok := pintf.(*github.Provider)
+				assert.Assert(t, ok, "expected *github.Provider for RepositoryNames check")
+				assert.DeepEqual(t, tt.wantRepoNames, gh.RepositoryNames)
+			}
 		})
 	}
+}
+
+func TestIncomingGitHubAppScopesTokenThroughClientSetup(t *testing.T) {
+	const (
+		namespace    = "pipelines-as-code"
+		secretName   = "pipelines-as-code-secret"
+		repoName     = "incoming-repo"
+		installation = int64(1)
+	)
+
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = info.StoreCurrentControllerName(ctx, "default")
+	ctx = info.StoreNS(ctx, namespace)
+
+	_, mux, serverURL, teardown := ghtesthelper.SetupGH()
+	defer teardown()
+	t.Setenv("PAC_GIT_PROVIDER_TOKEN_APIURL", serverURL+"/api/v3")
+
+	var capturedBody map[string]any
+	mux.HandleFunc(fmt.Sprintf("/app/installations/%d/access_tokens", installation), func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		assert.NilError(t, err)
+		assert.NilError(t, json.Unmarshal(body, &capturedBody))
+		_, _ = fmt.Fprint(w, `{"token":"scoped-token","expires_at":"2099-01-01T00:00:00Z"}`)
+	})
+
+	testLog := zap.NewNop().Sugar()
+	seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+		Namespaces: []*corev1.Namespace{{
+			ObjectMeta: metav1.ObjectMeta{Name: namespace},
+		}},
+		Secret: []*corev1.Secret{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: namespace,
+			},
+			Data: map[string][]byte{
+				"github-application-id": []byte("12345"),
+				"github-private-key":    []byte(fakePrivateKey),
+				"webhook.secret":        []byte("webhook-secret"),
+			},
+		}},
+	})
+
+	run := &params.Run{
+		Clients: clients.Clients{
+			Kube:           seedData.Kube,
+			PipelineAsCode: seedData.PipelineAsCode,
+			Log:            testLog,
+		},
+		Info: info.Info{
+			Controller: &info.ControllerInfo{Secret: secretName},
+			Kube:       &info.KubeOpts{Namespace: namespace},
+		},
+	}
+
+	kint, err := kubeinteraction.NewKubernetesInteraction(run)
+	assert.NilError(t, err)
+
+	targetRepo := &v1alpha1.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      repoName,
+			Namespace: "default",
+		},
+		Spec: v1alpha1.RepositorySpec{
+			URL: "https://github.com/owner/" + repoName,
+		},
+	}
+
+	event := info.NewEvent()
+	event.EventType = "incoming"
+	event.InstallationID = installation
+	event.URL = targetRepo.Spec.URL
+	event.Provider.Token = "initial-unscoped-token"
+
+	l := listener{run: run, logger: testLog}
+	vcx, eventLogger, err := l.processIncoming(event, targetRepo)
+	assert.NilError(t, err)
+
+	pacInfo := &info.PacOpts{}
+	vcx.SetPacInfo(pacInfo)
+
+	err = gitclient.SetupAuthenticatedClient(ctx, vcx, kint, run, event, targetRepo, nil, pacInfo, eventLogger)
+	assert.NilError(t, err)
+
+	assert.Equal(t, "scoped-token", event.Provider.Token)
+
+	rawRepos, ok := capturedBody["repositories"]
+	assert.Assert(t, ok, "expected repositories field in token request body")
+	repos, ok := rawRepos.([]any)
+	assert.Assert(t, ok, "repositories is not an array")
+	assert.DeepEqual(t, []any{repoName}, repos)
+
+	_, hasRepoIDs := capturedBody["repository_ids"]
+	assert.Assert(t, !hasRepoIDs, "repository_ids should not be present for incoming name-scoped token")
 }
 
 func TestApplyIncomingParams(t *testing.T) {

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -51,19 +51,20 @@ const (
 var _ provider.Interface = (*Provider)(nil)
 
 type Provider struct {
-	ghClient      *github.Client
-	Logger        *zap.SugaredLogger
-	Run           *params.Run
-	pacInfo       *info.PacOpts
-	Token, APIURL *string
-	ApplicationID *int64
-	providerName  string
-	provenance    string
-	RepositoryIDs []int64
-	repo          *v1alpha1.Repository
-	eventEmitter  *events.EventEmitter
-	PaginedNumber int
-	userType      string // The type of user i.e bot or not
+	ghClient        *github.Client
+	Logger          *zap.SugaredLogger
+	Run             *params.Run
+	pacInfo         *info.PacOpts
+	Token, APIURL   *string
+	ApplicationID   *int64
+	providerName    string
+	provenance      string
+	RepositoryIDs   []int64
+	RepositoryNames []string
+	repo            *v1alpha1.Repository
+	eventEmitter    *events.EventEmitter
+	PaginedNumber   int
+	userType        string // The type of user i.e bot or not
 	skippedRun
 	triggerEvent       string
 	cachedChangedFiles *changedfiles.ChangedFiles
@@ -360,9 +361,19 @@ func (v *Provider) SetClient(ctx context.Context, run *params.Run, event *info.E
 		if err != nil {
 			return fmt.Errorf("failed to scope token: %w", err)
 		}
-		// If Global and Repo level configurations are not provided then lets not override the provider token.
-		if token != "" {
+		switch {
+		case token != "":
 			event.Provider.Token = token
+		case len(v.RepositoryIDs) > 0 || len(v.RepositoryNames) > 0:
+			// Defer scoping until after ScopeTokenToListOfRepos so CreateToken can
+			// look up extra repos from the configmap first.  When no additional repos
+			// are configured, scope the token to only the triggering repo.
+			ns := info.GetNS(ctx)
+			scopedToken, err := v.GetAppToken(ctx, run.Clients.Kube, event.Provider.URL, event.InstallationID, ns)
+			if err != nil {
+				return fmt.Errorf("failed to scope token to triggering repository: %w", err)
+			}
+			event.Provider.Token = scopedToken
 		}
 	}
 

--- a/pkg/provider/github/github_test.go
+++ b/pkg/provider/github/github_test.go
@@ -1246,6 +1246,96 @@ func TestGithubSetClient(t *testing.T) {
 	}
 }
 
+func TestSetClientFallbackScopesToken(t *testing.T) {
+	testNamespace := "pipelinesascode"
+	secretName := "pipelines-as-code-secret"
+
+	ctx, _ := rtesting.SetupFakeContext(t)
+	seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+		Secret: []*corev1.Secret{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: testNamespace,
+				},
+				Data: map[string][]byte{
+					"github-application-id": []byte("12345"),
+					"github-private-key":    []byte(fakePrivateKey),
+				},
+			},
+		},
+	})
+
+	tests := []struct {
+		name            string
+		repositoryIDs   []int64
+		repositoryNames []string
+	}{
+		{
+			name:          "scopes by RepositoryIDs",
+			repositoryIDs: []int64{42},
+		},
+		{
+			name:            "scopes by RepositoryNames",
+			repositoryNames: []string{"my-repo"},
+		},
+		{
+			name:            "scopes by both",
+			repositoryIDs:   []int64{42},
+			repositoryNames: []string{"my-repo"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, mux, serverURL, teardown := ghtesthelper.SetupGH()
+			defer teardown()
+
+			scopedToken := "ghs_scoped_token_value"
+			mux.HandleFunc(fmt.Sprintf("/app/installations/%d/access_tokens", testInstallationID), func(w http.ResponseWriter, _ *http.Request) {
+				fmt.Fprintf(w, `{"token":%q,"expires_at":"2099-01-01T00:00:00Z"}`, scopedToken)
+			})
+
+			ctx = info.StoreCurrentControllerName(ctx, "default")
+			ctx = info.StoreNS(ctx, testNamespace)
+
+			t.Setenv("PAC_GIT_PROVIDER_TOKEN_APIURL", serverURL+"/api/v3")
+
+			initialToken := "ghs_initial_unscoped_token"
+			event := info.NewEvent()
+			event.InstallationID = testInstallationID
+			event.Provider.Token = initialToken
+
+			testLog, _ := logger.GetLogger()
+			v := Provider{
+				Logger:          testLog,
+				RepositoryIDs:   tt.repositoryIDs,
+				RepositoryNames: tt.repositoryNames,
+				pacInfo:         &info.PacOpts{},
+			}
+
+			run := &params.Run{
+				Clients: clients.Clients{
+					Log:  testLog,
+					Kube: seedData.Kube,
+				},
+				Info: info.Info{
+					Controller: &info.ControllerInfo{Secret: secretName},
+				},
+			}
+
+			repo := &v1alpha1.Repository{
+				Spec: v1alpha1.RepositorySpec{
+					Settings: &v1alpha1.Settings{},
+				},
+			}
+
+			err := v.SetClient(ctx, run, event, repo, nil)
+			assert.NilError(t, err)
+			assert.Equal(t, scopedToken, event.Provider.Token)
+		})
+	}
+}
+
 func TestValidate(t *testing.T) {
 	header := http.Header{}
 	header.Set(github.SHA256SignatureHeader, "hello")

--- a/pkg/provider/github/parse_payload.go
+++ b/pkg/provider/github/parse_payload.go
@@ -67,9 +67,14 @@ func (v *Provider) GetAppToken(ctx context.Context, kube kubernetes.Interface, g
 	if err != nil {
 		return "", err
 	}
-	itr.InstallationTokenOptions = &githubv84.InstallationTokenOptions{
-		RepositoryIDs: v.RepositoryIDs,
+	opts := &githubv84.InstallationTokenOptions{}
+	switch {
+	case len(v.RepositoryIDs) > 0:
+		opts.RepositoryIDs = v.RepositoryIDs
+	case len(v.RepositoryNames) > 0:
+		opts.Repositories = v.RepositoryNames
 	}
+	itr.InstallationTokenOptions = opts
 
 	// This is a hack when we have auth and api disassociated like in our
 	// unittests since we are using a custom http server with httptest
@@ -131,18 +136,26 @@ type Payload struct {
 	Installation struct {
 		ID *int64 `json:"id"`
 	} `json:"installation"`
+	Repository struct {
+		ID *int64 `json:"id"`
+	} `json:"repository"`
 }
 
-func getInstallationIDFromPayload(payload string) (int64, error) {
+func getInstallationAndRepoIDFromPayload(payload string) (int64, int64, error) {
 	var data Payload
-	err := json.Unmarshal([]byte(payload), &data)
-	if err != nil {
-		return -1, err
+	if err := json.Unmarshal([]byte(payload), &data); err != nil {
+		return -1, -1, err
 	}
+
+	installationID, repoID := int64(-1), int64(-1)
 	if data.Installation.ID != nil {
-		return *data.Installation.ID, nil
+		installationID = *data.Installation.ID
 	}
-	return -1, nil
+	if data.Repository.ID != nil {
+		repoID = *data.Repository.ID
+	}
+
+	return installationID, repoID, nil
 }
 
 // ParsePayload will parse the payload and return the event
@@ -177,7 +190,7 @@ func (v *Provider) ParsePayload(ctx context.Context, run *params.Run, request *h
 		return nil, err
 	}
 
-	installationIDFrompayload, err := getInstallationIDFromPayload(payload)
+	installationIDFrompayload, repoIDFromPayload, err := getInstallationAndRepoIDFromPayload(payload)
 	if err != nil {
 		return nil, err
 	}
@@ -187,6 +200,10 @@ func (v *Provider) ParsePayload(ctx context.Context, run *params.Run, request *h
 		if event.Provider.Token, err = v.GetAppToken(ctx, run.Clients.Kube, event.Provider.URL, installationIDFrompayload, systemNS); err != nil {
 			return nil, err
 		}
+	}
+
+	if repoIDFromPayload > 0 {
+		v.RepositoryIDs = []int64{repoIDFromPayload}
 	}
 
 	eventInt, err := github.ParseWebHook(event.EventType, []byte(payload))
@@ -537,6 +554,7 @@ func (v *Provider) handleReRequestEvent(ctx context.Context, event *github.Check
 		// fine because you can't do a rereq without being a github owner?
 		runevent.Sender = event.GetSender().GetLogin()
 		v.userType = event.GetSender().GetType()
+		v.RepositoryIDs = []int64{event.GetRepo().GetID()}
 		return runevent, nil
 	}
 	runevent.PullRequestNumber = event.GetCheckRun().GetCheckSuite().PullRequests[0].GetNumber()
@@ -584,6 +602,7 @@ func (v *Provider) handleCheckSuites(ctx context.Context, event *github.CheckSui
 		// fine because you can't do a rereq without being a github owner?
 		runevent.Sender = event.GetSender().GetLogin()
 		v.userType = event.GetSender().GetType()
+		v.RepositoryIDs = []int64{event.GetRepo().GetID()}
 		return runevent, nil
 	}
 	runevent.PullRequestNumber = event.GetCheckSuite().PullRequests[0].GetNumber()
@@ -699,6 +718,7 @@ func (v *Provider) handleCommitCommentEvent(ctx context.Context, event *github.C
 	runevent.BaseURL = runevent.HeadURL
 	runevent.TriggerTarget = triggertype.Push
 	v.userType = event.GetSender().GetType()
+	v.RepositoryIDs = []int64{event.GetRepo().GetID()}
 
 	repo, err := MatchEventURLRepo(ctx, v.Run, runevent, "")
 	if err != nil {

--- a/pkg/provider/github/parse_payload_test.go
+++ b/pkg/provider/github/parse_payload_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -1713,6 +1714,119 @@ func TestAppTokenGeneration(t *testing.T) {
 
 			// Verify client was created successfully for GitHub App
 			assert.Assert(t, gprovider.Client() != nil)
+		})
+	}
+}
+
+func TestGetAppTokenScopesRepositoryNames(t *testing.T) {
+	testNamespace := "pipelinesascode"
+	secretName := "pipelines-as-code-secret"
+
+	ctx, _ := rtesting.SetupFakeContext(t)
+	seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+		Secret: []*corev1.Secret{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: testNamespace,
+				},
+				Data: map[string][]byte{
+					"github-application-id": []byte("12345"),
+					"github-private-key":    []byte(fakePrivateKey),
+				},
+			},
+		},
+	})
+
+	tests := []struct {
+		name            string
+		repositoryIDs   []int64
+		repositoryNames []string
+		wantIDs         []int64
+		wantNames       []string
+	}{
+		{
+			name:            "only RepositoryNames",
+			repositoryNames: []string{"my-repo"},
+			wantNames:       []string{"my-repo"},
+		},
+		{
+			name:          "only RepositoryIDs",
+			repositoryIDs: []int64{42},
+			wantIDs:       []int64{42},
+		},
+		{
+			name:            "RepositoryIDs takes precedence over RepositoryNames",
+			repositoryIDs:   []int64{42},
+			repositoryNames: []string{"my-repo"},
+			wantIDs:         []int64{42},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, mux, serverURL, teardown := ghtesthelper.SetupGH()
+			defer teardown()
+
+			var capturedBody map[string]any
+			mux.HandleFunc(fmt.Sprintf("/app/installations/%d/access_tokens", testInstallationID), func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				_ = json.Unmarshal(body, &capturedBody)
+				_, _ = fmt.Fprint(w, `{"token":"fake-token","expires_at":"2099-01-01T00:00:00Z"}`)
+			})
+
+			logger, _ := logger.GetLogger()
+			gprovider := Provider{
+				Logger:          logger,
+				RepositoryIDs:   tt.repositoryIDs,
+				RepositoryNames: tt.repositoryNames,
+				Run: &params.Run{
+					Info: info.Info{
+						Controller: &info.ControllerInfo{Secret: secretName},
+					},
+				},
+			}
+
+			ctx = info.StoreCurrentControllerName(ctx, "default")
+			ctx = info.StoreNS(ctx, testNamespace)
+
+			envRemove := env.PatchAll(t, map[string]string{
+				"PAC_GIT_PROVIDER_TOKEN_APIURL": serverURL + "/api/v3",
+			})
+			defer envRemove()
+
+			token, err := gprovider.GetAppToken(ctx, seedData.Kube, "", testInstallationID, testNamespace)
+			assert.NilError(t, err)
+			assert.Assert(t, token != "")
+
+			if tt.wantNames != nil {
+				raw, ok := capturedBody["repositories"]
+				assert.Assert(t, ok, "expected repositories field in token request body")
+				rawSlice, ok := raw.([]any)
+				assert.Assert(t, ok, "repositories is not an array")
+				names := make([]string, 0, len(rawSlice))
+				for _, v := range rawSlice {
+					s, ok := v.(string)
+					assert.Assert(t, ok, "repository name is not a string")
+					names = append(names, s)
+				}
+				assert.DeepEqual(t, tt.wantNames, names)
+			} else {
+				_, ok := capturedBody["repositories"]
+				assert.Assert(t, !ok, "repositories field should not be present when IDs are used")
+			}
+			if tt.wantIDs != nil {
+				raw, ok := capturedBody["repository_ids"]
+				assert.Assert(t, ok, "expected repository_ids field in token request body")
+				rawSlice, ok := raw.([]any)
+				assert.Assert(t, ok, "repository_ids is not an array")
+				ids := make([]int64, 0, len(rawSlice))
+				for _, v := range rawSlice {
+					f, ok := v.(float64)
+					assert.Assert(t, ok, "repository_id is not a number")
+					ids = append(ids, int64(f))
+				}
+				assert.DeepEqual(t, tt.wantIDs, ids)
+			}
 		})
 	}
 }

--- a/pkg/resolve/remote.go
+++ b/pkg/resolve/remote.go
@@ -122,8 +122,8 @@ func resolveRemoteResources(ctx context.Context, rt *matcher.RemoteTasks, types 
 				// making sure that the pipeline with same annotation name is not fetched
 				if alreadyFetchedResource(fetchedResourcesForEvent.Pipelines, remotePipeline) {
 					rt.Logger.Debugf("skipping already fetched pipeline %s in annotations on pipelinerun %s", remotePipeline, pipelinerun.GetName())
-					// already fetched, then just get the pipeline to add to run specific Resources
-					pipeline = fetchedResourcesForEvent.Pipelines[remotePipeline]
+					// already fetched, deep-copy so inlining for this run doesn't mutate the cached original
+					pipeline = fetchedResourcesForEvent.Pipelines[remotePipeline].DeepCopy()
 				} else {
 					// seems like a new pipeline, fetch it based on name in annotation
 					pipeline, err = rt.GetPipelineFromAnnotationName(ctx, remotePipeline)
@@ -181,7 +181,7 @@ func resolveRemoteResources(ctx context.Context, rt *matcher.RemoteTasks, types 
 				// if task is already fetched in the event, then just copy the task
 				if alreadyFetchedResource(fetchedResourcesForEvent.Tasks, remoteTask) {
 					rt.Logger.Debugf("skipping already fetched task %s in annotations on pipelinerun %s", remoteTask, pipelinerun.GetName())
-					task = fetchedResourcesForEvent.Tasks[remoteTask]
+					task = fetchedResourcesForEvent.Tasks[remoteTask].DeepCopy()
 				} else {
 					// get the task from annotation name
 					task, err = rt.GetTaskFromAnnotationName(ctx, remoteTask)
@@ -213,7 +213,7 @@ func resolveRemoteResources(ctx context.Context, rt *matcher.RemoteTasks, types 
 
 		// if PipelineRef is used then, first resolve pipeline and replace all taskRef{Finally/Task} of Pipeline, then put inlinePipeline in PipelineRun
 		if pipelinerun.Spec.PipelineRef != nil && pipelinerun.Spec.PipelineRef.Resolver == "" {
-			pipelineResolved := fetchedResourcesForPipelineRun.Pipeline
+			pipelineResolved := fetchedResourcesForPipelineRun.Pipeline.DeepCopy()
 			turns, err := inlineTasks(pipelineResolved.Spec.Tasks, ropt, fetchedResourcesForPipelineRun)
 			if err != nil {
 				return nil, err

--- a/pkg/resolve/remote_test.go
+++ b/pkg/resolve/remote_test.go
@@ -512,6 +512,84 @@ func TestRemote(t *testing.T) {
 	}
 }
 
+// Verifies that cached remote pipelines are deep-copied before modification.
+// Without deep copy, when the first PipelineRun applies its task annotation,
+// it would mutate the cached pipeline and leak that task into the second run.
+func TestSharedRemotePipelineCacheNotMutated(t *testing.T) {
+	taskName := "shared-task"
+
+	pipelineTask := tektonv1.TaskSpec{
+		Steps: []tektonv1.Step{
+			{Name: "from-pipeline", Image: "alpine", Command: []string{"true"}},
+		},
+	}
+	pipelinerunTask := tektonv1.TaskSpec{
+		Steps: []tektonv1.Step{
+			{Name: "from-pipelinerun", Image: "busybox", Command: []string{"false"}},
+		},
+	}
+
+	// remote pipeline with a single TaskRef
+	pipeline := ttkn.MakePipeline("shared-pipeline", []tektonv1.PipelineTask{
+		{Name: taskName, TaskRef: &tektonv1.TaskRef{Name: taskName}},
+	}, map[string]string{
+		apipac.Task: "http://remote/shared-task",
+	})
+	pipelineB, err := yaml.Marshal(pipeline)
+	assert.NilError(t, err)
+
+	pipelineTaskB, err := ttkn.MakeTaskB(taskName, pipelineTask)
+	assert.NilError(t, err)
+	pipelinerunTaskB, err := ttkn.MakeTaskB(taskName, pipelinerunTask)
+	assert.NilError(t, err)
+
+	remoteURLS := map[string]map[string]string{
+		"http://remote/shared-pipeline": {"body": string(pipelineB), "code": "200"},
+		"http://remote/shared-task":     {"body": string(pipelineTaskB), "code": "200"},
+		"http://remote/pr-task":         {"body": string(pipelinerunTaskB), "code": "200"},
+	}
+
+	// first run: overrides the task via pipelinerun annotation
+	// second run: same pipeline, no override — should get the original task
+	pipelineruns := []*tektonv1.PipelineRun{
+		ttkn.MakePR("first-run", map[string]string{
+			apipac.Pipeline: "http://remote/shared-pipeline",
+			apipac.Task:     "http://remote/pr-task",
+		}, tektonv1.PipelineRunSpec{
+			PipelineRef: &tektonv1.PipelineRef{Name: "shared-pipeline"},
+		}),
+		ttkn.MakePR("second-run", map[string]string{
+			apipac.Pipeline: "http://remote/shared-pipeline",
+		}, tektonv1.PipelineRunSpec{
+			PipelineRef: &tektonv1.PipelineRef{Name: "shared-pipeline"},
+		}),
+	}
+
+	observer, _ := zapobserver.New(zap.InfoLevel)
+	logger := zap.New(observer).Sugar()
+	ctx, _ := rtesting.SetupFakeContext(t)
+	httpTestClient := httptesthelper.MakeHTTPTestClient(remoteURLS)
+	rt := &matcher.RemoteTasks{
+		ProviderInterface: &testprovider.TestProviderImp{},
+		Logger:            logger,
+		Run: &params.Run{
+			Clients: clients.Clients{HTTP: *httpTestClient},
+		},
+	}
+
+	ret, err := resolveRemoteResources(ctx, rt, TektonTypes{PipelineRuns: pipelineruns}, &Opts{RemoteTasks: true, GenerateName: true})
+	assert.NilError(t, err)
+	assert.Equal(t, len(ret), 2)
+
+	firstStep := ret[0].Spec.PipelineSpec.Tasks[0].TaskSpec.Steps[0]
+	assert.Equal(t, firstStep.Name, "from-pipelinerun")
+	assert.Equal(t, firstStep.Image, "busybox")
+
+	secondStep := ret[1].Spec.PipelineSpec.Tasks[0].TaskSpec.Steps[0]
+	assert.Equal(t, secondStep.Name, "from-pipeline")
+	assert.Equal(t, secondStep.Image, "alpine")
+}
+
 func TestAssembleTaskFQDNs(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## 📝 Description of the Change
- Scope GitHub App token to the triggering repository when no extra scope config is present, preventing remote task annotations from accessing private repos in the same installation. Incoming webhooks lack a payload
  repo ID, so a new RepositoryNames field lets SetClient scope
  the token by name parsed from the Repository CR URL.
- Deep-copy cached remote Pipeline and Task objects before inlining to prevent mutation from contaminating subsequent PipelineRuns that reference the same remote resource

## 🔗 Linked GitHub Issue
N/A


<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [x] Manual testing
- [ ] Not Applicable

### Github App token scoping
- Same github app installed in 2 private repos, `akshay-pac-test-repo` and `jj-test`
- `akshay-pac-test-repo` pipelinerun references pipeline defined in `jj-test`.
- Before fix: PipelineRun is able to access the remote task on the private `jj-test` without any extra config.
- After the fix:
  <img width="1029" height="367" alt="with-fix" src="https://github.com/user-attachments/assets/27b93f85-c5ad-48bd-b502-e389d3c9f505" />
- After the fix with repo configured in global PAC configmap
  <img width="1028" height="532" alt="image" src="https://github.com/user-attachments/assets/e1547d0e-ce5d-4dd6-861d-5b0e554468d3" />

```yaml
$ kg cm pipelines-as-code -oyaml
apiVersion: v1
data:
  application-name: Pipelines as Code CI
  ...
  secret-github-app-scope-extra-repos: theakshaypant/jj-test
  secret-github-app-token-scoped: "false"
  ...
kind: ConfigMap
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      ...
  labels:
    app.kubernetes.io/part-of: pipelines-as-code
    app.kubernetes.io/version: devel
  name: pipelines-as-code
  namespace: pipelines-as-code
  resourceVersion: "21512"
  uid: e118110b-2cda-446e-8f60-d087f6673bc0
``` 

### Github App Token Scoping for incoming webhook
After fix
```
$ curl -X POST http://controller.paac-127-0-0-1.nip.io/incoming \
    -H "Content-Type: application/json" \
    -d '{
        "repository": "akshay-pac-test-repo",
        "branch": "remote-task",
        "pipelinerun": "piplinerun-remote-annotations",
        "secret": "shhhh-secrete"
    }'
{"status":202,"message":"accepted"}

$ klf pipelines-as-code-controller-cbd456d88-z97b4
{"level":"error","ts":"2026-06-04T09:31:04.463Z","logger":"pipelinesascode","caller":"events/emit.go:49","msg":"an error occurred: error getting remote pipeline from pipelinerun annotations: error getting remote pipeline \"https://github.com/theakshaypant/jj-test/blob/bm/dummy-plr.yml\": Non-OK HTTP status: 404","commit":"e049181-dirty","provider":"incoming","namespace":"default","namespace":"default","stacktrace":"github.com/openshift-pipelines/pipelines-as-code/pkg/events.(*EventEmitter).EmitMessage\n\tgithub.com/openshift-pipelines/pipelines-as-code/pkg/events/emit.go:49\ngithub.com/openshift-pipelines/pipelines-as-code/pkg/pipelineascode.(*PacRun).Run\n\tgithub.com/openshift-pipelines/pipelines-as-code/pkg/pipelineascode/pipelineascode.go:91\ngithub.com/openshift-pipelines/pipelines-as-code/pkg/adapter.(*sinker).processEvent\n\tgithub.com/openshift-pipelines/pipelines-as-code/pkg/adapter/sinker.go:129\ngithub.com/openshift-pipelines/pipelines-as-code/pkg/adapter.(*listener).Start.listener.handleEvent.func2.1\n\tgithub.com/openshift-pipelines/pipelines-as-code/pkg/adapter/adapter.go:246"}

$ kd repo akshay-pac-test-repo -n default
Name:         akshay-pac-test-repo
Namespace:    default
Labels:       <none>
Annotations:  <none>
API Version:  pipelinesascode.tekton.dev/v1alpha1
Kind:         Repository
Metadata:
  Creation Timestamp:  2026-06-04T09:25:59Z
  Generation:          2
  Resource Version:    4100715
  UID:                 c8a4c6c2-5055-409d-9c53-2a2c6cafb3bb
Spec:
  Incoming:
    Secret:
      Key:   incoming
      Name:  pac-incoming-secret
    Targets:
      remote-task
    Type:  webhook-url
  URL:     https://github.com/theakshaypant/akshay-pac-test-repo
Events:
  Type     Reason                   Age        From               Message
  ----     ------                   ----       ----               -------
  Warning  RepositoryCreateStatus   <unknown>  Pipelines As Code  an error occurred: error getting remote pipeline from pipelinerun annotations: error getting remote pipeline "https://github.com/theakshaypant/jj-test/blob/bm/dummy-plr.yml": Non-OK HTTP status: 404
  Warning  RepositoryFailedToMatch  <unknown>  Pipelines As Code  failed to match pipelineRuns: error getting remote pipeline from pipelinerun annotations: error getting remote pipeline "https://github.com/theakshaypant/jj-test/blob/bm/dummy-plr.yml": Non-OK HTTP status: 404
```

### Remote-pipeline Task Mutation
- Same repository setup as above.
- `akshay-pac-test-repo` defines 2 pipelineruns with the same remote pipeline def in `jj-test`
  <img width="1874" height="598" alt="image" src="https://github.com/user-attachments/assets/02c98f7a-1376-4e6a-83b2-94928d9138a2" />
- `second-run` uses a local definition of `my-task` while `first-run` uses a remote definition.
- Before fix:
  <img width="1862" height="964" alt="remote-mutation-without-fix" src="https://github.com/user-attachments/assets/984c4fea-999f-4c9d-886a-4be96accdf03" />
- After fix:
  <img width="1862" height="964" alt="remote-mutation-with-fix" src="https://github.com/user-attachments/assets/cdceb3b0-aa92-44cb-97e7-c3acc837bc47" />


## 🤖 AI Assistance

AI assistance can be used for various tasks, such as code generation,
documentation, or testing.

Please indicate whether you have used AI assistance
for this PR and provide details if applicable.

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

> [!IMPORTANT]
>
> **Slop will be simply rejected**, if you are using AI assistance you need to make sure you
> understand the code generated and that it meets the project's standards. you
> need at least know how to run the code and deploy it (if needed). See
> [startpaac](https://github.com/openshift-pipelines/startpaac) to make it easy
> to deploy and test your code changes.
>
> If the **majority of the code** in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Claude <noreply@anthropic.com>

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
