### PR TITLE
fix: prevent GitHub Enterprise header hijacking in app token requests

### DIFF
--- a/pkg/adapter/incoming.go
+++ b/pkg/adapter/incoming.go
@@ -183,6 +183,7 @@ func (l *listener) detectIncoming(ctx context.Context, event *info.Event, req *h
 			return false, nil, err
 		}
 		event.Provider.URL = enterpriseURL
+		event.GHEURL = enterpriseURL
 		event.Provider.Token = token
 		event.InstallationID = installationID
 		// Github app is not installed for provided repository url

--- a/pkg/adapter/sinker.go
+++ b/pkg/adapter/sinker.go
@@ -71,12 +71,7 @@ func (s *sinker) processEventPayload(ctx context.Context, request *http.Request)
 }
 
 func (s *sinker) processEvent(ctx context.Context, request *http.Request) error {
-	if s.event.EventType == "incoming" {
-		if request.Header.Get("X-GitHub-Enterprise-Host") != "" {
-			s.event.Provider.URL = request.Header.Get("X-GitHub-Enterprise-Host")
-			s.event.GHEURL = request.Header.Get("X-GitHub-Enterprise-Host")
-		}
-	} else {
+	if s.event.EventType != "incoming" {
 		if err := s.processEventPayload(ctx, request); err != nil {
 			return err
 		}

--- a/pkg/provider/github/app/token.go
+++ b/pkg/provider/github/app/token.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/github"
@@ -65,9 +66,12 @@ func (ip *Install) GetAndUpdateInstallationID(ctx context.Context) (string, stri
 		return "", "", 0, fmt.Errorf("github client APIURL is nil")
 	}
 	apiURL := *ip.ghClient.APIURL
-	enterpriseHost := ip.request.Header.Get("X-GitHub-Enterprise-Host")
-	if enterpriseHost != "" {
-		apiURL = fmt.Sprintf("https://%s/api/v3", strings.TrimSuffix(enterpriseHost, "/"))
+	enterpriseHost := ""
+	if repoURL.Host != "" && repoURL.Host != "github.com" {
+		enterpriseHost = repoURL.Host
+		if apiURL == keys.PublicGithubAPIURL {
+			apiURL = fmt.Sprintf("https://%s/api/v3", strings.TrimSuffix(enterpriseHost, "/"))
+		}
 	}
 
 	client, _, _ := github.MakeClient(ctx, apiURL, jwtToken)

--- a/pkg/provider/github/app/token_test.go
+++ b/pkg/provider/github/app/token_test.go
@@ -266,6 +266,76 @@ func TestGetAndUpdateInstallationID(t *testing.T) {
 	assert.Equal(t, token, wantToken)
 }
 
+func TestGetAndUpdateInstallationIDIgnoresEnterpriseHostHeader(t *testing.T) {
+	tdata := testclient.Data{
+		Namespaces: []*corev1.Namespace{testNamespace},
+		Secret:     []*corev1.Secret{validSecret},
+	}
+	wantToken := "GOODTOKEN"
+	wantID := int64(120)
+	orgName := "org"
+	repoName := "repo"
+
+	fakeghclient, mux, serverURL, teardown := ghtesthelper.SetupGH()
+	defer teardown()
+
+	ctx, _ := rtesting.SetupFakeContext(t)
+	stdata, _ := testclient.SeedTestData(t, ctx, tdata)
+	logger, _ := logger.GetLogger()
+	run := &params.Run{
+		Clients: clients.Clients{
+			Log:            logger,
+			PipelineAsCode: stdata.PipelineAsCode,
+			Kube:           stdata.Kube,
+		},
+		Info: info.Info{
+			Pac: &info.PacOpts{
+				Settings: settings.Settings{},
+			},
+			Controller: &info.ControllerInfo{Secret: validSecret.GetName()},
+		},
+	}
+	ctx = info.StoreCurrentControllerName(ctx, "default")
+	ctx = info.StoreNS(ctx, testNamespace.GetName())
+
+	gh := github.New()
+	gh.Run = run
+	jwtToken, err := gh.GenerateJWT(ctx, testNamespace.GetName(), stdata.Kube)
+	assert.NilError(t, err)
+
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/installation", orgName, repoName), func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprintf(w, `{"id": %d}`, wantID)
+	})
+	mux.HandleFunc(fmt.Sprintf("/app/installations/%d/access_tokens", wantID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r)
+		w.Header().Set("Authorization", "Bearer "+jwtToken)
+		w.Header().Set("Accept", "application/vnd.github+json")
+		_, _ = fmt.Fprintf(w, `{"token": "%s"}`, wantToken)
+	})
+
+	repo := &v1alpha1.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "repo",
+		},
+		Spec: v1alpha1.RepositorySpec{
+			URL: fmt.Sprintf("https://github.com/%s/%s", orgName, repoName),
+		},
+	}
+
+	gprovider := &github.Provider{APIURL: &serverURL, Run: run}
+	gprovider.SetGithubClient(fakeghclient)
+	t.Setenv("PAC_GIT_PROVIDER_TOKEN_APIURL", serverURL+"/api/v3")
+
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "http://localhost", strings.NewReader(""))
+	req.Header.Set("X-GitHub-Enterprise-Host", "127.0.0.1:1")
+	ip := NewInstallation(req, run, repo, gprovider, testNamespace.GetName())
+	enterpriseURL, token, installationID, err := ip.GetAndUpdateInstallationID(ctx)
+	assert.NilError(t, err)
+	assert.Equal(t, enterpriseURL, "")
+	assert.Equal(t, installationID, wantID)
+	assert.Equal(t, token, wantToken)
+}
+
 func testMethod(t *testing.T, r *http.Request) {
 	want := "POST"
 	t.Helper()
@@ -293,6 +363,7 @@ func TestGetAndUpdateInstallationIDFallbacks(t *testing.T) {
 		wantErr             bool
 		wantInstallationID  int64
 		wantToken           string
+		wantEnterpriseHost  string
 		skip                bool
 		expectedErrorString string
 	}{
@@ -316,6 +387,7 @@ func TestGetAndUpdateInstallationIDFallbacks(t *testing.T) {
 			wantErr:            false,
 			wantInstallationID: orgID,
 			wantToken:          wantToken,
+			wantEnterpriseHost: "matched",
 		},
 		{
 			name:    "repo and org installation fail, user installation succeeds",
@@ -340,6 +412,7 @@ func TestGetAndUpdateInstallationIDFallbacks(t *testing.T) {
 			wantErr:            false,
 			wantInstallationID: userID,
 			wantToken:          wantToken,
+			wantEnterpriseHost: "matched",
 		},
 		{
 			name:    "all installations fail",
@@ -416,7 +489,7 @@ func TestGetAndUpdateInstallationIDFallbacks(t *testing.T) {
 			t.Setenv("PAC_GIT_PROVIDER_TOKEN_APIURL", serverURL)
 
 			ip := NewInstallation(httptest.NewRequestWithContext(ctx, http.MethodGet, "http://localhost", strings.NewReader("")), run, repo, gprovider, testNamespace.GetName())
-			_, token, installationID, err := ip.GetAndUpdateInstallationID(ctx)
+			enterpriseHost, token, installationID, err := ip.GetAndUpdateInstallationID(ctx)
 
 			if tt.wantErr {
 				assert.Assert(t, err != nil)
@@ -429,6 +502,7 @@ func TestGetAndUpdateInstallationIDFallbacks(t *testing.T) {
 			assert.NilError(t, err)
 			assert.Equal(t, installationID, tt.wantInstallationID)
 			assert.Equal(t, token, tt.wantToken)
+			assert.Equal(t, enterpriseHost, tt.wantEnterpriseHost)
 		})
 	}
 }

--- a/pkg/provider/github/parse_payload.go
+++ b/pkg/provider/github/parse_payload.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -24,6 +25,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/secrets"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/sort"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -33,6 +35,9 @@ const (
 	maxRetriesForMergeCommit = 3
 	githubNoreplyEmail       = "noreply@github.com"
 	githubWebFlowUser        = "web-flow"
+
+	githubAppTokenMintBlockedLog         = "[SECURITY] Blocked GitHub App token minting before webhook signature validation completed"
+	githubAppTokenExfiltrationBlockedLog = "[SECURITY][CRITICAL] Averted GitHub App credential exfiltration attempt before token minting"
 )
 
 // GetAppIDAndPrivateKey retrieves the GitHub application ID and private key from a secret in the specified namespace.
@@ -115,6 +120,29 @@ func (v *Provider) initGitHubWebhookClient(ctx context.Context, event *info.Even
 	return gitclient.SetupAuthenticatedClient(ctx, v, kint, v.Run, event, repo, nil, v.pacInfo, v.Logger)
 }
 
+func validateAppWebhookSignature(ctx context.Context, run *params.Run, event *info.Event) error {
+	signature := event.Request.Header.Get(github.SHA256SignatureHeader)
+	if signature == "" {
+		signature = event.Request.Header.Get(github.SHA1SignatureHeader)
+	}
+	if signature == "" || signature == "sha1=" {
+		return fmt.Errorf("no signature has been detected, for security reason we are not allowing webhooks that has no secret")
+	}
+
+	kint, err := kubeinteraction.NewKubernetesInteraction(run)
+	if err != nil {
+		return err
+	}
+	event.Provider.WebhookSecret, err = secrets.GetCurrentNSWebhookSecret(ctx, kint, run)
+	if err != nil {
+		return err
+	}
+	if event.Provider.WebhookSecret == "" {
+		return fmt.Errorf("no webhook secret has been set in controller secret")
+	}
+	return github.ValidateSignature(signature, event.Request.Payload, []byte(event.Provider.WebhookSecret))
+}
+
 func (v *Provider) parseEventType(request *http.Request, event *info.Event) error {
 	event.EventType = request.Header.Get("X-GitHub-Event")
 	if event.EventType == "" {
@@ -137,7 +165,8 @@ type Payload struct {
 		ID *int64 `json:"id"`
 	} `json:"installation"`
 	Repository struct {
-		ID *int64 `json:"id"`
+		ID      *int64 `json:"id"`
+		HTMLURL string `json:"html_url"`
 	} `json:"repository"`
 }
 
@@ -158,6 +187,67 @@ func getInstallationAndRepoIDFromPayload(payload string) (int64, int64, error) {
 	return installationID, repoID, nil
 }
 
+func validateEnterpriseHostMatchesPayload(gheURL, payload string) error {
+	if gheURL == "" {
+		return nil
+	}
+	if !strings.HasPrefix(gheURL, "https://") && !strings.HasPrefix(gheURL, "http://") {
+		gheURL = "https://" + gheURL
+	}
+	enterpriseURL, err := url.Parse(gheURL)
+	if err != nil || enterpriseURL.Host == "" {
+		return fmt.Errorf("invalid X-GitHub-Enterprise-Host header")
+	}
+
+	var data Payload
+	if err := json.Unmarshal([]byte(payload), &data); err != nil {
+		return err
+	}
+	if data.Repository.HTMLURL == "" {
+		return fmt.Errorf("repository HTML URL is missing in payload, cannot validate enterprise host")
+	}
+	repoURL, err := url.Parse(data.Repository.HTMLURL)
+	if err != nil || repoURL.Host == "" {
+		return fmt.Errorf("invalid repository URL in GitHub payload")
+	}
+	if !strings.EqualFold(enterpriseURL.Host, repoURL.Host) {
+		return fmt.Errorf("github enterprise host %q does not match repository host %q", enterpriseURL.Host, repoURL.Host)
+	}
+	return nil
+}
+
+func (v *Provider) logBlockedGitHubAppTokenMint(request *http.Request, event *info.Event, installationID int64, reason string, err error) {
+	if v.Logger == nil {
+		return
+	}
+	v.Logger.Errorw(githubAppTokenExfiltrationBlockedLog,
+		"severity", "critical",
+		"security-impact", "github-app-jwt-exfiltration-blocked",
+		"reason", reason,
+		"error", err,
+		"event-type", event.EventType,
+		"installation-id", installationID,
+		"github-enterprise-host-present", request.Header.Get("X-GitHub-Enterprise-Host") != "",
+		"remote-addr", request.RemoteAddr,
+	)
+}
+
+func (v *Provider) logGitHubAppTokenMintValidationFailure(request *http.Request, event *info.Event, installationID int64, reason string, err error) {
+	if v.Logger == nil {
+		return
+	}
+	v.Logger.Warnw(githubAppTokenMintBlockedLog,
+		"severity", "warning",
+		"security-impact", "github-app-token-mint-blocked",
+		"reason", reason,
+		"error", err,
+		"event-type", event.EventType,
+		"installation-id", installationID,
+		"github-enterprise-host-present", request.Header.Get("X-GitHub-Enterprise-Host") != "",
+		"remote-addr", request.RemoteAddr,
+	)
+}
+
 // ParsePayload will parse the payload and return the event
 // it generate the github app token targeting the installation id
 // this pieces of code is a bit messy because we need first getting a token to
@@ -172,10 +262,8 @@ func getInstallationAndRepoIDFromPayload(payload string) (int64, int64, error) {
 // app on a github org which has a mixed of private and public repos and some of
 // the public users should not have access to the private repos.
 //
-// Another thing: The payload is protected by the webhook signature so it cannot be tempered but even tho if it's
-// tempered with and somehow a malicious user found the token and set their own github endpoint to hijack and
-// exfiltrate the token, it would fail since the jwt token generation will fail, so we are safe here.
-// a bit too far fetched but i don't see any way we can exploit this.
+// Validate the webhook signature before generating an app token because the token
+// request signs a GitHub App JWT locally and sends it to the selected API host.
 func (v *Provider) ParsePayload(ctx context.Context, run *params.Run, request *http.Request, payload string) (*info.Event, error) {
 	// ParsePayload is really happening before SetClient so let's set this at first here.
 	// Only apply for GitHub provider since we do fancy token creation at payload parsing
@@ -196,6 +284,14 @@ func (v *Provider) ParsePayload(ctx context.Context, run *params.Run, request *h
 	}
 	if installationIDFrompayload != -1 {
 		var err error
+		if err := validateAppWebhookSignature(ctx, run, event); err != nil {
+			v.logGitHubAppTokenMintValidationFailure(request, event, installationIDFrompayload, "webhook-signature-validation-failed", err)
+			return nil, err
+		}
+		if err := validateEnterpriseHostMatchesPayload(event.Provider.URL, payload); err != nil {
+			v.logBlockedGitHubAppTokenMint(request, event, installationIDFrompayload, "enterprise-host-validation-failed", err)
+			return nil, err
+		}
 		// TODO: move this out of here when we move al config inside context
 		if event.Provider.Token, err = v.GetAppToken(ctx, run.Clients.Kube, event.Provider.URL, installationIDFrompayload, systemNS); err != nil {
 			return nil, err

--- a/pkg/provider/github/parse_payload_test.go
+++ b/pkg/provider/github/parse_payload_test.go
@@ -2,6 +2,9 @@ package github
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -72,6 +75,12 @@ var samplePRevent = github.PullRequestEvent{
 		Title: github.Ptr("my first PR"),
 	},
 	Repo: sampleRepo,
+}
+
+func githubSHA256Signature(secret string, payload []byte) string {
+	hm := hmac.New(sha256.New, []byte(secret))
+	hm.Write(payload)
+	return "sha256=" + hex.EncodeToString(hm.Sum(nil))
 }
 
 var samplePR = github.PullRequest{
@@ -1570,6 +1579,7 @@ func TestAppTokenGeneration(t *testing.T) {
 	secretName := "pipelines-as-code-secret"
 
 	ctx, _ := rtesting.SetupFakeContext(t)
+	webhookSecret := "webhook-secret"
 	vaildSecret, _ := testclient.SeedTestData(t, ctx, testclient.Data{
 		Secret: []*corev1.Secret{
 			{
@@ -1580,6 +1590,7 @@ func TestAppTokenGeneration(t *testing.T) {
 				Data: map[string][]byte{
 					"github-application-id": []byte("12345"),
 					"github-private-key":    []byte(fakePrivateKey),
+					"webhook.secret":        []byte(webhookSecret),
 				},
 			},
 		},
@@ -1596,6 +1607,7 @@ func TestAppTokenGeneration(t *testing.T) {
 				Data: map[string][]byte{
 					"github-application-id": []byte("abcd"),
 					"github-private-key":    []byte(fakePrivateKey),
+					"webhook.secret":        []byte(webhookSecret),
 				},
 			},
 		},
@@ -1612,26 +1624,59 @@ func TestAppTokenGeneration(t *testing.T) {
 				Data: map[string][]byte{
 					"github-application-id": []byte("12345"),
 					"github-private-key":    []byte("invalid-key"),
+					"webhook.secret":        []byte(webhookSecret),
 				},
 			},
 		},
 	})
 
 	tests := []struct {
-		ctx          context.Context
-		ctxNS        string
-		name         string
-		wantErrSubst string
-		nilClient    bool
-		seedData     testclient.Clients
-		envs         map[string]string
+		ctx            context.Context
+		ctxNS          string
+		name           string
+		wantErrSubst   string
+		nilClient      bool
+		seedData       testclient.Clients
+		omitSignature  bool
+		enterpriseHost string
+		payload        string
+		wantLogMessage string
 	}{
 		{
-			name:         "secret not found",
-			ctx:          ctxNoSecret,
-			ctxNS:        "foo",
-			seedData:     noSecret,
-			wantErrSubst: `secrets "pipelines-as-code-secret" not found`,
+			name:           "secret not found",
+			ctx:            ctxNoSecret,
+			ctxNS:          "foo",
+			seedData:       noSecret,
+			wantErrSubst:   `secrets "pipelines-as-code-secret" not found`,
+			wantLogMessage: githubAppTokenMintBlockedLog,
+		},
+		{
+			ctx:            ctx,
+			name:           "missing webhook signature",
+			ctxNS:          testNamespace,
+			seedData:       vaildSecret,
+			omitSignature:  true,
+			wantErrSubst:   "no signature has been detected",
+			wantLogMessage: githubAppTokenMintBlockedLog,
+		},
+		{
+			ctx:            ctx,
+			name:           "enterprise host does not match signed repository payload",
+			ctxNS:          testNamespace,
+			seedData:       vaildSecret,
+			enterpriseHost: "127.0.0.1:1",
+			wantErrSubst:   `github enterprise host "127.0.0.1:1" does not match repository host "github.com"`,
+			wantLogMessage: githubAppTokenExfiltrationBlockedLog,
+		},
+		{
+			ctx:            ctx,
+			name:           "enterprise host with missing repository HTML URL",
+			ctxNS:          testNamespace,
+			seedData:       vaildSecret,
+			enterpriseHost: "127.0.0.1:1",
+			payload:        fmt.Sprintf(`{"installation":{"id":%d},"repository":{}}`, testInstallationID),
+			wantErrSubst:   "repository HTML URL is missing in payload, cannot validate enterprise host",
+			wantLogMessage: githubAppTokenExfiltrationBlockedLog,
 		},
 		{
 			ctx:       ctx,
@@ -1662,8 +1707,6 @@ func TestAppTokenGeneration(t *testing.T) {
 			mux.HandleFunc(fmt.Sprintf("/app/installations/%d/access_tokens", testInstallationID), func(w http.ResponseWriter, _ *http.Request) {
 				_, _ = fmt.Fprint(w, "{}")
 			})
-			envRemove := env.PatchAll(t, tt.envs)
-			defer envRemove()
 
 			// adding installation id to event to enforce client creation
 			samplePRevent.Installation = &github.Installation{
@@ -1671,24 +1714,21 @@ func TestAppTokenGeneration(t *testing.T) {
 			}
 
 			jeez, _ := json.Marshal(samplePRevent)
-			logger, _ := logger.GetLogger()
+			if tt.payload != "" {
+				jeez = []byte(tt.payload)
+			}
+			testLogger, observedLogs := logger.GetLogger()
 			gprovider := Provider{
-				Logger:   logger,
+				Logger:   testLogger,
 				ghClient: fakeghclient,
 				pacInfo: &info.PacOpts{
 					Settings: settings.Settings{},
 				},
 			}
-			request := &http.Request{Header: map[string][]string{}}
-			request.Header.Set("X-GitHub-Event", "pull_request")
-			// a bit of a pain but works
-			request.Header.Set("X-GitHub-Enterprise-Host", serverURL)
-			tt.envs = make(map[string]string)
-			tt.envs["PAC_GIT_PROVIDER_TOKEN_APIURL"] = serverURL + "/api/v3"
 
 			run := &params.Run{
 				Clients: clients.Clients{
-					Log:  logger,
+					Log:  testLogger,
 					Kube: tt.seedData.Kube,
 				},
 
@@ -1697,6 +1737,16 @@ func TestAppTokenGeneration(t *testing.T) {
 				},
 			}
 
+			request := &http.Request{Header: map[string][]string{}}
+			request.Header.Set("X-GitHub-Event", "pull_request")
+			if !tt.omitSignature {
+				request.Header.Set(github.SHA256SignatureHeader, githubSHA256Signature(webhookSecret, jeez))
+			}
+			if tt.enterpriseHost != "" {
+				request.Header.Set("X-GitHub-Enterprise-Host", tt.enterpriseHost)
+			}
+			t.Setenv("PAC_GIT_PROVIDER_TOKEN_APIURL", serverURL+"/api/v3")
+
 			tt.ctx = info.StoreCurrentControllerName(tt.ctx, "default")
 			tt.ctx = info.StoreNS(tt.ctx, tt.ctxNS)
 
@@ -1704,6 +1754,16 @@ func TestAppTokenGeneration(t *testing.T) {
 			if tt.wantErrSubst != "" {
 				assert.Assert(t, err != nil)
 				assert.ErrorContains(t, err, tt.wantErrSubst)
+				if tt.wantLogMessage != "" {
+					found := false
+					for _, entry := range observedLogs.All() {
+						if entry.Message == tt.wantLogMessage {
+							found = true
+							break
+						}
+					}
+					assert.Assert(t, found, "expected log message %q for blocked GitHub App token mint", tt.wantLogMessage)
+				}
 				return
 			}
 			assert.NilError(t, err)


### PR DESCRIPTION
Jira: SRVKP-12216

## Description

An attacker who can send crafted webhook payloads (even without the webhook secret) could forge the `X-GitHub-Enterprise-Host` header to redirect the GitHub App JWT token request to an arbitrary host and exfiltrate the token.

This PR closes two attack surfaces:

### 1. Validate webhook signature before minting tokens

`ParsePayload` previously generated a GitHub App token from the installation ID in the payload **before** the webhook signature was verified. A new `validateAppWebhookSignature` step now runs first, rejecting unsigned or tampered payloads before any token is minted.

### 2. Validate Enterprise Host header against payload

Added `validateEnterpriseHostMatchesPayload` which cross-checks the `X-GitHub-Enterprise-Host` header against the `repository.html_url` in the (now signature-verified) payload. If the hosts don't match, the request is rejected.

### 3. Derive Enterprise host from repo URL instead of header (`app/token.go`)

`GetAndUpdateInstallationID` no longer trusts `X-GitHub-Enterprise-Host` to build the API URL. Instead it derives the enterprise host from the repository's parsed URL, falling back only when the host is not `github.com`.

### 4. Remove redundant header reading in sinker

The incoming webhook path (`sinker.go`) previously re-read `X-GitHub-Enterprise-Host` from the raw HTTP request for incoming events. This is now set earlier in `incoming.go` during detection, making the sinker branch unnecessary.

### Logging

Both validation failures produce structured security log entries (`[SECURITY]` / `[SECURITY][CRITICAL]`) with event type, installation ID, and remote address for incident response.

## Testing Strategy

- [x] Unit tests
- [x] Not Applicable (no E2E needed — no new user-facing behavior, only hardening)

Existing `TestAppTokenGeneration` cases extended with:
- Missing webhook signature → blocked
- Enterprise host mismatch → blocked with `[SECURITY][CRITICAL]` log
- Missing `repository.html_url` with enterprise host → blocked
- New `TestGetAndUpdateInstallationIDIgnoresEnterpriseHostHeader` verifying the header is ignored

## Submitter Checklist

- [x] Commit messages follow project conventions
- [x] `make test` and `make lint` pass locally
- [x] Unit tests added for all new validation paths
