### PR TITLE
fix(release): preserve dots in image tags for version tag pushes

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -54,6 +54,8 @@ jobs:
           releaseBranchFormat='release-v'
           if [[ ${GITHUB_REF_NAME} == ${releaseBranchFormat}* ]]; then
             tag=v$(echo ${GITHUB_REF_NAME}|sed "s,${releaseBranchFormat},,")
+          elif [[ ${GITHUB_REF} == refs/tags/v* ]]; then
+            tag=${GITHUB_REF_NAME}
           elif [[ ${GITHUB_REF} == refs/pull/* ]]; then
             tag=pr-$(echo ${GITHUB_REF} | cut -c11-|sed 's,/merge,,')
           else


### PR DESCRIPTION
## 📝 Description of the Change

When a version tag (e.g. `v0.47.0`) is pushed, the container workflow's tag
sanitization converts dots to dashes, producing `v0-47-0` images. But the
release pipeline generates `release.yaml` referencing `v0.47.0` (with dots),
causing a mismatch where manifests point to nonexistent image tags.

This adds a condition for `refs/tags/v*` pushes that uses the tag name as-is,
since Docker image tags support dots.

## 🔗 Linked GitHub Issue

Fixes #2741

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [x] Manual testing
- [ ] Not Applicable

Verified by tracing the conditional logic for all ref types:
- Tag push `refs/tags/v0.47.0` → new branch fires → tag `v0.47.0` (dots preserved, matches release.yaml)
- Release branch `release-v0.47.0` → first branch fires → tag `v0.47.0` (unchanged)
- PR `refs/pull/123/merge` → PR branch fires → tag `pr-123` (unchanged)
- Generic branch `feature/foo` → else branch fires → tag `feature-foo` (unchanged)

## 🤖 AI Assistance

- [x] I have used AI assistance for this PR.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any issues. For an efficient workflow, I have considered installing [pre-commit](https://pre-commit.com/) and running `pre-commit install` to automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [x] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.