### PR TITLE
ci: enforce gofumpt formatting check in lint pipeline

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -131,6 +131,7 @@ formatters:
     generated: lax
     paths:
       - vendor
+      - go-build-cache
       - pkg/provider/gitea/structs
       - third_party$
       - builtin$

--- a/.tekton/go.yaml
+++ b/.tekton/go.yaml
@@ -121,6 +121,7 @@ spec:
                 #!/usr/bin/env bash
                 set -eux
                 make lint-go
+                make lint-fmt
             - name: cache-upload
               ref:
                 resolver: http

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ html-coverage: ## generate html coverage
 
 ##@ Linting
 .PHONY: lint
-lint: lint-go lint-yaml lint-md lint-python lint-shell lint-e2e-naming ## run all linters
+lint: lint-go lint-fmt lint-yaml lint-md lint-python lint-shell lint-e2e-naming ## run all linters
 
 .PHONY: lint-e2e-naming
 lint-e2e-naming: ## check e2e test naming conventions
@@ -104,6 +104,11 @@ lint-go: ## runs go linter on all go files
 							--max-issues-per-linter=0 \
 							--max-same-issues=0 \
 							--timeout $(TIMEOUT_UNIT)
+
+.PHONY: lint-fmt
+lint-fmt: ## check go files are formatted with gofumpt
+	@echo "Checking Go formatting with gofumpt..."
+	@$(GOLANGCI_LINT) fmt --diff ./pkg/... ./test/... ./cmd/... || { echo "Go files are not formatted, run 'make fumpt' to fix"; exit 1; }
 
 .PHONY: lint-yaml
 lint-yaml: ## runs yamllint on all yaml files


### PR DESCRIPTION
## 📝 Description of the Change

Adds a `lint-fmt` Makefile target that runs `golangci-lint fmt --diff` to verify Go files are formatted with gofumpt. The check fails with a clear message directing the user to run `make fumpt` to fix formatting issues.

The check is wired into:
- `make lint` (via the `lint-fmt` target)
- `.tekton/go.yaml` lint step, reusing the already-present `golangci/golangci-lint:v2.12.2` image

In golangci-lint v2, formatters (including gofumpt) are a separate subsystem from linters — `golangci-lint run` does not check formatting; that requires `golangci-lint fmt`. The `.golangci.yml` already declared gofumpt under `formatters`, but it was never enforced in CI.

## 🔗 Linked GitHub Issue

Fixes #

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [x] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any issues. For an efficient workflow, I have considered installing [pre-commit](https://pre-commit.com/) and running `pre-commit install` to automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [x] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center