### PR TITLE
chore: add .cve-fix/examples.md guidance for CVE fixer workflow

### DIFF
--- a/.cve-fix/examples.md
+++ b/.cve-fix/examples.md
@@ -1,0 +1,72 @@
+<!-- last-analyzed: 2026-06-12 | cve-merged: 16 -->
+
+## Titles
+
+- `fix(security): backport <version> fixes to <release-branch>` (security code fixes, 3/16 PRs)
+- `[release-v0.42.2] fix(deps): update <package> to fix <GHSA-ID>` (GHSA dep bumps, 2/16 PRs)
+- `chore(deps): bump <module> from <old> to <new>` (dependabot-style dep bumps, 8/16 PRs)
+- Prefix `[DNM]` for work-in-progress backport PRs not yet ready to merge
+
+## Branches
+
+- Security code fixes: `security-<short-description>-<release-branch-hyphenated>` (e.g. `security-header-hijacking-v0-42-x`)
+- Manual dep bumps: `deps/<package>` or `update-<package>-security-fix` (e.g. `deps/go-jose`, `update-go-jose-security-fix`)
+- Backport per release branch: one branch per release stream (e.g. `deps/go-jose-v0.42`)
+
+## Files
+
+- Go dependency CVEs: `go.mod`, `go.sum` (always together)
+- GitHub App token / host-header security: `pkg/provider/github/app/token.go`, `pkg/provider/github/github.go`, `pkg/provider/github/parse_payload.go`
+- Webhook security: `pkg/adapter/incoming.go`, `pkg/adapter/sinker.go`
+- Remote task resolution: `pkg/resolve/remote.go`
+- Tests always accompany code changes: `pkg/adapter/incoming_test.go`, `pkg/provider/github/app/token_test.go`, `pkg/resolve/remote_test.go`
+
+## Co-upgrades
+
+- When bumping `go-jose/v3`, also bump `go-jose/v4` (and vice versa) — both must be at fixed versions together (12/16 dep PRs)
+- Security backports to older release branches: also update `go-jose/v3`, `go-jose/v4`, and `tektoncd/pipeline` on that branch
+
+## PR Description
+
+Use the repo's standard template sections (in order):
+
+```markdown
+## 📝 Description of the Change
+<what changed and why — include bullet points for each security hardening>
+
+### How this backport was done
+<step-by-step: which branch, API differences resolved, dependency bumps, GOTOOLCHAIN pinning>
+
+### Commits
+| Commit | Description |
+|--------|-------------|
+| `<sha>` | `<conventional commit message>` |
+
+## 👨🏻‍ Linked Jira
+<Jira ticket or N/A>
+
+## 🔗 Linked GitHub Issue
+Fixes #<issue> (or N/A)
+
+## 🧪 Testing Strategy
+- [x] Unit tests
+- [ ] Integration tests
+- [ ] End-to-end tests
+- [ ] Manual testing
+- [ ] Not Applicable
+
+Validation run locally:
+- `make test`
+- `make lint-go`
+- `go test ./pkg/adapter` (for adapter/webhook changes)
+
+## 🤖 AI Assistance
+<note if AI was used>
+```
+
+## Don'ts
+
+- ❌ Do not combine multiple release-branch backports in one PR — one PR per release branch
+- ❌ Do not skip `go.sum` when updating `go.mod` — always commit both together
+- ❌ Do not bump `go-jose/v3` without also bumping `go-jose/v4` in the same PR
+- ❌ Do not use `GOTOOLCHAIN=local` — pin `GOTOOLCHAIN` to the exact Go version in the branch's `go.mod` (e.g. `GOTOOLCHAIN=go1.24.2`)


### PR DESCRIPTION
Adds `.cve-fix/examples.md` so the CVE fixer workflow knows how to
create fix PRs matching this repo's conventions.

Patterns extracted from analysis of **16 merged CVE/security PRs**:

- **Branch naming**: `security-<description>-<release-branch-hyphenated>` for code fixes; `deps/<package>` for dep bumps
- **Co-upgrades**: `go-jose/v3` and `go-jose/v4` must always be bumped together
- **Files**: security fixes touch `pkg/adapter/incoming.go`, `pkg/provider/github/app/token.go`, `pkg/resolve/remote.go`
- **GOTOOLCHAIN**: pin to the exact version in the branch's `go.mod` (e.g. `GOTOOLCHAIN=go1.24.2`)
- **PR template**: uses the repo's standard sections (`📝 Description`, `🔗 Linked Issue`, `🧪 Testing Strategy`)

Generated by `/onboard` — run `/guidance.update` after more CVE fixes merge to improve coverage.

🤖 Generated by /onboard