### PR TITLE
feat(forgejo): cache org teams in policy check

### DIFF
--- a/pkg/provider/gitea/acl.go
+++ b/pkg/provider/gitea/acl.go
@@ -17,20 +17,12 @@ func (v *Provider) CheckPolicyAllowing(_ context.Context, event *info.Event, all
 	if event.Organization == event.Repository {
 		return true, ""
 	}
-	// TODO: caching
-	orgTeams, resp, err := v.Client().ListOrgTeams(event.Organization, forgejo.ListTeamsOptions{})
-	if resp.StatusCode == http.StatusNotFound {
-		// we explicitly disallow the policy when there is no team on org
-		return false, fmt.Sprintf("no teams on org %s", event.Organization)
-	}
-	if resp.StatusCode == http.StatusForbidden {
-		v.Logger.Warnf("policy check: ListOrgTeams returned 403 for org %s, sender %s: %v", event.Organization, event.Sender, err)
-		return false, fmt.Sprintf("unable to list teams on org %s: the token used doesn't have permission to list teams in this org, make sure the token owner is a member of the org", event.Organization)
-	}
+
+	orgTeams, err := v.listOrgTeams(event.Organization, event.Sender)
 	if err != nil {
-		// probably a 500 or another api error, no need to try again and again with other teams
-		return false, fmt.Sprintf("error while getting org team, error: %s", err.Error())
+		return false, err.Error()
 	}
+
 	for _, allowedTeam := range allowedTeams {
 		for _, orgTeam := range orgTeams {
 			if orgTeam.Name == allowedTeam {
@@ -205,6 +197,32 @@ func (v *Provider) IsAllowedOwnersFile(ctx context.Context, rev *info.Event) (bo
 	}
 
 	return acl.UserInOwnerFile(ownerContent, ownerAliasesContent, rev.Sender)
+}
+
+func (v *Provider) listOrgTeams(org, sender string) ([]*forgejo.Team, error) {
+	if v.cachedOrgTeams == nil {
+		v.cachedOrgTeams = make(map[string][]*forgejo.Team)
+	}
+	if teams, ok := v.cachedOrgTeams[org]; ok {
+		return teams, nil
+	}
+
+	teams, resp, err := v.Client().ListOrgTeams(org, forgejo.ListTeamsOptions{})
+	if err != nil {
+		if resp != nil && resp.Response != nil {
+			switch resp.StatusCode {
+			case http.StatusNotFound:
+				return nil, fmt.Errorf("no teams on org %s", org)
+			case http.StatusForbidden:
+				v.Logger.Warnf("policy check: ListOrgTeams returned 403 for org %s, sender %s: %v", org, sender, err)
+				return nil, fmt.Errorf("unable to list teams on org %s: the token used doesn't have permission to list teams in this org, make sure the token owner is a member of the org", org)
+			}
+		}
+		return nil, fmt.Errorf("error while getting org team, error: %w", err)
+	}
+
+	v.cachedOrgTeams[org] = teams
+	return teams, nil
 }
 
 func (v *Provider) checkSenderRepoMembership(_ context.Context, runevent *info.Event) (bool, error) {

--- a/pkg/provider/gitea/acl_test.go
+++ b/pkg/provider/gitea/acl_test.go
@@ -110,6 +110,40 @@ func TestCheckPolicyAllowing(t *testing.T) {
 	}
 }
 
+func TestCheckPolicyAllowingCaching(t *testing.T) {
+	fakeclient, mux, teardown := tgitea.Setup(t)
+	defer teardown()
+
+	apiCallCount := 0
+	event := &info.Event{
+		Organization: "myorg",
+		Sender:       "allowedUser",
+	}
+
+	mux.HandleFunc("/orgs/myorg/teams", func(rw http.ResponseWriter, _ *http.Request) {
+		apiCallCount++
+		fmt.Fprint(rw, `[{"name": "team1", "id": 1}]`)
+	})
+	mux.HandleFunc("/teams/1/members/allowedUser", func(rw http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(rw, `{"id": 2}`)
+	})
+
+	ctx, _ := rtesting.SetupFakeContext(t)
+	observer, _ := zapobserver.New(zap.InfoLevel)
+	logger := zap.New(observer).Sugar()
+	gprovider := Provider{giteaClient: fakeclient, Logger: logger}
+
+	allowed1, reason1 := gprovider.CheckPolicyAllowing(ctx, event, []string{"team1"})
+	assert.Assert(t, allowed1)
+	assert.Equal(t, "allowing user: allowedUser as a member of the team: team1", reason1)
+
+	allowed2, reason2 := gprovider.CheckPolicyAllowing(ctx, event, []string{"team1"})
+	assert.Assert(t, allowed2)
+	assert.Equal(t, "allowing user: allowedUser as a member of the team: team1", reason2)
+
+	assert.Equal(t, 1, apiCallCount)
+}
+
 func TestOkToTestComment(t *testing.T) {
 	issueCommentPayload := &forgejostructs.IssueCommentPayload{
 		Comment: &forgejostructs.Comment{

--- a/pkg/provider/gitea/gitea.go
+++ b/pkg/provider/gitea/gitea.go
@@ -70,6 +70,7 @@ type Provider struct {
 	triggerEvent       string
 	pacUserID          int64 // user login used by PAC
 	cachedChangedFiles *changedfiles.ChangedFiles
+	cachedOrgTeams     map[string][]*forgejo.Team
 	clock              clockwork.Clock
 }
 


### PR DESCRIPTION

## 📝 Description of the Change
Cache ListOrgTeams API responses per organization to avoid redundant API calls when checking policy for the same org across multiple allowed teams evaluations.

## 🔗 Linked GitHub Issue
N/A

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

AI assistance can be used for various tasks, such as code generation,
documentation, or testing.

Please indicate whether you have used AI assistance
for this PR and provide details if applicable.

- [x] I have not used any AI assistance for this PR.
- [ ] I have used AI assistance for this PR.

> [!IMPORTANT]
>
> **Slop will be simply rejected**, if you are using AI assistance you need to make sure you
> understand the code generated and that it meets the project's standards. you
> need at least know how to run the code and deploy it (if needed). See
> [startpaac](https://github.com/openshift-pipelines/startpaac) to make it easy
> to deploy and test your code changes.
>
> If the **majority of the code** in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Claude <noreply@anthropic.com>

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
