### PR TITLE
fix: retry VCS status on finalize for failed state

### DIFF
--- a/pkg/reconciler/finalizer.go
+++ b/pkg/reconciler/finalizer.go
@@ -69,6 +69,47 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, pr *tektonv1.PipelineRun)
 			return nil
 		}
 	}
+
+	if state == kubeinteraction.StateFailed {
+		repoName, ok := pr.GetAnnotations()[keys.Repository]
+		if !ok {
+			return nil
+		}
+		repo, err := r.repoLister.Repositories(pr.Namespace).Get(repoName)
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		if err := r.retryFinalStatusUpdate(ctx, repo, pr); err != nil {
+			logger.Errorf("failed to retry final status update on finalize: %v", err)
+		}
+	}
+
+	return nil
+}
+
+func (r *Reconciler) retryFinalStatusUpdate(ctx context.Context, repo *v1alpha1.Repository, pr *tektonv1.PipelineRun) error {
+	logger := logging.FromContext(ctx)
+	pacInfo := r.run.Info.GetPacOpts()
+
+	detectedProvider, event, err := r.initGitProviderClient(ctx, logger, repo, pr)
+	if err != nil {
+		return err
+	}
+
+	if r.run.Clients.Log == nil {
+		r.run.Clients.Log = logger
+	}
+
+	_, _, err = r.postFinalStatus(ctx, logger, &pacInfo, detectedProvider, event, pr)
+	if err != nil {
+		return fmt.Errorf("failed to post final status on finalize: %w", err)
+	}
+
+	logger.Infof("successfully retried final status update for pipelineRun %s/%s", pr.GetNamespace(), pr.GetName())
 	return nil
 }
 

--- a/pkg/reconciler/finalizer_test.go
+++ b/pkg/reconciler/finalizer_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/consoleui"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/events"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
@@ -20,7 +21,9 @@ import (
 	"go.uber.org/zap"
 	zapobserver "go.uber.org/zap/zaptest/observer"
 	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
 	"knative.dev/pkg/logging"
 	rtesting "knative.dev/pkg/reconciler/testing"
 )
@@ -126,6 +129,18 @@ func TestReconcilerFinalizeKind(t *testing.T) {
 				getTestPR("pr3", kubeinteraction.StateQueued),
 			},
 		},
+		{
+			name: "failed state retries final status",
+			pipelinerun: func() *tektonv1.PipelineRun {
+				pr := getTestPR("pr1", kubeinteraction.StateFailed)
+				pr.Status.Conditions = append(pr.Status.Conditions, apis.Condition{
+					Type:   apis.ConditionSucceeded,
+					Status: corev1.ConditionFalse,
+					Reason: tektonv1.PipelineRunReasonFailed.String(),
+				})
+				return pr
+			}(),
+		},
 	}
 
 	for _, tt := range tests {
@@ -134,6 +149,7 @@ func TestReconcilerFinalizeKind(t *testing.T) {
 			ctx = logging.WithLogger(ctx, fakelogger)
 			testData := testclient.Data{
 				Repositories: []*v1alpha1.Repository{finalizeTestRepo},
+				PipelineRuns: []*tektonv1.PipelineRun{tt.pipelinerun},
 			}
 			if tt.skipAddingRepo {
 				testData.Repositories = []*v1alpha1.Repository{}
@@ -148,6 +164,7 @@ func TestReconcilerFinalizeKind(t *testing.T) {
 			cs := &params.Run{
 				Clients: clients.Clients{
 					PipelineAsCode: stdata.PipelineAsCode,
+					Tekton:         stdata.Pipeline,
 					Log:            fakelogger,
 				},
 				Info: info.Info{
@@ -158,10 +175,11 @@ func TestReconcilerFinalizeKind(t *testing.T) {
 			}
 			cs.Clients.SetConsoleUI(consoleui.FallBackConsole{})
 			r := Reconciler{
-				repoLister: informers.Repository.Lister(),
-				qm:         queuepkg.NewManager(fakelogger),
-				run:        cs,
-				kinteract:  kinterfaceTest,
+				repoLister:   informers.Repository.Lister(),
+				qm:           queuepkg.NewManager(fakelogger),
+				run:          cs,
+				kinteract:    kinterfaceTest,
+				eventEmitter: events.NewEventEmitter(stdata.Kube, fakelogger),
 			}
 
 			if len(tt.addToQueue) != 0 {


### PR DESCRIPTION
## 📝 Description of the Change
When the VCS update fails, PaC sets `state` to `failed` and never re-attempts during FinalizeKind when the PipelineRun is being deleted. This leaves the VCS commit status stuck at `pending`. This PR adds a `StateFailed` handler in `FinalizeKind` that retries the VCS status update one last time when the PipelineRun is deleted, following the same pattern as the existing `reportPipelineRunAsCancelled`

## 🔗 Linked GitHub Issue

Fixes #

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [x] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

AI assistance can be used for various tasks, such as code generation,
documentation, or testing.

Please indicate whether you have used AI assistance
for this PR and provide details if applicable.

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

> [!IMPORTANT]
>
> **Slop will be simply rejected**, if you are using AI assistance you need to make sure you
> understand the code generated and that it meets the project's standards. you
> need at least know how to run the code and deploy it (if needed). See
> [startpaac](https://github.com/openshift-pipelines/startpaac) to make it easy
> to deploy and test your code changes.
>
> If the **majority of the code** in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Claude <noreply@anthropic.com>

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
