### PR TITLE
feat: Implement automatic GitLab access token rotation

### DIFF
--- a/config/201-controller-role.yaml
+++ b/config/201-controller-role.yaml
@@ -67,7 +67,7 @@ rules:
     verbs: ["create"]
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get"]
+    verbs: ["get", "update"]
   - apiGroups: ["pipelinesascode.tekton.dev"]
     resources: ["repositories"]
     verbs: ["get", "create", "list"]

--- a/config/300-repositories.yaml
+++ b/config/300-repositories.yaml
@@ -506,6 +506,14 @@ spec:
                             - disable_all
                             - update
                           type: string
+                        token_auto_rotation:
+                          description: |-
+                            TokenAutoRotation controls automatic rotation of expiring GitLab access tokens.
+                            This is disabled by default. When enabled, PAC checks the token's expiry on each webhook event and
+                            rotates it when within 7 days of expiration. The new token is written back to the
+                            Kubernetes Secret. Requires the token to have the 'api' scope.
+                            Set to true to enable.
+                          type: boolean
                       type: object
                     gitops_command_prefix:
                       description: |-

--- a/docs/content/docs/api/settings.md
+++ b/docs/content/docs/api/settings.md
@@ -139,6 +139,22 @@ settings:
 
 {{< /param >}}
 
+{{< param name="gitlab.token_auto_rotation" type="boolean" id="param-gitlab-token-auto-rotation" >}}
+Controls automatic rotation of expiring GitLab access tokens.
+
+- Default: `false` (disabled)
+- `true`: On each webhook event, Pipelines-as-Code checks token expiry and rotates when within 7 days
+
+This can be set on the global Repository CR to enable rotation by default for repositories that do not set a local value.
+
+```yaml
+settings:
+  gitlab:
+    token_auto_rotation: true
+```
+
+{{< /param >}}
+
 {{< /param-group >}}
 {{< /param >}}
 

--- a/docs/content/docs/providers/gitlab.md
+++ b/docs/content/docs/providers/gitlab.md
@@ -26,6 +26,13 @@ on the Merge Request.
 
 Store the generated token in a safe place, or you will have to recreate it.
 
+{{< callout type="info" >}}
+Give the token an expiration date. When
+[automatic token rotation](#automatic-token-rotation) is enabled,
+Pipelines-as-Code will rotate it before it expires as long as it has the
+`api` scope (or `self_rotate` on newer GitLab versions).
+{{< /callout >}}
+
 ## Webhook Configuration using the CLI
 
 Use the [`tkn pac create repo`]({{< relref "/docs/cli" >}}) command to
@@ -333,3 +340,100 @@ Replace `$NEW_TOKEN` and `$target_namespace` with your values:
 ```shell
 kubectl -n $target_namespace patch secret gitlab-webhook-config -p "{\"data\": {\"provider.token\": \"$(echo -n $NEW_TOKEN|base64 -w0)\"}}"
 ```
+
+## Automatic Token Rotation
+
+Pipelines-as-Code automatically rotates GitLab access tokens before they expire. On each webhook event, it checks the token's expiry date and rotates it when it is within 7 days of expiration. The new token (valid for 30 days) is written back to the Kubernetes Secret configured directly on the Repository CR.
+
+This works for Personal Access Tokens and Project Access Tokens. The token must have the `api` scope (or the `self_rotate` scope available in newer GitLab versions).
+
+Automatic rotation is **disabled by default**. If the token does not have the required scope for self-rotation, the rotation is silently skipped and webhook processing continues normally.
+
+In the future, this behavior may become enabled by default.
+
+Automatic rotation does not run for `git_provider.secret` values inherited from the global Repository. Global Repository secrets are shared configuration and must be rotated manually, for example by updating the global secret with `kubectl` or the process you use to manage controller-wide credentials.
+
+### Enabling Automatic Rotation
+
+To enable automatic token rotation for a repository, set `token_auto_rotation` to `true`:
+
+```yaml
+spec:
+  settings:
+    gitlab:
+      token_auto_rotation: true
+```
+
+To enable it by default for repositories that do not set a local value, set it on the global Repository CR.
+
+When both global and repository settings are present, the repository-level value takes precedence.
+
+### How It Works
+
+1. When Pipelines-as-Code sets up the GitLab client (on webhook events and watcher reconciliation loops), it calls the GitLab [token self-introspection API](https://docs.gitlab.com/api/personal_access_tokens/#self-inform) to check the token's expiry. The result is cached per repository (for up to 1 hour, invalidated if the token changes), so repeated events don't each trigger an API call.
+2. If the token expires within 7 days, it calls the [self-rotation API](https://docs.gitlab.com/api/personal_access_tokens/#self-rotate) to rotate it.
+3. The old token is revoked and a new token (valid for 30 days) is returned.
+4. The new token is written back to the Kubernetes Secret referenced directly in the Repository CR.
+5. A Kubernetes event (`GitLabTokenRotated`) is emitted on the Repository CR.
+
+Token rotation is atomic: the old token is revoked the moment the new one is
+created. If the Kubernetes Secret update fails after rotation, the old token is
+already revoked and you must create a new token and update the Secret by hand
+(see [Recovering from an expired or revoked token](#recovering-from-an-expired-or-revoked-token)).
+This is logged as a CRITICAL error and the webhook event is rejected.
+
+### Introspection Caching
+
+To keep GitLab API consumption low, the result of the token introspection call
+is cached in memory per repository (keyed by the Repository CR's
+namespace/name):
+
+- A cached result is reused for up to **1 hour**, as long as the token's known
+  expiry stays outside the 7-day rotation window. Within that hour, webhook
+  events and watcher reconciliation loops do not trigger additional
+  introspection calls.
+- The cache is bound to the token value itself: if you update the Secret
+  manually (for example with `tkn pac webhook update-token` or `kubectl
+  patch`), the cached entry no longer matches and the next event
+  re-introspects the new token immediately.
+- After a successful rotation, the cache is refreshed with the new token and
+  its new expiry.
+- The cache is per process and not persisted: the controller and the watcher
+  each keep their own, and a pod restart starts with an empty cache. This only
+  means at most one extra introspection call per component after a restart.
+
+### Monitoring Rotation
+
+Each successful rotation emits a `GitLabTokenRotated` Kubernetes event on the Repository CR, including the new expiry date:
+
+```shell
+kubectl -n <namespace> get events --field-selector reason=GitLabTokenRotated
+```
+
+Rotation failures other than the critical Secret-update case do not block webhook processing; they are only logged by the controller. If you suspect tokens are not being rotated, check the controller logs:
+
+```shell
+kubectl -n pipelines-as-code logs deployment/pipelines-as-code-controller | grep -i "token auto-rotation"
+```
+
+### Recovering from an Expired or Revoked Token
+
+Rotation only works while the token is still valid. Once a token has expired,
+GitLab rejects the introspection call and Pipelines-as-Code cannot renew it.
+This typically happens on dormant repositories that received no webhook event
+during the rotation window. The same applies when rotation succeeded on the
+GitLab side but the Secret update failed: the old token is revoked and the new
+one was lost.
+
+In both cases, create a new token in GitLab and update the Secret as described
+in [Update Token](#update-token), using either `tkn pac webhook update-token`
+or `kubectl patch`.
+
+### Requirements
+
+- The token must have `api` or `self_rotate` scope.
+- The token must have an expiration date. Tokens created without one are never rotated.
+- The token secret must be configured directly on the Repository CR. Tokens inherited from the global Repository are not auto-rotated.
+- The repository must receive at least one webhook event within the 7-day rotation window. Dormant repositories that receive no events will not have their tokens rotated and the tokens will eventually expire. For low-traffic repositories, create the token with a longer expiry, or disable auto-rotation and manage the token manually.
+- The Pipelines-as-Code controller needs `update` permission on `secrets` resources. This is included in the default RBAC configuration (`pipeline-as-code-controller-clusterrole`). If you use custom RBAC, ensure the controller's ClusterRole includes `update` on secrets.
+- Group Access Token rotation is not yet supported.

--- a/pkg/apis/pipelinesascode/v1alpha1/types.go
+++ b/pkg/apis/pipelinesascode/v1alpha1/types.go
@@ -118,8 +118,20 @@ func (r *RepositorySpec) Merge(newRepo RepositorySpec) {
 	if newRepo.ConcurrencyLimit != nil && r.ConcurrencyLimit == nil {
 		r.ConcurrencyLimit = newRepo.ConcurrencyLimit
 	}
-	if newRepo.Settings != nil && r.Settings != nil {
-		r.Settings.Merge(newRepo.Settings)
+	if newRepo.Settings != nil {
+		if r.Settings == nil {
+			// copy instead of aliasing the pointer, the source may be a shared
+			// object (e.g. the global Repository from an informer cache) and
+			// later merges must not mutate it.
+			settings := *newRepo.Settings
+			if settings.Gitlab != nil {
+				gitlabSettings := *settings.Gitlab
+				settings.Gitlab = &gitlabSettings
+			}
+			r.Settings = &settings
+		} else {
+			r.Settings.Merge(newRepo.Settings)
+		}
 	}
 	if r.GitProvider != nil && newRepo.GitProvider != nil {
 		r.GitProvider.Merge(newRepo.GitProvider)
@@ -183,6 +195,14 @@ type GitlabSettings struct {
 	// +optional
 	// +kubebuilder:validation:Enum="";disable_all;update
 	CommentStrategy string `json:"comment_strategy,omitempty"`
+
+	// TokenAutoRotation controls automatic rotation of expiring GitLab access tokens.
+	// This is disabled by default. When enabled, PAC checks the token's expiry on each webhook event and
+	// rotates it when within 7 days of expiration. The new token is written back to the
+	// Kubernetes Secret. Requires the token to have the 'api' scope.
+	// Set to true to enable.
+	// +optional
+	TokenAutoRotation *bool `json:"token_auto_rotation,omitempty"`
 }
 
 type GithubSettings struct {
@@ -225,12 +245,30 @@ func (s *Settings) Merge(newSettings *Settings) {
 	if newSettings.Forgejo != nil && s.Forgejo == nil {
 		s.Forgejo = newSettings.Forgejo
 	}
+	if newSettings.Gitlab != nil {
+		if s.Gitlab == nil {
+			// copy instead of aliasing, later merges must not mutate the source.
+			gitlabSettings := *newSettings.Gitlab
+			s.Gitlab = &gitlabSettings
+		} else {
+			s.Gitlab.Merge(newSettings.Gitlab)
+		}
+	}
 	if newSettings.AIAnalysis != nil && s.AIAnalysis == nil {
 		s.AIAnalysis = newSettings.AIAnalysis
 	}
 
 	if newSettings.GitOpsCommandPrefix != "" && s.GitOpsCommandPrefix == "" {
 		s.GitOpsCommandPrefix = newSettings.GitOpsCommandPrefix
+	}
+}
+
+func (s *GitlabSettings) Merge(newSettings *GitlabSettings) {
+	if newSettings.CommentStrategy != "" && s.CommentStrategy == "" {
+		s.CommentStrategy = newSettings.CommentStrategy
+	}
+	if newSettings.TokenAutoRotation != nil && s.TokenAutoRotation == nil {
+		s.TokenAutoRotation = newSettings.TokenAutoRotation
 	}
 }
 

--- a/pkg/apis/pipelinesascode/v1alpha1/types_test.go
+++ b/pkg/apis/pipelinesascode/v1alpha1/types_test.go
@@ -8,6 +8,8 @@ import (
 
 func TestMergeSpecs(t *testing.T) {
 	two := 2
+	tokenAutoRotationFalse := false
+	tokenAutoRotationTrue := true
 	incomings := &[]Incoming{{
 		Type: "type",
 		Secret: Secret{
@@ -43,6 +45,28 @@ func TestMergeSpecs(t *testing.T) {
 			expected: &RepositorySpec{
 				Params:           params,
 				ConcurrencyLimit: &two,
+			},
+		},
+		{
+			name: "global settings merge when local settings are nil",
+			local: &RepositorySpec{
+				GitProvider: &GitProvider{},
+			},
+			global: RepositorySpec{
+				Settings: &Settings{
+					Gitlab: &GitlabSettings{
+						TokenAutoRotation: &tokenAutoRotationTrue,
+					},
+				},
+				GitProvider: gp,
+			},
+			expected: &RepositorySpec{
+				Settings: &Settings{
+					Gitlab: &GitlabSettings{
+						TokenAutoRotation: &tokenAutoRotationTrue,
+					},
+				},
+				GitProvider: gp,
 			},
 		},
 		{
@@ -139,6 +163,90 @@ func TestMergeSpecs(t *testing.T) {
 				Settings: &Settings{
 					Forgejo: &ForgejoSettings{
 						UserAgent: "my-custom-agent",
+					},
+				},
+				GitProvider: &GitProvider{},
+			},
+		},
+		{
+			name: "gitlab settings from global",
+			local: &RepositorySpec{
+				Settings:    &Settings{},
+				GitProvider: &GitProvider{},
+			},
+			global: RepositorySpec{
+				Settings: &Settings{
+					Gitlab: &GitlabSettings{
+						CommentStrategy:   "disable_all",
+						TokenAutoRotation: &tokenAutoRotationFalse,
+					},
+				},
+				GitProvider: &GitProvider{},
+			},
+			expected: &RepositorySpec{
+				Settings: &Settings{
+					Gitlab: &GitlabSettings{
+						CommentStrategy:   "disable_all",
+						TokenAutoRotation: &tokenAutoRotationFalse,
+					},
+				},
+				GitProvider: &GitProvider{},
+			},
+		},
+		{
+			name: "local gitlab settings take precedence",
+			local: &RepositorySpec{
+				Settings: &Settings{
+					Gitlab: &GitlabSettings{
+						CommentStrategy:   "update",
+						TokenAutoRotation: &tokenAutoRotationTrue,
+					},
+				},
+				GitProvider: &GitProvider{},
+			},
+			global: RepositorySpec{
+				Settings: &Settings{
+					Gitlab: &GitlabSettings{
+						CommentStrategy:   "disable_all",
+						TokenAutoRotation: &tokenAutoRotationFalse,
+					},
+				},
+				GitProvider: &GitProvider{},
+			},
+			expected: &RepositorySpec{
+				Settings: &Settings{
+					Gitlab: &GitlabSettings{
+						CommentStrategy:   "update",
+						TokenAutoRotation: &tokenAutoRotationTrue,
+					},
+				},
+				GitProvider: &GitProvider{},
+			},
+		},
+		{
+			name: "local gitlab settings merge missing fields from global",
+			local: &RepositorySpec{
+				Settings: &Settings{
+					Gitlab: &GitlabSettings{
+						CommentStrategy: "update",
+					},
+				},
+				GitProvider: &GitProvider{},
+			},
+			global: RepositorySpec{
+				Settings: &Settings{
+					Gitlab: &GitlabSettings{
+						CommentStrategy:   "disable_all",
+						TokenAutoRotation: &tokenAutoRotationFalse,
+					},
+				},
+				GitProvider: &GitProvider{},
+			},
+			expected: &RepositorySpec{
+				Settings: &Settings{
+					Gitlab: &GitlabSettings{
+						CommentStrategy:   "update",
+						TokenAutoRotation: &tokenAutoRotationFalse,
 					},
 				},
 				GitProvider: &GitProvider{},

--- a/pkg/gitclient/client_setup.go
+++ b/pkg/gitclient/client_setup.go
@@ -49,9 +49,11 @@ func SetupAuthenticatedClient(
 	// Determine secret namespace BEFORE merging repos
 	// This preserves the ability to detect when credentials come from global repo
 	secretNS := repo.GetNamespace()
+	inheritedGlobalSecret := false
 	if repo.Spec.GitProvider != nil && repo.Spec.GitProvider.Secret == nil &&
 		globalRepo != nil && globalRepo.Spec.GitProvider != nil && globalRepo.Spec.GitProvider.Secret != nil {
 		secretNS = globalRepo.GetNamespace()
+		inheritedGlobalSecret = true
 	}
 	logger.Debugf("setupAuthenticatedClient: repo=%s/%s secret_namespace=%s", repo.GetNamespace(), repo.GetName(), secretNS)
 	// merge global repo settings into local repo (after determining secret namespace)
@@ -67,13 +69,14 @@ func SetupAuthenticatedClient(
 	} else {
 		// Non-GitHub App providers use git_provider section in Repository spec
 		scm := secrets.SecretFromRepository{
-			K8int:       kint,
-			Config:      vcx.GetConfig(),
-			Event:       event,
-			Repo:        repo,
-			WebhookType: pacInfo.WebhookType,
-			Logger:      logger,
-			Namespace:   secretNS,
+			K8int:                 kint,
+			Config:                vcx.GetConfig(),
+			Event:                 event,
+			Repo:                  repo,
+			WebhookType:           pacInfo.WebhookType,
+			Logger:                logger,
+			Namespace:             secretNS,
+			InheritedGlobalSecret: inheritedGlobalSecret,
 		}
 		if err := scm.Get(ctx); err != nil {
 			return fmt.Errorf("cannot get secret from repository: %w", err)

--- a/pkg/gitclient/client_setup_test.go
+++ b/pkg/gitclient/client_setup_test.go
@@ -444,6 +444,7 @@ func TestSetupAuthenticatedClientGlobalRepoMergesSettings(t *testing.T) {
 	t.Parallel()
 
 	ctx, log := setupTestContext(t)
+	enableAutoRotation := true
 
 	// Local repo with git_provider URL but no secret (secret comes from global)
 	repo := testnewrepo.NewRepo(testnewrepo.RepoTestcreationOpts{
@@ -472,6 +473,11 @@ func TestSetupAuthenticatedClientGlobalRepoMergesSettings(t *testing.T) {
 			Key:  "webhook.secret",
 		},
 	}
+	globalRepo.Spec.Settings = &v1alpha1.Settings{
+		Gitlab: &v1alpha1.GitlabSettings{
+			TokenAutoRotation: &enableAutoRotation,
+		},
+	}
 
 	run := seedTestData(ctx, t, []*v1alpha1.Repository{repo, globalRepo})
 	testProvider := createTestProvider(log)
@@ -489,7 +495,13 @@ func TestSetupAuthenticatedClientGlobalRepoMergesSettings(t *testing.T) {
 	assert.NilError(t, err, "should succeed with auto-fetched global repo providing credentials")
 	// After merge, the repo should have secret from global repo
 	assert.Assert(t, repo.Spec.GitProvider.Secret != nil, "secret should be merged from global repo")
+	assert.Assert(t, repo.Spec.Settings != nil, "settings should be merged from global repo")
+	assert.Assert(t, repo.Spec.Settings.Gitlab != nil, "gitlab settings should be merged from global repo")
+	assert.Assert(t, repo.Spec.Settings.Gitlab.TokenAutoRotation != nil, "token auto-rotation should be inherited from global repo")
+	assert.Equal(t, true, *repo.Spec.Settings.Gitlab.TokenAutoRotation, "global token auto-rotation setting should be preserved")
 	assert.Equal(t, "global-token-value", event.Provider.Token, "token should come from global repo secret")
+	assert.Equal(t, "default", event.Provider.GitProviderSecretNamespace, "secret namespace should be tracked")
+	assert.Assert(t, event.Provider.GitProviderSecretFromGlobalRepo, "secret should be marked as inherited from global repo")
 }
 
 // TestSetupAuthenticatedClient_WebhookValidation tests webhook secret validation.

--- a/pkg/params/info/events.go
+++ b/pkg/params/info/events.go
@@ -89,11 +89,13 @@ type State struct {
 }
 
 type Provider struct {
-	Token                 string
-	URL                   string
-	User                  string
-	WebhookSecret         string
-	WebhookSecretFromRepo bool
+	Token                           string
+	URL                             string
+	User                            string
+	WebhookSecret                   string
+	WebhookSecretFromRepo           bool
+	GitProviderSecretNamespace      string
+	GitProviderSecretFromGlobalRepo bool
 }
 
 type Request struct {

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -3,6 +3,7 @@ package gitlab
 import (
 	"context"
 	"crypto/subtle"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -216,6 +217,10 @@ func (v *Provider) GetConfig() *info.ProviderConfig {
 }
 
 func (v *Provider) SetClient(ctx context.Context, run *params.Run, runevent *info.Event, repo *v1alpha1.Repository, eventsEmitter *events.EventEmitter) error {
+	return v.setClient(ctx, run, runevent, repo, eventsEmitter, true)
+}
+
+func (v *Provider) setClient(ctx context.Context, run *params.Run, runevent *info.Event, repo *v1alpha1.Repository, eventsEmitter *events.EventEmitter, rotateToken bool) error {
 	var err error
 	if runevent.Provider.Token == "" {
 		return fmt.Errorf("no git_provider.secret has been set in the repo crd")
@@ -259,6 +264,7 @@ func (v *Provider) SetClient(ctx context.Context, run *params.Run, runevent *inf
 	v.Token = &runevent.Provider.Token
 
 	run.Clients.Log.Infof("gitlab: initialized for client with token for apiURL=%s, org=%s, repo=%s", apiURL, runevent.Organization, runevent.Repository)
+
 	// In a scenario where the source repository is forked and a merge request (MR) is created on the upstream
 	// repository, runevent.SourceProjectID will not be 0 when SetClient is called from the pac-watcher code.
 	// This is because, in the controller, SourceProjectID is set in the annotation of the pull request,
@@ -266,6 +272,34 @@ func (v *Provider) SetClient(ctx context.Context, run *params.Run, runevent *inf
 	// the ID from runevent.SourceProjectID when v.sourceProject is 0 (nil).
 	if v.sourceProjectID == 0 && runevent.SourceProjectID > 0 {
 		v.sourceProjectID = runevent.SourceProjectID
+	}
+	if v.targetProjectID == 0 && runevent.TargetProjectID > 0 {
+		v.targetProjectID = runevent.TargetProjectID
+	}
+
+	switch {
+	case runevent.Provider.GitProviderSecretFromGlobalRepo:
+		run.Clients.Log.Debugf("gitlab token auto-rotation skipped: git_provider.secret is inherited from global Repository secret namespace=%s", runevent.Provider.GitProviderSecretNamespace)
+	case !rotateToken:
+		run.Clients.Log.Debugf("gitlab token auto-rotation skipped: client initialized before webhook validation")
+	case v.isTokenAutoRotationEnabled():
+		if newToken, rotateErr := v.maybeRotateToken(ctx); rotateErr != nil {
+			switch {
+			case errors.Is(rotateErr, errMissingSelfRotateScope):
+				run.Clients.Log.Debugf("gitlab token auto-rotation: %v", rotateErr)
+			case errors.Is(rotateErr, errTokenRotatedSecretUpdateFailed):
+				return fmt.Errorf("gitlab token auto-rotation failed: %w", rotateErr)
+			default:
+				run.Clients.Log.Warnf("gitlab token auto-rotation check failed: %v", rotateErr)
+			}
+		} else if newToken != "" {
+			v.gitlabClient, err = gitlab.NewClient(newToken, gitlab.WithBaseURL(apiURL))
+			if err != nil {
+				return fmt.Errorf("failed to create client with rotated token: %w", err)
+			}
+			runevent.Provider.Token = newToken
+			v.Token = &runevent.Provider.Token
+		}
 	}
 
 	// check that we have access to the source project if it's a private repo, this should only occur on Merge Requests

--- a/pkg/provider/gitlab/parse_payload.go
+++ b/pkg/provider/gitlab/parse_payload.go
@@ -190,12 +190,14 @@ func (v *Provider) initGitLabClient(ctx context.Context, event *info.Event) (*in
 
 	// should check global repository for secrets
 	secretNS := repo.GetNamespace()
+	inheritedGlobalSecret := false
 	globalRepo, err := v.run.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(v.run.Info.Kube.Namespace).Get(
 		ctx, v.run.Info.Controller.GlobalRepository, metav1.GetOptions{},
 	)
 	if err == nil && globalRepo != nil {
 		if repo.Spec.GitProvider != nil && repo.Spec.GitProvider.Secret == nil && globalRepo.Spec.GitProvider != nil && globalRepo.Spec.GitProvider.Secret != nil {
 			secretNS = globalRepo.GetNamespace()
+			inheritedGlobalSecret = true
 		}
 		repo.Spec.Merge(globalRepo.Spec)
 	}
@@ -206,19 +208,20 @@ func (v *Provider) initGitLabClient(ctx context.Context, event *info.Event) (*in
 	}
 
 	scm := secrets.SecretFromRepository{
-		K8int:       kubeInterface,
-		Config:      v.GetConfig(),
-		Event:       event,
-		Repo:        repo,
-		WebhookType: v.pacInfo.WebhookType,
-		Logger:      v.Logger,
-		Namespace:   secretNS,
+		K8int:                 kubeInterface,
+		Config:                v.GetConfig(),
+		Event:                 event,
+		Repo:                  repo,
+		WebhookType:           v.pacInfo.WebhookType,
+		Logger:                v.Logger,
+		Namespace:             secretNS,
+		InheritedGlobalSecret: inheritedGlobalSecret,
 	}
 	if err := scm.Get(ctx); err != nil {
 		return event, fmt.Errorf("cannot get secret from repository: %w", err)
 	}
 
-	err = v.SetClient(ctx, v.run, event, repo, v.eventEmitter)
+	err = v.setClient(ctx, v.run, event, repo, v.eventEmitter, false)
 	if err != nil {
 		return event, err
 	}

--- a/pkg/provider/gitlab/parse_payload_test.go
+++ b/pkg/provider/gitlab/parse_payload_test.go
@@ -514,3 +514,76 @@ func TestParsePayload(t *testing.T) {
 		})
 	}
 }
+
+func TestInitGitLabClientSkipsTokenAutoRotation(t *testing.T) {
+	ctx, _ := rtesting.SetupFakeContext(t)
+	log, _ := logger.GetLogger()
+	client, mux, tearDown := thelp.Setup(t)
+	defer tearDown()
+
+	introspectionCalled := false
+	mux.HandleFunc("/personal_access_tokens/self", func(rw http.ResponseWriter, _ *http.Request) {
+		introspectionCalled = true
+		fmt.Fprint(rw, `{"id": 1, "active": true, "expires_at": "2000-01-01"}`)
+	})
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "fakeNs",
+			Name:      "gitlab-webhook-config",
+		},
+		Data: map[string][]byte{
+			"provider.token": []byte("glpat_124ABC"),
+			"webhook.secret": []byte("shhhhhhit'ssecret"),
+		},
+	}
+	repo := &v1alpha1.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "fakeNs",
+			Name:      "repo",
+		},
+		Spec: v1alpha1.RepositorySpec{
+			URL: "https://foo.com",
+			GitProvider: &v1alpha1.GitProvider{
+				URL:           client.BaseURL().String(),
+				Secret:        &v1alpha1.Secret{Name: "gitlab-webhook-config"},
+				WebhookSecret: &v1alpha1.Secret{Name: "gitlab-webhook-config"},
+			},
+		},
+	}
+	run := &params.Run{
+		Info: info.NewInfo(),
+	}
+	run.Info.Kube.Namespace = "fakeNs"
+	stdata, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+		Repositories: []*v1alpha1.Repository{repo},
+		Secret:       []*corev1.Secret{secret},
+	})
+	run.Clients = clients.Clients{
+		Kube:           stdata.Kube,
+		PipelineAsCode: stdata.PipelineAsCode,
+		Log:            log,
+	}
+
+	v := &Provider{
+		run: run,
+		pacInfo: &info.PacOpts{
+			Settings: settings.Settings{
+				ApplicationName: settings.PACApplicationNameDefaultValue,
+			},
+		},
+		eventEmitter: events.NewEventEmitter(run.Clients.Kube, log),
+		Logger:       log,
+	}
+	event := info.NewEvent()
+	event.URL = "https://foo.com"
+	event.Organization = "hello"
+	event.Repository = "project"
+	event.SourceProjectID = 200
+	event.TargetProjectID = 200
+
+	_, err := v.initGitLabClient(ctx, event)
+	assert.NilError(t, err)
+	assert.Assert(t, v.gitlabClient != nil, "gitlab client should be initialized")
+	assert.Assert(t, !introspectionCalled, "token rotation must not run before webhook validation")
+}

--- a/pkg/provider/gitlab/token_rotation.go
+++ b/pkg/provider/gitlab/token_rotation.go
@@ -1,0 +1,239 @@
+package gitlab
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/secrets"
+	gitlab "gitlab.com/gitlab-org/api/client-go"
+	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+)
+
+const (
+	rotationThreshold     = 7 * 24 * time.Hour
+	rotationNewExpiry     = 30 * 24 * time.Hour
+	introspectionCacheTTL = 1 * time.Hour
+)
+
+// introspectionCacheEntry caches the result of a token introspection so the
+// GitLab API is not hit on every webhook event or watcher reconciliation loop.
+type introspectionCacheEntry struct {
+	tokenHash string
+	expiresAt *time.Time
+	checkedAt time.Time
+}
+
+var (
+	errTokenRotatedSecretUpdateFailed = errors.New("token rotated but secret update failed")
+	tokenRotationLocks                sync.Map
+	// tokenIntrospectionCache is keyed by "namespace/name" of the Repository CR.
+	tokenIntrospectionCache sync.Map
+)
+
+func hashToken(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}
+
+// cachedIntrospectionFresh reports whether a cached introspection result for
+// repoKey is still valid for the given token: the entry must be younger than
+// introspectionCacheTTL, match the current token (so a manually updated
+// secret invalidates the cache), and the cached expiry must not be within the
+// rotation threshold.
+func cachedIntrospectionFresh(repoKey, tokenHash string) bool {
+	val, ok := tokenIntrospectionCache.Load(repoKey)
+	if !ok {
+		return false
+	}
+	entry, ok := val.(introspectionCacheEntry)
+	if !ok || entry.tokenHash != tokenHash {
+		return false
+	}
+	if time.Since(entry.checkedAt) > introspectionCacheTTL {
+		return false
+	}
+	// Non-expiring token or expiry still far enough away.
+	return entry.expiresAt == nil || time.Until(*entry.expiresAt) >= rotationThreshold
+}
+
+func cacheIntrospection(repoKey, tokenHash string, pat *gitlab.PersonalAccessToken) {
+	entry := introspectionCacheEntry{tokenHash: tokenHash, checkedAt: time.Now()}
+	if pat.ExpiresAt != nil {
+		expiresAt := time.Time(*pat.ExpiresAt)
+		entry.expiresAt = &expiresAt
+	}
+	tokenIntrospectionCache.Store(repoKey, entry)
+}
+
+func getRepositoryLock(repoKey string) *sync.Mutex {
+	val, _ := tokenRotationLocks.LoadOrStore(repoKey, &sync.Mutex{})
+	mu, ok := val.(*sync.Mutex)
+	if !ok {
+		return &sync.Mutex{}
+	}
+	return mu
+}
+
+func (v *Provider) hasGitProviderSecret() bool {
+	return v.repo != nil && v.repo.Spec.GitProvider != nil &&
+		v.repo.Spec.GitProvider.Secret != nil && v.repo.Spec.GitProvider.Secret.Name != ""
+}
+
+func (v *Provider) isTokenAutoRotationEnabled() bool {
+	if !v.hasGitProviderSecret() {
+		return false
+	}
+	if v.repo.Spec.Settings == nil || v.repo.Spec.Settings.Gitlab == nil {
+		return false
+	}
+	if v.repo.Spec.Settings.Gitlab.TokenAutoRotation == nil {
+		return false
+	}
+	return *v.repo.Spec.Settings.Gitlab.TokenAutoRotation
+}
+
+func (v *Provider) introspectToken() (*gitlab.PersonalAccessToken, error) {
+	pat, resp, err := v.Client().PersonalAccessTokens.GetSinglePersonalAccessToken()
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusUnauthorized {
+			return nil, fmt.Errorf("token is invalid or expired")
+		}
+		return nil, fmt.Errorf("introspect token: %w", err)
+	}
+	return pat, nil
+}
+
+func needsRotation(pat *gitlab.PersonalAccessToken) bool {
+	if pat.ExpiresAt == nil {
+		return false
+	}
+	if !pat.Active {
+		return false
+	}
+	expiresAt := time.Time(*pat.ExpiresAt)
+	return time.Until(expiresAt) < rotationThreshold
+}
+
+var errMissingSelfRotateScope = fmt.Errorf("token lacks 'api' or 'self_rotate' scope required for auto-rotation — disable with spec.settings.gitlab.token_auto_rotation: false")
+
+func (v *Provider) rotateToken() (*gitlab.PersonalAccessToken, error) {
+	newExpiry := gitlab.ISOTime(time.Now().Add(rotationNewExpiry))
+	opts := &gitlab.RotatePersonalAccessTokenOptions{
+		ExpiresAt: &newExpiry,
+	}
+
+	pat, resp, err := v.Client().PersonalAccessTokens.RotatePersonalAccessTokenSelf(opts)
+	if err == nil {
+		return pat, nil
+	}
+
+	if resp != nil && resp.StatusCode == http.StatusForbidden {
+		return nil, errMissingSelfRotateScope
+	}
+
+	// If PAT self-rotate fails with other 4xx, try project access token self-rotate.
+	if resp != nil && resp.StatusCode >= 400 && resp.StatusCode < 500 && v.targetProjectID != 0 {
+		v.Logger.Debugf("PAT self-rotate returned %d, trying project access token rotation for project %d", resp.StatusCode, v.targetProjectID)
+		projectOpts := &gitlab.RotateProjectAccessTokenOptions{
+			ExpiresAt: &newExpiry,
+		}
+		projectPat, projectResp, projectErr := v.Client().ProjectAccessTokens.RotateProjectAccessTokenSelf(v.targetProjectID, projectOpts)
+		if projectErr == nil {
+			return &projectPat.PersonalAccessToken, nil
+		}
+		if projectResp != nil && projectResp.StatusCode == http.StatusForbidden {
+			return nil, errMissingSelfRotateScope
+		}
+		return nil, fmt.Errorf("PAT rotation failed (%w), project token rotation also failed: %w", err, projectErr)
+	}
+
+	return nil, fmt.Errorf("rotate token: %w", err)
+}
+
+func (v *Provider) updateKubeSecret(ctx context.Context, newToken string) error {
+	if !v.hasGitProviderSecret() {
+		return fmt.Errorf("repository CR has no git_provider.secret configured")
+	}
+
+	secretName := v.repo.Spec.GitProvider.Secret.Name
+	secretKey := v.repo.Spec.GitProvider.Secret.Key
+	if secretKey == "" {
+		secretKey = secrets.DefaultGitProviderSecretKey
+	}
+	secretNS := v.repo.GetNamespace()
+
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		secret, err := v.run.Clients.Kube.CoreV1().Secrets(secretNS).Get(ctx, secretName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if secret.Data == nil {
+			secret.Data = make(map[string][]byte)
+		}
+		secret.Data[secretKey] = []byte(newToken)
+		_, err = v.run.Clients.Kube.CoreV1().Secrets(secretNS).Update(ctx, secret, metav1.UpdateOptions{})
+		return err
+	})
+}
+
+func (v *Provider) maybeRotateToken(ctx context.Context) (string, error) {
+	if !v.hasGitProviderSecret() {
+		return "", fmt.Errorf("repository CR has no git_provider.secret configured")
+	}
+
+	repoKey := fmt.Sprintf("%s/%s", v.repo.Namespace, v.repo.Name)
+	mu := getRepositoryLock(repoKey)
+	mu.Lock()
+	defer mu.Unlock()
+
+	tokenHash := ""
+	if v.Token != nil {
+		tokenHash = hashToken(*v.Token)
+	}
+
+	if cachedIntrospectionFresh(repoKey, tokenHash) {
+		return "", nil
+	}
+
+	pat, err := v.introspectToken()
+	if err != nil {
+		return "", fmt.Errorf("introspect: %w", err)
+	}
+
+	if !needsRotation(pat) {
+		cacheIntrospection(repoKey, tokenHash, pat)
+		return "", nil
+	}
+
+	expiresAt := time.Time(*pat.ExpiresAt)
+	v.Logger.Infof("gitlab token expires at %s (within %v threshold), rotating", expiresAt.Format(time.RFC3339), rotationThreshold)
+
+	newPat, err := v.rotateToken()
+	if err != nil {
+		return "", fmt.Errorf("rotate: %w", err)
+	}
+
+	if err := v.updateKubeSecret(ctx, newPat.Token); err != nil {
+		v.Logger.Errorf("CRITICAL: gitlab token was rotated but failed to update kubernetes secret: %v — old token is revoked, manual intervention required", err)
+		return "", fmt.Errorf("%w (old token revoked): %w", errTokenRotatedSecretUpdateFailed, err)
+	}
+
+	newExpiryStr := "unknown"
+	if newPat.ExpiresAt != nil {
+		newExpiryStr = time.Time(*newPat.ExpiresAt).Format(time.RFC3339)
+	}
+	v.eventEmitter.EmitMessage(v.repo, zap.InfoLevel, "GitLabTokenRotated",
+		fmt.Sprintf("GitLab access token rotated, new expiry: %s", newExpiryStr))
+
+	cacheIntrospection(repoKey, hashToken(newPat.Token), newPat)
+
+	return newPat.Token, nil
+}

--- a/pkg/provider/gitlab/token_rotation_test.go
+++ b/pkg/provider/gitlab/token_rotation_test.go
@@ -1,0 +1,823 @@
+package gitlab
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/events"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
+	thelp "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/gitlab/test"
+	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
+	testlogger "github.com/openshift-pipelines/pipelines-as-code/pkg/test/logger"
+	gitlab "gitlab.com/gitlab-org/api/client-go"
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	rtesting "knative.dev/pkg/reconciler/testing"
+)
+
+func boolPtr(b bool) *bool {
+	return &b
+}
+
+func TestIsTokenAutoRotationEnabled(t *testing.T) {
+	repoWithSecret := func(settings *v1alpha1.Settings) *v1alpha1.Repository {
+		return &v1alpha1.Repository{
+			Spec: v1alpha1.RepositorySpec{
+				GitProvider: &v1alpha1.GitProvider{
+					Secret: &v1alpha1.Secret{Name: "gitlab-token"},
+				},
+				Settings: settings,
+			},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		repo     *v1alpha1.Repository
+		expected bool
+	}{
+		{
+			name:     "nil repo",
+			repo:     nil,
+			expected: false,
+		},
+		{
+			name: "nil git provider",
+			repo: &v1alpha1.Repository{
+				Spec: v1alpha1.RepositorySpec{},
+			},
+			expected: false,
+		},
+		{
+			name: "nil git provider secret",
+			repo: &v1alpha1.Repository{
+				Spec: v1alpha1.RepositorySpec{
+					GitProvider: &v1alpha1.GitProvider{},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "empty git provider secret name",
+			repo: &v1alpha1.Repository{
+				Spec: v1alpha1.RepositorySpec{
+					GitProvider: &v1alpha1.GitProvider{
+						Secret: &v1alpha1.Secret{},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name:     "nil settings",
+			repo:     repoWithSecret(nil),
+			expected: false,
+		},
+		{
+			name:     "nil gitlab settings",
+			repo:     repoWithSecret(&v1alpha1.Settings{}),
+			expected: false,
+		},
+		{
+			name: "nil token auto rotation",
+			repo: repoWithSecret(&v1alpha1.Settings{
+				Gitlab: &v1alpha1.GitlabSettings{},
+			}),
+			expected: false,
+		},
+		{
+			name: "explicitly true",
+			repo: repoWithSecret(&v1alpha1.Settings{
+				Gitlab: &v1alpha1.GitlabSettings{
+					TokenAutoRotation: boolPtr(true),
+				},
+			}),
+			expected: true,
+		},
+		{
+			name: "explicitly false",
+			repo: repoWithSecret(&v1alpha1.Settings{
+				Gitlab: &v1alpha1.GitlabSettings{
+					TokenAutoRotation: boolPtr(false),
+				},
+			}),
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &Provider{repo: tt.repo}
+			assert.Equal(t, tt.expected, v.isTokenAutoRotationEnabled())
+		})
+	}
+}
+
+func TestGetRepositoryLock(t *testing.T) {
+	first := getRepositoryLock(t.Name() + "/repo")
+	second := getRepositoryLock(t.Name() + "/repo")
+	other := getRepositoryLock(t.Name() + "/other-repo")
+
+	assert.Assert(t, first == second, "same repository should use the same token rotation lock")
+	assert.Assert(t, first != other, "different repositories should not share the same token rotation lock")
+}
+
+func TestNeedsRotation(t *testing.T) {
+	expiringIn3Days := gitlab.ISOTime(time.Now().Add(3 * 24 * time.Hour))
+	expiringIn30Days := gitlab.ISOTime(time.Now().Add(30 * 24 * time.Hour))
+	expiredYesterday := gitlab.ISOTime(time.Now().Add(-24 * time.Hour))
+
+	tests := []struct {
+		name     string
+		pat      *gitlab.PersonalAccessToken
+		expected bool
+	}{
+		{
+			name:     "no expiry",
+			pat:      &gitlab.PersonalAccessToken{Active: true, ExpiresAt: nil},
+			expected: false,
+		},
+		{
+			name:     "not active",
+			pat:      &gitlab.PersonalAccessToken{Active: false, ExpiresAt: &expiredYesterday},
+			expected: false,
+		},
+		{
+			name:     "expires within threshold",
+			pat:      &gitlab.PersonalAccessToken{Active: true, ExpiresAt: &expiringIn3Days},
+			expected: true,
+		},
+		{
+			name:     "expires after threshold",
+			pat:      &gitlab.PersonalAccessToken{Active: true, ExpiresAt: &expiringIn30Days},
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, needsRotation(tt.pat))
+		})
+	}
+}
+
+func TestMaybeRotateToken(t *testing.T) {
+	expiringIn3Days := time.Now().Add(3 * 24 * time.Hour).Format("2006-01-02")
+	expiringIn30Days := time.Now().Add(30 * 24 * time.Hour).Format("2006-01-02")
+	newExpiry := time.Now().Add(rotationNewExpiry).Format("2006-01-02")
+
+	tests := []struct {
+		name             string
+		setup            func(t *testing.T, mux *http.ServeMux)
+		wantNewToken     bool
+		wantErr          bool
+		wantSecretUpdate bool
+		wantErrContains  string
+		nilSecretData    bool
+	}{
+		{
+			name: "token not expiring soon",
+			setup: func(_ *testing.T, mux *http.ServeMux) {
+				mux.HandleFunc("/personal_access_tokens/self", func(rw http.ResponseWriter, _ *http.Request) {
+					fmt.Fprintf(rw, `{"id": 1, "active": true, "expires_at": %q}`, expiringIn30Days)
+				})
+			},
+			wantNewToken: false,
+		},
+		{
+			name: "token no expiry",
+			setup: func(_ *testing.T, mux *http.ServeMux) {
+				mux.HandleFunc("/personal_access_tokens/self", func(rw http.ResponseWriter, _ *http.Request) {
+					fmt.Fprint(rw, `{"id": 1, "active": true, "expires_at": null}`)
+				})
+			},
+			wantNewToken: false,
+		},
+		{
+			name: "token expiring soon and rotated",
+			setup: func(_ *testing.T, mux *http.ServeMux) {
+				mux.HandleFunc("/personal_access_tokens/self", func(rw http.ResponseWriter, r *http.Request) {
+					if r.Method == http.MethodGet {
+						fmt.Fprintf(rw, `{"id": 1, "active": true, "expires_at": %q}`, expiringIn3Days)
+						return
+					}
+					fmt.Fprintf(rw, `{"id": 2, "active": true, "token": "new-rotated-token", "expires_at": %q}`, newExpiry)
+				})
+				mux.HandleFunc("/personal_access_tokens/self/rotate", func(rw http.ResponseWriter, _ *http.Request) {
+					fmt.Fprintf(rw, `{"id": 2, "active": true, "token": "new-rotated-token", "expires_at": %q}`, newExpiry)
+				})
+			},
+			wantNewToken:     true,
+			wantSecretUpdate: true,
+		},
+		{
+			name: "token expiring soon and rotated with nil secret data",
+			setup: func(_ *testing.T, mux *http.ServeMux) {
+				mux.HandleFunc("/personal_access_tokens/self", func(rw http.ResponseWriter, r *http.Request) {
+					if r.Method == http.MethodGet {
+						fmt.Fprintf(rw, `{"id": 1, "active": true, "expires_at": %q}`, expiringIn3Days)
+						return
+					}
+					fmt.Fprintf(rw, `{"id": 2, "active": true, "token": "new-rotated-token", "expires_at": %q}`, newExpiry)
+				})
+				mux.HandleFunc("/personal_access_tokens/self/rotate", func(rw http.ResponseWriter, _ *http.Request) {
+					fmt.Fprintf(rw, `{"id": 2, "active": true, "token": "new-rotated-token", "expires_at": %q}`, newExpiry)
+				})
+			},
+			wantNewToken:     true,
+			wantSecretUpdate: true,
+			nilSecretData:    true,
+		},
+		{
+			name: "token expiring soon and rotated without expiry",
+			setup: func(_ *testing.T, mux *http.ServeMux) {
+				mux.HandleFunc("/personal_access_tokens/self", func(rw http.ResponseWriter, r *http.Request) {
+					if r.Method == http.MethodGet {
+						fmt.Fprintf(rw, `{"id": 1, "active": true, "expires_at": %q}`, expiringIn3Days)
+						return
+					}
+					fmt.Fprint(rw, `{"id": 2, "active": true, "token": "new-rotated-token", "expires_at": null}`)
+				})
+				mux.HandleFunc("/personal_access_tokens/self/rotate", func(rw http.ResponseWriter, _ *http.Request) {
+					fmt.Fprint(rw, `{"id": 2, "active": true, "token": "new-rotated-token", "expires_at": null}`)
+				})
+			},
+			wantNewToken:     true,
+			wantSecretUpdate: true,
+		},
+		{
+			name: "introspection fails",
+			setup: func(_ *testing.T, mux *http.ServeMux) {
+				mux.HandleFunc("/personal_access_tokens/self", func(rw http.ResponseWriter, _ *http.Request) {
+					rw.WriteHeader(http.StatusInternalServerError)
+				})
+			},
+			wantErr: true,
+		},
+		{
+			name: "token expired and unauthorized",
+			setup: func(_ *testing.T, mux *http.ServeMux) {
+				mux.HandleFunc("/personal_access_tokens/self", func(rw http.ResponseWriter, _ *http.Request) {
+					rw.WriteHeader(http.StatusUnauthorized)
+				})
+			},
+			wantErr: true,
+		},
+		{
+			name: "rotation returns 403 missing scope",
+			setup: func(_ *testing.T, mux *http.ServeMux) {
+				mux.HandleFunc("/personal_access_tokens/self", func(rw http.ResponseWriter, r *http.Request) {
+					if r.Method == http.MethodGet {
+						fmt.Fprintf(rw, `{"id": 1, "active": true, "expires_at": %q}`, expiringIn3Days)
+						return
+					}
+					rw.WriteHeader(http.StatusForbidden)
+					fmt.Fprint(rw, `{"message": "403 Forbidden"}`)
+				})
+				mux.HandleFunc("/personal_access_tokens/self/rotate", func(rw http.ResponseWriter, _ *http.Request) {
+					rw.WriteHeader(http.StatusForbidden)
+					fmt.Fprint(rw, `{"message": "403 Forbidden"}`)
+				})
+			},
+			wantErr:         true,
+			wantErrContains: "self_rotate",
+		},
+		{
+			name: "PAT rotation fails with 405, fallback to project token",
+			setup: func(_ *testing.T, mux *http.ServeMux) {
+				mux.HandleFunc("/personal_access_tokens/self", func(rw http.ResponseWriter, r *http.Request) {
+					if r.Method == http.MethodGet {
+						fmt.Fprintf(rw, `{"id": 1, "active": true, "expires_at": %q}`, expiringIn3Days)
+						return
+					}
+					rw.WriteHeader(http.StatusMethodNotAllowed)
+				})
+				mux.HandleFunc("/personal_access_tokens/self/rotate", func(rw http.ResponseWriter, _ *http.Request) {
+					rw.WriteHeader(http.StatusMethodNotAllowed)
+				})
+				mux.HandleFunc("/projects/123/access_tokens/self/rotate", func(rw http.ResponseWriter, _ *http.Request) {
+					fmt.Fprintf(rw, `{"id": 3, "active": true, "token": "new-project-token", "expires_at": %q}`, newExpiry)
+				})
+			},
+			wantNewToken:     true,
+			wantSecretUpdate: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tokenIntrospectionCache.Clear()
+			ctx, _ := rtesting.SetupFakeContext(t)
+			logger, _ := testlogger.GetLogger()
+			client, mux, tearDown := thelp.Setup(t)
+			defer tearDown()
+
+			secretData := map[string][]byte{
+				"provider.token": []byte("old-token"),
+			}
+			if tt.nilSecretData {
+				secretData = nil
+			}
+
+			stdata, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+				Secret: []*corev1.Secret{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "gitlab-token",
+							Namespace: "default",
+						},
+						Data: secretData,
+					},
+				},
+			})
+
+			run := &params.Run{
+				Clients: clients.Clients{
+					Kube: stdata.Kube,
+					Log:  logger,
+				},
+			}
+
+			v := &Provider{
+				Logger:          logger,
+				run:             run,
+				sourceProjectID: 123,
+				targetProjectID: 123,
+				eventEmitter:    events.NewEventEmitter(stdata.Kube, logger),
+				repo: &v1alpha1.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-repo",
+						Namespace: "default",
+					},
+					Spec: v1alpha1.RepositorySpec{
+						GitProvider: &v1alpha1.GitProvider{
+							Secret: &v1alpha1.Secret{
+								Name: "gitlab-token",
+							},
+						},
+					},
+				},
+			}
+			v.SetGitLabClient(client)
+			tt.setup(t, mux)
+
+			newToken, err := v.maybeRotateToken(ctx)
+			if tt.wantErr {
+				assert.Assert(t, err != nil, "expected error but got nil")
+				if tt.wantErrContains != "" {
+					assert.ErrorContains(t, err, tt.wantErrContains)
+				}
+				return
+			}
+			assert.NilError(t, err)
+
+			if tt.wantNewToken {
+				assert.Assert(t, newToken != "", "expected new token but got empty")
+			} else {
+				assert.Equal(t, "", newToken)
+			}
+
+			if tt.wantSecretUpdate {
+				secret, err := stdata.Kube.CoreV1().Secrets("default").Get(ctx, "gitlab-token", metav1.GetOptions{})
+				assert.NilError(t, err)
+				actualToken := string(secret.Data["provider.token"])
+				assert.Assert(t, actualToken != "old-token", "secret should have been updated")
+				assert.Equal(t, newToken, actualToken)
+			}
+		})
+	}
+}
+
+func TestMaybeRotateTokenSecretUpdateFails(t *testing.T) {
+	tokenIntrospectionCache.Clear()
+	expiringIn3Days := time.Now().Add(3 * 24 * time.Hour).Format("2006-01-02")
+	newExpiry := time.Now().Add(rotationNewExpiry).Format("2006-01-02")
+
+	ctx, _ := rtesting.SetupFakeContext(t)
+	logger, observer := testlogger.GetLogger()
+	client, mux, tearDown := thelp.Setup(t)
+	defer tearDown()
+
+	// No secret seeded — the update will fail because the secret doesn't exist
+	stdata, _ := testclient.SeedTestData(t, ctx, testclient.Data{})
+
+	run := &params.Run{
+		Clients: clients.Clients{
+			Kube: stdata.Kube,
+			Log:  logger,
+		},
+	}
+
+	v := &Provider{
+		Logger:          logger,
+		run:             run,
+		sourceProjectID: 123,
+		eventEmitter:    events.NewEventEmitter(stdata.Kube, logger),
+		repo: &v1alpha1.Repository{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-repo",
+				Namespace: "default",
+			},
+			Spec: v1alpha1.RepositorySpec{
+				GitProvider: &v1alpha1.GitProvider{
+					Secret: &v1alpha1.Secret{
+						Name: "gitlab-token",
+					},
+				},
+			},
+		},
+	}
+	v.SetGitLabClient(client)
+
+	mux.HandleFunc("/personal_access_tokens/self", func(rw http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			fmt.Fprintf(rw, `{"id": 1, "active": true, "expires_at": %q}`, expiringIn3Days)
+			return
+		}
+		fmt.Fprintf(rw, `{"id": 2, "active": true, "token": "new-token", "expires_at": %q}`, newExpiry)
+	})
+	mux.HandleFunc("/personal_access_tokens/self/rotate", func(rw http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(rw, `{"id": 2, "active": true, "token": "new-token", "expires_at": %q}`, newExpiry)
+	})
+
+	_, err := v.maybeRotateToken(ctx)
+	assert.Assert(t, err != nil, "expected error for failed secret update")
+	assert.ErrorContains(t, err, "secret update failed")
+
+	criticalLogs := observer.FilterMessageSnippet("CRITICAL")
+	assert.Assert(t, criticalLogs.Len() > 0, "should have logged CRITICAL message")
+}
+
+func TestSetClientReturnsErrorWhenRotatedTokenCannotBeStored(t *testing.T) {
+	expiringIn3Days := time.Now().Add(3 * 24 * time.Hour).Format("2006-01-02")
+	newExpiry := time.Now().Add(rotationNewExpiry).Format("2006-01-02")
+
+	ctx, _ := rtesting.SetupFakeContext(t)
+	logger, _ := testlogger.GetLogger()
+	client, mux, tearDown := thelp.Setup(t)
+	defer tearDown()
+
+	stdata, _ := testclient.SeedTestData(t, ctx, testclient.Data{})
+	run := &params.Run{
+		Clients: clients.Clients{
+			Kube: stdata.Kube,
+			Log:  logger,
+		},
+	}
+
+	mux.HandleFunc("/personal_access_tokens/self", func(rw http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			fmt.Fprintf(rw, `{"id": 1, "active": true, "expires_at": %q}`, expiringIn3Days)
+			return
+		}
+		fmt.Fprintf(rw, `{"id": 2, "active": true, "token": "new-token", "expires_at": %q}`, newExpiry)
+	})
+	mux.HandleFunc("/personal_access_tokens/self/rotate", func(rw http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(rw, `{"id": 2, "active": true, "token": "new-token", "expires_at": %q}`, newExpiry)
+	})
+
+	v := &Provider{Logger: logger}
+	v.SetGitLabClient(client)
+	event := &info.Event{
+		Provider: &info.Provider{
+			Token: "old-token",
+		},
+		TriggerTarget: triggertype.Push,
+	}
+	repo := &v1alpha1.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-repo",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.RepositorySpec{
+			GitProvider: &v1alpha1.GitProvider{
+				Secret: &v1alpha1.Secret{
+					Name: "gitlab-token",
+				},
+			},
+			Settings: &v1alpha1.Settings{
+				Gitlab: &v1alpha1.GitlabSettings{
+					TokenAutoRotation: boolPtr(true),
+				},
+			},
+		},
+	}
+
+	err := v.SetClient(ctx, run, event, repo, events.NewEventEmitter(stdata.Kube, logger))
+	assert.ErrorContains(t, err, "gitlab token auto-rotation failed")
+	assert.ErrorContains(t, err, "secret update failed")
+	assert.Equal(t, "old-token", event.Provider.Token)
+}
+
+func TestIntrospectToken(t *testing.T) {
+	tests := []struct {
+		name        string
+		statusCode  int
+		body        string
+		wantErr     bool
+		wantActive  bool
+		wantTokenID int64
+	}{
+		{
+			name:        "valid active token",
+			statusCode:  http.StatusOK,
+			body:        `{"id": 42, "active": true, "scopes": ["api"], "expires_at": "2025-12-31"}`,
+			wantActive:  true,
+			wantTokenID: 42,
+		},
+		{
+			name:       "unauthorized",
+			statusCode: http.StatusUnauthorized,
+			wantErr:    true,
+		},
+		{
+			name:       "server error",
+			statusCode: http.StatusInternalServerError,
+			wantErr:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, _ := testlogger.GetLogger()
+			client, mux, tearDown := thelp.Setup(t)
+			defer tearDown()
+
+			v := &Provider{Logger: logger}
+			v.SetGitLabClient(client)
+
+			mux.HandleFunc("/personal_access_tokens/self", func(rw http.ResponseWriter, _ *http.Request) {
+				if tt.statusCode != http.StatusOK {
+					rw.WriteHeader(tt.statusCode)
+					return
+				}
+				fmt.Fprint(rw, tt.body)
+			})
+
+			pat, err := v.introspectToken()
+			if tt.wantErr {
+				assert.Assert(t, err != nil)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, tt.wantActive, pat.Active)
+			assert.Equal(t, tt.wantTokenID, pat.ID)
+		})
+	}
+}
+
+func TestRotateTokenFallbackToProjectToken(t *testing.T) {
+	newExpiry := time.Now().Add(rotationNewExpiry).Format("2006-01-02")
+
+	logger, _ := testlogger.GetLogger()
+	client, mux, tearDown := thelp.Setup(t)
+	defer tearDown()
+
+	v := &Provider{
+		Logger:          logger,
+		sourceProjectID: 123,
+		targetProjectID: 456,
+	}
+	v.SetGitLabClient(client)
+
+	// PAT rotation returns 405 (not a personal access token)
+	mux.HandleFunc("/personal_access_tokens/self/rotate", func(rw http.ResponseWriter, _ *http.Request) {
+		rw.WriteHeader(http.StatusMethodNotAllowed)
+		fmt.Fprint(rw, `{"message": "405 Method Not Allowed"}`)
+	})
+
+	sourceProjectFallbackCalled := false
+	mux.HandleFunc("/projects/123/access_tokens/self/rotate", func(rw http.ResponseWriter, _ *http.Request) {
+		sourceProjectFallbackCalled = true
+		rw.WriteHeader(http.StatusInternalServerError)
+	})
+
+	// Project token rotation succeeds
+	mux.HandleFunc("/projects/456/access_tokens/self/rotate", func(rw http.ResponseWriter, _ *http.Request) {
+		resp := map[string]any{
+			"id":         3,
+			"active":     true,
+			"token":      "project-token-rotated",
+			"expires_at": newExpiry,
+		}
+		b, _ := json.Marshal(resp)
+		_, _ = rw.Write(b)
+	})
+
+	pat, err := v.rotateToken()
+	assert.NilError(t, err)
+	assert.Equal(t, "project-token-rotated", pat.Token)
+	assert.Assert(t, !sourceProjectFallbackCalled, "source project should not be used for project token rotation")
+}
+
+func TestRotateTokenSkipsProjectFallbackWithoutTargetProjectID(t *testing.T) {
+	logger, _ := testlogger.GetLogger()
+	client, mux, tearDown := thelp.Setup(t)
+	defer tearDown()
+
+	v := &Provider{
+		Logger:          logger,
+		sourceProjectID: 456,
+	}
+	v.SetGitLabClient(client)
+
+	mux.HandleFunc("/personal_access_tokens/self/rotate", func(rw http.ResponseWriter, _ *http.Request) {
+		rw.WriteHeader(http.StatusMethodNotAllowed)
+		fmt.Fprint(rw, `{"message": "405 Method Not Allowed"}`)
+	})
+
+	projectFallbackCalled := false
+	mux.HandleFunc("/projects/456/access_tokens/self/rotate", func(rw http.ResponseWriter, _ *http.Request) {
+		projectFallbackCalled = true
+		rw.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := v.rotateToken()
+	assert.Assert(t, err != nil, "expected rotation error")
+	assert.ErrorContains(t, err, "rotate token")
+	assert.Assert(t, !projectFallbackCalled, "project token fallback should not run without target project id")
+}
+
+func TestSetClientSkipsTokenAutoRotationForGlobalRepositorySecret(t *testing.T) {
+	ctx, _ := rtesting.SetupFakeContext(t)
+	logger, _ := testlogger.GetLogger()
+	client, mux, tearDown := thelp.Setup(t)
+	defer tearDown()
+
+	stdata, _ := testclient.SeedTestData(t, ctx, testclient.Data{})
+	run := &params.Run{
+		Clients: clients.Clients{
+			Kube: stdata.Kube,
+			Log:  logger,
+		},
+	}
+
+	introspectionCalled := false
+	mux.HandleFunc("/personal_access_tokens/self", func(rw http.ResponseWriter, _ *http.Request) {
+		introspectionCalled = true
+		fmt.Fprint(rw, `{"id": 1, "active": true, "expires_at": "2000-01-01"}`)
+	})
+
+	v := &Provider{Logger: logger}
+	v.SetGitLabClient(client)
+
+	event := &info.Event{
+		Provider: &info.Provider{
+			Token:                           "global-token",
+			GitProviderSecretNamespace:      "global-ns",
+			GitProviderSecretFromGlobalRepo: true,
+		},
+		TriggerTarget:   triggertype.Push,
+		SourceProjectID: 123,
+		TargetProjectID: 123,
+	}
+	repo := &v1alpha1.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-repo",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.RepositorySpec{
+			GitProvider: &v1alpha1.GitProvider{
+				Secret: &v1alpha1.Secret{
+					Name: "global-token-secret",
+				},
+			},
+		},
+	}
+
+	err := v.SetClient(ctx, run, event, repo, events.NewEventEmitter(stdata.Kube, logger))
+	assert.NilError(t, err)
+	assert.Assert(t, !introspectionCalled, "global Repository secret should not be introspected for auto-rotation")
+	assert.Equal(t, "global-token", event.Provider.Token)
+}
+
+func TestSetClientSkipsTokenAutoRotationWithoutRepositorySecret(t *testing.T) {
+	ctx, _ := rtesting.SetupFakeContext(t)
+	logger, _ := testlogger.GetLogger()
+	client, mux, tearDown := thelp.Setup(t)
+	defer tearDown()
+
+	stdata, _ := testclient.SeedTestData(t, ctx, testclient.Data{})
+	run := &params.Run{
+		Clients: clients.Clients{
+			Kube: stdata.Kube,
+			Log:  logger,
+		},
+	}
+
+	introspectionCalled := false
+	mux.HandleFunc("/personal_access_tokens/self", func(rw http.ResponseWriter, _ *http.Request) {
+		introspectionCalled = true
+		fmt.Fprint(rw, `{"id": 1, "active": true, "expires_at": "2000-01-01"}`)
+	})
+
+	v := &Provider{Logger: logger}
+	v.SetGitLabClient(client)
+
+	event := &info.Event{
+		Provider: &info.Provider{
+			Token: "gitlab-token",
+		},
+		TriggerTarget: triggertype.Push,
+	}
+	repo := &v1alpha1.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-repo",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.RepositorySpec{},
+	}
+
+	err := v.SetClient(ctx, run, event, repo, events.NewEventEmitter(stdata.Kube, logger))
+	assert.NilError(t, err)
+	assert.Assert(t, !introspectionCalled, "token auto-rotation should not run without a Repository git_provider.secret")
+	assert.Equal(t, "gitlab-token", event.Provider.Token)
+}
+
+func TestSetClientProjectTokenFallbackUsesTargetProjectID(t *testing.T) {
+	expiringIn3Days := time.Now().Add(3 * 24 * time.Hour).Format("2006-01-02")
+	newExpiry := time.Now().Add(rotationNewExpiry).Format("2006-01-02")
+
+	ctx, _ := rtesting.SetupFakeContext(t)
+	logger, _ := testlogger.GetLogger()
+	client, mux, tearDown := thelp.Setup(t)
+	defer tearDown()
+
+	stdata, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+		Secret: []*corev1.Secret{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gitlab-token",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"provider.token": []byte("old-token"),
+				},
+			},
+		},
+	})
+	run := &params.Run{
+		Clients: clients.Clients{
+			Kube: stdata.Kube,
+			Log:  logger,
+		},
+	}
+
+	mux.HandleFunc("/personal_access_tokens/self", func(rw http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(rw, `{"id": 1, "active": true, "expires_at": %q}`, expiringIn3Days)
+	})
+	mux.HandleFunc("/personal_access_tokens/self/rotate", func(rw http.ResponseWriter, _ *http.Request) {
+		rw.WriteHeader(http.StatusMethodNotAllowed)
+	})
+
+	sourceProjectFallbackCalled := false
+	mux.HandleFunc("/projects/111/access_tokens/self/rotate", func(rw http.ResponseWriter, _ *http.Request) {
+		sourceProjectFallbackCalled = true
+		rw.WriteHeader(http.StatusInternalServerError)
+	})
+	mux.HandleFunc("/projects/222/access_tokens/self/rotate", func(rw http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(rw, `{"id": 3, "active": true, "token": "target-project-token", "expires_at": %q}`, newExpiry)
+	})
+
+	v := &Provider{Logger: logger}
+	v.SetGitLabClient(client)
+	event := &info.Event{
+		Provider: &info.Provider{
+			Token: "old-token",
+		},
+		TriggerTarget:   triggertype.Push,
+		SourceProjectID: 111,
+		TargetProjectID: 222,
+	}
+	repo := &v1alpha1.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-repo",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.RepositorySpec{
+			GitProvider: &v1alpha1.GitProvider{
+				Secret: &v1alpha1.Secret{
+					Name: "gitlab-token",
+				},
+			},
+			Settings: &v1alpha1.Settings{
+				Gitlab: &v1alpha1.GitlabSettings{
+					TokenAutoRotation: boolPtr(true),
+				},
+			},
+		},
+	}
+
+	err := v.SetClient(ctx, run, event, repo, events.NewEventEmitter(stdata.Kube, logger))
+	assert.NilError(t, err)
+	assert.Assert(t, !sourceProjectFallbackCalled, "source project should not be used for project token rotation")
+	assert.Equal(t, "target-project-token", event.Provider.Token)
+
+	secret, err := stdata.Kube.CoreV1().Secrets("default").Get(ctx, "gitlab-token", metav1.GetOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, "target-project-token", string(secret.Data["provider.token"]))
+}

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -311,9 +311,11 @@ func (r *Reconciler) reportFinalStatus(ctx context.Context, logger *zap.SugaredL
 	}
 
 	secretNS := repo.GetNamespace()
+	inheritedGlobalSecret := false
 	if globalRepo, err := r.repoLister.Repositories(r.run.Info.Kube.Namespace).Get(r.run.Info.Controller.GlobalRepository); err == nil && globalRepo != nil {
 		if repo.Spec.GitProvider != nil && repo.Spec.GitProvider.Secret == nil && globalRepo.Spec.GitProvider != nil && globalRepo.Spec.GitProvider.Secret != nil {
 			secretNS = globalRepo.GetNamespace()
+			inheritedGlobalSecret = true
 		}
 		repo = copyRepositoryForMerge(repo)
 		repo.Spec.Merge(globalRepo.Spec)
@@ -331,13 +333,14 @@ func (r *Reconciler) reportFinalStatus(ctx context.Context, logger *zap.SugaredL
 		event.Provider.WebhookSecret, _ = secrets.GetCurrentNSWebhookSecret(ctx, r.kinteract, r.run)
 	} else {
 		secretFromRepo := secrets.SecretFromRepository{
-			K8int:       r.kinteract,
-			Config:      provider.GetConfig(),
-			Event:       event,
-			Repo:        repo,
-			WebhookType: pacInfo.WebhookType,
-			Logger:      logger,
-			Namespace:   secretNS,
+			K8int:                 r.kinteract,
+			Config:                provider.GetConfig(),
+			Event:                 event,
+			Repo:                  repo,
+			WebhookType:           pacInfo.WebhookType,
+			Logger:                logger,
+			Namespace:             secretNS,
+			InheritedGlobalSecret: inheritedGlobalSecret,
 		}
 		if err := secretFromRepo.Get(ctx); err != nil {
 			return repo, fmt.Errorf("cannot get secret from repository: %w", err)
@@ -470,22 +473,25 @@ func (r *Reconciler) initGitProviderClient(ctx context.Context, logger *zap.Suga
 	} else {
 		// secretNS is needed when git provider is other than Github App.
 		secretNS := repo.GetNamespace()
+		inheritedGlobalSecret := false
 		if globalRepo, err := r.repoLister.Repositories(r.run.Info.Kube.Namespace).Get(r.run.Info.Controller.GlobalRepository); err == nil && globalRepo != nil {
 			if repo.Spec.GitProvider != nil && repo.Spec.GitProvider.Secret == nil && globalRepo.Spec.GitProvider != nil && globalRepo.Spec.GitProvider.Secret != nil {
 				secretNS = globalRepo.GetNamespace()
+				inheritedGlobalSecret = true
 			}
 			repo = copyRepositoryForMerge(repo)
 			repo.Spec.Merge(globalRepo.Spec)
 		}
 
 		secretFromRepo := secrets.SecretFromRepository{
-			K8int:       r.kinteract,
-			Config:      detectedProvider.GetConfig(),
-			Event:       event,
-			Repo:        repo,
-			WebhookType: pacInfo.WebhookType,
-			Logger:      logger,
-			Namespace:   secretNS,
+			K8int:                 r.kinteract,
+			Config:                detectedProvider.GetConfig(),
+			Event:                 event,
+			Repo:                  repo,
+			WebhookType:           pacInfo.WebhookType,
+			Logger:                logger,
+			Namespace:             secretNS,
+			InheritedGlobalSecret: inheritedGlobalSecret,
 		}
 		if err := secretFromRepo.Get(ctx); err != nil {
 			return nil, nil, fmt.Errorf("cannot get secret from repository: %w", err)

--- a/pkg/secrets/secret.go
+++ b/pkg/secrets/secret.go
@@ -20,13 +20,14 @@ const (
 )
 
 type SecretFromRepository struct {
-	K8int       kubeinteraction.Interface
-	Config      *info.ProviderConfig
-	Event       *info.Event
-	Repo        *apipac.Repository
-	WebhookType string
-	Namespace   string
-	Logger      *zap.SugaredLogger
+	K8int                 kubeinteraction.Interface
+	Config                *info.ProviderConfig
+	Event                 *info.Event
+	Repo                  *apipac.Repository
+	WebhookType           string
+	Namespace             string
+	InheritedGlobalSecret bool
+	Logger                *zap.SugaredLogger
 }
 
 // Get grab the secret from the repository CRD.
@@ -58,6 +59,8 @@ func (s *SecretFromRepository) Get(ctx context.Context) error {
 	}); err != nil {
 		return err
 	}
+	s.Event.Provider.GitProviderSecretNamespace = s.Namespace
+	s.Event.Provider.GitProviderSecretFromGlobalRepo = s.InheritedGlobalSecret
 
 	// if we don't have a provider token in repo crd we won't be able to do much with it
 	// let it go and it will fail later on when doing SetClients or success if it was done from a github app

--- a/pkg/secrets/secret_test.go
+++ b/pkg/secrets/secret_test.go
@@ -108,7 +108,13 @@ func TestSecretFromRepository(t *testing.T) {
 			}
 			event := info.NewEvent()
 			sfr := SecretFromRepository{
-				k8int, tt.providerconfig, event, tt.repo, tt.providerType, "namespace", logger,
+				K8int:       k8int,
+				Config:      tt.providerconfig,
+				Event:       event,
+				Repo:        tt.repo,
+				WebhookType: tt.providerType,
+				Namespace:   "namespace",
+				Logger:      logger,
 			}
 
 			err := sfr.Get(ctx)


### PR DESCRIPTION
## 📝 Description of the Change

This PR implements automatic token rotation for GitLab access tokens in Pipelines-as-Code. When a GitLab token is approaching expiration (within 7 days), the system can automatically rotate it by requesting a new token from the GitLab API and updating the corresponding Kubernetes Secret.

This settings is **OFF by default**. Repositories can enable it explicitly with:

```yaml
spec:
  settings:
    gitlab:
      token_auto_rotation: true
```

Cluster admins can enable it by default using the **global Repository CR** with the same setting; repository-level settings continue to take precedence. Documentation also notes this behavior may be enabled by default in the future.

**Key Features:**
- Automatic rotation of tokens expiring within 7 days with new 30-day expiry
- Default behavior is now opt-in (`token_auto_rotation: true`)
- Global Repository CR can provide a default enablement for repositories without local override
- Shared secrets from the global repository are excluded to prevent unintended side effects
- Synchronized per-repository to avoid concurrent rotation attempts

## 🔗 Linked GitHub Issue

Fixes [SRVKP-11153](https://redhat.atlassian.net/browse/SRVKP-11153)

## 🧪 Testing Strategy

- [x] Unit tests — Comprehensive coverage for token rotation logic and default behavior
- [x] Integration tests — Token rotation behavior tested in client setup and provider flows
- [ ] End-to-end tests — Not applicable for this scope
- [ ] Not Applicable

## 🤖 AI Assistance

- [x] I have not used any AI assistance for this PR.
- [ ] I have used AI assistance for this PR.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any issues. For an efficient workflow, I have considered installing [pre-commit](https://pre-commit.com/) and running `pre-commit install` to automate these checks.
- [x] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [x] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [x] GitLab — Token rotation feature updated with default-off behavior and global-setting enablement
  - [ ] GitHub App — Not applicable
  - [ ] GitHub Webhook — Not applicable
  - [ ] Gitea/Forgejo — Not applicable
  - [ ] Bitbucket Cloud — Not applicable
  - [ ] Bitbucket Data Center — Not applicable
