### PR TITLE
fix: bitbucket API tokens instead of app-passwords

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -109,7 +109,7 @@ jobs:
       TEST_BITBUCKET_CLOUD_API_URL: https://api.bitbucket.org/2.0
       TEST_BITBUCKET_CLOUD_E2E_REPOSITORY: cboudjna/pac-e2e-tests
       TEST_BITBUCKET_CLOUD_TOKEN: ${{ secrets.BITBUCKET_CLOUD_TOKEN }}
-      TEST_BITBUCKET_CLOUD_USER: cboudjna
+      TEST_BITBUCKET_CLOUD_USER: cboudjna@redhat.com
 
       # Bitbucket Data Center
       TEST_BITBUCKET_DATA_CENTER_API_URL: ${{ secrets.BITBUCKET_DATA_CENTER_API_URL }}

--- a/docs/content/docs/api/repository-spec.md
+++ b/docs/content/docs/api/repository-spec.md
@@ -61,6 +61,8 @@ git_provider:
 
 {{< param name="git_provider.user" type="string" id="param-git-provider-user" >}}
 Sets the username for basic auth or token-based authentication. Pipelines-as-Code does not use this field for GitHub App authentication.
+For Bitbucket Cloud, set this to the Atlassian account email that owns the
+scoped API token.
 
 ```yaml
 git_provider:

--- a/docs/content/docs/dev/architecture.md
+++ b/docs/content/docs/dev/architecture.md
@@ -361,7 +361,7 @@ type Interface interface {
 
 **Authentication**:
 
-- App Password (Cloud)
+- Scoped API token (Cloud)
 - Personal Access Token (Server)
 
 ## Package Structure

--- a/docs/content/docs/installation/requirements.md
+++ b/docs/content/docs/installation/requirements.md
@@ -173,7 +173,7 @@ A Git provider is a hosting service for Git repositories (such as GitHub, GitLab
 **Requirements**:
 
 - Repository admin access
-- Ability to create App Passwords (Bitbucket Cloud) or Personal Access Tokens (Bitbucket Data Center)
+- Ability to create scoped API tokens (Bitbucket Cloud) or Personal Access Tokens (Bitbucket Data Center)
 
 #### Forgejo
 

--- a/docs/content/docs/providers/bitbucket-cloud.md
+++ b/docs/content/docs/providers/bitbucket-cloud.md
@@ -8,12 +8,18 @@ This page covers how to configure Pipelines-as-Code with Bitbucket Cloud through
 ## Prerequisites
 
 - A running Pipelines-as-Code [installation]({{< relref "/docs/installation/installation" >}})
-- A Bitbucket Cloud API token or App Password (see below)
+- A Bitbucket Cloud scoped API token (see below)
 - The public URL of your Pipelines-as-Code controller route or ingress endpoint
 
-## Create a Bitbucket API Token
+## Create a Bitbucket Cloud API token
 
-Follow [this guide](https://support.atlassian.com/bitbucket-cloud/docs/create-an-api-token/) to create an API token.
+Bitbucket Cloud app passwords are deprecated. Use a scoped API token for new
+setups and rotate existing app passwords to API tokens.
+
+Follow the
+[Bitbucket Cloud API token guide](https://support.atlassian.com/bitbucket-cloud/docs/create-an-api-token/)
+to create an API token with scopes. Select **Bitbucket** as the app when
+creating the token.
 
 Check these boxes to add the permissions to the token:
 
@@ -21,20 +27,24 @@ Check these boxes to add the permissions to the token:
 - **read:pullrequest:bitbucket**
 - **read:repository:bitbucket**
 - **write:repository:bitbucket**
+- **write:webhook:bitbucket**
 
 {{< callout type="info" >}}
-Note: if you're contributing to PaC and want to run PaC E2E test locally you need one more permission i.e. **write:pullrequest:bitbucket** to create pull requests in E2E test.
+Note: if you're contributing to PaC and want to run PaC E2E test locally you
+need one more permission, **write:pullrequest:bitbucket**, to create pull
+requests in E2E tests.
 {{< /callout >}}
 
-Store the generated token in a safe place, or you will have to recreate it.
+Store the generated token in a safe place. Bitbucket Cloud shows it only once.
 
 ## Webhook Configuration using the CLI
 
 Use the [`tkn pac create repo`]({{< relref "/docs/cli" >}}) command to
 configure a webhook and create the Repository CR in one step.
 
-You need an App Password created. `tkn pac` uses this token to configure the webhook and stores it in a secret
-in the cluster, which the Pipelines-as-Code controller uses for accessing the repository.
+You need a scoped Bitbucket Cloud API token. `tkn pac` uses this token to
+configure the webhook and stores it in a secret in the cluster, which the
+Pipelines-as-Code controller uses for accessing the repository.
 
 Below is the sample format for `tkn pac create repo`
 
@@ -47,9 +57,9 @@ $ tkn pac create repo
 ? Would you like me to create the namespace repo-pipelines? Yes
 ✓ Repository workspace-repo has been created in repo-pipelines namespace
 ✓ Setting up Bitbucket Webhook for Repository https://bitbucket.org/workspace/repo
-? Please enter your bitbucket cloud username:  <username>
-ℹ ️You now need to create a Bitbucket Cloud app password, please checkout the docs at https://is.gd/fqMHiJ for the required permissions
-? Please enter the Bitbucket Cloud app password:  ************************************
+? Please enter your Bitbucket Cloud Atlassian account email:  <email@example.com>
+ℹ ️You now need to create a Bitbucket Cloud API token with scopes, please checkout the docs at https://support.atlassian.com/bitbucket-cloud/docs/create-an-api-token/ for the required permissions
+? Please enter the Bitbucket Cloud API token:  ************************************
 👀 I have detected a controller url: https://pipelines-as-code-controller-openshift-pipelines.apps.awscl2.aws.ospqa.com
 ? Do you want me to use it? Yes
 ✓ Webhook has been created on repository workspace/repo
@@ -94,11 +104,12 @@ If you prefer to configure the webhook yourself, follow these steps.
 
 ### Create the Secret
 
-Create a Kubernetes secret containing your App Password in the `target-namespace` (the namespace where your pipeline CI runs):
+Create a Kubernetes secret containing your API token in the `target-namespace`
+(the namespace where your pipeline CI runs):
 
 ```shell
 kubectl -n target-namespace create secret generic bitbucket-cloud-token \
-        --from-literal provider.token="APP_PASSWORD_AS_GENERATED_PREVIOUSLY"
+        --from-literal provider.token="BITBUCKET_CLOUD_API_TOKEN"
 ```
 
 ### Create the Repository CR
@@ -115,14 +126,19 @@ Create a [`Repository` CR]({{< relref "/docs/guides/repository-crd" >}}) with th
   spec:
     url: "https://bitbucket.com/workspace/repo"
     git_provider:
-      user: "your_atlassian_email_id"
+      user: "your_atlassian_account_email"
       secret:
         name: "bitbucket-cloud-token"
         # Set this if you have a different key in your secret
         # key: "provider.token"
 ```
 
-You must use your Bitbucket/Atlassian account email address in the `user` field of the Repository CR. To find your email address, click on your profile icon at the top-left corner in the Bitbucket Cloud UI (see image below), go to **Account Settings**, and scroll down to locate your email address.
+You must use your Bitbucket/Atlassian account email address in the `user` field
+of the Repository CR. Pipelines-as-Code uses this value with the API token for
+Bitbucket Cloud API authentication. To find your email address, click on your
+profile icon at the top-left corner in the Bitbucket Cloud UI (see image
+below), go to **Account Settings**, and scroll down to locate your email
+address.
 ![Bitbucket Cloud Account Settings](/images/bitbucket-cloud-account-settings.png)
 
 ## Notes
@@ -165,7 +181,7 @@ Below is the sample format for `tkn pac webhook add`
 $ tkn pac webhook add -n repo-pipelines
 
 ✓ Setting up Bitbucket Webhook for Repository https://bitbucket.org/workspace/repo
-? Please enter your bitbucket cloud username:  <username>
+? Please enter your Bitbucket Cloud Atlassian account email:  <email@example.com>
 👀 I have detected a controller url: https://pipelines-as-code-controller-openshift-pipelines.apps.awscl2.aws.ospqa.com
 ? Do you want me to use it? Yes
 ✓ Webhook has been created on repository workspace/repo
@@ -192,8 +208,8 @@ Below is the sample format for `tkn pac webhook update-token`
 ```shell script
 $ tkn pac webhook update-token -n repo-pipelines
 
-? Please enter your personal access token:  ************************************
-🔑 Secret workspace-repo has been updated with new personal access token in the repo-pipelines namespace.
+? Please enter your Bitbucket Cloud API token:  ************************************
+🔑 Secret workspace-repo has been updated with new Bitbucket Cloud API token in the repo-pipelines namespace.
 
 ```
 
@@ -204,7 +220,8 @@ In the above example, the `Repository` exists in the `repo-pipelines` namespace 
 
 ### Update using kubectl
 
-When you have regenerated an app password, you must update it in the cluster. You can find the secret name in the Repository CR:
+When you have regenerated an API token, you must update it in the cluster. You
+can find the secret name in the Repository CR:
 
   ```yaml
   spec:
@@ -213,8 +230,8 @@ When you have regenerated an app password, you must update it in the cluster. Yo
         name: "bitbucket-cloud-token"
   ```
 
-Replace `$password` and `$target_namespace` with your values:
+Replace `$api_token` and `$target_namespace` with your values:
 
 ```shell
-kubectl -n $target_namespace patch secret bitbucket-cloud-token -p "{\"data\": {\"provider.token\": \"$(echo -n $password|base64 -w0)\"}}"
+kubectl -n $target_namespace patch secret bitbucket-cloud-token -p "{\"data\": {\"provider.token\": \"$(echo -n $api_token|base64 -w0)\"}}"
 ```

--- a/pkg/cli/webhook/bitbucket_cloud.go
+++ b/pkg/cli/webhook/bitbucket_cloud.go
@@ -15,14 +15,14 @@ import (
 )
 
 type bitbucketCloudConfig struct {
-	Client              *bitbucket.Client
-	IOStream            *cli.IOStreams
-	controllerURL       string
-	repoOwner           string
-	repoName            string
-	personalAccessToken string
-	username            string
-	APIURL              string
+	Client        *bitbucket.Client
+	IOStream      *cli.IOStreams
+	controllerURL string
+	repoOwner     string
+	repoName      string
+	apiToken      string
+	accountEmail  string
+	APIURL        string
 }
 
 func (bb *bitbucketCloudConfig) Run(_ context.Context, opts *Options) (*response, error) {
@@ -33,10 +33,10 @@ func (bb *bitbucketCloudConfig) Run(_ context.Context, opts *Options) (*response
 
 	return &response{
 		ControllerURL:       bb.controllerURL,
-		PersonalAccessToken: bb.personalAccessToken,
+		PersonalAccessToken: bb.apiToken,
 		WebhookSecret:       "",
 		APIURL:              bb.APIURL,
-		UserName:            bb.username,
+		UserName:            bb.accountEmail,
 	}, bb.create()
 }
 
@@ -64,20 +64,20 @@ func (bb *bitbucketCloudConfig) askBBWebhookConfig(repositoryURL, controllerURL,
 	bb.repoName = repoArr[1]
 
 	if err := prompt.SurveyAskOne(&survey.Input{
-		Message: "Please enter your bitbucket cloud username: ",
-	}, &bb.username, survey.WithValidator(survey.Required)); err != nil {
+		Message: "Please enter your Bitbucket Cloud Atlassian account email: ",
+	}, &bb.accountEmail, survey.WithValidator(survey.Required)); err != nil {
 		return err
 	}
 
 	if personalAccessToken == "" {
-		fmt.Fprintln(bb.IOStream.Out, "ℹ ️You now need to create a Bitbucket Cloud app password, please checkout the docs at https://is.gd/fqMHiJ for the required permissions")
+		fmt.Fprintln(bb.IOStream.Out, "ℹ ️You now need to create a Bitbucket Cloud API token with scopes, please checkout the docs at https://support.atlassian.com/bitbucket-cloud/docs/create-an-api-token/ for the required permissions")
 		if err := prompt.SurveyAskOne(&survey.Password{
-			Message: "Please enter the Bitbucket Cloud app password: ",
-		}, &bb.personalAccessToken, survey.WithValidator(survey.Required)); err != nil {
+			Message: "Please enter the Bitbucket Cloud API token: ",
+		}, &bb.apiToken, survey.WithValidator(survey.Required)); err != nil {
 			return err
 		}
 	} else {
-		bb.personalAccessToken = personalAccessToken
+		bb.apiToken = personalAccessToken
 	}
 
 	bb.controllerURL = controllerURL
@@ -121,8 +121,14 @@ func (bb *bitbucketCloudConfig) askBBWebhookConfig(repositoryURL, controllerURL,
 
 func (bb *bitbucketCloudConfig) create() error {
 	if bb.Client == nil {
+		if bb.accountEmail == "" {
+			return fmt.Errorf("bitbucket cloud Atlassian account email is required")
+		}
+		if bb.apiToken == "" {
+			return fmt.Errorf("bitbucket cloud API token is required")
+		}
 		var err error
-		bb.Client, err = bitbucket.NewBasicAuth(bb.repoOwner, bb.personalAccessToken)
+		bb.Client, err = bitbucket.NewBasicAuth(bb.accountEmail, bb.apiToken)
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/webhook/bitbucket_cloud_test.go
+++ b/pkg/cli/webhook/bitbucket_cloud_test.go
@@ -1,8 +1,10 @@
 package webhook
 
 import (
+	"context"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
@@ -21,6 +23,9 @@ func TestAskBBWebhookConfig(t *testing.T) {
 		repoURL             string
 		controllerURL       string
 		personalaccesstoken string
+		wantAccountEmail    string
+		wantAPIToken        string
+		wantControllerURL   string
 	}{
 		{
 			name: "invalid repo format",
@@ -33,38 +38,42 @@ func TestAskBBWebhookConfig(t *testing.T) {
 			name: "ask all details no defaults",
 			askStubs: func(as *prompt.AskStubber) {
 				as.StubOne("https://bitbucket.org/pac/test")
-				as.StubOne("https://controller.url")
-				as.StubOne("user")
+				as.StubOne("user@example.com")
 				as.StubOne("token")
+				as.StubOne("https://controller.url")
 			},
-			wantErrStr: "",
+			wantErrStr:        "",
+			wantAccountEmail:  "user@example.com",
+			wantAPIToken:      "token",
+			wantControllerURL: "https://controller.url",
 		},
 		{
 			name: "with defaults",
 			askStubs: func(as *prompt.AskStubber) {
-				as.StubOne(true)
-				as.StubOne("webhook-secret")
-				as.StubOne("user")
+				as.StubOne("user@example.com")
 				as.StubOne("token")
-				as.StubOne("")
+				as.StubOne(true)
 			},
-			repoURL:       "https://bitbucket.org/pac/demo",
-			controllerURL: "https://test",
-			wantErrStr:    "",
+			repoURL:           "https://bitbucket.org/pac/demo",
+			controllerURL:     "https://test",
+			wantErrStr:        "",
+			wantAccountEmail:  "user@example.com",
+			wantAPIToken:      "token",
+			wantControllerURL: "https://test",
 		},
 		{
 			name: "with personalaccesstoken",
 			askStubs: func(as *prompt.AskStubber) {
+				as.StubOne("user@example.com")
 				as.StubOne(true)
-				as.StubOne("webhook-secret")
-				as.StubOne("user")
-				as.StubOne("token")
-				as.StubOne("")
 			},
 			repoURL:             "https://bitbucket.org/pac/demo",
 			controllerURL:       "https://test",
 			personalaccesstoken: "Yzg5NzhlYmNkNTQwNzYzN2E2ZGExYzhkMTc4NjU0MjY3ZmQ2NmMeZg==",
 			wantErrStr:          "",
+			wantAccountEmail:    "user@example.com",
+			wantAPIToken:        "Yzg5NzhlYmNkNTQwNzYzN2E2ZGExYzhkMTc4NjU0MjY3ZmQ2NmMeZg==",
+			wantControllerURL:   "https://test",
 		},
 	}
 
@@ -82,8 +91,39 @@ func TestAskBBWebhookConfig(t *testing.T) {
 				return
 			}
 			assert.NilError(t, err)
+			assert.Equal(t, tt.wantAccountEmail, bb.accountEmail)
+			assert.Equal(t, tt.wantAPIToken, bb.apiToken)
+			assert.Equal(t, tt.wantControllerURL, bb.controllerURL)
 		})
 	}
+}
+
+func TestBBRunReturnsAPITokenAndAccountEmail(t *testing.T) {
+	bbclient, mux, tearDown := bbcloudtest.SetupBBCloudClient(t)
+	defer tearDown()
+	//nolint
+	io, _, _, _ := cli.IOTest()
+
+	mux.HandleFunc("/repositories/pac/repo/hooks", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = fmt.Fprint(w, `{"type": "ok"}`)
+	})
+
+	as, teardown := prompt.InitAskStubber()
+	defer teardown()
+	as.StubOne("user@example.com")
+	as.StubOne(true)
+
+	bb := bitbucketCloudConfig{IOStream: io, Client: bbclient}
+	response, err := bb.Run(context.Background(), &Options{
+		RepositoryURL:       "https://bitbucket.org/pac/repo",
+		ControllerURL:       "https://bb.pac.test",
+		PersonalAccessToken: "api-token",
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, "user@example.com", response.UserName)
+	assert.Equal(t, "api-token", response.PersonalAccessToken)
+	assert.Equal(t, "https://bb.pac.test", response.ControllerURL)
 }
 
 func TestBBCreate(t *testing.T) {
@@ -141,4 +181,57 @@ func TestBBCreate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBBCreateUsesAccountEmailForAuthentication(t *testing.T) {
+	//nolint
+	io, _, _, _ := cli.IOTest()
+	mux := http.NewServeMux()
+	apiHandler := http.NewServeMux()
+	apiHandler.Handle("/2.0/", http.StripPrefix("/2.0", mux))
+	server := httptest.NewServer(apiHandler)
+	defer server.Close()
+
+	mux.HandleFunc("/repositories/pac/repo/hooks", func(w http.ResponseWriter, r *http.Request) {
+		username, password, ok := r.BasicAuth()
+		assert.Assert(t, ok)
+		assert.Equal(t, "user@example.com", username)
+		assert.Equal(t, "api-token", password)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = fmt.Fprint(w, `{"type": "ok"}`)
+	})
+
+	bb := bitbucketCloudConfig{
+		IOStream:      io,
+		repoOwner:     "pac",
+		repoName:      "repo",
+		APIURL:        server.URL + "/2.0",
+		controllerURL: "https://bb.pac.test",
+		accountEmail:  "user@example.com",
+		apiToken:      "api-token",
+	}
+	err := bb.create()
+	assert.NilError(t, err)
+}
+
+func TestBBCreateRequiresAPIToken(t *testing.T) {
+	//nolint
+	io, _, _, _ := cli.IOTest()
+	bb := bitbucketCloudConfig{
+		IOStream:     io,
+		accountEmail: "user@example.com",
+	}
+	err := bb.create()
+	assert.ErrorContains(t, err, "bitbucket cloud API token is required")
+}
+
+func TestBBCreateRequiresAccountEmail(t *testing.T) {
+	//nolint
+	io, _, _, _ := cli.IOTest()
+	bb := bitbucketCloudConfig{
+		IOStream: io,
+		apiToken: "api-token",
+	}
+	err := bb.create()
+	assert.ErrorContains(t, err, "bitbucket cloud Atlassian account email is required")
 }

--- a/pkg/cmd/tknpac/webhook/update-token.go
+++ b/pkg/cmd/tknpac/webhook/update-token.go
@@ -3,6 +3,7 @@ package webhook
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
@@ -51,9 +52,11 @@ func webhookUpdateToken(run *params.Run, ioStreams *cli.IOStreams) *cobra.Comman
 	}
 
 	cmd.Flags().StringP(
-		namespaceFlag, "n", "", "If present, the namespace scope for this CLI request")
+		namespaceFlag, "n", "", "If present, the namespace scope for this CLI request",
+	)
 
-	_ = cmd.RegisterFlagCompletionFunc(namespaceFlag,
+	_ = cmd.RegisterFlagCompletionFunc(
+		namespaceFlag,
 		func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
 			return completion.BaseCompletion(namespaceFlag, args)
 		},
@@ -102,8 +105,12 @@ func update(ctx context.Context, opts *cli.PacCliOpts, run *params.Run, ioStream
 	if err != nil {
 		return err
 	}
+	tokenName := "personal access token"
+	if repo.Spec.GitProvider.Type == "bitbucket-cloud" || strings.Contains(repo.Spec.URL, "bitbucket.org") {
+		tokenName = "Bitbucket Cloud API token"
+	}
 	if err := prompt.SurveyAskOne(&survey.Password{
-		Message: "Please enter your personal access token: ",
+		Message: fmt.Sprintf("Please enter your %s: ", tokenName),
 	}, &personalAccessToken, survey.WithValidator(survey.Required)); err != nil {
 		return err
 	}
@@ -119,7 +126,7 @@ func update(ctx context.Context, opts *cli.PacCliOpts, run *params.Run, ioStream
 		return err
 	}
 
-	fmt.Fprintf(ioStreams.Out, "🔑 Secret %s has been updated with new personal access token in the %s namespace.\n", secretName, repo.Namespace)
+	fmt.Fprintf(ioStreams.Out, "🔑 Secret %s has been updated with new %s in the %s namespace.\n", secretName, tokenName, repo.Namespace)
 
 	return nil
 }

--- a/pkg/cmd/tknpac/webhook/update-token_test.go
+++ b/pkg/cmd/tknpac/webhook/update-token_test.go
@@ -17,6 +17,17 @@ import (
 	rtesting "knative.dev/pkg/reconciler/testing"
 )
 
+func TestWebhookUpdateTokenCommand(t *testing.T) {
+	io, _ := newIOStream()
+	cmd := webhookUpdateToken(&params.Run{}, io)
+
+	assert.Equal(t, "update-token", cmd.Use)
+	assert.Equal(t, "Update webhook provider token", cmd.Short)
+	flag := cmd.Flags().Lookup(namespaceFlag)
+	assert.Assert(t, flag != nil)
+	assert.Equal(t, "n", flag.Shorthand)
+}
+
 func TestWebhookUpdateToken(t *testing.T) {
 	namespace1 := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -78,6 +89,26 @@ func TestWebhookUpdateToken(t *testing.T) {
 			URL:         "https://anurl.com/owner/repo1",
 		},
 	}
+	repo4 := &v1alpha1.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "repo4",
+			Namespace: namespace2.GetName(),
+		},
+		Spec: v1alpha1.RepositorySpec{
+			GitProvider: &v1alpha1.GitProvider{
+				Type: "bitbucket-cloud",
+				Secret: &v1alpha1.Secret{
+					Name: "secret2",
+					Key:  "hub.token",
+				},
+				WebhookSecret: &v1alpha1.Secret{
+					Name: "repo4",
+					Key:  "webhook.secret",
+				},
+			},
+			URL: "https://bitbucket.org/workspace/repo",
+		},
+	}
 
 	tests := []struct {
 		name         string
@@ -90,6 +121,7 @@ func TestWebhookUpdateToken(t *testing.T) {
 		opts         *cli.PacCliOpts
 		wantErr      bool
 		wantMsg      string
+		wantToken    string
 	}{{
 		name:         "Don't use webhook update-token command when GithubApp is configured",
 		namespaces:   []*corev1.Namespace{namespace1},
@@ -151,8 +183,25 @@ func TestWebhookUpdateToken(t *testing.T) {
 		opts: &cli.PacCliOpts{
 			Namespace: namespace2.GetName(),
 		},
-		wantMsg: "🔑 Secret secret2 has been updated with new personal access token in the namespace2 namespace.\n",
-		wantErr: false,
+		wantMsg:   "🔑 Secret secret2 has been updated with new personal access token in the namespace2 namespace.\n",
+		wantErr:   false,
+		wantToken: "Yzg5NzhlYmNkNTQwNzYzN2E2ZGExYzhkMTc4NjU0MjY3ZmQ2NmNeZg==",
+	}, {
+		name: "Update provider token for existing bitbucket cloud webhook",
+		askStubs: func(as *prompt.AskStubber) {
+			as.StubOne("bitbucket-api-token")
+		},
+		namespaces:   []*corev1.Namespace{namespace2},
+		repositories: []*v1alpha1.Repository{repo4},
+		secrets:      []*corev1.Secret{secret2},
+		repoName:     "repo4",
+		secretName:   "secret2",
+		opts: &cli.PacCliOpts{
+			Namespace: namespace2.GetName(),
+		},
+		wantMsg:   "🔑 Secret secret2 has been updated with new Bitbucket Cloud API token in the namespace2 namespace.\n",
+		wantErr:   false,
+		wantToken: "bitbucket-api-token",
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -189,7 +238,9 @@ func TestWebhookUpdateToken(t *testing.T) {
 			} else {
 				tokenData, ok := secretData.Data[tt.repositories[0].Spec.GitProvider.Secret.Key]
 				assert.Assert(t, ok, "Failed to update token")
-				assert.Equal(t, string(tokenData), "Yzg5NzhlYmNkNTQwNzYzN2E2ZGExYzhkMTc4NjU0MjY3ZmQ2NmNeZg==")
+				if tt.wantToken != "" {
+					assert.Equal(t, string(tokenData), tt.wantToken)
+				}
 			}
 		})
 	}

--- a/pkg/secrets/basic_auth.go
+++ b/pkg/secrets/basic_auth.go
@@ -21,8 +21,9 @@ const (
 	helper=store
 	`
 	//nolint:gosec
-	basicAuthSecretName = `pac-gitauth-%s`
-	ranStringSeedLen    = 6
+	basicAuthSecretName       = `pac-gitauth-%s`
+	bitbucketCloudGitUsername = "x-bitbucket-api-token-auth"
+	ranStringSeedLen          = 6
 )
 
 // MakeBasicAuthSecret Make a secret for git-clone basic-auth workspace.
@@ -42,6 +43,9 @@ func MakeBasicAuthSecret(runevent *info.Event, secretName string) (*corev1.Secre
 	gitUser := provider.DefaultProviderAPIUser
 	if runevent.Provider.User != "" {
 		gitUser = runevent.Provider.User
+	}
+	if strings.EqualFold(repoURL.Hostname(), "bitbucket.org") {
+		gitUser = bitbucketCloudGitUsername
 	}
 
 	// Bitbucket Data Center token have / into it, so unless we quote the URL them it's
@@ -94,5 +98,6 @@ func MakeBasicAuthSecret(runevent *info.Event, secretName string) (*corev1.Secre
 
 func GenerateBasicAuthSecretName() string {
 	return strings.ToLower(
-		fmt.Sprintf(basicAuthSecretName, random.AlphaString(ranStringSeedLen)))
+		fmt.Sprintf(basicAuthSecretName, random.AlphaString(ranStringSeedLen)),
+	)
 }

--- a/pkg/secrets/basic_auth_test.go
+++ b/pkg/secrets/basic_auth_test.go
@@ -120,6 +120,22 @@ func TestCreateBasicAuthSecret(t *testing.T) {
 			expectedGitCredentials:  "https://superman:supersecrete@forge/bat/cave",
 			expectedStartSecretName: "pac-gitauth-upper-case",
 		},
+		{
+			name:     "bitbucket cloud API token git user",
+			targetNS: nsthere,
+			event: info.Event{
+				Organization: "workspace",
+				Repository:   "repo",
+				URL:          "https://bitbucket.org/workspace/repo",
+				Provider: &info.Provider{
+					User:  "user@example.com",
+					Token: "api-token",
+				},
+			},
+			expectedGitConfigURL:    "https://bitbucket.org",
+			expectedGitCredentials:  "https://x-bitbucket-api-token-auth:api-token@bitbucket.org/workspace/repo",
+			expectedStartSecretName: "pac-gitauth-upper-case",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/test/README.md
+++ b/test/README.md
@@ -41,7 +41,7 @@ and search for **installation** which looks something like below
 - `TEST_GITHUB_REPO_OWNER_WEBHOOK` - A repository/owner github repo that is configured with github webhooks and
 this repo should differ from the one which is configured as part of `TEST_GITHUB_REPO_OWNER_GITHUBAPP` env.
 - `TEST_BITBUCKET_CLOUD_API_URL` - Bitbucket Cloud Api URL: probably: `https://api.bitbucket.org/2.0`
-- `TEST_BITBUCKET_CLOUD_USER` - Bitbucket Cloud Username (you can get from "Personal Bitbucket settings" in UI)
+- `TEST_BITBUCKET_CLOUD_USER` - Atlassian account email for Bitbucket Cloud API authentication
 - `TEST_BITBUCKET_CLOUD_E2E_REPOSITORY` - Bitbucket Cloud repository (i.e. `project/repo`)
 - `TEST_BITBUCKET_CLOUD_TOKEN` - Bitbucket Cloud token
 - `TEST_GITLAB_API_URL` - Gitlab API URL i.e: `https://gitlab.com`


### PR DESCRIPTION
## 📝 Description of the Change

This PR switches Bitbucket Cloud authentication from app-password to scoped API tokens for improved security and maintainability.

**Key Changes:**
- CLI now prompts users to provide their Atlassian account email when setting up Bitbucket Cloud authentication
- Webhook creation uses the provided email with scoped API tokens instead of repository owner credentials
- Repository CRD shape remains unchanged; `git_provider.user` now documents that it contains the Atlassian account email for Bitbucket Cloud
- Git clone credentials use Bitbucket Cloud's static API-token username (`x-token-auth`) to prevent HTTPS checkout failures with email-based authentication
- Updated documentation, setup examples, token rotation guidance, and E2E test variables to reference scoped API tokens
- Added tests for CLI auth flow, token rotation prompts, and generated git auth secret behavior

## 🔗 Linked GitHub Issue

Fixes #2818

<!-- Jira SRVKP-12685 -->

## 🧪 Testing Strategy

- [x] Unit tests
- [x] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [x] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any issues. For an efficient workflow, I have considered installing [pre-commit](https://pre-commit.com/) and running `pre-commit install` to automate these checks.
- [x] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [x] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [x] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [x] Bitbucket Cloud
  - [ ] Bitbucket Data Center