### PR TITLE
fix(provider): ensure providers always log using Provider logger

### DIFF
--- a/pkg/cmd/tknpac/resolve/resolve.go
+++ b/pkg/cmd/tknpac/resolve/resolve.go
@@ -206,6 +206,7 @@ func resolveFilenames(ctx context.Context, cs *params.Run, filenames []string, p
 	allTheYamls = templates.ReplacePlaceHoldersVariables(allTheYamls, params, nil, http.Header{}, map[string]any{})
 	// We use github here but since we don't do remotetask we would not care
 	providerintf := github.New()
+	providerintf.SetLogger(cs.Clients.Log)
 	event := info.NewEvent()
 	types, err := resolve.ReadTektonTypes(ctx, cs.Clients.Log, allTheYamls)
 	if err != nil {

--- a/pkg/provider/bitbucketcloud/bitbucket.go
+++ b/pkg/provider/bitbucketcloud/bitbucket.go
@@ -221,7 +221,7 @@ func (v *Provider) SetClient(_ context.Context, run *params.Run, event *info.Eve
 	v.bbClient = bbClient
 
 	// Added log for security audit purposes to log client access when a token is used
-	run.Clients.Log.Infof("bitbucket-cloud: initialized client with provided token for user=%s", event.Provider.User)
+	v.Logger.Infof("bitbucket-cloud: initialized client with provided token for user=%s", event.Provider.User)
 
 	v.Token = &event.Provider.Token
 	v.Username = &event.Provider.User

--- a/pkg/provider/bitbucketcloud/bitbucket_test.go
+++ b/pkg/provider/bitbucketcloud/bitbucket_test.go
@@ -157,6 +157,7 @@ func TestSetClient(t *testing.T) {
 			}
 
 			v := Provider{}
+			v.SetLogger(testLog)
 			err := v.SetClient(ctx, fakeRun, tt.event, nil, nil)
 
 			if tt.wantErrSubstr != "" {

--- a/pkg/provider/bitbucketdatacenter/bitbucketdatacenter.go
+++ b/pkg/provider/bitbucketdatacenter/bitbucketdatacenter.go
@@ -309,7 +309,7 @@ func (v *Provider) SetClient(ctx context.Context, run *params.Run, event *info.E
 		v.client = client
 
 		// Added for security audit purposes to log client access when a token is used
-		run.Clients.Log.Infof("bitbucket-datacenter: initialized client with provided token for user=%s providerURL=%s", event.Provider.User, event.Provider.URL)
+		v.Logger.Infof("bitbucket-datacenter: initialized client with provided token for user=%s providerURL=%s", event.Provider.User, event.Provider.URL)
 	}
 	v.run = run
 	v.repo = repo

--- a/pkg/provider/bitbucketdatacenter/bitbucketdatacenter_test.go
+++ b/pkg/provider/bitbucketdatacenter/bitbucketdatacenter_test.go
@@ -473,6 +473,7 @@ func TestSetClient(t *testing.T) {
 				mux.HandleFunc("/users/foo", tt.muxUser)
 			}
 			v := &Provider{client: client, baseURL: tURL}
+			v.SetLogger(testLog)
 			err := v.SetClient(ctx, fakeRun, tt.opts, tt.repo, nil)
 			if tt.wantErrSubstr != "" {
 				assert.ErrorContains(t, err, tt.wantErrSubstr)

--- a/pkg/provider/gitea/gitea.go
+++ b/pkg/provider/gitea/gitea.go
@@ -287,7 +287,7 @@ func (v *Provider) SetClient(_ context.Context, run *params.Run, runevent *info.
 	}
 
 	// Added log for security audit purposes to log client access when a token is used
-	run.Clients.Log.Infof("gitea: initialized API client with provided credentials user=%s providerURL=%s", runevent.Provider.User, apiURL)
+	v.Logger.Infof("gitea: initialized API client with provided credentials user=%s providerURL=%s", runevent.Provider.User, apiURL)
 
 	v.giteaInstanceURL = runevent.Provider.URL
 	v.eventEmitter = emitter

--- a/pkg/provider/github/acl.go
+++ b/pkg/provider/github/acl.go
@@ -211,7 +211,7 @@ func (v *Provider) aclCheckAll(ctx context.Context, rev *info.Event) (bool, erro
 		if isFromSameRepo {
 			return true, nil
 		}
-	} else if rev.PullRequestNumber != 0 && v.Logger != nil {
+	} else if rev.PullRequestNumber != 0 {
 		v.Logger.Debugf(
 			"Skipping same-repo pull request shortcut for untrusted event %T on %s/%s#%d from sender %s",
 			rev.Event, rev.Organization, rev.Repository, rev.PullRequestNumber, rev.Sender,

--- a/pkg/provider/github/acl_test.go
+++ b/pkg/provider/github/acl_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
 	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
 	ghtesthelper "github.com/openshift-pipelines/pipelines-as-code/pkg/test/github"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/test/logger"
 	"go.uber.org/zap"
 	zapobserver "go.uber.org/zap/zaptest/observer"
 	"gotest.tools/v3/assert"
@@ -805,9 +806,11 @@ func TestIfPullRequestIsForSameRepoWithoutFork(t *testing.T) {
 			repo := &v1alpha1.Repository{Spec: v1alpha1.RepositorySpec{
 				Settings: &v1alpha1.Settings{},
 			}}
+			l, _ := logger.GetLogger()
 			gprovider := Provider{
 				ghClient: fakeclient,
 				repo:     repo,
+				Logger:   l,
 			}
 
 			got, err := gprovider.aclCheckAll(ctx, tt.event)

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -343,7 +343,7 @@ func (v *Provider) SetClient(ctx context.Context, run *params.Run, event *info.E
 	if event.InstallationID != 0 {
 		integration = "github-app"
 	}
-	run.Clients.Log.Infof(integration+": initialized OAuth2 client for providerName=%s providerURL=%s", v.providerName, event.Provider.URL)
+	v.Logger.Infof(integration+": initialized OAuth2 client for providerName=%s providerURL=%s", v.providerName, event.Provider.URL)
 
 	v.APIURL = apiURL
 
@@ -973,10 +973,6 @@ func (v *Provider) newCommentTraceLogContext(ctx context.Context, event *info.Ev
 }
 
 func (v *Provider) debugCommentPhase(event *info.Event, trace commentTraceLogContext, phase string, kv ...any) {
-	if v.Logger == nil {
-		return
-	}
-
 	org := "unknown"
 	repo := "unknown"
 	pr := 0

--- a/pkg/provider/github/github_test.go
+++ b/pkg/provider/github/github_test.go
@@ -79,7 +79,10 @@ func TestGetTaskURI(t *testing.T) {
 			ctx, _ := rtesting.SetupFakeContext(t)
 			fakeclient, mux, _, teardown := ghtesthelper.SetupGH()
 			defer teardown()
-			provider := &Provider{ghClient: fakeclient}
+			l, _ := logger.GetLogger()
+			provider := New()
+			provider.SetGithubClient(fakeclient)
+			provider.SetLogger(l)
 			event := info.NewEvent()
 			event.HeadBranch = "main"
 			event.URL = tt.eventURL
@@ -705,8 +708,10 @@ func TestGetFileInsideRepo(t *testing.T) {
 			ctx, _ := rtesting.SetupFakeContext(t)
 			fakeclient, mux, _, teardown := ghtesthelper.SetupGH()
 			defer teardown()
+			l, _ := logger.GetLogger()
 			gvcs := Provider{
 				ghClient: fakeclient,
+				Logger:   l,
 			}
 			for s, f := range tt.rets {
 				mux.HandleFunc(s, f)
@@ -780,9 +785,11 @@ func TestGetFileInsideRepoRefSelection(t *testing.T) {
 			ctx, _ := rtesting.SetupFakeContext(t)
 			fakeclient, mux, _, teardown := ghtesthelper.SetupGH()
 			defer teardown()
+			l, _ := logger.GetLogger()
 			gvcs := Provider{
 				ghClient:   fakeclient,
 				provenance: tt.provenance,
+				Logger:     l,
 			}
 
 			mux.HandleFunc("/repos/org/repo/contents/OWNERS", func(w http.ResponseWriter, r *http.Request) {
@@ -842,8 +849,10 @@ func TestCheckSenderOrgMembership(t *testing.T) {
 			fakeclient, mux, _, teardown := ghtesthelper.SetupGH()
 			defer teardown()
 			ctx, _ := rtesting.SetupFakeContext(t)
+			l, _ := logger.GetLogger()
 			gprovider := Provider{
 				ghClient: fakeclient,
+				Logger:   l,
 			}
 			mux.HandleFunc(fmt.Sprintf("/orgs/%s/members", tt.runevent.Organization), func(rw http.ResponseWriter, _ *http.Request) {
 				fmt.Fprint(rw, tt.apiReturn)
@@ -891,9 +900,11 @@ func TestGetStringPullRequestComment(t *testing.T) {
 					Settings: &v1alpha1.Settings{},
 				},
 			}
+			l, _ := logger.GetLogger()
 			gprovider := Provider{
 				ghClient: fakeclient,
 				repo:     repo,
+				Logger:   l,
 			}
 			mux.HandleFunc(fmt.Sprintf("/repos/issues/%s/comments", filepath.Base(tt.runevent.URL)), func(rw http.ResponseWriter, _ *http.Request) {
 				fmt.Fprint(rw, tt.apiReturn)
@@ -1118,9 +1129,15 @@ func TestGithubGetCommitInfo(t *testing.T) {
 				fmt.Fprint(rw, string(jsonData))
 			})
 			ctx, _ := rtesting.SetupFakeContext(t)
-			provider := &Provider{ghClient: fakeclient}
+			l, _ := logger.GetLogger()
+			provider := &Provider{
+				ghClient: fakeclient,
+				Logger:   l,
+			}
 			if tt.noclient {
-				provider = &Provider{}
+				provider = &Provider{
+					Logger: l,
+				}
 			}
 			err := provider.GetCommitInfo(ctx, tt.event)
 			if tt.wantErr != "" {
@@ -1756,7 +1773,12 @@ func TestListRepos(t *testing.T) {
 	})
 
 	ctx, _ := rtesting.SetupFakeContext(t)
-	provider := &Provider{ghClient: fakeclient, PaginedNumber: 1}
+	l, _ := logger.GetLogger()
+	provider := &Provider{
+		ghClient:      fakeclient,
+		PaginedNumber: 1,
+		Logger:        l,
+	}
 	data, err := ListRepos(ctx, provider)
 	assert.NilError(t, err)
 	assert.Equal(t, data[0], "https://matched/by/incoming")
@@ -1851,7 +1873,7 @@ func TestCreateToken(t *testing.T) {
 		})
 	}
 
-	provider := &Provider{ghClient: fakeclient}
+	provider := &Provider{ghClient: fakeclient, Logger: logger}
 	provider.Run = run
 	_, err := provider.CreateToken(ctx, urlData, info)
 	assert.Assert(t, len(provider.RepositoryIDs) == 2, "found repositoryIDs are %d which is less than expected", len(provider.RepositoryIDs))
@@ -1954,7 +1976,8 @@ func TestGetPullRequest(t *testing.T) {
 					})
 			}
 
-			provider := &Provider{ghClient: fakeclient}
+			l, _ := logger.GetLogger()
+			provider := &Provider{ghClient: fakeclient, Logger: l}
 			got, err := provider.getPullRequest(ctx, tt.event)
 			if tt.wantErr {
 				assert.Assert(t, err != nil)
@@ -2007,7 +2030,8 @@ func TestGetPullRequestCaching(t *testing.T) {
 		Repository:        "repo",
 		PullRequestNumber: 1,
 	}
-	provider := &Provider{ghClient: fakeclient}
+	l, _ := logger.GetLogger()
+	provider := &Provider{ghClient: fakeclient, Logger: l}
 
 	_, err := provider.getPullRequest(ctx, event)
 	assert.NilError(t, err)
@@ -2055,7 +2079,8 @@ func TestIsHeadCommitOfBranch(t *testing.T) {
 			})
 
 			ctx, _ := rtesting.SetupFakeContext(t)
-			provider := &Provider{ghClient: fakeclient}
+			l, _ := logger.GetLogger()
+			provider := &Provider{ghClient: fakeclient, Logger: l}
 			err := provider.isHeadCommitOfBranch(ctx, runEvent, "test1")
 			assert.Equal(t, err != nil, tt.wantErr)
 		})
@@ -2193,7 +2218,7 @@ func TestCreateComment(t *testing.T) {
 					postAssert = tt.setup(t, mux)
 				}
 			} else {
-				provider = &Provider{} // nil client
+				provider = &Provider{Logger: fakelogger} // nil client
 			}
 
 			body := tt.commentBody
@@ -2696,7 +2721,8 @@ func TestFetchAppSlug(t *testing.T) {
 			stdata, _ := testclient.SeedTestData(t, ctx, tdata)
 
 			// Create a provider with mocked kubernetes client
-			provider := &Provider{}
+			l, _ := logger.GetLogger()
+			provider := &Provider{Logger: l}
 			provider.Run = &params.Run{
 				Clients: clients.Clients{
 					Kube: stdata.Kube,

--- a/pkg/provider/github/parse_payload.go
+++ b/pkg/provider/github/parse_payload.go
@@ -217,9 +217,6 @@ func validateEnterpriseHostMatchesPayload(gheURL, payload string) error {
 }
 
 func (v *Provider) logBlockedGitHubAppTokenMint(request *http.Request, event *info.Event, installationID int64, reason string, err error) {
-	if v.Logger == nil {
-		return
-	}
 	v.Logger.Errorw(
 		githubAppTokenExfiltrationBlockedLog,
 		"severity", "critical",
@@ -234,9 +231,6 @@ func (v *Provider) logBlockedGitHubAppTokenMint(request *http.Request, event *in
 }
 
 func (v *Provider) logGitHubAppTokenMintValidationFailure(request *http.Request, event *info.Event, installationID int64, reason string, err error) {
-	if v.Logger == nil {
-		return
-	}
 	v.Logger.Warnw(
 		githubAppTokenMintBlockedLog,
 		"severity", "warning",

--- a/pkg/provider/github/profiler.go
+++ b/pkg/provider/github/profiler.go
@@ -92,11 +92,6 @@ func (v *Provider) checkRateLimit(resp *github.Response) (remaining string) {
 
 // wrapAPI wraps a GitHub API call with logging, metrics, and operation context.
 func wrapAPI[T any](v *Provider, operation string, call func() (T, *github.Response, error)) (T, *github.Response, error) {
-	// This check ensures we only profile if a logger is available.
-	if v.Logger == nil {
-		return call()
-	}
-
 	start := time.Now()
 	data, resp, err := call()
 	duration := time.Since(start)
@@ -150,11 +145,6 @@ func (v *Provider) logAPICall(operation string, duration time.Duration, resp *gi
 
 // wrapAPIGetContents wraps the GetContents API call with operation context.
 func wrapAPIGetContents(v *Provider, operation string, call func() (*github.RepositoryContent, []*github.RepositoryContent, *github.Response, error)) (*github.RepositoryContent, []*github.RepositoryContent, *github.Response, error) {
-	// This check ensures we only profile if a logger is available.
-	if v.Logger == nil {
-		return call()
-	}
-
 	start := time.Now()
 	file, dir, resp, err := call()
 	duration := time.Since(start)

--- a/pkg/provider/github/profiler_test.go
+++ b/pkg/provider/github/profiler_test.go
@@ -17,22 +17,6 @@ import (
 )
 
 func TestWrapAPI(t *testing.T) {
-	// Test case: Logger is nil
-	t.Run("Logger is nil", func(t *testing.T) {
-		p := &Provider{}
-		called := false
-		call := func() (string, *github.Response, error) {
-			called = true
-			return "test", nil, nil
-		}
-
-		data, resp, err := wrapAPI(p, "test_api_call", call)
-		assert.Assert(t, called, "Original call should be made")
-		assert.Equal(t, "test", data)
-		assert.Assert(t, resp == nil)
-		assert.Assert(t, err == nil)
-	})
-
 	errorLogTests := []struct {
 		name          string
 		statusCode    int
@@ -126,8 +110,8 @@ func TestWrapAPI(t *testing.T) {
 		})
 	}
 
-	// Nil response omits URL and rate-limit fields from the log entry.
-	t.Run("Logger is not nil, response is nil", func(t *testing.T) {
+	// Test case: response is nil
+	t.Run("response is nil", func(t *testing.T) {
 		observedZapCore, observedLogs := observer.New(zap.DebugLevel)
 		observedLogger := zap.New(observedZapCore).Sugar()
 		p := &Provider{
@@ -279,96 +263,79 @@ func TestRateLimitWarnings(t *testing.T) {
 }
 
 func TestWrapGetContents(t *testing.T) {
-	// Test case: Logger is nil
-	t.Run("Logger is nil", func(t *testing.T) {
-		p := &Provider{}
-		called := false
-		call := func() (*github.RepositoryContent, []*github.RepositoryContent, *github.Response, error) {
-			called = true
-			return nil, nil, nil, nil
-		}
-
-		_, _, _, _ = wrapAPIGetContents(p, "get_contents", call)
-		assert.Assert(t, called, "Original call should be made")
-	})
-
-	// Test case: Logger is not nil
-	t.Run("Logger is not nil", func(t *testing.T) {
-		observedZapCore, observedLogs := observer.New(zap.DebugLevel)
-		observedLogger := zap.New(observedZapCore).Sugar()
-		p := &Provider{
-			Logger:       observedLogger,
-			providerName: "github",
-			triggerEvent: "pull_request",
-			repo: &v1alpha1.Repository{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "test-ns",
-					Name:      "test-repo",
-				},
+	observedZapCore, observedLogs := observer.New(zap.DebugLevel)
+	observedLogger := zap.New(observedZapCore).Sugar()
+	p := &Provider{
+		Logger:       observedLogger,
+		providerName: "github",
+		triggerEvent: "pull_request",
+		repo: &v1alpha1.Repository{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test-ns",
+				Name:      "test-repo",
 			},
+		},
+	}
+	reqURL, _ := url.Parse("https://api.github.com/contents")
+	headers := http.Header{}
+	headers.Set("X-RateLimit-Remaining", "42")
+	resp := &github.Response{
+		Response: &http.Response{
+			Request: &http.Request{URL: reqURL},
+			Header:  headers,
+		},
+	}
+	fileContent := &github.RepositoryContent{Name: github.Ptr("file")}
+	dirContent := []*github.RepositoryContent{{Name: github.Ptr("dir_file")}}
+
+	call := func() (*github.RepositoryContent, []*github.RepositoryContent, *github.Response, error) {
+		return fileContent, dirContent, resp, fmt.Errorf("contents error")
+	}
+
+	file, dir, r, e := wrapAPIGetContents(p, "get_contents", call)
+
+	assert.Equal(t, file, fileContent)
+	assert.Equal(t, len(dir), 1)
+	assert.Equal(t, r, resp)
+	assert.Error(t, e, "contents error")
+
+	logs := observedLogs.All()
+	assert.Assert(t, len(logs) > 0, "Should have log entries")
+
+	// Find the API call log entry
+	var apiCallLog *observer.LoggedEntry
+	for i := range logs {
+		if logs[i].Message == "GitHub API call failed" {
+			apiCallLog = &logs[i]
+			break
 		}
-		reqURL, _ := url.Parse("https://api.github.com/contents")
-		headers := http.Header{}
-		headers.Set("X-RateLimit-Remaining", "42")
-		resp := &github.Response{
-			Response: &http.Response{
-				StatusCode: http.StatusForbidden,
-				Request:    &http.Request{URL: reqURL},
-				Header:     headers,
-			},
+	}
+	assert.Assert(t, apiCallLog != nil, "Should have API call failed log entry")
+
+	// Check structured fields
+	foundOperation := false
+	foundProvider := false
+	foundRepo := false
+	foundRateLimit := false
+	for _, field := range apiCallLog.Context {
+		switch field.Key {
+		case "operation":
+			assert.Equal(t, "get_contents", field.String)
+			foundOperation = true
+		case "provider":
+			assert.Equal(t, "github", field.String)
+			foundProvider = true
+		case "repo":
+			assert.Equal(t, "test-ns/test-repo", field.String)
+			foundRepo = true
+		case "rate_limit_remaining":
+			assert.Equal(t, "42", field.String)
+			foundRateLimit = true
 		}
-		fileContent := &github.RepositoryContent{Name: github.Ptr("file")}
-		dirContent := []*github.RepositoryContent{{Name: github.Ptr("dir_file")}}
+	}
 
-		call := func() (*github.RepositoryContent, []*github.RepositoryContent, *github.Response, error) {
-			return fileContent, dirContent, resp, fmt.Errorf("contents error")
-		}
-
-		file, dir, r, e := wrapAPIGetContents(p, "get_contents", call)
-
-		assert.Equal(t, file, fileContent)
-		assert.Equal(t, len(dir), 1)
-		assert.Equal(t, r, resp)
-		assert.Error(t, e, "contents error")
-
-		logs := observedLogs.All()
-		assert.Assert(t, len(logs) > 0, "Should have log entries")
-
-		// Find the API call log entry
-		var apiCallLog *observer.LoggedEntry
-		for i := range logs {
-			if logs[i].Message == "GitHub API call failed" {
-				apiCallLog = &logs[i]
-				break
-			}
-		}
-		assert.Assert(t, apiCallLog != nil, "Should have API call failed log entry")
-
-		// Check structured fields
-		foundOperation := false
-		foundProvider := false
-		foundRepo := false
-		foundRateLimit := false
-		for _, field := range apiCallLog.Context {
-			switch field.Key {
-			case "operation":
-				assert.Equal(t, "get_contents", field.String)
-				foundOperation = true
-			case "provider":
-				assert.Equal(t, "github", field.String)
-				foundProvider = true
-			case "repo":
-				assert.Equal(t, "test-ns/test-repo", field.String)
-				foundRepo = true
-			case "rate_limit_remaining":
-				assert.Equal(t, "42", field.String)
-				foundRateLimit = true
-			}
-		}
-
-		assert.Assert(t, foundOperation, "Should have operation field")
-		assert.Assert(t, foundProvider, "Should have provider field")
-		assert.Assert(t, foundRepo, "Should have repo field")
-		assert.Assert(t, foundRateLimit, "Should have rate limit field")
-	})
+	assert.Assert(t, foundOperation, "Should have operation field")
+	assert.Assert(t, foundProvider, "Should have provider field")
+	assert.Assert(t, foundRepo, "Should have repo field")
+	assert.Assert(t, foundRateLimit, "Should have rate limit field")
 }

--- a/pkg/provider/github/status.go
+++ b/pkg/provider/github/status.go
@@ -135,11 +135,9 @@ func (v *Provider) fetchAllCheckRunPagesWithRetry(ctx context.Context, runevent 
 		}
 
 		backoff := time.Duration(1<<uint(attempt)) * checkRunsFetchInitialBackoff
-		if v.Logger != nil {
-			v.Logger.Debugf("check-runs lookup failed for %s/%s@%s (attempt %d/%d): %v; retrying in %v",
-				runevent.Organization, runevent.Repository, runevent.SHA,
-				attempt+1, checkRunsFetchMaxRetries+1, err, backoff)
-		}
+		v.Logger.Debugf("check-runs lookup failed for %s/%s@%s (attempt %d/%d): %v; retrying in %v",
+			runevent.Organization, runevent.Repository, runevent.SHA,
+			attempt+1, checkRunsFetchMaxRetries+1, err, backoff)
 
 		select {
 		case <-ctx.Done():

--- a/pkg/provider/github/status_test.go
+++ b/pkg/provider/github/status_test.go
@@ -31,6 +31,7 @@ import (
 func TestGithubProviderCreateCheckRun(t *testing.T) {
 	ctx, _ := rtesting.SetupFakeContext(t)
 	fakeclient, mux, _, teardown := ghtesthelper.SetupGH()
+	l, _ := logger.GetLogger()
 	cnx := Provider{
 		ghClient: fakeclient,
 		Run:      params.New(),
@@ -39,6 +40,7 @@ func TestGithubProviderCreateCheckRun(t *testing.T) {
 				ApplicationName: settings.PACApplicationNameDefaultValue,
 			},
 		},
+		Logger: l,
 	}
 	defer teardown()
 	mux.HandleFunc("/repos/check/info/check-runs", func(w http.ResponseWriter, _ *http.Request) {
@@ -65,10 +67,12 @@ func TestGithubProviderCreateCheckRun(t *testing.T) {
 func TestGetOrUpdateCheckRunStatusForMultipleFailedPipelineRun(t *testing.T) {
 	ctx, _ := rtesting.SetupFakeContext(t)
 	fakeclient, mux, _, teardown := ghtesthelper.SetupGH()
+	l, _ := logger.GetLogger()
 	cnx := Provider{
 		ghClient: fakeclient,
 		Run:      params.New(),
 		pacInfo:  &info.PacOpts{},
+		Logger:   l,
 	}
 	defer teardown()
 	statusOptionData := []providerstatus.StatusOpts{{
@@ -105,9 +109,11 @@ func TestGetExistingCheckRunIDFromMultiple(t *testing.T) {
 	client, mux, _, teardown := ghtesthelper.SetupGH()
 	defer teardown()
 
+	l, _ := logger.GetLogger()
 	cnx := &Provider{
 		ghClient:      client,
 		PaginedNumber: 1,
+		Logger:        l,
 	}
 	event := &info.Event{
 		Organization: "owner",
@@ -152,8 +158,10 @@ func TestGetExistingPendingApprovalCheckRunID(t *testing.T) {
 	client, mux, _, teardown := ghtesthelper.SetupGH()
 	defer teardown()
 
+	l, _ := logger.GetLogger()
 	cnx := New()
 	cnx.SetGithubClient(client)
+	cnx.SetLogger(l)
 
 	event := &info.Event{
 		Organization: "owner",
@@ -191,8 +199,10 @@ func TestGetExistingFailedCheckRunID(t *testing.T) {
 	client, mux, _, teardown := ghtesthelper.SetupGH()
 	defer teardown()
 
+	l, _ := logger.GetLogger()
 	cnx := New()
 	cnx.SetGithubClient(client)
+	cnx.SetLogger(l)
 
 	event := &info.Event{
 		Organization: "owner",
@@ -606,6 +616,7 @@ func TestGithubProvidercreateStatusCommit(t *testing.T) {
 			}
 
 			ctx, _ := rtesting.SetupFakeContext(t)
+			l, _ := logger.GetLogger()
 			provider := &Provider{
 				ghClient: fakeclient,
 				Run:      params.New(),
@@ -614,6 +625,7 @@ func TestGithubProvidercreateStatusCommit(t *testing.T) {
 						ApplicationName: settings.PACApplicationNameDefaultValue,
 					},
 				},
+				Logger: l,
 			}
 
 			if err := provider.createStatusCommit(ctx, tt.event, tt.status); (err != nil) != tt.wantErr {
@@ -668,8 +680,10 @@ func TestProviderGetExistingCheckRunID(t *testing.T) {
 				Repository:   "repository",
 				SHA:          "sha",
 			}
+			l, _ := logger.GetLogger()
 			v := &Provider{
 				ghClient: client,
+				Logger:   l,
 			}
 			mux.HandleFunc(fmt.Sprintf("/repos/%v/%v/commits/%v/check-runs", event.Organization, event.Repository, event.SHA), func(w http.ResponseWriter, _ *http.Request) {
 				_, _ = fmt.Fprintf(w, "%s", tt.jsonret)
@@ -742,8 +756,10 @@ func TestGetExistingCheckRunIDCache(t *testing.T) {
 				fmt.Fprint(w, tt.jsonret)
 			})
 
+			l, _ := logger.GetLogger()
 			cnx := New()
 			cnx.SetGithubClient(client)
+			cnx.SetLogger(l)
 
 			if tt.goroutines > 1 {
 				var wg sync.WaitGroup

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -263,8 +263,7 @@ func (v *Provider) setClient(ctx context.Context, run *params.Run, runevent *inf
 	}
 	v.Token = &runevent.Provider.Token
 
-	run.Clients.Log.Infof("gitlab: initialized for client with token for apiURL=%s, org=%s, repo=%s", apiURL, runevent.Organization, runevent.Repository)
-
+	v.Logger.Infof("gitlab: initialized for client with token for apiURL=%s, org=%s, repo=%s", apiURL, runevent.Organization, runevent.Repository)
 	// In a scenario where the source repository is forked and a merge request (MR) is created on the upstream
 	// repository, runevent.SourceProjectID will not be 0 when SetClient is called from the pac-watcher code.
 	// This is because, in the controller, SourceProjectID is set in the annotation of the pull request,
@@ -320,7 +319,7 @@ func (v *Provider) setClient(ctx context.Context, run *params.Run, runevent *inf
 				marker := "<!-- pac-source-repo-inaccessible -->"
 				comment := fmt.Sprintf("%s\n%s", marker, formatSourceRepoInaccessibleComment(runevent.SourceProjectID))
 				if commentErr := v.CreateComment(ctx, runevent, comment, marker); commentErr != nil {
-					run.Clients.Log.Warnf("failed to post source repository access error as MR comment: %v", commentErr)
+					v.Logger.Warnf("failed to post source repository access error as MR comment: %v", commentErr)
 				}
 			}
 			return returnErr
@@ -547,9 +546,7 @@ func (v *Provider) GetCommitStatuses(_ context.Context, event *info.Event) ([]pr
 			if firstErr == nil {
 				firstErr = err
 			}
-			if v.Logger != nil {
-				v.Logger.Debugf("failed to get commit statuses from gitlab project ID %d for SHA %s: %v", projectID, event.SHA, err)
-			}
+			v.Logger.Debugf("failed to get commit statuses from gitlab project ID %d for SHA %s: %v", projectID, event.SHA, err)
 			continue
 		}
 

--- a/pkg/provider/gitlab/gitlab_test.go
+++ b/pkg/provider/gitlab/gitlab_test.go
@@ -1046,12 +1046,14 @@ func TestSetClient(t *testing.T) {
 	}
 
 	v := &Provider{}
+	v.SetLogger(fakelogger)
 	assert.Assert(t, v.SetClient(ctx, run, info.NewEvent(), nil, nil) != nil)
 
 	client, _, tearDown := thelp.Setup(t)
 	defer tearDown()
 
 	vv := &Provider{gitlabClient: client}
+	vv.SetLogger(fakelogger)
 	err := vv.SetClient(ctx, run, &info.Event{
 		Provider: &info.Provider{
 			Token: "hello",
@@ -1134,6 +1136,7 @@ func TestSetClientFieldsInitializedOnError(t *testing.T) {
 			}
 
 			v := &Provider{gitlabClient: mockClient}
+			v.SetLogger(fakelogger)
 			repo := &v1alpha1.Repository{}
 			repo.SetName("test-repo")
 			eventsEmitter := events.NewEventEmitter(run.Clients.Kube, fakelogger)
@@ -1238,6 +1241,7 @@ func TestSetClientRepositoryAccessCheck(t *testing.T) {
 			}
 
 			v := &Provider{gitlabClient: mockClient}
+			v.SetLogger(fakelogger)
 			event := &info.Event{
 				Provider: &info.Provider{
 					Token: "test-token",
@@ -1375,6 +1379,7 @@ func TestSetClientDetectAPIURL(t *testing.T) {
 				repoURL:           tc.repoURL,
 				pathWithNamespace: tc.pathWithNamespace,
 			}
+			v.SetLogger(fakelogger)
 			event := info.NewEvent()
 			event.Provider.Token = tc.providerToken
 			event.Provider.URL = tc.providerURL
@@ -2438,6 +2443,7 @@ func TestSetClientSourceRepoAccessPostsComment(t *testing.T) {
 			}
 
 			v := &Provider{gitlabClient: mockClient}
+			v.SetLogger(fakelogger)
 			event := &info.Event{
 				Provider: &info.Provider{
 					Token: "test-token",

--- a/test/pkg/bitbucketcloud/setup.go
+++ b/test/pkg/bitbucketcloud/setup.go
@@ -43,6 +43,7 @@ func Setup(ctx context.Context) (*params.Run, options.E2E, bitbucketcloud.Provid
 		Repo:         split[1],
 	}
 	bbc := bitbucketcloud.Provider{}
+	bbc.SetLogger(run.Clients.Log)
 	event := info.NewEvent()
 	event.Provider = &info.Provider{
 		Token: bitbucketCloudToken,

--- a/test/pkg/gitea/setup.go
+++ b/test/pkg/gitea/setup.go
@@ -26,6 +26,7 @@ func CreateProvider(ctx context.Context, giteaURL, user, password string) (gitea
 		Password: password,
 		Token:    github.Ptr(password),
 	}
+	gprovider.SetLogger(run.Clients.Log)
 	event := info.NewEvent()
 	event.Provider = &info.Provider{
 		URL:   giteaURL,

--- a/test/pkg/github/setup.go
+++ b/test/pkg/github/setup.go
@@ -46,6 +46,7 @@ func Setup(ctx context.Context, onGHE, viaDirectWebhook bool) (context.Context, 
 	}
 	gprovider := github.New()
 	gprovider.Run = run
+	gprovider.SetLogger(run.Clients.Log)
 	event := info.NewEvent()
 
 	if err := setupGithubAppToken(ctx, config, viaDirectWebhook, run, gprovider); err != nil {

--- a/test/pkg/gitlab/setup.go
+++ b/test/pkg/gitlab/setup.go
@@ -40,6 +40,7 @@ func Setup(ctx context.Context) (*params.Run, options.E2E, *gitlab.Provider, err
 		Password:      gitlabToken,
 	}
 	glprovider := &gitlab.Provider{}
+	glprovider.SetLogger(run.Clients.Log)
 	err := glprovider.SetClient(ctx, run, &info.Event{
 		Provider: &info.Provider{
 			Token: gitlabToken,
@@ -82,6 +83,7 @@ func SetupSecond(ctx context.Context, run *params.Run) (options.E2E, *gitlab.Pro
 		Password:      gitlabToken,
 	}
 	glprovider := &gitlab.Provider{}
+	glprovider.SetLogger(run.Clients.Log)
 	err := glprovider.SetClient(ctx, run, &info.Event{
 		Provider: &info.Provider{
 			Token: gitlabToken,


### PR DESCRIPTION
## 📝 Description of the Change

Switch all logs inside the Providers to use `provider.Logger` instead of the k8s client logger. 

The `run.CLients.Log` logger is created early and does not have the standard context variables (`provider`, `repository`, `event-id`, etc). The provider logger is already used in most cases, and while it can technically be nil because pointers, provider.Logger == nil is an illegal state. 

There were a couple code paths which created Provider instances without setting its logger which needed to be fixed, mostly in tests. 

I also removed several `v.Logger != nil` and `v.Logger == nil` checks because they are (now) unnecessary and incorrectly imply the `v.Logger != nil` is a valid state.

I propose as a next step to refactor the provider classes to be private, and only creatable with constructors to enforce the non-nil logger (and other illegal states) at compile time, but I felt that was a larger scope and could be done separately. 

## 🔗 Linked GitHub Issue

Fixes #

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

AI assistance can be used for various tasks, such as code generation,
documentation, or testing.

Please indicate whether you have used AI assistance
for this PR and provide details if applicable.

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

> [!IMPORTANT]
>
> **Slop will be simply rejected**, if you are using AI assistance you need to make sure you
> understand the code generated and that it meets the project's standards. you
> need at least know how to run the code and deploy it (if needed). See
> [startpaac](https://github.com/openshift-pipelines/startpaac) to make it easy
> to deploy and test your code changes.
>
> If the **majority of the code** in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Claude <noreply@anthropic.com>

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
