### PR TITLE
fix(security): redact query string from incoming webhook log

### DIFF
--- a/pkg/adapter/incoming.go
+++ b/pkg/adapter/incoming.go
@@ -117,7 +117,7 @@ func (l *listener) detectIncoming(ctx context.Context, event *info.Event, req *h
 		return false, nil, nil
 	}
 
-	l.logger.Infof("incoming request has been requested: %v", req.URL)
+	l.logger.Infof("incoming request has been requested: %v", req.URL.Path)
 	payload, err := parseIncomingPayload(req, payloadBody)
 	if payload.legacyMode {
 		// Log this, even if the request is invalid


### PR DESCRIPTION
## 📝 Description of the Change
  - Fix secret leakage in the incoming-webhook handler where req.URL was logged verbatim, exposing the ?secret=<value> query parameter to stdout and any downstream log forwarders
  - Changed to log req.URL.Path only, which contains no sensitive data

  Details

 In pkg/adapter/incoming.go:120, the log line fires before any validation or rejection of legacy query-string secrets, so even after FIND-009 remediation (rejecting query-string secrets), the plaintext secret would still be logged on every rejected request.
## 🔗 Linked GitHub Issue

Fixes #

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

AI assistance can be used for various tasks, such as code generation,
documentation, or testing.

Please indicate whether you have used AI assistance
for this PR and provide details if applicable.

- [ ] I have not used any AI assistance for this PR.
- [ ] I have used AI assistance for this PR.

> [!IMPORTANT]
>
> **Slop will be simply rejected**, if you are using AI assistance you need to make sure you
> understand the code generated and that it meets the project's standards. you
> need at least know how to run the code and deploy it (if needed). See
> [startpaac](https://github.com/openshift-pipelines/startpaac) to make it easy
> to deploy and test your code changes.
>
> If the **majority of the code** in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Claude <noreply@anthropic.com>

## ✅ Submitter Checklist

- [ ] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [ ] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [ ] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
