### PR TITLE
fix(github-webhook): clear pending check on ok-to-test

### DIFF
--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -124,7 +124,9 @@ func (p *PacRun) verifyRepoAndUser(ctx context.Context) (*v1alpha1.Repository, e
 		}
 		// When /ok-to-test is approved, update the parent "Pipelines as Code CI" status to success
 		// to indicate the approval was successful before pipelines start running.
-		if p.event.EventType == opscomments.OkToTestCommentEventType.String() && !strings.Contains(p.vcx.GetConfig().Name, "github") {
+		// we only do this for all providers except github apps since github apps use the checkRun API to update the status
+		// checking installationID is <= 0 because sometime it's set to -1
+		if p.event.EventType == opscomments.OkToTestCommentEventType.String() && p.event.InstallationID <= 0 {
 			approvalStatus := providerstatus.StatusOpts{
 				Status:     CompletedStatus,
 				Title:      "Approved",

--- a/pkg/pipelineascode/match_test.go
+++ b/pkg/pipelineascode/match_test.go
@@ -4,7 +4,9 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -752,6 +754,36 @@ func TestVerifyRepoAndUser(t *testing.T) {
 			wantRepoNil:   false,
 			wantErr:       false,
 		},
+		{
+			name: "happy path with ok-to-test comment status reporting",
+			runevent: info.Event{
+				Organization:  "owner",
+				Repository:    "repo",
+				URL:           "https://example.com/owner/repo",
+				SHA:           "123abc",
+				EventType:     opscomments.OkToTestCommentEventType.String(),
+				TriggerTarget: triggertype.PullRequest,
+				Sender:        "owner",
+				Request:       request,
+			},
+			repositories: []*v1alpha1.Repository{{
+				ObjectMeta: metav1.ObjectMeta{Name: "repo", Namespace: "ns"},
+				Spec: v1alpha1.RepositorySpec{
+					URL: "https://example.com/owner/repo",
+					GitProvider: &v1alpha1.GitProvider{
+						Secret: &v1alpha1.Secret{
+							Name: "secret",
+						},
+						WebhookSecret: &v1alpha1.Secret{
+							Name: "webhook-secret",
+						},
+					},
+				},
+			}},
+			webhookSecret: "secret",
+			wantRepoNil:   false,
+			wantErr:       false,
+		},
 	}
 
 	pacInfo := &info.PacOpts{Settings: settings.DefaultSettings()}
@@ -786,14 +818,23 @@ func TestVerifyRepoAndUser(t *testing.T) {
 			// status endpoint stub (used when CreateStatus is called)
 			mux.HandleFunc(
 				fmt.Sprintf("/repos/%s/%s/statuses/%s", tt.runevent.Organization, tt.runevent.Repository, tt.runevent.SHA),
-				func(rw http.ResponseWriter, _ *http.Request) { fmt.Fprint(rw, `{}`) },
+				func(rw http.ResponseWriter, r *http.Request) {
+					body, _ := io.ReadAll(r.Body)
+					a := struct {
+						State string `json:"state"`
+					}{}
+					err := json.Unmarshal(body, &a)
+					assert.NilError(t, err)
+					assert.Equal(t, a.State, "success")
+					fmt.Fprint(rw, `{}`)
+				},
 			)
 
 			vcx := &ghprovider.Provider{Token: github.Ptr("token"), Logger: logger}
 			vcx.SetGithubClient(ghClient)
 			vcx.SetPacInfo(pacInfo)
 
-			k8int := &kitesthelper.KinterfaceTest{GetSecretResult: map[string]string{"pipelines-as-code-secret": tt.webhookSecret}}
+			k8int := &kitesthelper.KinterfaceTest{GetSecretResult: map[string]string{"pipelines-as-code-secret": tt.webhookSecret, "secret": "token", "webhook-secret": "secret"}}
 
 			stdata, _ := testclient.SeedTestData(t, ctx, testclient.Data{Repositories: tt.repositories /*Secret: []*corev1.Secret{secret}*/})
 			in := info.NewInfo()


### PR DESCRIPTION
When using GitHub Webhook, the pending check run created for unauthorized PRs was never resolved after an admin commented /ok-to-test, leaving it stuck indefinitely.

https://redhat.atlassian.net/browse/SRVKP-11789

## 📝 Description of the Change

## 🔗 Linked GitHub Issue

Fixes #

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [x] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

AI assistance can be used for various tasks, such as code generation,
documentation, or testing.

Please indicate whether you have used AI assistance
for this PR and provide details if applicable.

- [x] I have not used any AI assistance for this PR.
- [ ] I have used AI assistance for this PR.

> [!IMPORTANT]
>
> **Slop will be simply rejected**, if you are using AI assistance you need to make sure you
> understand the code generated and that it meets the project's standards. you
> need at least know how to run the code and deploy it (if needed). See
> [startpaac](https://github.com/openshift-pipelines/startpaac) to make it easy
> to deploy and test your code changes.
>
> If the **majority of the code** in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Claude <noreply@anthropic.com>

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [x] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
