### PR TITLE
fix(opscomments): skip key=value args as PR names

### DIFF
--- a/docs/content/docs/guides/event-matching/comment-and-label.md
+++ b/docs/content/docs/guides/event-matching/comment-and-label.md
@@ -36,6 +36,8 @@ The `on-comment` annotation follows the pull_request [Policy]({{< relref "/docs/
 
 {{< callout type="info" >}}
 The `on-comment` annotation works with pull_request events. For push events, Pipelines-as-Code supports it only [when targeting the main branch without arguments]({{< relref "/docs/guides/gitops-commands/push-commands" >}}).
+
+Avoid using Pipelines-as-Code's built-in [GitOps commands]({{< relref "/docs/guides/gitops-commands" >}}) — such as `/test`, `/retest`, `/cancel`, or `/ok-to-test` — as `on-comment` patterns. These commands are processed before `on-comment` matching and can lead to unexpected behavior.
 {{< /callout >}}
 
 ## Matching on pull request labels

--- a/pkg/opscomments/comments.go
+++ b/pkg/opscomments/comments.go
@@ -182,6 +182,9 @@ func getNameFromComment(typeOfComment, comment string) string {
 		return ""
 	}
 
-	// trim spaces
-	return strings.TrimSpace(firstArg[1])
+	name := strings.TrimSpace(firstArg[1])
+	if strings.Contains(name, "=") {
+		return ""
+	}
+	return name
 }

--- a/pkg/opscomments/comments_test.go
+++ b/pkg/opscomments/comments_test.go
@@ -87,6 +87,18 @@ func TestGetNameFromFunction(t *testing.T) {
 			commentType: testComment,
 		},
 		{
+			name:        "key value arg is not a pipeline name",
+			comment:     "/test custom1=value",
+			expected:    "",
+			commentType: testComment,
+		},
+		{
+			name:        "key value args without pipeline name",
+			comment:     "/test foo=bar hello=moto",
+			expected:    "",
+			commentType: testComment,
+		},
+		{
 			name:        "get name from cancel comment",
 			comment:     "/cancel prname",
 			expected:    "prname",
@@ -294,6 +306,12 @@ func TestSetEventTypeTestPipelineRun(t *testing.T) {
 			comment:    "/test prname",
 			wantType:   TestSingleCommentEventType.String(),
 			wantTestPr: "prname",
+		},
+		{
+			name:       "test with key value arg treated as test all",
+			comment:    "/test custom1=value",
+			wantType:   TestSingleCommentEventType.String(),
+			wantTestPr: "",
 		},
 		{
 			name:         "cancel single pr",

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -108,8 +108,18 @@ func getNameFromComment(typeOfComment, comment string) string {
 	splitTest := strings.Split(comment, typeOfComment)
 	// now get the first line
 	getFirstLine := strings.Split(splitTest[1], "\n")
-	// trim spaces
-	return strings.TrimSpace(getFirstLine[0])
+
+	// and the first argument
+	firstArg := strings.Split(getFirstLine[0], " ")
+	if len(firstArg) < 2 {
+		return ""
+	}
+
+	name := strings.TrimSpace(firstArg[1])
+	if strings.Contains(name, "=") {
+		return ""
+	}
+	return name
 }
 
 func GetPipelineRunAndBranchOrTagNameFromTestComment(comment, prefix string) (string, string, string, error) {
@@ -159,6 +169,9 @@ func getPipelineRunAndBranchOrTagNameFromComment(typeOfComment, comment string) 
 		prData := strings.Split(strings.TrimSpace(branchData[0]), " ")
 		if len(prData) > 1 {
 			prName = strings.TrimSpace(prData[0])
+			if strings.Contains(prName, "=") {
+				prName = ""
+			}
 		}
 	} else {
 		// get the second part of the typeOfComment (/test, /retest or /cancel)
@@ -168,6 +181,9 @@ func getPipelineRunAndBranchOrTagNameFromComment(typeOfComment, comment string) 
 		// trim spaces
 		// adapt for the comment contains the key=value pair
 		prName = strings.Split(strings.TrimSpace(getFirstLine[0]), " ")[0]
+		if strings.Contains(prName, "=") {
+			prName = ""
+		}
 	}
 	return prName, branchName, tagName, nil
 }

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -216,6 +216,11 @@ func TestGetPipelineRunFromComment(t *testing.T) {
 			want:    "abc-01-pr",
 		},
 		{
+			name:    "test with key value is not a pipeline name",
+			comment: "/test custom1=value",
+			want:    "",
+		},
+		{
 			name:    "retest a pipeline",
 			comment: "/retest abc-01-pr",
 			want:    "abc-01-pr",
@@ -260,6 +265,11 @@ func TestGetPipelineRunFromCancelComment(t *testing.T) {
 			name:    "cancel a pipeline",
 			comment: "/cancel abc-01-pr",
 			want:    "abc-01-pr",
+		},
+		{
+			name:    "cancel with key value is not a pipeline name",
+			comment: "/cancel custom1=value",
+			want:    "",
 		},
 		{
 			name:    "string before cancel command",
@@ -364,6 +374,19 @@ func TestGetPipelineRunAndBranchNameFromTestComment(t *testing.T) {
 			comment:    "/test abc-01-pr key=value",
 			prName:     "abc-01-pr",
 			branchName: "",
+			wantError:  false,
+		},
+		{
+			name:      "test with only key value is not a pipeline name",
+			comment:   "/test custom1=value",
+			prName:    "",
+			wantError: false,
+		},
+		{
+			name:       "test with key value and branch is not a pipeline name",
+			comment:    "/test custom1=value branch:nightly",
+			prName:     "",
+			branchName: "nightly",
 			wantError:  false,
 		},
 		{

--- a/test/gitea_gitops_commands_test.go
+++ b/test/gitea_gitops_commands_test.go
@@ -130,6 +130,57 @@ func TestGiteaOnCommentAnnotation(t *testing.T) {
 	assert.NilError(t, err)
 }
 
+// TestGiteaOnCommentTestOverride tests that a PipelineRun with
+// on-comment: "^/test.*" is triggered when posting "/test custom1=value".
+// This verifies that key=value arguments are not mistaken for a PipelineRun
+// name, which would bypass the on-comment annotation matching entirely.
+func TestGiteaOnCommentTestOverride(t *testing.T) {
+	var err error
+	ctx := context.Background()
+	topts := &tgitea.TestOpts{
+		TargetRefName: names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test"),
+		RepoCRParams: &[]v1alpha1.Params{
+			{
+				Name:  "custom1",
+				Value: "default",
+			},
+		},
+	}
+	topts.TargetNS = topts.TargetRefName
+	topts.ParamsRun, topts.Opts, topts.GiteaCNX, err = tgitea.Setup(ctx)
+	assert.NilError(t, err, fmt.Errorf("cannot do gitea setup: %w", err))
+	ctx, err = cctx.GetControllerCtxInfo(ctx, topts.ParamsRun)
+	assert.NilError(t, err)
+	assert.NilError(t, pacrepo.CreateNS(ctx, topts.TargetNS, topts.ParamsRun))
+	assert.NilError(t, secret.Create(ctx, topts.ParamsRun, map[string]string{"secret": "SHHHHHHH"}, topts.TargetNS, "pac-secret"))
+	topts.TargetEvent = triggertype.PullRequest.String()
+	topts.YAMLFiles = map[string]string{
+		".tekton/on-comment-test-override.yaml": "testdata/pipelinerun-on-comment-test-override.yaml",
+	}
+	topts.ExpectEvents = false
+	_, f := tgitea.TestPR(t, topts)
+	defer f()
+
+	tgitea.PostCommentOnPullRequest(t, topts, "/test custom1=overridden")
+	waitOpts := twait.Opts{
+		RepoName:        topts.TargetNS,
+		Namespace:       topts.TargetNS,
+		MinNumberStatus: 1,
+		PollTimeout:     twait.DefaultTimeout,
+	}
+	repo, err := twait.UntilRepositoryUpdated(context.Background(), topts.ParamsRun.Clients, waitOpts)
+	assert.NilError(t, err)
+	assert.Equal(t, len(repo.Status), 1, "should have exactly 1 status")
+	assert.Equal(t, *repo.Status[0].EventType, opscomments.OnCommentEventType.String(),
+		"should have matched via on-comment annotation, not built-in /test handler")
+
+	last := repo.Status[0]
+	err = twait.RegexpMatchingInPodLog(context.Background(), topts.ParamsRun, topts.TargetNS,
+		fmt.Sprintf("tekton.dev/pipelineRun=%s", last.PipelineRunName), "step-task",
+		*regexp.MustCompile("custom1 is overridden"), "", 2, nil)
+	assert.NilError(t, err)
+}
+
 // TestGiteaTestPipelineRunExplicitlyWithTestComment will test a pipelinerun
 // even if it hasn't matched when we are doing a /test comment.
 func TestGiteaTestPipelineRunExplicitlyWithTestComment(t *testing.T) {

--- a/test/testdata/pipelinerun-on-comment-test-override.yaml
+++ b/test/testdata/pipelinerun-on-comment-test-override.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: "on-comment-test-override"
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-comment: "^/test.*"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: task
+        taskSpec:
+          steps:
+            - name: task
+              image: registry.access.redhat.com/ubi10/ubi-micro
+              script: |
+                echo "event_type is {{ event_type }}"
+                echo "custom1 is {{ custom1 }}"


### PR DESCRIPTION
## 📝 Description of the Change
When a user posts "/test custom1=value", the key=value argument was being treated as a PipelineRun name, which bypassed on-comment annotation matching. Return empty string when the first argument contains "=" so the comment falls through to on-comment handling.

## 🔗 Linked GitHub Issue
Fixes #1952

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [x] End-to-end tests
- [x] Manual testing
- [ ] Not Applicable

e2e test on Forgejo with `/test custom1=value` run successfully. 
<img width="1857" height="908" alt="image" src="https://github.com/user-attachments/assets/d465c0d3-6551-4f7d-975d-9ea8be4b1bda" />


## 🤖 AI Assistance

AI assistance can be used for various tasks, such as code generation,
documentation, or testing.

Please indicate whether you have used AI assistance
for this PR and provide details if applicable.

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

> [!IMPORTANT]
>
> **Slop will be simply rejected**, if you are using AI assistance you need to make sure you
> understand the code generated and that it meets the project's standards. you
> need at least know how to run the code and deploy it (if needed). See
> [startpaac](https://github.com/openshift-pipelines/startpaac) to make it easy
> to deploy and test your code changes.
>
> If the **majority of the code** in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Claude <noreply@anthropic.com>

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [x] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
