### PR TITLE
fix: point to the right doc in formatting

### DIFF
--- a/pkg/formatting/k8labels.go
+++ b/pkg/formatting/k8labels.go
@@ -23,12 +23,11 @@ var (
 )
 
 // CleanValueKubernetes conforms a string to kubernetes naming convention
-// see https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
-// rules are:
-// • contain at most 63 characters
-// • contain only alphanumeric characters or '-', '.', and '_'
-// • start with an alphanumeric character
-// • end with an alphanumeric character.
+// see https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set.
+// Valid label value:
+// * must be 63 characters or less (can be empty),
+// * unless empty, must begin and end with an alphanumeric character ([a-z0-9A-Z]),
+// * could contain dashes (-), underscores (_), dots (.), and alphanumerics between.
 func CleanValueKubernetes(s string) string {
 	// cut short if the string is already a valid label
 	if len(validation.IsValidLabelValue(s)) == 0 {


### PR DESCRIPTION
The function `CleanValueKubernetes` from the `formatting` package is poiting to the wrong documentation.
This change updates the comment only.

Signed-off-by: Francesco Ilario <filario@redhat.com>

## 📝 Description of the Change

## 🔗 Linked GitHub Issue

N/A

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [x] Not Applicable

## 🤖 AI Assistance

AI assistance can be used for various tasks, such as code generation,
documentation, or testing.

Please indicate whether you have used AI assistance
for this PR and provide details if applicable.

- [x] I have not used any AI assistance for this PR.
- [ ] I have used AI assistance for this PR.

> [!IMPORTANT]
>
> **Slop will be simply rejected**, if you are using AI assistance you need to make sure you
> understand the code generated and that it meets the project's standards. you
> need at least know how to run the code and deploy it (if needed). See
> [startpaac](https://github.com/openshift-pipelines/startpaac) to make it easy
> to deploy and test your code changes.
>
> If the **majority of the code** in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Claude <noreply@anthropic.com>

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
