### PR TITLE
fix(gitlab): post MR comment on inaccessible fork

### DIFF
--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -215,7 +215,7 @@ func (v *Provider) GetConfig() *info.ProviderConfig {
 	}
 }
 
-func (v *Provider) SetClient(_ context.Context, run *params.Run, runevent *info.Event, repo *v1alpha1.Repository, eventsEmitter *events.EventEmitter) error {
+func (v *Provider) SetClient(ctx context.Context, run *params.Run, runevent *info.Event, repo *v1alpha1.Repository, eventsEmitter *events.EventEmitter) error {
 	var err error
 	if runevent.Provider.Token == "" {
 		return fmt.Errorf("no git_provider.secret has been set in the repo crd")
@@ -273,11 +273,23 @@ func (v *Provider) SetClient(_ context.Context, run *params.Run, runevent *info.
 		_, resp, err := v.Client().Projects.GetProject(runevent.SourceProjectID, &gitlab.GetProjectOptions{})
 		errmsg := fmt.Sprintf("failed to access GitLab source repository ID %d: please ensure token has 'read_repository' scope on that repository",
 			runevent.SourceProjectID)
+
+		var returnErr error
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("%s", errmsg)
+			returnErr = fmt.Errorf("%s", errmsg)
+		} else if err != nil {
+			returnErr = fmt.Errorf("%s: %w", errmsg, err)
 		}
-		if err != nil {
-			return fmt.Errorf("%s: %w", errmsg, err)
+
+		if returnErr != nil {
+			if runevent.PullRequestNumber > 0 {
+				marker := "<!-- pac-source-repo-inaccessible -->"
+				comment := fmt.Sprintf("%s\n%s", marker, formatSourceRepoInaccessibleComment(runevent.SourceProjectID))
+				if commentErr := v.CreateComment(ctx, runevent, comment, marker); commentErr != nil {
+					run.Clients.Log.Warnf("failed to post source repository access error as MR comment: %v", commentErr)
+				}
+			}
+			return returnErr
 		}
 	}
 
@@ -862,6 +874,13 @@ func (v *Provider) isHeadCommitOfBranch(runevent *info.Event, branchName string)
 	}
 
 	return fmt.Errorf("provided SHA %s is not the HEAD commit of the branch %s", runevent.SHA, branchName)
+}
+
+func formatSourceRepoInaccessibleComment(sourceProjectID int64) string {
+	return fmt.Sprintf("**Could not access source repository (project ID: %d)**\n\n"+
+		"Ensure the token has `read_repository` scope on the source project, "+
+		"or use a branch in the same repository instead of a fork.",
+		sourceProjectID)
 }
 
 func (v *Provider) GetTemplate(commentType provider.CommentType) string {

--- a/pkg/provider/gitlab/gitlab_test.go
+++ b/pkg/provider/gitlab/gitlab_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -2299,4 +2300,165 @@ func TestGitLabCreateCommentPaging(t *testing.T) {
 	err := p.CreateComment(context.Background(), event, commit, updateMarker)
 	assert.NilError(t, err)
 	assert.Assert(t, updated == true, "comment update handler has not been called")
+}
+
+func TestSetClientSourceRepoAccessPostsComment(t *testing.T) {
+	ctx, _ := rtesting.SetupFakeContext(t)
+	observer, _ := zapobserver.New(zap.DebugLevel)
+	fakelogger := zap.New(observer).Sugar()
+	run := &params.Run{
+		Clients: clients.Clients{
+			Log: fakelogger,
+		},
+	}
+
+	tests := []struct {
+		name              string
+		triggerTarget     triggertype.Trigger
+		sourceProjectID   int64
+		targetProjectID   int64
+		pullRequestNumber int
+		setupMockResponse func(*http.ServeMux, *bool)
+		expectedError     string
+		expectComment     bool
+	}{
+		{
+			name:              "404 on source project posts MR comment",
+			triggerTarget:     triggertype.PullRequest,
+			sourceProjectID:   456,
+			targetProjectID:   789,
+			pullRequestNumber: 42,
+			setupMockResponse: func(mux *http.ServeMux, commentPosted *bool) {
+				mux.HandleFunc("/projects/456", func(rw http.ResponseWriter, _ *http.Request) {
+					rw.WriteHeader(http.StatusNotFound)
+					fmt.Fprint(rw, `{"message": "404 Project Not Found"}`)
+				})
+				mux.HandleFunc("/projects/789/merge_requests/42/notes", func(rw http.ResponseWriter, r *http.Request) {
+					if r.Method == http.MethodGet {
+						fmt.Fprint(rw, `[]`)
+						return
+					}
+					if r.Method == http.MethodPost {
+						body, _ := io.ReadAll(r.Body)
+						bodyStr := string(body)
+						assert.Assert(t, strings.Contains(bodyStr, "source repository"), "comment should mention source repository, got: %s", bodyStr)
+						assert.Assert(t, strings.Contains(bodyStr, "read_repository"), "comment should mention read_repository scope, got: %s", bodyStr)
+						*commentPosted = true
+					}
+					fmt.Fprint(rw, `{}`)
+				})
+			},
+			expectedError: "failed to access GitLab source repository ID 456: please ensure token has 'read_repository' scope on that repository",
+			expectComment: true,
+		},
+		{
+			name:              "403 on source project posts MR comment",
+			triggerTarget:     triggertype.PullRequest,
+			sourceProjectID:   456,
+			targetProjectID:   789,
+			pullRequestNumber: 42,
+			setupMockResponse: func(mux *http.ServeMux, commentPosted *bool) {
+				mux.HandleFunc("/projects/456", func(rw http.ResponseWriter, _ *http.Request) {
+					rw.WriteHeader(http.StatusForbidden)
+					fmt.Fprint(rw, `{"message": "403 Forbidden"}`)
+				})
+				mux.HandleFunc("/projects/789/merge_requests/42/notes", func(rw http.ResponseWriter, r *http.Request) {
+					if r.Method == http.MethodGet {
+						fmt.Fprint(rw, `[]`)
+						return
+					}
+					if r.Method == http.MethodPost {
+						*commentPosted = true
+					}
+					fmt.Fprint(rw, `{}`)
+				})
+			},
+			expectedError: "failed to access GitLab source repository ID 456: please ensure token has 'read_repository' scope on that repository",
+			expectComment: true,
+		},
+		{
+			name:              "Comment posting failure is non-fatal",
+			triggerTarget:     triggertype.PullRequest,
+			sourceProjectID:   456,
+			targetProjectID:   789,
+			pullRequestNumber: 42,
+			setupMockResponse: func(mux *http.ServeMux, _ *bool) {
+				mux.HandleFunc("/projects/456", func(rw http.ResponseWriter, _ *http.Request) {
+					rw.WriteHeader(http.StatusNotFound)
+					fmt.Fprint(rw, `{"message": "404 Project Not Found"}`)
+				})
+				mux.HandleFunc("/projects/789/merge_requests/42/notes", func(rw http.ResponseWriter, _ *http.Request) {
+					rw.WriteHeader(http.StatusInternalServerError)
+					fmt.Fprint(rw, `{"message": "500 Internal Server Error"}`)
+				})
+			},
+			expectedError: "failed to access GitLab source repository ID 456",
+			expectComment: false,
+		},
+		{
+			name:              "Successful access posts no comment",
+			triggerTarget:     triggertype.PullRequest,
+			sourceProjectID:   456,
+			targetProjectID:   789,
+			pullRequestNumber: 42,
+			setupMockResponse: func(mux *http.ServeMux, _ *bool) {
+				mux.HandleFunc("/projects/456", func(rw http.ResponseWriter, _ *http.Request) {
+					rw.WriteHeader(http.StatusOK)
+					fmt.Fprint(rw, `{"id": 456, "name": "test-repo"}`)
+				})
+			},
+			expectedError: "",
+			expectComment: false,
+		},
+		{
+			name:              "Push event skips source project check entirely",
+			triggerTarget:     triggertype.Push,
+			sourceProjectID:   456,
+			targetProjectID:   789,
+			pullRequestNumber: 0,
+			setupMockResponse: func(mux *http.ServeMux, _ *bool) {
+				mux.HandleFunc("/projects/456", func(rw http.ResponseWriter, _ *http.Request) {
+					fmt.Fprint(rw, `{"id": 456, "name": "test-repo"}`)
+				})
+			},
+			expectedError: "",
+			expectComment: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient, mux, tearDown := thelp.Setup(t)
+			defer tearDown()
+
+			commentPosted := false
+			if tt.setupMockResponse != nil {
+				tt.setupMockResponse(mux, &commentPosted)
+			}
+
+			v := &Provider{gitlabClient: mockClient}
+			event := &info.Event{
+				Provider: &info.Provider{
+					Token: "test-token",
+				},
+				Organization:      "test-org",
+				Repository:        "test-repo",
+				TriggerTarget:     tt.triggerTarget,
+				SourceProjectID:   tt.sourceProjectID,
+				TargetProjectID:   tt.targetProjectID,
+				PullRequestNumber: tt.pullRequestNumber,
+			}
+
+			err := v.SetClient(ctx, run, event, nil, nil)
+
+			if tt.expectedError != "" {
+				assert.Assert(t, err != nil, "expected error but got none")
+				assert.ErrorContains(t, err, tt.expectedError)
+			} else {
+				assert.NilError(t, err)
+			}
+
+			assert.Equal(t, tt.expectComment, commentPosted, "comment posted mismatch")
+		})
+	}
 }


### PR DESCRIPTION

## 📝 Description of the Change
When a merge request originates from a fork the bot cannot access, post an informative comment on the MR explaining the issue. Uses CreateComment with an update marker to prevent duplicate comments on reconciler retries.

## 🔗 Linked GitHub Issue
N/A

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [x] Manual testing
- [ ] Not Applicable

Created a repo and a private fork. Raised a PR from thr private fork to upstream repo.
The token used only had access to the original repo.
<img width="1018" height="826" alt="Screenshot From 2026-05-25 11-32-08" src="https://github.com/user-attachments/assets/c049b8ee-cdd1-482f-858b-fd34c559e81e" />


## 🤖 AI Assistance

AI assistance can be used for various tasks, such as code generation,
documentation, or testing.

Please indicate whether you have used AI assistance
for this PR and provide details if applicable.

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

> [!IMPORTANT]
>
> **Slop will be simply rejected**, if you are using AI assistance you need to make sure you
> understand the code generated and that it meets the project's standards. you
> need at least know how to run the code and deploy it (if needed). See
> [startpaac](https://github.com/openshift-pipelines/startpaac) to make it easy
> to deploy and test your code changes.
>
> If the **majority of the code** in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Claude <noreply@anthropic.com>

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
