### PR TITLE
[DNM] fix(reconciler): gate PipelineRun on secret auto-creation

### DIFF
--- a/pkg/kubeinteraction/labels.go
+++ b/pkg/kubeinteraction/labels.go
@@ -63,6 +63,7 @@ func AddLabelsAndAnnotations(ctx context.Context, event *info.Event, pipelineRun
 		keys.SourceBranch:  event.HeadBranch,
 		keys.Repository:    repo.GetName(),
 		keys.GitProvider:   providerConfig.Name,
+		keys.State:         StateStarted,
 		keys.SecretCreated: "false",
 		keys.ControllerInfo: fmt.Sprintf(`{"name":"%s","configmap":"%s","secret":"%s", "gRepo": "%s"}`,
 			paramsinfo.Controller.Name, paramsinfo.Controller.Configmap, paramsinfo.Controller.Secret, paramsinfo.Controller.GlobalRepository),

--- a/pkg/kubeinteraction/labels_test.go
+++ b/pkg/kubeinteraction/labels_test.go
@@ -90,6 +90,11 @@ func TestAddLabelsAndAnnotations(t *testing.T) {
 			assert.Equal(t, tt.args.pipelineRun.Annotations[keys.ControllerInfo],
 				fmt.Sprintf(`{"name":"%s","configmap":"%s","secret":"%s", "gRepo": "%s"}`, tt.args.controllerInfo.Name, tt.args.controllerInfo.Configmap, tt.args.controllerInfo.Secret, tt.args.controllerInfo.GlobalRepository))
 			assert.Equal(t, tt.args.pipelineRun.Annotations[keys.CloneURL], tt.args.event.CloneURL)
+
+			// Verify state annotation is set at creation time (#2751)
+			state, hasState := tt.args.pipelineRun.Annotations[keys.State]
+			assert.Assert(t, hasState, "State annotation should be set at creation time")
+			assert.Equal(t, state, StateStarted, "State annotation should default to 'started'")
 		})
 	}
 }

--- a/pkg/pipelineascode/pipelineascode.go
+++ b/pkg/pipelineascode/pipelineascode.go
@@ -224,10 +224,31 @@ func (p *PacRun) startPR(ctx context.Context, match matcher.Match) (*tektonv1.Pi
 	}
 
 	// if concurrency is defined then start the pipelineRun in pending state
-	if match.Repo.Spec.ConcurrencyLimit != nil && *match.Repo.Spec.ConcurrencyLimit != 0 {
+	hasConcurrencyLimit := match.Repo.Spec.ConcurrencyLimit != nil && *match.Repo.Spec.ConcurrencyLimit != 0
+	if hasConcurrencyLimit {
 		// pending status
 		match.PipelineRun.Spec.Status = tektonv1.PipelineRunSpecStatusPending
 		p.debugf("startPR: marking pipelinerun=%s as pending due to concurrency limit", prName)
+	} else if p.pacInfo.SecretAutoCreation {
+		// When secret auto-creation is enabled, the secret is created by the
+		// reconciler. Prevent Tekton controller from executing the PipelineRun
+		// before the secret exists. Set pending status to gate execution until
+		// the reconciler creates the secret and clears the pending status.
+		// The state annotation will be "started" (not "queued"), so the
+		// reconciler can distinguish this from concurrency-pending PRs.
+		if _, hasGitAuth := match.PipelineRun.GetAnnotations()[keys.GitAuthSecret]; hasGitAuth {
+			match.PipelineRun.Spec.Status = tektonv1.PipelineRunSpecStatusPending
+			p.debugf("startPR: marking pipelinerun=%s as pending until git-auth secret is created", prName)
+		}
+	}
+
+	// Override the state for concurrency-pending PRs before creation.
+	// labels.go already sets state="started" for all PRs; only the
+	// concurrency path needs to change it to "queued".
+	// See https://github.com/tektoncd/pipelines-as-code/issues/2751
+	if hasConcurrencyLimit {
+		match.PipelineRun.Annotations[keys.State] = kubeinteraction.StateQueued
+		match.PipelineRun.Labels[keys.State] = kubeinteraction.StateQueued
 	}
 
 	// Create the actual pipelineRun
@@ -274,9 +295,13 @@ func (p *PacRun) startPR(ctx context.Context, match matcher.Match) (*tektonv1.Pi
 	patchAnnotations := map[string]string{}
 	patchLabels := map[string]string{}
 	whatPatching := ""
-	// if pipelineRun is in pending state then report status as queued
-	// The pipelineRun can be pending because of PAC's concurrency limit or because of an external mutatingwebhook
-	if pr.Spec.Status == tektonv1.PipelineRunSpecStatusPending {
+	// Determine the state and status based on why the pipelineRun is pending.
+	// Concurrency-pending PRs report as "queued" with state="queued".
+	// Secret-pending PRs (pending only for secret auto-creation) report as
+	// "in_progress" with state="started", so the reconciler can distinguish
+	// them from concurrency-queued PRs and clear the pending status after
+	// creating the secret.
+	if pr.Spec.Status == tektonv1.PipelineRunSpecStatusPending && hasConcurrencyLimit {
 		status.Status = queuedStatus
 		if status.Text, err = mt.MakeTemplate(p.vcx.GetTemplate(provider.QueueingPipelineType)); err != nil {
 			return nil, fmt.Errorf("cannot create message template: %w", err)

--- a/pkg/pipelineascode/pipelineascode_startpr_test.go
+++ b/pkg/pipelineascode/pipelineascode_startpr_test.go
@@ -356,37 +356,60 @@ func TestStartPRConcurrencyLimitBehavior(t *testing.T) {
 	tests := []struct {
 		name                    string
 		concurrencyLimit        *int
+		secretAutoCreation      bool
 		expectedState           string
 		expectedStatus          pipelinev1.PipelineRunSpecStatus
 		verifySCMStartedMissing bool   // true if SCMReportingPLRStarted should NOT be set
 		expectedSCMStartedVal   string // expected value for SCMReportingPLRStarted when it should be set
 	}{
 		{
-			name:                    "nil concurrency limit - starts immediately",
+			name:                    "nil concurrency limit with secret auto-creation - pending for secret",
 			concurrencyLimit:        nil,
+			secretAutoCreation:      true,
+			expectedState:           kubeinteraction.StateStarted,
+			expectedStatus:          pipelinev1.PipelineRunSpecStatusPending,
+			verifySCMStartedMissing: false,
+			expectedSCMStartedVal:   "true",
+		},
+		{
+			name:                    "nil concurrency limit without secret auto-creation - starts immediately",
+			concurrencyLimit:        nil,
+			secretAutoCreation:      false,
 			expectedState:           kubeinteraction.StateStarted,
 			expectedStatus:          "",
 			verifySCMStartedMissing: false,
 			expectedSCMStartedVal:   "true",
 		},
 		{
-			name:                    "zero concurrency limit - treated as no limit",
+			name:                    "zero concurrency limit with secret auto-creation - pending for secret",
 			concurrencyLimit:        intPtr(0),
+			secretAutoCreation:      true,
+			expectedState:           kubeinteraction.StateStarted,
+			expectedStatus:          pipelinev1.PipelineRunSpecStatusPending,
+			verifySCMStartedMissing: false,
+			expectedSCMStartedVal:   "true",
+		},
+		{
+			name:                    "zero concurrency limit without secret auto-creation - starts immediately",
+			concurrencyLimit:        intPtr(0),
+			secretAutoCreation:      false,
 			expectedState:           kubeinteraction.StateStarted,
 			expectedStatus:          "",
 			verifySCMStartedMissing: false,
 			expectedSCMStartedVal:   "true",
 		},
 		{
-			name:                    "positive concurrency limit - sets pending",
+			name:                    "positive concurrency limit - sets pending and queued",
 			concurrencyLimit:        intPtr(1),
+			secretAutoCreation:      true,
 			expectedState:           kubeinteraction.StateQueued,
 			expectedStatus:          pipelinev1.PipelineRunSpecStatusPending,
 			verifySCMStartedMissing: true,
 		},
 		{
-			name:                    "higher concurrency limit - still sets pending",
+			name:                    "higher concurrency limit - still sets pending and queued",
 			concurrencyLimit:        intPtr(5),
+			secretAutoCreation:      true,
 			expectedState:           kubeinteraction.StateQueued,
 			expectedStatus:          pipelinev1.PipelineRunSpecStatusPending,
 			verifySCMStartedMissing: true,
@@ -394,6 +417,7 @@ func TestStartPRConcurrencyLimitBehavior(t *testing.T) {
 		{
 			name:                    "negative concurrency limit - treated as having limit (queued)",
 			concurrencyLimit:        intPtr(-1),
+			secretAutoCreation:      true,
 			expectedState:           kubeinteraction.StateQueued,
 			expectedStatus:          pipelinev1.PipelineRunSpecStatusPending,
 			verifySCMStartedMissing: true,
@@ -402,7 +426,9 @@ func TestStartPRConcurrencyLimitBehavior(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fixture := setupStartPRTestDefault(t)
+			config := defaultStartPRTestConfig()
+			config.secretAutoCreation = tt.secretAutoCreation
+			fixture := setupStartPRTestWithConfig(t, config)
 			defer fixture.teardown()
 
 			match := createTestMatch(tt.concurrencyLimit)
@@ -590,6 +616,14 @@ func TestStartPRPatchBehavior(t *testing.T) {
 				}
 				assert.Equal(t, pr.GetNamespace(), "test-namespace")
 				assert.Assert(t, patchAttempts >= 1, "Patch should have been attempted")
+
+				// Even when the post-creation patch fails, the state annotation
+				// should still be present because it is set before Create.
+				// This is the fix for https://github.com/tektoncd/pipelines-as-code/issues/2751
+				state, hasState := pr.GetAnnotations()[keys.State]
+				assert.Assert(t, hasState, "State annotation should be set at creation time even when patch fails")
+				assert.Equal(t, state, kubeinteraction.StateStarted,
+					"State should be 'started' for non-concurrency PRs even when patch fails")
 			} else {
 				fixture := setupStartPRTestDefault(t)
 				defer fixture.teardown()
@@ -714,4 +748,140 @@ func TestStartPRConcurrentCreation(t *testing.T) {
 	// All should succeed with proper isolation (each has unique name and secret)
 	assert.Equal(t, successCount, numConcurrent, "All concurrent PipelineRuns should succeed with proper isolation, got %d/%d (failures: %d)", successCount, numConcurrent, failureCount)
 	t.Logf("Successfully created %d/%d concurrent PipelineRuns", successCount, numConcurrent)
+}
+
+// TestStartPRStateAnnotationSurvivesPatchFailure verifies the fix for
+// https://github.com/tektoncd/pipelines-as-code/issues/2751
+//
+// When the post-creation patch that sets state/reporting annotations fails
+// transiently, the PipelineRun must still have the state annotation so the
+// controller's enqueue guard can pick it up for reconciliation. Without the
+// state annotation, the reconciler never creates the generated git-auth secret.
+func TestStartPRStateAnnotationSurvivesPatchFailure(t *testing.T) {
+	tests := []struct {
+		name             string
+		concurrencyLimit *int
+		expectedState    string
+	}{
+		{
+			name:             "no concurrency limit - state annotation is started at creation",
+			concurrencyLimit: nil,
+			expectedState:    kubeinteraction.StateStarted,
+		},
+		{
+			name:             "with concurrency limit - state annotation is queued at creation",
+			concurrencyLimit: intPtr(1),
+			expectedState:    kubeinteraction.StateQueued,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			observer, _ := zapobserver.New(zap.InfoLevel)
+			logger := zap.New(observer).Sugar()
+
+			stdata, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+				Namespaces: []*corev1.Namespace{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-namespace",
+						},
+					},
+				},
+			})
+
+			// Make ALL patches fail to simulate the transient failure in #2751
+			stdata.Pipeline.PrependReactor("patch", "pipelineruns", func(_ k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+				return true, nil, fmt.Errorf("webhook validation timeout")
+			})
+
+			cs := &params.Run{
+				Clients: clients.Clients{
+					PipelineAsCode: stdata.PipelineAsCode,
+					Log:            logger,
+					Kube:           stdata.Kube,
+					Tekton:         stdata.Pipeline,
+				},
+				Info: info.Info{
+					Controller: &info.ControllerInfo{
+						Name:      "default",
+						Configmap: "pipelines-as-code",
+						Secret:    "pipelines-as-code-secret",
+					},
+				},
+			}
+			cs.Clients.SetConsoleUI(consoleui.FallBackConsole{})
+
+			event := &info.Event{
+				SHA:               "test-sha",
+				Organization:      "test-org",
+				Repository:        "test-repo",
+				URL:               "https://test.com/repo",
+				HeadBranch:        "test-branch",
+				BaseBranch:        "main",
+				Sender:            "test-user",
+				EventType:         "pull_request",
+				TriggerTarget:     "pull_request",
+				PullRequestNumber: 123,
+				Provider: &info.Provider{
+					Token: "test-token",
+					User:  "git",
+					URL:   "https://api.github.com",
+				},
+			}
+
+			fakeclient, mux, ghTestServerURL, teardown := ghtesthelper.SetupGH()
+			defer teardown()
+
+			replyString(mux, fmt.Sprintf("/repos/%s/%s/statuses/%s", event.Organization, event.Repository, event.SHA), "{}")
+			replyString(mux, fmt.Sprintf("/repos/%s/%s/check-runs", event.Organization, event.Repository), `{"id": 123}`)
+			event.Provider.URL = ghTestServerURL
+
+			kint := &kitesthelper.KinterfaceTest{
+				ConsoleURL: "https://console.test",
+			}
+
+			pacInfo := &info.PacOpts{
+				Settings: settings.Settings{
+					SecretAutoCreation: true,
+				},
+			}
+
+			vcx := setupProviderForTest(cs, logger, fakeclient, pacInfo)
+			p := NewPacs(event, vcx, cs, pacInfo, kint, logger, nil)
+
+			match := createTestMatch(tt.concurrencyLimit)
+
+			pr, err := p.startPR(ctx, match)
+
+			// startPR logs the patch error but returns the PR without error
+			assert.Assert(t, pr != nil, "PipelineRun should be returned even when patch fails")
+			assert.NilError(t, err, "startPR should not return error on patch failure")
+
+			// The critical assertion: the state annotation must be present on
+			// the created PipelineRun so the controller can enqueue it
+			state, hasState := pr.GetAnnotations()[keys.State]
+			assert.Assert(t, hasState,
+				"State annotation MUST be set at creation time so the reconciler "+
+					"can enqueue the PipelineRun even when the post-creation patch fails (#2751)")
+			assert.Equal(t, state, tt.expectedState,
+				"State annotation should match expected initial state")
+
+			// Also verify the state label matches
+			labelState, hasLabelState := pr.GetLabels()[keys.State]
+			assert.Assert(t, hasLabelState, "State label should be set at creation time")
+			assert.Equal(t, labelState, tt.expectedState,
+				"State label should match annotation state")
+
+			// Verify the git auth secret annotation is present
+			_, hasGitAuth := pr.GetAnnotations()[keys.GitAuthSecret]
+			assert.Assert(t, hasGitAuth, "GitAuthSecret annotation should be set")
+
+			// Verify secret-created is false (secret hasn't been created yet)
+			secretCreated, hasSecretCreated := pr.GetAnnotations()[keys.SecretCreated]
+			assert.Assert(t, hasSecretCreated, "SecretCreated annotation should be set")
+			assert.Equal(t, secretCreated, "false", "SecretCreated should be false before reconciler creates it")
+		})
+	}
 }

--- a/pkg/pipelineascode/pipelineascode_test.go
+++ b/pkg/pipelineascode/pipelineascode_test.go
@@ -709,18 +709,20 @@ func TestRun(t *testing.T) {
 						secretName, ok := pr.GetAnnotations()[keys.GitAuthSecret]
 						assert.Assert(t, ok, "Cannot find secret %s on annotations", secretName)
 					}
-					if pr.Spec.Status == pipelinev1.PipelineRunSpecStatusPending {
-						state, ok := pr.GetAnnotations()[keys.State]
-						assert.Assert(t, ok, "State hasn't been set on PR", state)
-						assert.Equal(t, state, kubeinteraction.StateQueued)
+					state, ok := pr.GetAnnotations()[keys.State]
+					assert.Assert(t, ok, "State hasn't been set on PR")
 
-						// When PipelineRun is queued, SCMReportingPLRStarted should not be set
+					if state == kubeinteraction.StateQueued {
+						// Concurrency-pending: must be pending, no SCMReportingPLRStarted
+						assert.Equal(t, pr.Spec.Status, pipelinev1.PipelineRunSpecStatusPending,
+							"queued PipelineRun should be in pending state")
 						_, scmStartedExists := pr.GetAnnotations()[keys.SCMReportingPLRStarted]
 						assert.Assert(t, !scmStartedExists, "SCMReportingPLRStarted should not be set for queued PipelineRuns")
 					} else {
-						// When PipelineRun is not queued, SCMReportingPLRStarted should be set to "true"
+						// State is "started" — may be pending (secret-pending) or not pending (no secret auto-creation).
+						// Either way, SCMReportingPLRStarted should be set to "true".
 						scmStarted, scmStartedExists := pr.GetAnnotations()[keys.SCMReportingPLRStarted]
-						assert.Assert(t, scmStartedExists, "SCMReportingPLRStarted should be set for non-queued PipelineRuns")
+						assert.Assert(t, scmStartedExists, "SCMReportingPLRStarted should be set for started PipelineRuns")
 						assert.Equal(t, scmStarted, "true", "SCMReportingPLRStarted should be 'true'")
 					}
 				}

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -117,6 +117,16 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, pr *tektonv1.PipelineRun
 		} else if err != nil {
 			logger.Errorf("failed to create secret for pipelineRun %s/%s: %v", pr.GetNamespace(), pr.GetName(), err)
 		}
+
+		// If the PipelineRun was made pending for secret creation (state="started"
+		// with pending status), clear the pending status now that the secret exists
+		// so Tekton controller can start execution.
+		if err == nil && state == kubeinteraction.StateStarted && pr.Spec.Status == tektonv1.PipelineRunSpecStatusPending {
+			logger.Infof("secret created for pipelineRun %s/%s, clearing pending status to allow execution", pr.GetNamespace(), pr.GetName())
+			if _, err := r.updatePipelineRunState(ctx, logger, pr, kubeinteraction.StateStarted); err != nil {
+				return fmt.Errorf("failed to clear pending status for pipelineRun %s/%s after secret creation: %w", pr.GetNamespace(), pr.GetName(), err)
+			}
+		}
 	}
 
 	reason := ""

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -803,3 +803,142 @@ func TestReconcileKindSecretCreationDoesNotLogOnSuccess(t *testing.T) {
 	logEntries := log.FilterMessageSnippet("failed to create secret for pipelineRun").TakeAll()
 	assert.Equal(t, len(logEntries), 0)
 }
+
+func TestReconcileKindClearsPendingAfterSecretCreationForStartedState(t *testing.T) {
+	tests := []struct {
+		name                  string
+		state                 string
+		specStatus            tektonv1.PipelineRunSpecStatus
+		expectPendingCleared  bool
+		expectSecretCreated   bool
+		expectSCMStartedAdded bool
+	}{
+		{
+			name:                  "secret-pending PR (state=started, pending) - pending cleared after secret creation",
+			state:                 kubeinteraction.StateStarted,
+			specStatus:            tektonv1.PipelineRunSpecStatusPending,
+			expectPendingCleared:  true,
+			expectSecretCreated:   true,
+			expectSCMStartedAdded: true,
+		},
+		{
+			name:                  "concurrency-pending PR (state=queued, pending) - pending NOT cleared",
+			state:                 kubeinteraction.StateQueued,
+			specStatus:            tektonv1.PipelineRunSpecStatusPending,
+			expectPendingCleared:  false,
+			expectSecretCreated:   true,
+			expectSCMStartedAdded: false,
+		},
+		{
+			name:                  "already running PR (state=started, no pending) - no change to status",
+			state:                 kubeinteraction.StateStarted,
+			specStatus:            "",
+			expectPendingCleared:  false, // was not pending, nothing to clear
+			expectSecretCreated:   true,
+			expectSCMStartedAdded: false, // updatePipelineRunState not called
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			observer, _ := zapobserver.New(zap.InfoLevel)
+			logger := zap.New(observer).Sugar()
+
+			ctx, _ := rtesting.SetupFakeContext(t)
+
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+					Name:      "test-pr",
+					Annotations: map[string]string{
+						keys.State:         tt.state,
+						keys.Repository:    "test-repo",
+						keys.SecretCreated: "false",
+						keys.GitAuthSecret: "pac-git-basic-auth-owner-repo",
+						keys.GitProvider:   "github",
+						keys.RepoURL:       "https://github.com/org/repo",
+						keys.URLOrg:        "org",
+						keys.URLRepository: "repo",
+						keys.SHA:           "abc123",
+					},
+				},
+				Spec: tektonv1.PipelineRunSpec{
+					Status: tt.specStatus,
+				},
+			}
+
+			repo := &v1alpha1.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-repo",
+					Namespace: "test-ns",
+				},
+				Spec: v1alpha1.RepositorySpec{
+					GitProvider: &v1alpha1.GitProvider{
+						Secret: &v1alpha1.Secret{
+							Name: "pac-provider-secret",
+						},
+						User: "test-user",
+					},
+				},
+			}
+
+			testData := testclient.Data{
+				PipelineRuns: []*tektonv1.PipelineRun{pr},
+				Repositories: []*v1alpha1.Repository{repo},
+			}
+			stdata, informers := testclient.SeedTestData(t, ctx, testData)
+
+			r := &Reconciler{
+				repoLister: informers.Repository.Lister(),
+				run: &params.Run{
+					Clients: clients.Clients{
+						Tekton: stdata.Pipeline,
+						Log:    logger,
+					},
+					Info: info.Info{
+						Pac: &info.PacOpts{
+							Settings: settings.Settings{
+								SecretAutoCreation: true,
+							},
+						},
+						Kube: &info.KubeOpts{
+							Namespace: "global",
+						},
+						Controller: &info.ControllerInfo{
+							GlobalRepository: "global-repo",
+						},
+					},
+				},
+				kinteract: &testkubernetestint.KinterfaceTest{
+					GetSecretResult: map[string]string{
+						"pac-provider-secret": "test-token",
+					},
+				},
+			}
+
+			err := r.ReconcileKind(ctx, pr)
+			assert.NilError(t, err)
+
+			updatedPR, getErr := stdata.Pipeline.TektonV1().PipelineRuns(pr.Namespace).Get(ctx, pr.Name, metav1.GetOptions{})
+			assert.NilError(t, getErr)
+
+			if tt.expectSecretCreated {
+				assert.Equal(t, updatedPR.Annotations[keys.SecretCreated], "true")
+			}
+
+			if tt.expectPendingCleared {
+				assert.Equal(t, string(updatedPR.Spec.Status), "",
+					"pending status should be cleared after secret creation for state=started PRs")
+			} else if tt.specStatus == tektonv1.PipelineRunSpecStatusPending {
+				assert.Equal(t, string(updatedPR.Spec.Status), string(tektonv1.PipelineRunSpecStatusPending),
+					"pending status should NOT be cleared for state=queued PRs (queue manager handles this)")
+			}
+
+			if tt.expectSCMStartedAdded {
+				scmStarted, ok := updatedPR.Annotations[keys.SCMReportingPLRStarted]
+				assert.Assert(t, ok, "SCMReportingPLRStarted annotation should be set")
+				assert.Equal(t, scmStarted, "true")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 📝 Description of the Change
Set state annotation at PipelineRun creation time (in labels.go) so the controller's enqueue guard picks it up even if the post-creation state patch fails transiently. Mark PipelineRuns as pending when secret auto-creation is active, and clear the pending status in the reconciler after the secret is created.

## 🔗 Linked GitHub Issue
#2751

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing - TODO
- [ ] Not Applicable

## 🤖 AI Assistance

AI assistance can be used for various tasks, such as code generation,
documentation, or testing.

Please indicate whether you have used AI assistance
for this PR and provide details if applicable.

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

> [!IMPORTANT]
>
> **Slop will be simply rejected**, if you are using AI assistance you need to make sure you
> understand the code generated and that it meets the project's standards. you
> need at least know how to run the code and deploy it (if needed). See
> [startpaac](https://github.com/openshift-pipelines/startpaac) to make it easy
> to deploy and test your code changes.
>
> If the **majority of the code** in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Claude <noreply@anthropic.com>

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
