### PR TITLE
fix(reconciler): avoid shared state

### DIFF
--- a/pkg/reconciler/finalizer.go
+++ b/pkg/reconciler/finalizer.go
@@ -46,12 +46,9 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, pr *tektonv1.PipelineRun)
 			logger.Errorf("failed to report deleted pipeline run as cancelled: %w", err)
 		}
 
-		r.secretNS = repo.GetNamespace()
-		if r.globalRepo, err = r.repoLister.Repositories(r.run.Info.Kube.Namespace).Get(r.run.Info.Controller.GlobalRepository); err == nil && r.globalRepo != nil {
-			if repo.Spec.GitProvider != nil && repo.Spec.GitProvider.Secret == nil && r.globalRepo.Spec.GitProvider != nil && r.globalRepo.Spec.GitProvider.Secret != nil {
-				r.secretNS = r.globalRepo.GetNamespace()
-			}
-			repo.Spec.Merge(r.globalRepo.Spec)
+		if globalRepo, err := r.repoLister.Repositories(r.run.Info.Kube.Namespace).Get(r.run.Info.Controller.GlobalRepository); err == nil && globalRepo != nil {
+			repo = copyRepositoryForMerge(repo)
+			repo.Spec.Merge(globalRepo.Spec)
 		}
 		logger = logger.With("namespace", repo.Namespace)
 		next := r.qm.RemoveAndTakeItemFromQueue(repo, pr)

--- a/pkg/reconciler/finalizer_test.go
+++ b/pkg/reconciler/finalizer_test.go
@@ -86,6 +86,7 @@ func TestReconcilerFinalizeKind(t *testing.T) {
 		name           string
 		pipelinerun    *tektonv1.PipelineRun
 		addToQueue     []*tektonv1.PipelineRun
+		globalRepo     *v1alpha1.Repository
 		skipAddingRepo bool
 	}{
 		{
@@ -101,6 +102,17 @@ func TestReconcilerFinalizeKind(t *testing.T) {
 		{
 			name:        "queued pipelinerun",
 			pipelinerun: getTestPR("pr3", kubeinteraction.StateQueued),
+			globalRepo: &v1alpha1.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pac",
+					Namespace: "pac",
+				},
+				Spec: v1alpha1.RepositorySpec{
+					Settings: &v1alpha1.Settings{
+						PipelineRunProvenance: "default_branch",
+					},
+				},
+			},
 			addToQueue: []*tektonv1.PipelineRun{
 				getTestPR("pr1", kubeinteraction.StateQueued),
 				getTestPR("pr2", kubeinteraction.StateQueued),
@@ -134,6 +146,9 @@ func TestReconcilerFinalizeKind(t *testing.T) {
 			ctx = logging.WithLogger(ctx, fakelogger)
 			testData := testclient.Data{
 				Repositories: []*v1alpha1.Repository{finalizeTestRepo},
+			}
+			if tt.globalRepo != nil {
+				testData.Repositories = append(testData.Repositories, tt.globalRepo)
 			}
 			if tt.skipAddingRepo {
 				testData.Repositories = []*v1alpha1.Repository{}
@@ -185,6 +200,11 @@ func TestReconcilerFinalizeKind(t *testing.T) {
 			if len(tt.addToQueue) != 0 {
 				totalInQueue := len(r.qm.QueuedPipelineRuns(finalizeTestRepo)) + len(r.qm.RunningPipelineRuns(finalizeTestRepo))
 				assert.Equal(t, totalInQueue, len(tt.addToQueue)-1)
+			}
+			if tt.globalRepo != nil {
+				cachedRepo, err := informers.Repository.Lister().Repositories(finalizeTestRepo.Namespace).Get(finalizeTestRepo.Name)
+				assert.NilError(t, err)
+				assert.Assert(t, cachedRepo.Spec.Settings == nil, "global settings should not mutate the cached Repository")
 			}
 		})
 	}

--- a/pkg/reconciler/queue_pipelineruns.go
+++ b/pkg/reconciler/queue_pipelineruns.go
@@ -47,9 +47,10 @@ func (r *Reconciler) queuePipelineRun(ctx context.Context, logger *zap.SugaredLo
 
 	// merge local repo with global repo here in order to derive settings from global
 	// for further concurrency and other operations.
-	if r.globalRepo, err = r.repoLister.Repositories(r.run.Info.Kube.Namespace).Get(r.run.Info.Controller.GlobalRepository); err == nil && r.globalRepo != nil {
+	if globalRepo, err := r.repoLister.Repositories(r.run.Info.Kube.Namespace).Get(r.run.Info.Controller.GlobalRepository); err == nil && globalRepo != nil {
 		logger.Info("Merging global repository settings with local repository settings")
-		repo.Spec.Merge(r.globalRepo.Spec)
+		repo = copyRepositoryForMerge(repo)
+		repo.Spec.Merge(globalRepo.Spec)
 	}
 
 	// if concurrency was set and later removed or changed to zero

--- a/pkg/reconciler/queue_pipelineruns_test.go
+++ b/pkg/reconciler/queue_pipelineruns_test.go
@@ -205,6 +205,11 @@ func TestQueuePipelineRun(t *testing.T) {
 			if tt.wantLog != "" {
 				assert.Assert(t, logcatch.FilterMessage(tt.wantLog).Len() != 0, "We didn't get the expected log message", logcatch.All())
 			}
+			if tt.globalRepo != nil && tt.testRepo != nil {
+				cachedRepo, err := informers.Repository.Lister().Repositories(tt.testRepo.Namespace).Get(tt.testRepo.Name)
+				assert.NilError(t, err)
+				assert.Assert(t, cachedRepo.Spec.Settings == nil, "global settings should not mutate the cached Repository")
+			}
 		})
 	}
 }

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -46,14 +46,56 @@ type Reconciler struct {
 	qm                queuepkg.ManagerInterface
 	metrics           *prmetrics.Recorder
 	eventEmitter      *events.EventEmitter
-	globalRepo        *v1alpha1.Repository
-	secretNS          string
 }
 
 var (
 	_ pipelinerunreconciler.Interface = (*Reconciler)(nil)
 	_ pipelinerunreconciler.Finalizer = (*Reconciler)(nil)
 )
+
+func copyRepositoryForMerge(repo *v1alpha1.Repository) *v1alpha1.Repository {
+	repo = repo.DeepCopy()
+	if repo.Spec.Settings != nil {
+		settings := *repo.Spec.Settings
+		if settings.Policy != nil {
+			policy := *settings.Policy
+			policy.OkToTest = append([]string(nil), settings.Policy.OkToTest...)
+			policy.PullRequest = append([]string(nil), settings.Policy.PullRequest...)
+			settings.Policy = &policy
+		}
+		if settings.Gitlab != nil {
+			gitlab := *settings.Gitlab
+			settings.Gitlab = &gitlab
+		}
+		if settings.Github != nil {
+			github := *settings.Github
+			settings.Github = &github
+		}
+		if settings.Forgejo != nil {
+			forgejo := *settings.Forgejo
+			settings.Forgejo = &forgejo
+		}
+		if settings.AIAnalysis != nil {
+			aiAnalysis := *settings.AIAnalysis
+			settings.AIAnalysis = &aiAnalysis
+		}
+		settings.GithubAppTokenScopeRepos = append([]string(nil), settings.GithubAppTokenScopeRepos...)
+		repo.Spec.Settings = &settings
+	}
+	if repo.Spec.GitProvider != nil {
+		gitProvider := *repo.Spec.GitProvider
+		if gitProvider.Secret != nil {
+			secret := *gitProvider.Secret
+			gitProvider.Secret = &secret
+		}
+		if gitProvider.WebhookSecret != nil {
+			webhookSecret := *gitProvider.WebhookSecret
+			gitProvider.WebhookSecret = &webhookSecret
+		}
+		repo.Spec.GitProvider = &gitProvider
+	}
+	return repo
+}
 
 // ReconcileKind is the main entry point for reconciling PipelineRun resources.
 func (r *Reconciler) ReconcileKind(ctx context.Context, pr *tektonv1.PipelineRun) pkgreconciler.Event {
@@ -268,12 +310,13 @@ func (r *Reconciler) reportFinalStatus(ctx context.Context, logger *zap.SugaredL
 		return nil, fmt.Errorf("reportFinalStatus: %w", err)
 	}
 
-	r.secretNS = repo.GetNamespace()
-	if r.globalRepo, err = r.repoLister.Repositories(r.run.Info.Kube.Namespace).Get(r.run.Info.Controller.GlobalRepository); err == nil && r.globalRepo != nil {
-		if repo.Spec.GitProvider != nil && repo.Spec.GitProvider.Secret == nil && r.globalRepo.Spec.GitProvider != nil && r.globalRepo.Spec.GitProvider.Secret != nil {
-			r.secretNS = r.globalRepo.GetNamespace()
+	secretNS := repo.GetNamespace()
+	if globalRepo, err := r.repoLister.Repositories(r.run.Info.Kube.Namespace).Get(r.run.Info.Controller.GlobalRepository); err == nil && globalRepo != nil {
+		if repo.Spec.GitProvider != nil && repo.Spec.GitProvider.Secret == nil && globalRepo.Spec.GitProvider != nil && globalRepo.Spec.GitProvider.Secret != nil {
+			secretNS = globalRepo.GetNamespace()
 		}
-		repo.Spec.Merge(r.globalRepo.Spec)
+		repo = copyRepositoryForMerge(repo)
+		repo.Spec.Merge(globalRepo.Spec)
 	}
 
 	cp := customparams.NewCustomParams(event, repo, r.run, r.kinteract, r.eventEmitter, nil)
@@ -294,7 +337,7 @@ func (r *Reconciler) reportFinalStatus(ctx context.Context, logger *zap.SugaredL
 			Repo:        repo,
 			WebhookType: pacInfo.WebhookType,
 			Logger:      logger,
-			Namespace:   r.secretNS,
+			Namespace:   secretNS,
 		}
 		if err := secretFromRepo.Get(ctx); err != nil {
 			return repo, fmt.Errorf("cannot get secret from repository: %w", err)
@@ -427,11 +470,12 @@ func (r *Reconciler) initGitProviderClient(ctx context.Context, logger *zap.Suga
 	} else {
 		// secretNS is needed when git provider is other than Github App.
 		secretNS := repo.GetNamespace()
-		if r.globalRepo, err = r.repoLister.Repositories(r.run.Info.Kube.Namespace).Get(r.run.Info.Controller.GlobalRepository); err == nil && r.globalRepo != nil {
-			if repo.Spec.GitProvider != nil && repo.Spec.GitProvider.Secret == nil && r.globalRepo.Spec.GitProvider != nil && r.globalRepo.Spec.GitProvider.Secret != nil {
-				r.secretNS = r.globalRepo.GetNamespace()
+		if globalRepo, err := r.repoLister.Repositories(r.run.Info.Kube.Namespace).Get(r.run.Info.Controller.GlobalRepository); err == nil && globalRepo != nil {
+			if repo.Spec.GitProvider != nil && repo.Spec.GitProvider.Secret == nil && globalRepo.Spec.GitProvider != nil && globalRepo.Spec.GitProvider.Secret != nil {
+				secretNS = globalRepo.GetNamespace()
 			}
-			repo.Spec.Merge(r.globalRepo.Spec)
+			repo = copyRepositoryForMerge(repo)
+			repo.Spec.Merge(globalRepo.Spec)
 		}
 
 		secretFromRepo := secrets.SecretFromRepository{

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -50,6 +50,64 @@ var (
 	finalFailureStatus = "failure"
 )
 
+func TestCopyRepositoryForMergeCopiesMutableSpecPointers(t *testing.T) {
+	repo := &v1alpha1.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "repo",
+			Namespace: "ns",
+		},
+		Spec: v1alpha1.RepositorySpec{
+			Settings: &v1alpha1.Settings{
+				GithubAppTokenScopeRepos: []string{"org/repo"},
+				Policy: &v1alpha1.Policy{
+					OkToTest:    []string{"alice"},
+					PullRequest: []string{"bob"},
+				},
+				Gitlab: &v1alpha1.GitlabSettings{
+					CommentStrategy: "update",
+				},
+				Github: &v1alpha1.GithubSettings{
+					CommentStrategy: "update",
+				},
+				Forgejo: &v1alpha1.ForgejoSettings{
+					UserAgent: "pac-test",
+				},
+				AIAnalysis: &v1alpha1.AIAnalysisConfig{
+					Enabled: true,
+				},
+			},
+			GitProvider: &v1alpha1.GitProvider{
+				Secret:        &v1alpha1.Secret{Name: "provider-secret"},
+				WebhookSecret: &v1alpha1.Secret{Name: "webhook-secret"},
+			},
+		},
+	}
+
+	copied := copyRepositoryForMerge(repo)
+	assert.Assert(t, copied != repo)
+	assert.Assert(t, copied.Spec.Settings != repo.Spec.Settings)
+	assert.Assert(t, copied.Spec.Settings.Policy != repo.Spec.Settings.Policy)
+	assert.Assert(t, copied.Spec.Settings.Gitlab != repo.Spec.Settings.Gitlab)
+	assert.Assert(t, copied.Spec.Settings.Github != repo.Spec.Settings.Github)
+	assert.Assert(t, copied.Spec.Settings.Forgejo != repo.Spec.Settings.Forgejo)
+	assert.Assert(t, copied.Spec.Settings.AIAnalysis != repo.Spec.Settings.AIAnalysis)
+	assert.Assert(t, copied.Spec.GitProvider != repo.Spec.GitProvider)
+	assert.Assert(t, copied.Spec.GitProvider.Secret != repo.Spec.GitProvider.Secret)
+	assert.Assert(t, copied.Spec.GitProvider.WebhookSecret != repo.Spec.GitProvider.WebhookSecret)
+
+	copied.Spec.Settings.GithubAppTokenScopeRepos[0] = "changed/repo"
+	copied.Spec.Settings.Policy.OkToTest[0] = "mallory"
+	copied.Spec.Settings.Policy.PullRequest[0] = "eve"
+	copied.Spec.GitProvider.Secret.Name = "changed-provider-secret"
+	copied.Spec.GitProvider.WebhookSecret.Name = "changed-webhook-secret"
+
+	assert.Equal(t, "org/repo", repo.Spec.Settings.GithubAppTokenScopeRepos[0])
+	assert.Equal(t, "alice", repo.Spec.Settings.Policy.OkToTest[0])
+	assert.Equal(t, "bob", repo.Spec.Settings.Policy.PullRequest[0])
+	assert.Equal(t, "provider-secret", repo.Spec.GitProvider.Secret.Name)
+	assert.Equal(t, "webhook-secret", repo.Spec.GitProvider.WebhookSecret.Name)
+}
+
 func testSetupGHReplies(t *testing.T, mux *http.ServeMux, runevent *info.Event, checkrunID, finalStatus string) {
 	t.Helper()
 	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/check-runs/%s", runevent.Organization, runevent.Repository, checkrunID),
@@ -158,6 +216,17 @@ func TestReconcilerReconcileKind(t *testing.T) {
 					URL: randomURL,
 				},
 			}
+			globalRepo := &v1alpha1.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "global-repo",
+					Namespace: "ns",
+				},
+				Spec: v1alpha1.RepositorySpec{
+					Settings: &v1alpha1.Settings{
+						PipelineRunProvenance: "default_branch",
+					},
+				},
+			}
 
 			taskStatus := tektonv1.TaskRunStatusFields{
 				PodName: "task1",
@@ -173,7 +242,7 @@ func TestReconcilerReconcileKind(t *testing.T) {
 				},
 			}
 			testData := testclient.Data{
-				Repositories: []*v1alpha1.Repository{testRepo},
+				Repositories: []*v1alpha1.Repository{testRepo, globalRepo},
 				PipelineRuns: []*tektonv1.PipelineRun{pr},
 				TaskRuns: []*tektonv1.TaskRun{
 					tektontest.MakeTaskRunCompletion(clock, "task1", "ns", "pipeline-newest",
@@ -203,9 +272,12 @@ func TestReconcilerReconcileKind(t *testing.T) {
 						Kube:           stdata.Kube,
 					},
 					Info: info.Info{
-						Kube: &info.KubeOpts{},
+						Kube: &info.KubeOpts{
+							Namespace: "ns",
+						},
 						Controller: &info.ControllerInfo{
-							Secret: secretName,
+							Secret:           secretName,
+							GlobalRepository: "global-repo",
 						},
 					},
 				},
@@ -240,8 +312,93 @@ func TestReconcilerReconcileKind(t *testing.T) {
 
 			// state must be updated to completed
 			assert.Equal(t, got.Annotations[keys.State], kubeinteraction.StateCompleted)
+			cachedRepo, err := informers.Repository.Lister().Repositories(testRepo.Namespace).Get(testRepo.Name)
+			assert.NilError(t, err)
+			assert.Assert(t, cachedRepo.Spec.Settings == nil, "global settings should not mutate the cached Repository")
 		})
 	}
+}
+
+func TestInitGitProviderClientUsesGlobalSecretWithoutMutatingCache(t *testing.T) {
+	ctx, _ := rtesting.SetupFakeContext(t)
+	observer, _ := zapobserver.New(zap.InfoLevel)
+	logger := zap.New(observer).Sugar()
+
+	pr := &tektonv1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pr",
+			Namespace: "test-ns",
+			Annotations: map[string]string{
+				keys.GitProvider:   "github",
+				keys.RepoURL:       "https://github.com/org/repo",
+				keys.URLOrg:        "org",
+				keys.URLRepository: "repo",
+				keys.SHA:           "abc123",
+			},
+		},
+	}
+	repo := &v1alpha1.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-repo",
+			Namespace: "test-ns",
+		},
+		Spec: v1alpha1.RepositorySpec{
+			URL:         "https://github.com/org/repo",
+			GitProvider: &v1alpha1.GitProvider{},
+		},
+	}
+	globalRepo := &v1alpha1.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "global-repo",
+			Namespace: "global",
+		},
+		Spec: v1alpha1.RepositorySpec{
+			GitProvider: &v1alpha1.GitProvider{
+				Secret: &v1alpha1.Secret{
+					Name: "global-provider-secret",
+				},
+			},
+		},
+	}
+	stdata, informers := testclient.SeedTestData(t, ctx, testclient.Data{
+		Repositories: []*v1alpha1.Repository{repo, globalRepo},
+	})
+	kint := &testkubernetestint.KinterfaceTest{
+		GetSecretResult: map[string]string{
+			"global-provider-secret": "test-token",
+		},
+	}
+	r := &Reconciler{
+		repoLister:   informers.Repository.Lister(),
+		kinteract:    kint,
+		eventEmitter: events.NewEventEmitter(stdata.Kube, logger),
+		run: &params.Run{
+			Clients: clients.Clients{
+				Kube:           stdata.Kube,
+				PipelineAsCode: stdata.PipelineAsCode,
+				Log:            logger,
+			},
+			Info: info.Info{
+				Kube: &info.KubeOpts{
+					Namespace: "global",
+				},
+				Controller: &info.ControllerInfo{
+					GlobalRepository: "global-repo",
+				},
+				Pac: info.NewPacOpts(),
+			},
+		},
+	}
+
+	cachedRepo, err := informers.Repository.Lister().Repositories(repo.Namespace).Get(repo.Name)
+	assert.NilError(t, err)
+	_, event, err := r.initGitProviderClient(ctx, logger, cachedRepo, pr)
+	assert.NilError(t, err)
+	assert.Equal(t, "test-token", event.Provider.Token)
+
+	cachedRepo, err = informers.Repository.Lister().Repositories(repo.Namespace).Get(repo.Name)
+	assert.NilError(t, err)
+	assert.Assert(t, cachedRepo.Spec.GitProvider.Secret == nil, "global secret should not mutate the cached Repository")
 }
 
 func TestUpdatePipelineRunState(t *testing.T) {


### PR DESCRIPTION
## 📝 Description of the Change

`Reconciler` was storing per-reconciliation state on the shared controller struct:

```go
r.globalRepo
r.secretNS
```

Those values are specific to the PipelineRun and Repository currently being processed. A single reconciler instance can process multiple PipelineRuns at the same time, so one reconciliation could overwrite `r.secretNS` while another reconciliation was still preparing to load Git provider credentials.

This PR removes that shared state. `reportFinalStatus`, `initGitProviderClient`, `FinalizeKind`, and `queuePipelineRun` now keep the global Repository lookup and selected secret namespace in local variables.

Those paths still merge local Repository settings with the global Repository. Before doing that merge, the code now copies the Repository spec data it may mutate. A plain `Repository.DeepCopy()` is not enough here because the generated copy method only shallow-copies `Spec`.

That keeps each reconciliation using its own namespace decision, including the case where a Repository inherits `git_provider.secret` from the global Repository.

## 🔗 Linked GitHub Issue

Fixes #2824

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

Ran:

```bash
go test ./pkg/reconciler
```

The added tests cover the global Repository merge paths and assert that lister-backed Repository objects are not mutated while local reconciliations still inherit global Git provider secrets.

The push also ran the repository pre-push checks, including unit testing, Go linting, gitlint, codespell, and generated-file checks.

## 🤖 AI Assistance

AI assistance was used to inspect the shared-state race, split the fix into a separate worktree, and draft the PR text. The code change is small and was reviewed against the affected reconciler paths.

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

> [!IMPORTANT]
>
> **Slop will be simply rejected**, if you are using AI assistance you need to make sure you
> understand the code generated and that it meets the project's standards. you
> need at least know how to run the code and deploy it (if needed). See
> [startpaac](https://github.com/openshift-pipelines/startpaac) to make it easy
> to deploy and test your code changes.
>
> If the **majority of the code** in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Claude <noreply@anthropic.com>

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [ ] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [x] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
