### PR TITLE
docs: Update homebrew installation instructions for tap trust

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -87,6 +87,9 @@ homebrew_casks:
     homepage: "https://pipelinesascode.com"
     description: tkn-pac - A command line interface for interacting with Pipelines as Code
     binaries: ["tkn-pac"]
+    caveats: |
+      On first run, macOS may block the binary. To remove the quarantine attribute:
+        xattr -d com.apple.quarantine "$(brew --prefix)/bin/tkn-pac"
     custom_block: |
       zsh_completion = "#{staged_path}/_tkn-pac"
       bash_completion = "#{staged_path}/tkn-pac.bash"

--- a/docs/content/docs/cli/installation.md
+++ b/docs/content/docs/cli/installation.md
@@ -27,7 +27,16 @@ On Windows, tkn-pac will look for the Kubernetes config in `%USERPROFILE%\.kube\
 {{< /tab >}}
 
 {{< tab name="Homebrew" >}}
-The `tkn pac` plug-in is available from Homebrew as a cask. Install it with:
+The `tkn pac` plug-in is available from Homebrew as a cask.
+
+Before installing, trust the tap (required for Homebrew 5.2+, mandatory in 6.0):
+
+```shell
+brew tap openshift-pipelines/pipelines-as-code
+brew trust openshift-pipelines/pipelines-as-code
+```
+
+Then install with:
 
 ```shell
 brew install --cask openshift-pipelines/pipelines-as-code/tektoncd-pac
@@ -37,6 +46,12 @@ To upgrade:
 
 ```shell
 brew upgrade --cask openshift-pipelines/pipelines-as-code/tektoncd-pac
+```
+
+If this is the first time you are adding `tkn-pac` on macOS (not needed on Linux), Gatekeeper may block the binary on first run. Remove the quarantine attribute with:
+
+```shell
+xattr -d com.apple.quarantine "$(brew --prefix)/bin/tkn-pac"
 ```
 
 The `tkn pac` plug-in is compatible with [Homebrew on Linux](https://docs.brew.sh/Homebrew-on-Linux).


### PR DESCRIPTION
## Description of the Change

This PR improves the Homebrew installation documentation for tkn-pac by addressing two user-facing issues:

1. **Homebrew tap trust requirement**: Newer versions of Homebrew (5.2+) require explicit tap trust before installing from a custom tap. This PR documents the required `brew tap` and `brew trust` commands, which are mandatory in Homebrew 6.0.

2. **macOS Gatekeeper quarantine attribute**: Users on macOS may encounter issues with Gatekeeper blocking the binary on first run. This PR documents the issue and provides the `xattr` command to remove the quarantine attribute.

The documentation changes are mirrored in the goreleaser release configuration to ensure users see the information both in the installation guide and in Homebrew release notes.

## Linked GitHub Issue

N/A

## Testing Strategy

- [x] Manual - Documentation updated and verified for clarity
- [ ] Unit tests - Not applicable (documentation-only change with release config update)
- [ ] Integration tests - Not applicable
- [ ] E2E tests - Not applicable

## AI Assistance

This change was developed with AI assistance. Claude was used for drafting the documentation improvements and release configuration updates. The majority of the content was AI-generated, and a `Co-authored-by: Claude <noreply@anthropic.com>` footer has been added to the commit.

## Submitter Checklist

- [x] Commit message follows [Google's style guide](https://google.github.io/styleguide/shellguide.html) with clear, descriptive summary
- [x] Commit prefix (`docs:`) correctly identifies the type of change
- [x] Ran `make lint` locally and confirmed no issues
- [x] Updated documentation for user-facing changes (Homebrew installation instructions and release config)
- [x] No unit or E2E tests needed - documentation-only change
- [x] No provider feature matrix updates needed