### PR TITLE
feat: Add deprecation warnings for Tekton Hub integration

### DIFF
--- a/docs/content/docs/api/configmap.md
+++ b/docs/content/docs/api/configmap.md
@@ -67,7 +67,7 @@ hub-url: "https://artifacthub.io/api/v1"
 {{< /param >}}
 
 {{< param name="hub-catalog-type" type="string" default="artifacthub" id="param-hub-catalog-type" >}}
-Sets the default hub catalog type. Supported values: `artifacthub`, `tektonhub`.
+Sets the default hub catalog type. Supported values: `artifacthub`, `tektonhub`. **Note:** The `tektonhub` type is deprecated and will be removed in a future release. Please migrate to `artifacthub`.
 
 ```yaml
 hub-catalog-type: "artifacthub"
@@ -93,7 +93,7 @@ URL of the catalog API endpoint.
 {{< /param >}}
 
 {{< param name="catalog-{N}-type" type="string" id="param-catalog-n-type" >}}
-Type of catalog (`tektonhub` or `artifacthub`).
+Type of catalog (`tektonhub` or `artifacthub`). **Note:** The `tektonhub` type is deprecated and will be removed in a future release.
 {{< /param >}}
 
 {{< /param-group >}}

--- a/docs/content/docs/concepts.md
+++ b/docs/content/docs/concepts.md
@@ -32,7 +32,7 @@ The **controller** (`pipelines-as-code-controller`) is the central component. It
 - Receives webhook events from Git providers (push, pull request, etc.)
 - Matches events to Repository CRs in the cluster
 - Fetches pipeline definitions from the `.tekton/` directory in your repository
-- Resolves remote tasks from Tekton Hub or Artifact Hub
+- Resolves remote tasks from Artifact Hub (Tekton Hub support is deprecated)
 - Validates pipeline YAML before submission
 - Creates PipelineRuns in the appropriate namespace
 - Injects authentication tokens and secrets

--- a/docs/content/docs/guides/pipeline-resolution/_index.md
+++ b/docs/content/docs/guides/pipeline-resolution/_index.md
@@ -56,6 +56,10 @@ pipelinesascode.tekton.dev/task: "[git-clone, pylint]"
 
 ### Hub support for tasks
 
+{{< callout type="warning" >}}
+**Deprecated**: Tekton Hub integration (the `tektonhub` catalog type) is deprecated and will be removed in a future release. If you are using a self-hosted Tekton Hub instance, please migrate to [Artifact Hub](https://artifacthub.io) or fetch tasks directly from a [remote URL](#remote-http-url) or [git repository](#tasks-inside-the-repository). The default Artifact Hub integration is unaffected.
+{{< /callout >}}
+
 [Artifact Hub](https://artifacthub.io/packages/search?kind=7&kind=11) is a public registry where the Tekton community publishes reusable Tasks and Pipelines. When you reference a task by name alone, Pipelines-as-Code fetches it from Artifact Hub by default.
 
 ```yaml
@@ -94,7 +98,7 @@ pipelinesascode.tekton.dev/task: "git-clone:0.9.0"
 
 #### Custom hub support for tasks
 
-If your cluster administrator has [configured]({{< relref "/docs/api/configmap#hub-configuration" >}}) custom Hub catalogs beyond the default Artifact Hub and Tekton Hub, you can reference them from your template:
+If your cluster administrator has [configured]({{< relref "/docs/api/configmap#hub-configuration" >}}) custom Hub catalogs beyond the default Artifact Hub, you can reference them from your template. Note that `tektonhub`-type custom catalogs are deprecated and will be removed in a future release.
 
 ```yaml
 pipelinesascode.tekton.dev/task: "[customcatalog://curl]" # this will install curl from the custom catalog configured by the cluster administrator as customcatalog

--- a/docs/content/docs/guides/pipeline-resolution/remote-pipelines.md
+++ b/docs/content/docs/guides/pipeline-resolution/remote-pipelines.md
@@ -25,6 +25,10 @@ See [Tasks and Pipelines inside the repository](#tasks-or-pipelines-inside-the-r
 
 ## Hub support for Pipelines
 
+{{< callout type="warning" >}}
+**Deprecated**: Tekton Hub integration (the `tektonhub` catalog type) is deprecated and will be removed in a future release. Please migrate to [Artifact Hub](https://artifacthub.io) or fetch pipelines from remote URLs. The default Artifact Hub integration is unaffected.
+{{< /callout >}}
+
 Just as with tasks, you can reference pipelines from [Artifact Hub](https://artifacthub.io) by name. Artifact Hub is a public registry for discovering and sharing Tekton resources.
 
 ```yaml
@@ -49,7 +53,7 @@ pipelinesascode.tekton.dev/pipeline: "buildpacks:0.1"
 
 ### Custom hub support for Pipelines
 
-If your cluster administrator has [configured]({{< relref "/docs/api/configmap#hub-configuration" >}}) custom Hub catalogs beyond the default Artifact Hub and Tekton Hub, you can reference them from your template:
+If your cluster administrator has [configured]({{< relref "/docs/api/configmap#hub-configuration" >}}) custom Hub catalogs beyond the default Artifact Hub, you can reference them from your template. Note that `tektonhub`-type custom catalogs are deprecated and will be removed in a future release.
 
 ```yaml
 pipelinesascode.tekton.dev/pipeline: "[customcatalog://buildpacks:0.1]" # this will install buildpacks from the custom catalog configured by the cluster administrator as customcatalog

--- a/docs/content/docs/installation/openshift.md
+++ b/docs/content/docs/installation/openshift.md
@@ -30,11 +30,15 @@ to the `pipelines-as-code` ConfigMap or `OpenShiftPipelinesAsCode` custom resour
 The default configuration for Pipelines-as-Code in `TektonConfig` is shown
 below.
 
-{{< callout type="info" >}}
-Since version v0.37.0, Pipelines-as-Code defaults to using Artifact
-Hub. The public Tekton Hub (hub.tekton.dev) has been deprecated and is no longer
-available. You can still use custom self-hosted Tekton Hub instances by
-configuring them as custom catalogs (see [Remote Hub Catalogs]({{< relref "/docs/api/configmap#hub-configuration" >}})).
+{{< callout type="warning" >}}
+Tekton Hub integration in Pipelines-as-Code is **deprecated** and will be
+**removed in a future release**. The public Tekton Hub (hub.tekton.dev) has been
+shut down, and support for self-hosted Tekton Hub instances (the `tektonhub`
+catalog type) is now deprecated as well. Please migrate to
+[Artifact Hub](https://artifacthub.io) or fetch tasks directly from a git
+repository or remote URL. See the
+[pipeline resolution guide]({{< relref "/docs/guides/pipeline-resolution" >}})
+for alternatives.
 {{< /callout >}}
 
 ```yaml

--- a/pkg/cmd/tknpac/resolve/resolve.go
+++ b/pkg/cmd/tknpac/resolve/resolve.go
@@ -211,7 +211,7 @@ func resolveFilenames(ctx context.Context, cs *params.Run, filenames []string, p
 	if err != nil {
 		return "", err
 	}
-	prun, err := resolve.Resolve(ctx, cs, cs.Clients.Log, providerintf, types, event, ropt)
+	prun, _, err := resolve.Resolve(ctx, cs, cs.Clients.Log, providerintf, types, event, ropt)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/matcher/annotation_tasks_install.go
+++ b/pkg/matcher/annotation_tasks_install.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/hub"
+	hubtypes "github.com/openshift-pipelines/pipelines-as-code/pkg/hub/vars"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
@@ -26,14 +27,15 @@ const (
 )
 
 type RemoteTasks struct {
-	Run               *params.Run
-	ProviderInterface provider.Interface
-	Event             *info.Event
-	Logger            *zap.SugaredLogger
+	Run                    *params.Run
+	ProviderInterface      provider.Interface
+	Event                  *info.Event
+	Logger                 *zap.SugaredLogger
+	DeprecatedHubResources []string // tracks resources resolved from deprecated tektonhub catalogs
 }
 
 // nolint: dupl
-func (rt RemoteTasks) convertToPipeline(ctx context.Context, uri, data string) (*tektonv1.Pipeline, error) {
+func (rt *RemoteTasks) convertToPipeline(ctx context.Context, uri, data string) (*tektonv1.Pipeline, error) {
 	decoder := k8scheme.Codecs.UniversalDeserializer()
 	obj, _, err := decoder.Decode([]byte(data), nil, nil)
 	if err != nil {
@@ -68,7 +70,7 @@ func (rt RemoteTasks) convertToPipeline(ctx context.Context, uri, data string) (
 // nolint: dupl
 // golint has decided that this is a duplication with convertToPipeline but I swear it isn't - these two are different functions
 // and not even sure this is possible to do with generic complexity.
-func (rt RemoteTasks) convertTotask(ctx context.Context, uri, data string) (*tektonv1.Task, error) {
+func (rt *RemoteTasks) convertTotask(ctx context.Context, uri, data string) (*tektonv1.Task, error) {
 	decoder := k8scheme.Codecs.UniversalDeserializer()
 	obj, _, err := decoder.Decode([]byte(data), nil, nil)
 	if err != nil {
@@ -97,7 +99,7 @@ func (rt RemoteTasks) convertTotask(ctx context.Context, uri, data string) (*tek
 	return task, nil
 }
 
-func (rt RemoteTasks) getRemote(ctx context.Context, uri string, fromHub bool, kind string) (string, error) {
+func (rt *RemoteTasks) getRemote(ctx context.Context, uri string, fromHub bool, kind string) (string, error) {
 	rt.Logger.Debugf("getRemote: uri=%s kind=%s fromHub=%t", uri, kind, fromHub)
 	if fetchedFromURIFromProvider, task, err := rt.ProviderInterface.GetTaskURI(ctx, rt.Event, uri); fetchedFromURIFromProvider {
 		rt.Logger.Debugf("getRemote: fetched %s via provider hook for uri=%s", kind, uri)
@@ -132,6 +134,10 @@ func (rt RemoteTasks) getRemote(ctx context.Context, uri string, fromHub bool, k
 			return "", fmt.Errorf("could not get details for catalog name: %s", catalogID)
 		}
 		rt.Logger.Infof("successfully fetched %s %s from custom catalog Hub %s on URL %s", kind, uri, catalogID, catalogValue.URL)
+		if catalogValue.Type == hubtypes.TektonHubType {
+			rt.Logger.Warnf("Tekton Hub integration is deprecated and will be removed in a future release. Resource %s %s was fetched from Tekton Hub catalog %s. Please migrate to Artifact Hub or fetch tasks from a git repository. See https://pipelinesascode.com/docs/guides/pipeline-resolution/", kind, uri, catalogID)
+			rt.DeprecatedHubResources = append(rt.DeprecatedHubResources, fmt.Sprintf("%s %s (catalog: %s)", kind, uri, catalogID))
+		}
 		return data, nil
 	case strings.Contains(uri, "/"): // if it contains a slash, it is a file inside a repository
 		rt.Logger.Debugf("getRemote: fetching %s from repository path", kind)
@@ -166,6 +172,10 @@ func (rt RemoteTasks) getRemote(ctx context.Context, uri string, fromHub bool, k
 			return "", fmt.Errorf("could not get details for catalog name: %s", "default")
 		}
 		rt.Logger.Infof("successfully fetched %s %s from default configured catalog Hub on URL %s", uri, kind, catalogValue.URL)
+		if catalogValue.Type == hubtypes.TektonHubType {
+			rt.Logger.Warnf("Tekton Hub integration is deprecated and will be removed in a future release. Resource %s %s was fetched from the default Tekton Hub catalog. Please migrate to Artifact Hub or fetch tasks from a git repository. See https://pipelinesascode.com/docs/guides/pipeline-resolution/", kind, uri)
+			rt.DeprecatedHubResources = append(rt.DeprecatedHubResources, fmt.Sprintf("%s %s (default catalog)", kind, uri))
+		}
 		return data, nil
 	}
 	return "", fmt.Errorf(`cannot find "%s" anywhere`, uri)
@@ -205,7 +215,7 @@ func GrabPipelineFromAnnotations(annotations map[string]string) (string, error) 
 	return pipelinesAnnotation[0], nil
 }
 
-func (rt RemoteTasks) GetTaskFromAnnotationName(ctx context.Context, name string) (*tektonv1.Task, error) {
+func (rt *RemoteTasks) GetTaskFromAnnotationName(ctx context.Context, name string) (*tektonv1.Task, error) {
 	rt.Logger.Debugf("GetTaskFromAnnotationName: name=%s", name)
 	data, err := rt.getRemote(ctx, name, true, "task")
 	if err != nil {
@@ -222,7 +232,7 @@ func (rt RemoteTasks) GetTaskFromAnnotationName(ctx context.Context, name string
 	return task, nil
 }
 
-func (rt RemoteTasks) GetPipelineFromAnnotationName(ctx context.Context, name string) (*tektonv1.Pipeline, error) {
+func (rt *RemoteTasks) GetPipelineFromAnnotationName(ctx context.Context, name string) (*tektonv1.Pipeline, error) {
 	rt.Logger.Debugf("GetPipelineFromAnnotationName: name=%s", name)
 	data, err := rt.getRemote(ctx, name, true, "pipeline")
 	if err != nil {

--- a/pkg/matcher/annotation_tasks_install_test.go
+++ b/pkg/matcher/annotation_tasks_install_test.go
@@ -243,6 +243,7 @@ func TestGetTaskFromAnnotationName(t *testing.T) {
 		wantErr                string
 		wantLog                string
 		wantProviderRemoteTask bool
+		wantDeprecated         bool
 	}{
 		{
 			name: "test-annotations-error-remote-http-not-k8",
@@ -346,10 +347,11 @@ func TestGetTaskFromAnnotationName(t *testing.T) {
 			wantErr: "remote task \"foo://bar\" not found",
 		},
 		{
-			name:        "test-get-from-custom-hub",
-			gotTaskName: "task",
-			task:        "anotherHub://chmouzie",
-			wantLog:     "successfully fetched task chmouzie from custom catalog Hub anotherHub on URL https://mybelovedhub",
+			name:           "test-get-from-custom-hub",
+			gotTaskName:    "task",
+			task:           "anotherHub://chmouzie",
+			wantLog:        "successfully fetched task chmouzie from custom catalog Hub anotherHub on URL https://mybelovedhub",
+			wantDeprecated: true,
 			remoteURLS: map[string]map[string]string{
 				testHubURL + "/resource/" + testCatalogHubName + "/task/chmouzie": {
 					"body": `{"data": {"LatestVersion": {"version": "0.1"}}}`,
@@ -362,9 +364,10 @@ func TestGetTaskFromAnnotationName(t *testing.T) {
 			},
 		},
 		{
-			name:        "test-get-from-hub-latest",
-			gotTaskName: "task",
-			task:        "chmouzie",
+			name:           "test-get-from-hub-latest",
+			gotTaskName:    "task",
+			task:           "chmouzie",
+			wantDeprecated: true,
 			remoteURLS: map[string]map[string]string{
 				testHubURL + "/resource/" + testCatalogHubName + "/task/chmouzie": {
 					"body": `{"data": {"LatestVersion": {"version": "0.1"}}}`,
@@ -377,9 +380,10 @@ func TestGetTaskFromAnnotationName(t *testing.T) {
 			},
 		},
 		{
-			name:        "test-get-from-hub-specific-version",
-			gotTaskName: "task",
-			task:        "chmouzie:0.2",
+			name:           "test-get-from-hub-specific-version",
+			gotTaskName:    "task",
+			task:           "chmouzie:0.2",
+			wantDeprecated: true,
 			remoteURLS: map[string]map[string]string{
 				testHubURL + "/resource/" + testCatalogHubName + "/task/chmouzie/0.2": {
 					"body": `{}`,
@@ -468,6 +472,13 @@ func TestGetTaskFromAnnotationName(t *testing.T) {
 			if tt.gotTaskName != "" {
 				assert.Equal(t, tt.gotTaskName, got.GetName())
 			}
+
+			if tt.wantDeprecated {
+				assert.Assert(t, len(rt.DeprecatedHubResources) > 0, "expected DeprecatedHubResources to be populated for tektonhub catalog")
+				assert.Assert(t, len(fakelog.FilterMessageSnippet("Tekton Hub integration is deprecated").TakeAll()) > 0, "expected deprecation warning in logs")
+			} else {
+				assert.Assert(t, len(rt.DeprecatedHubResources) == 0, "expected DeprecatedHubResources to be empty for non-tektonhub catalog")
+			}
 		})
 	}
 }
@@ -511,6 +522,7 @@ func TestGetPipelineFromAnnotationName(t *testing.T) {
 		runevent        info.Event
 		wantErr         string
 		wantLog         string
+		wantDeprecated  bool
 	}{
 		{
 			name:            "good/fetching from remote http",
@@ -609,6 +621,7 @@ func TestGetPipelineFromAnnotationName(t *testing.T) {
 			gotPipelineName: "pipeline",
 			pipeline:        "anotherHub://chmouzie",
 			wantLog:         "successfully fetched pipeline chmouzie from custom catalog Hub anotherHub on URL https://mybelovedhub",
+			wantDeprecated:  true,
 			remoteURLS: map[string]map[string]string{
 				testHubURL + "/resource/" + testCatalogHubName + "/pipeline/chmouzie": {
 					"body": `{"data": {"LatestVersion": {"version": "0.1"}}}`,
@@ -624,6 +637,7 @@ func TestGetPipelineFromAnnotationName(t *testing.T) {
 			name:            "test-get-from-hub-latest",
 			gotPipelineName: "pipeline",
 			pipeline:        "chmouzie",
+			wantDeprecated:  true,
 			remoteURLS: map[string]map[string]string{
 				testHubURL + "/resource/" + testCatalogHubName + "/pipeline/chmouzie": {
 					"body": `{"data": {"LatestVersion": {"version": "0.1"}}}`,
@@ -639,6 +653,7 @@ func TestGetPipelineFromAnnotationName(t *testing.T) {
 			name:            "test-get-from-hub-specific-version",
 			gotPipelineName: "pipeline",
 			pipeline:        "chmouzie:0.2",
+			wantDeprecated:  true,
 			remoteURLS: map[string]map[string]string{
 				testHubURL + "/resource/" + testCatalogHubName + "/pipeline/chmouzie/0.2": {
 					"body": `{}`,
@@ -727,6 +742,13 @@ func TestGetPipelineFromAnnotationName(t *testing.T) {
 
 			if tt.gotPipelineName != "" {
 				assert.Equal(t, tt.gotPipelineName, got.GetName())
+			}
+
+			if tt.wantDeprecated {
+				assert.Assert(t, len(rt.DeprecatedHubResources) > 0, "expected DeprecatedHubResources to be populated for tektonhub catalog")
+				assert.Assert(t, len(fakelog.FilterMessageSnippet("Tekton Hub integration is deprecated").TakeAll()) > 0, "expected deprecation warning in logs")
+			} else {
+				assert.Assert(t, len(rt.DeprecatedHubResources) == 0, "expected DeprecatedHubResources to be empty for non-tektonhub catalog")
 			}
 		})
 	}

--- a/pkg/params/settings/default.go
+++ b/pkg/params/settings/default.go
@@ -38,6 +38,9 @@ func getHubCatalogs(logger *zap.SugaredLogger, catalogs *sync.Map, config map[st
 		Type:  config[HubCatalogTypeKey],
 	}
 	catalogs.Store("default", hc)
+	if hc.Type == hubtypes.TektonHubType {
+		logger.Warnf("CONFIG: Tekton Hub catalog type is deprecated and will be removed in a future release. Please migrate to Artifact Hub. See https://pipelinesascode.com/docs/guides/pipeline-resolution/")
+	}
 
 	for k := range config {
 		m := hubCatalogNameRegex.FindStringSubmatch(k)
@@ -90,6 +93,9 @@ func getHubCatalogs(logger *zap.SugaredLogger, catalogs *sync.Map, config map[st
 					URL:   catalogURL,
 					Type:  catalogType,
 				})
+				if catalogType == hubtypes.TektonHubType {
+					logger.Warnf("CONFIG: custom catalog %s uses Tekton Hub type, which is deprecated and will be removed in a future release. Please migrate to Artifact Hub.", catalogID)
+				}
 			}
 		}
 	}

--- a/pkg/params/settings/default_test.go
+++ b/pkg/params/settings/default_test.go
@@ -175,6 +175,29 @@ func TestGetCatalogHub(t *testing.T) {
 			httpClient:  mockHTTPClient,
 		},
 		{
+			name: "tektonhub default catalog emits deprecation warning",
+			config: map[string]string{
+				"hub-catalog-type": "tektonhub",
+			},
+			numCatalogs: 1,
+			hubCatalogs: &sync.Map{},
+			wantLog:     "CONFIG: Tekton Hub catalog type is deprecated and will be removed in a future release",
+			httpClient:  mockHTTPClient,
+		},
+		{
+			name: "tektonhub custom catalog emits deprecation warning",
+			config: map[string]string{
+				"catalog-1-id":   "myhub",
+				"catalog-1-url":  "https://myhub.com",
+				"catalog-1-name": "tekton",
+				"catalog-1-type": "tektonhub",
+			},
+			numCatalogs: 2,
+			hubCatalogs: &sync.Map{},
+			wantLog:     "CONFIG: custom catalog myhub uses Tekton Hub type, which is deprecated",
+			httpClient:  mockHTTPClient,
+		},
+		{
 			name: "custom catalog type detection via API - success (ArtifactHub)",
 			config: map[string]string{
 				"catalog-1-id":   "example-ah",

--- a/pkg/pipelineascode/match.go
+++ b/pkg/pipelineascode/match.go
@@ -351,13 +351,17 @@ func (p *PacRun) getPipelineRunsFromRepo(ctx context.Context, repo *v1alpha1.Rep
 			}
 		}
 		p.debugf("getPipelineRunsFromRepo: resolving remote tasks for pipelineRuns=%d", len(types.PipelineRuns))
-		pipelineRuns, err = resolve.Resolve(ctx, p.run, p.logger, p.vcx, types, p.event, &resolve.Opts{
+		var deprecatedHubResources []string
+		pipelineRuns, deprecatedHubResources, err = resolve.Resolve(ctx, p.run, p.logger, p.vcx, types, p.event, &resolve.Opts{
 			GenerateName: true,
 			RemoteTasks:  true,
 		})
 		if err != nil {
 			p.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "RepositoryFailedToMatch", fmt.Sprintf("failed to match pipelineRuns: %s", err.Error()))
 			return nil, err
+		}
+		if len(deprecatedHubResources) > 0 {
+			p.postTektonHubDeprecationNotice(ctx, repo, deprecatedHubResources)
 		}
 	}
 
@@ -489,6 +493,40 @@ func (p *PacRun) changePipelineRun(ctx context.Context, repo *v1alpha1.Repositor
 		p.debugf("changePipelineRun: updated pipelinerun=%s with git_auth_secret annotation", prName)
 	}
 	return nil
+}
+
+const tektonHubDeprecationMarker = "<!-- pac-deprecation-tektonhub -->"
+
+func (p *PacRun) postTektonHubDeprecationNotice(ctx context.Context, repo *v1alpha1.Repository, deprecatedResources []string) {
+	// Emit Kubernetes Event on the Repository CR
+	deprecMsg := fmt.Sprintf("Tekton Hub integration is deprecated and will be removed in a future release. The following resources were resolved from a Tekton Hub catalog: %s. Please migrate to Artifact Hub or fetch tasks from a git repository.", strings.Join(deprecatedResources, ", "))
+	p.eventEmitter.EmitMessage(repo, zap.WarnLevel, "DeprecatedTektonHub", deprecMsg)
+
+	// Post a consolidated comment on the pull request (force-posted, ignores disable_all)
+	if p.event.PullRequestNumber > 0 {
+		commentBody := formatTektonHubDeprecationComment(deprecatedResources)
+		if commentErr := p.vcx.CreateComment(ctx, p.event, commentBody, tektonHubDeprecationMarker); commentErr != nil {
+			p.logger.Warnf("failed to post Tekton Hub deprecation comment on PR: %s", commentErr)
+		}
+	}
+}
+
+func formatTektonHubDeprecationComment(deprecatedResources []string) string {
+	var sb strings.Builder
+	sb.WriteString("> [!WARNING]\n")
+	sb.WriteString("> **Tekton Hub Deprecation Notice**\n")
+	sb.WriteString(">\n")
+	sb.WriteString("> The following resources were resolved from a Tekton Hub catalog, which is **deprecated** and will be **removed in a future release**:\n")
+	sb.WriteString(">\n")
+	for _, r := range deprecatedResources {
+		fmt.Fprintf(&sb, "> - %s\n", r)
+	}
+	sb.WriteString(">\n")
+	sb.WriteString("> Please migrate to [Artifact Hub](https://artifacthub.io) or fetch tasks directly from a git repository or remote URL.\n")
+	sb.WriteString("> See the [migration guide](https://pipelinesascode.com/docs/guides/pipeline-resolution/) for alternatives.\n")
+	sb.WriteString("\n")
+	sb.WriteString(tektonHubDeprecationMarker)
+	return sb.String()
 }
 
 // checkNeedUpdate checks if the template needs an update form the user, try to

--- a/pkg/resolve/resolve.go
+++ b/pkg/resolve/resolve.go
@@ -215,14 +215,14 @@ func ReadTektonTypes(ctx context.Context, log *zap.SugaredLogger, data string) (
 // Pipeline/PipelineRuns/Tasks and resolve them inline as a single PipelineRun
 // generateName can be set as True to set the name as a generateName + "-" for
 // unique pipelinerun.
-func Resolve(ctx context.Context, cs *params.Run, logger *zap.SugaredLogger, providerintf provider.Interface, types TektonTypes, event *info.Event, ropt *Opts) ([]*tektonv1.PipelineRun, error) {
+func Resolve(ctx context.Context, cs *params.Run, logger *zap.SugaredLogger, providerintf provider.Interface, types TektonTypes, event *info.Event, ropt *Opts) ([]*tektonv1.PipelineRun, []string, error) {
 	if len(types.PipelineRuns) == 0 {
-		return []*tektonv1.PipelineRun{}, fmt.Errorf("could not find any PipelineRun in your .tekton/ directory")
+		return []*tektonv1.PipelineRun{}, nil, fmt.Errorf("could not find any PipelineRun in your .tekton/ directory")
 	}
 	debugf(logger, "Resolve: pipelineruns=%d pipelines=%d tasks=%d remote_tasks=%t generate_name=%t", len(types.PipelineRuns), len(types.Pipelines), len(types.Tasks), ropt.RemoteTasks, ropt.GenerateName)
 
 	if _, err := MetadataResolve(types.PipelineRuns); err != nil {
-		return []*tektonv1.PipelineRun{}, err
+		return []*tektonv1.PipelineRun{}, nil, err
 	}
 
 	rt := &matcher.RemoteTasks{
@@ -234,10 +234,10 @@ func Resolve(ctx context.Context, cs *params.Run, logger *zap.SugaredLogger, pro
 
 	fetchedResources, err := resolveRemoteResources(ctx, rt, types, ropt)
 	if err != nil {
-		return []*tektonv1.PipelineRun{}, err
+		return []*tektonv1.PipelineRun{}, nil, err
 	}
 	debugf(logger, "Resolve: resolved pipelineruns=%d", len(fetchedResources))
-	return fetchedResources, nil
+	return fetchedResources, rt.DeprecatedHubResources, nil
 }
 
 func MetadataResolve(prs []*tektonv1.PipelineRun) ([]*tektonv1.PipelineRun, error) {

--- a/pkg/resolve/resolve_test.go
+++ b/pkg/resolve/resolve_test.go
@@ -61,7 +61,7 @@ func readTDfile(t *testing.T, testname string, generateName, remoteTasking bool)
 	if err != nil {
 		return &tektonv1.PipelineRun{}, nil, err
 	}
-	resolved, err := Resolve(ctx, cs, logger, tprovider, types, event, ropt)
+	resolved, _, err := Resolve(ctx, cs, logger, tprovider, types, event, ropt)
 	if err != nil {
 		return &tektonv1.PipelineRun{}, nil, err
 	}


### PR DESCRIPTION
## 📝 Description of the Change

Deprecated the Tekton Hub catalog integration across documentation, configuration, and resource resolution. The public Tekton Hub (hub.tekton.dev) has been shut down, and support for self-hosted Tekton Hub instances (`tektonhub` catalog type) is now being formally deprecated ahead of full removal in a future release.

Changes:
- **Docs**: Added `[!WARNING]` deprecation callouts to the pipeline resolution guides (`_index.md`, `remote-pipelines.md`), configmap reference, concepts overview, and OpenShift installation page. Updated language to favour Artifact Hub.
- **Config loading** (`pkg/params/settings/default.go`): Emits a logger `Warn` at startup when the default or any custom catalog is configured with `type: tektonhub`.
- **Runtime resolution** (`pkg/matcher/annotation_tasks_install.go`, `pkg/resolve/resolve.go`): `RemoteTasks` gains a `DeprecatedHubResources []string` field (receivers switched to pointer receivers to propagate mutations). When a resource is fetched from a `tektonhub`-typed catalog, the resource name is appended to this slice and a `Warn` log line is emitted.
- **`resolve.Resolve`** signature changed to `([]*tektonv1.PipelineRun, []string, error)` to surface deprecated resources to callers.
- **PR notice** (`pkg/pipelineascode/match.go`): After resolution, if any deprecated hub resources were found, emits a Kubernetes Event on the Repository CR (`DeprecatedTektonHub`) and posts a consolidated `[!WARNING]` block comment on the pull request (idempotent via `<!-- pac-deprecation-tektonhub -->` marker).

## 🔗 Linked GitHub Issue

Fixes https://issues.redhat.com/browse/SRVKP-12187

## 🧪 Testing Strategy

- [x] Unit tests — added `wantDeprecated` assertions in `TestGetTaskFromAnnotationName` and `TestGetPipelineFromAnnotationName`; added two new test cases in `TestGetCatalogHub` for default and custom `tektonhub` deprecation warnings
- [ ] Integration tests
- [ ] End-to-end tests
- [x] Manual testing — deployed locally with a mock Tekton Hub server; confirmed deprecation warning fires in controller logs, K8s Event is emitted on the Repository CR, and PR comment is posted
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any issues.
- [x] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible.
- [x] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center