### PR TITLE
fix(reconciler): skip watcher status updates

### DIFF
--- a/pkg/reconciler/controller.go
+++ b/pkg/reconciler/controller.go
@@ -100,6 +100,10 @@ func ctrlOpts() func(impl *controller.Impl) controller.Options {
 	return func(_ *controller.Impl) controller.Options {
 		return controller.Options{
 			FinalizerName: path.Join(pipelinesascode.GroupName, pipelinesascode.FinalizerName),
+			// The watcher observes PipelineRun status but never owns it. Skipping
+			// generated status sync avoids doing UpdateStatus() calls when
+			// informer transforms trim cached status fields.
+			SkipStatusUpdates: true,
 			PromoteFilterFunc: func(obj any) bool {
 				_, exist := obj.(*tektonv1.PipelineRun).GetAnnotations()[keys.State]
 				return exist

--- a/pkg/reconciler/controller_test.go
+++ b/pkg/reconciler/controller_test.go
@@ -65,6 +65,7 @@ func TestCtrlOpts(t *testing.T) {
 
 	// Assert that the finalizer name is set correctly.
 	assert.Equal(t, path.Join(pipelinesascode.GroupName, pipelinesascode.FinalizerName), opts.FinalizerName)
+	assert.Assert(t, opts.SkipStatusUpdates)
 
 	// Create a new PipelineRun object with the "started" state label.
 	pr := &pipelinev1.PipelineRun{


### PR DESCRIPTION
## 📝 Description of the Change

Disable generated status synchronization for the PipelineRun watcher. Since the watcher observes the PipelineRun status but doesn't own it, disabling this sync prevents informer cache transforms from incorrectly triggering UpdateStatus calls against the /status subresource.

This avoids forbidden errors on clusters where the watcher only has metadata and spec-level PipelineRun permissions.

This regression was introduced in PR #2667 and only surfaces when a specific code path is exercised, which is why it doesn't reproduce consistently across all clusters.

* **The Cache Mismatch:** Before PR #2667, the watcher informer cache stored the full `PipelineRun.Status`. After #2667, `PipelineRunForCache` trims most of the status object to save memory. 
* **The Finalizer Flow:** The watcher itself doesn't intentionally update the PipelineRun status, but it does implement a finalizer. In the generated Tekton/Knative reconciler, finalizer handling happens before the automatic status-sync check. 
* **The Fake Out:** When the reconciler adds or updates the finalizer, it replaces the working object with the fresh API response, which contains the full Status. The original cached object still has the trimmed Status.
* **The Broken Check:** The generated equality check compares the two, sees a difference, and incorrectly decides that the status must be updated. This triggers an unauthorized `UpdateStatus()` call on the `pipelineruns/status` subresource.

The bug only pops up when two conditions are met:
1. It's a newly reconciled PipelineRun where the watcher is adding its finalizer.
2. The cluster's watcher service account lacks update permissions on `pipelineruns/status`.

## 🔗 Linked GitHub Issue

Fixes #

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

AI assistance can be used for various tasks, such as code generation,
documentation, or testing.

Please indicate whether you have used AI assistance
for this PR and provide details if applicable.

- [ ] I have not used any AI assistance for this PR.
- [X] I have used AI assistance for this PR. (for comments and reviews)

> [!IMPORTANT]
>
> **Slop will be simply rejected**, if you are using AI assistance you need to make sure you
> understand the code generated and that it meets the project's standards. you
> need at least know how to run the code and deploy it (if needed). See
> [startpaac](https://github.com/openshift-pipelines/startpaac) to make it easy
> to deploy and test your code changes.
>
> If the **majority of the code** in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Claude <noreply@anthropic.com>

## ✅ Submitter Checklist

- [ ] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [ ] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [ ] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
