### PR TITLE
feat:wildcard repository url

### DIFF
--- a/pkg/matcher/repo_runinfo_matcher.go
+++ b/pkg/matcher/repo_runinfo_matcher.go
@@ -25,11 +25,14 @@ func MatchEventURLRepo(ctx context.Context, cs *params.Run, event *info.Event, n
 	}
 	for _, repo := range repositories.Items {
 		repo.Spec.URL = strings.TrimSuffix(repo.Spec.URL, "/")
-		if repo.Spec.URL == event.URL {
+		match, err := matchRepo(event.URL, repo.Spec.URL)
+		if err != nil {
+			return nil, err
+		}
+		if match {
 			return &repo, nil
 		}
 	}
-
 	return nil, nil
 }
 
@@ -88,4 +91,21 @@ func matchTarget(branch, target string) (bool, error) {
 	}
 
 	return g.Match(branch), nil
+}
+
+// matchTarget checks if a branch matches a target pattern using glob matching.
+// Supports both exact string matching and glob patterns.
+func matchRepo(repo, target string) (bool, error) {
+	if target == repo {
+		return true, nil
+	}
+	// Check unix glob match
+	globPattern, err := glob.Compile(target)
+	if err != nil {
+		return false, err
+	}
+	if globPattern.Match(repo) {
+		return true, nil
+	}
+	return false, nil
 }

--- a/pkg/matcher/repo_runinfo_matcher_test.go
+++ b/pkg/matcher/repo_runinfo_matcher_test.go
@@ -468,6 +468,103 @@ func TestIncomingWebhookRule(t *testing.T) {
 	}
 }
 
+func TestMatchRepo(t *testing.T) {
+	tests := []struct {
+		name       string
+		eventURL   string
+		repoURL    string
+		wantMatch  bool
+		wantError  bool
+		errorCheck string
+	}{
+		// Exact matching
+		{
+			name:      "exact match",
+			eventURL:  "https://github.com/tektoncd/pipelines-as-code",
+			repoURL:   "https://github.com/tektoncd/pipelines-as-code",
+			wantMatch: true,
+		},
+		{
+			name:      "no substring match",
+			eventURL:  "https://github.com/forked/pipelines-as-code",
+			repoURL:   "https://github.com/tektoncd/pipelines-as-code",
+			wantMatch: false,
+		},
+		// Wildcard * - matches zero or more characters
+		{
+			name:      "glob * - prefix pattern",
+			eventURL:  "https://github.com/tektoncd/pipelines-as-code",
+			repoURL:   "https://github.com/tektoncd/*",
+			wantMatch: true,
+		},
+		{
+			name:      "glob * - must match from start",
+			eventURL:  "https://gitlab.com/tektoncd/pipelines-as-code",
+			repoURL:   "https://github.com/tektoncd/*",
+			wantMatch: false,
+		},
+		{
+			name:      "glob * - substring match with wildcards",
+			eventURL:  "https://github.com/tektoncd/pipelines-as-code",
+			repoURL:   "*/tektoncd/*",
+			wantMatch: true,
+		},
+		{
+			name:      "glob * - catch-all",
+			eventURL:  "https://github.com/tektoncd/pipelines-as-code",
+			repoURL:   "*",
+			wantMatch: true,
+		},
+		// Wildcard ? - matches exactly one character
+		{
+			name:      "glob ? - single char match",
+			eventURL:  "https://github.com/tektoncd/pipelines-as-code-v2",
+			repoURL:   "https://github.com/tektoncd/pipelines-as-code-v?",
+			wantMatch: true,
+		},
+		// Character classes [...]
+		{
+			name:      "glob [range] - character class",
+			eventURL:  "https://gitlab.com/tektoncd/pipelines-as-code",
+			repoURL:   "https://[a-z]*.com/tektoncd/pipelines-as-code",
+			wantMatch: true,
+		},
+		// Error handling
+		{
+			name:       "invalid glob - unclosed bracket",
+			eventURL:   "https://github.com/tektoncd/pipelines-as-code",
+			repoURL:    "https://[github.com/tektoncd/pipelines-as-code",
+			wantMatch:  false,
+			wantError:  true,
+			errorCheck: "unexpected end of input",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotMatch, err := matchRepo(tt.eventURL, tt.repoURL)
+
+			if tt.wantError {
+				if err == nil {
+					t.Errorf("matchRepo() expected error but got nil")
+					return
+				}
+				if tt.errorCheck != "" {
+					assert.ErrorContains(t, err, tt.errorCheck)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("matchRepo() unexpected error = %v", err)
+					return
+				}
+				if gotMatch != tt.wantMatch {
+					t.Errorf("matchRepo() gotMatch = %v, want %v for eventURL=%q, repoURL=%q", gotMatch, tt.wantMatch, tt.eventURL, tt.repoURL)
+				}
+			}
+		})
+	}
+}
+
 func TestMatchTarget(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/pkg/webhook/validation_test.go
+++ b/pkg/webhook/validation_test.go
@@ -220,3 +220,66 @@ func TestReconcilerAdmit(t *testing.T) {
 		})
 	}
 }
+
+func TestMatchRepo(t *testing.T) {
+	tests := []struct {
+		name       string
+		url        string
+		wantError  bool
+		errorCheck string
+	}{
+		// Exact matching
+		{
+			name:      "std https",
+			url:       "https://github.com/tektoncd/pipelines-as-code",
+			wantError: false,
+		},
+		{
+			name:      "std http",
+			url:       "http://github.com/tektoncd/pipelines-as-code",
+			wantError: false,
+		},
+		// Wildcard * - matches zero or more characters
+		{
+			name:      "glob * - prefix pattern",
+			url:       "https://github.com/tektoncd/*",
+			wantError: false,
+		},
+		{
+			name:      "glob * - domain",
+			url:       "https://*/tektoncd/pipelines-as-code",
+			wantError: false,
+		},
+		{
+			name:      "std not github ",
+			url:       "https://gitlab.com/tektoncd/pipelines-as-code",
+			wantError: false,
+		},
+		{
+			name:      "std not github deep path",
+			url:       "https://gitlab.com/tektoncd/group/pipelines-as-code",
+			wantError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateRepositoryURL(tt.url, "")
+
+			if tt.wantError {
+				if err == nil {
+					t.Errorf("validateRepositoryURL() expected error but got nil")
+					return
+				}
+				if tt.errorCheck != "" {
+					assert.ErrorContains(t, err, tt.errorCheck)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("validateRepositoryURL() unexpected error = %v", err)
+					return
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 📝 Description of the Change

This change introduce posibility to match repository over glob or regex pattern making able to setup a single repository cr to handle set of repositories 

## 🔗 Linked GitHub Issue

Fixes #1246

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing

## 🤖 AI Assistance

AI assistance can be used for various tasks, such as code generation,
documentation, or testing.

Please indicate whether you have used AI assistance
for this PR and provide details if applicable.

- [x] I have not used any AI assistance for this PR.
- [ ] I have used AI assistance for this PR.

> [!IMPORTANT]
>
> **Slop will be simply rejected**, if you are using AI assistance you need to make sure you
> understand the code generated and that it meets the project's standards. you
> need at least know how to run the code and deploy it (if needed). See
> [startpaac](https://github.com/openshift-pipelines/startpaac) to make it easy
> to deploy and test your code changes.
>
> If the **majority of the code** in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Claude <noreply@anthropic.com>

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
