### PR TITLE
refactor(e2e): finish Repository.Status removal in waits

### DIFF
--- a/test/bitbucket_cloud_pullrequest_test.go
+++ b/test/bitbucket_cloud_pullrequest_test.go
@@ -85,7 +85,6 @@ func TestBitbucketCloudPullRequestCancelInProgressMerged(t *testing.T) {
 	assert.Assert(t, ok)
 
 	waitOpts := twait.Opts{
-		RepoName:        targetNS,
 		Namespace:       targetNS,
 		MinNumberStatus: 1,
 		PollTimeout:     twait.DefaultTimeout,

--- a/test/gitea_access_control_test.go
+++ b/test/gitea_access_control_test.go
@@ -469,7 +469,6 @@ func TestGiteaPolicyAllowedOwnerFiles(t *testing.T) {
 
 	npr := tgitea.CreateForkPullRequest(t, topts, allowedCnx, "")
 	waitOpts := twait.Opts{
-		RepoName:        topts.TargetNS,
 		Namespace:       topts.TargetNS,
 		MinNumberStatus: 1,
 		PollTimeout:     twait.DefaultTimeout,

--- a/test/gitea_gitops_commands_test.go
+++ b/test/gitea_gitops_commands_test.go
@@ -42,7 +42,6 @@ func TestGiteaCancelRun(t *testing.T) {
 	tgitea.PostCommentOnPullRequest(t, topts, "/cancel")
 
 	waitOpts := twait.Opts{
-		RepoName:        topts.TargetNS,
 		Namespace:       topts.TargetNS,
 		MinNumberStatus: 1,
 		PollTimeout:     twait.DefaultTimeout,
@@ -97,7 +96,6 @@ func TestGiteaOnCommentAnnotation(t *testing.T) {
 	tgitea.PostCommentOnPullRequest(t, topts, triggerComment)
 	// we have two status one for the pull request match and one on comment match from the comment sent
 	waitOpts := twait.Opts{
-		RepoName:        topts.TargetNS,
 		Namespace:       topts.TargetNS,
 		MinNumberStatus: 2,
 		PollTimeout:     twait.DefaultTimeout,
@@ -165,7 +163,6 @@ func TestGiteaOnCommentTestOverride(t *testing.T) {
 
 	tgitea.PostCommentOnPullRequest(t, topts, "/test custom1=overridden")
 	waitOpts := twait.Opts{
-		RepoName:        topts.TargetNS,
 		Namespace:       topts.TargetNS,
 		MinNumberStatus: 1,
 		PollTimeout:     twait.DefaultTimeout,
@@ -215,7 +212,6 @@ func TestGiteaTestPipelineRunExplicitlyWithTestComment(t *testing.T) {
 	tgitea.PostCommentOnPullRequest(t, topts, fmt.Sprintf("/test %s custom=awesome", targetPrName))
 	tgitea.WaitForStatus(t, topts, "heads/"+topts.TargetRefName, "", false)
 	waitOpts := twait.Opts{
-		RepoName:        topts.TargetNS,
 		Namespace:       topts.TargetNS,
 		MinNumberStatus: 1,
 		PollTimeout:     twait.DefaultTimeout,
@@ -262,7 +258,6 @@ func TestGiteaTestAll(t *testing.T) {
 	defer f()
 	tgitea.PostCommentOnPullRequest(t, topts, "/test")
 	waitOpts := twait.Opts{
-		RepoName:        topts.TargetNS,
 		Namespace:       topts.TargetNS,
 		MinNumberStatus: 2,
 		PollTimeout:     twait.DefaultTimeout,
@@ -330,7 +325,6 @@ func TestGiteaRetestCommentUpdate(t *testing.T) {
 			defer f()
 			tgitea.PostCommentOnPullRequest(t, topts, "/retest")
 			waitOpts := twait.Opts{
-				RepoName:        topts.TargetNS,
 				Namespace:       topts.TargetNS,
 				MinNumberStatus: 2,
 				PollTimeout:     twait.DefaultTimeout,

--- a/test/gitea_params_test.go
+++ b/test/gitea_params_test.go
@@ -125,7 +125,6 @@ func TestGiteaRetestPreservesSourceURL(t *testing.T) {
 
 	tgitea.PostCommentOnPullRequest(t, topts, fmt.Sprintf("/retest %s", originalPRName))
 	waitOpts := twait.Opts{
-		RepoName:        topts.TargetNS,
 		Namespace:       topts.TargetNS,
 		MinNumberStatus: 2,
 		PollTimeout:     twait.DefaultTimeout,
@@ -307,7 +306,6 @@ func TestGiteaGlobalRepoParams(t *testing.T) {
 	defer f()
 
 	waitOpts := twait.Opts{
-		RepoName:        topts.TargetNS,
 		Namespace:       topts.TargetNS,
 		MinNumberStatus: 1,
 		PollTimeout:     twait.DefaultTimeout,
@@ -387,7 +385,6 @@ func TestGiteaGlobalRepoUseLocalDef(t *testing.T) {
 	defer f()
 
 	waitOpts := twait.Opts{
-		RepoName:        topts.TargetNS,
 		Namespace:       topts.TargetNS,
 		MinNumberStatus: 1,
 		PollTimeout:     twait.DefaultTimeout,
@@ -478,7 +475,6 @@ func TestGiteaParamsOnRepoCR(t *testing.T) {
 
 	// Wait for PipelineRun to succeed
 	waitOpts := twait.Opts{
-		RepoName:        topts.TargetNS,
 		Namespace:       topts.TargetNS,
 		MinNumberStatus: 1,
 		PollTimeout:     twait.DefaultTimeout,
@@ -489,7 +485,8 @@ func TestGiteaParamsOnRepoCR(t *testing.T) {
 	assert.NilError(t,
 		twait.RegexpMatchingInPodLog(context.Background(), topts.ParamsRun, topts.TargetNS, fmt.Sprintf("tekton.dev/pipelineRun=%s,tekton.dev/pipelineTask=params",
 			prs[0].Name), "step-test-params-value", *regexp.MustCompile(
-			"I am the most Kawaī params\nSHHHHHHH\nFollow me on my ig #nofilter\n{{ no_match }}\nHey I show up from a payload match\n{{ secret_nothere }}\n{{ no_initial_value }}"), "", 2, nil))
+			"I am the most Kawaī params\nSHHHHHHH\nFollow me on my ig #nofilter\n{{ no_match }}\nHey I show up from a payload match\n{{ secret_nothere }}\n{{ no_initial_value }}",
+		), "", 2, nil))
 }
 
 // TestGiteaParamsBodyHeadersCEL Test that we can access the pull request body and headers in params
@@ -512,7 +509,6 @@ func TestGiteaParamsBodyHeadersCEL(t *testing.T) {
 	defer f()
 
 	prs, err := twait.UntilPipelineRunsFinished(context.Background(), topts.ParamsRun.Clients, twait.Opts{
-		RepoName:        topts.TargetNS,
 		Namespace:       topts.TargetNS,
 		MinNumberStatus: 1,
 		PollTimeout:     twait.DefaultTimeout,
@@ -540,7 +536,6 @@ my email is a true beauty and like groot, I AM pac`
 	assert.Assert(t, merged)
 
 	waitOpts := twait.Opts{
-		RepoName:        topts.TargetNS,
 		Namespace:       topts.TargetNS,
 		MinNumberStatus: 2, // 1 means 2 🙃
 		PollTimeout:     twait.DefaultTimeout,
@@ -552,7 +547,6 @@ my email is a true beauty and like groot, I AM pac`
 
 	// check we have two PipelineRuns: the previous pull request and new one on push
 	prs, err = twait.UntilPipelineRunsFinished(context.Background(), topts.ParamsRun.Clients, twait.Opts{
-		RepoName:        topts.TargetNS,
 		Namespace:       topts.TargetNS,
 		MinNumberStatus: 2,
 		PollTimeout:     twait.DefaultTimeout,
@@ -628,7 +622,6 @@ func TestGiteaParamsChangedFilesCEL(t *testing.T) {
 	assert.Assert(t, merged)
 
 	waitOpts := twait.Opts{
-		RepoName:        topts.TargetNS,
 		Namespace:       topts.TargetNS,
 		MinNumberStatus: 2, // 1 means 2 🙃
 		PollTimeout:     twait.DefaultTimeout,
@@ -671,7 +664,6 @@ func TestGiteaParamsChangedFilesCEL(t *testing.T) {
 	assert.Assert(t, merged)
 
 	waitOpts = twait.Opts{
-		RepoName:        topts.TargetNS,
 		Namespace:       topts.TargetNS,
 		MinNumberStatus: 4, // 1 means 2 🙃
 		PollTimeout:     twait.DefaultTimeout,

--- a/test/gitea_retest_pruned_test.go
+++ b/test/gitea_retest_pruned_test.go
@@ -50,7 +50,6 @@ func TestGiteaRetestAfterPipelineRunPruning(t *testing.T) {
 	// Wait for both PipelineRuns to appear
 	topts.ParamsRun.Clients.Log.Infof("Waiting for 2 PipelineRuns to appear")
 	err := twait.UntilMinPRAppeared(ctx, topts.ParamsRun.Clients, twait.Opts{
-		RepoName:    topts.TargetNS,
 		Namespace:   topts.TargetNS,
 		PollTimeout: twait.DefaultTimeout,
 		TargetSHA:   []string{formatting.CleanValueKubernetes(sha)},
@@ -60,7 +59,6 @@ func TestGiteaRetestAfterPipelineRunPruning(t *testing.T) {
 	// Wait for both PipelineRuns to finish (1 success + 1 failure)
 	topts.ParamsRun.Clients.Log.Infof("Waiting for 2 PipelineRuns to finish")
 	_, err = twait.UntilPipelineRunsFinished(ctx, topts.ParamsRun.Clients, twait.Opts{
-		RepoName:        topts.TargetNS,
 		Namespace:       topts.TargetNS,
 		MinNumberStatus: 2,
 		PollTimeout:     twait.DefaultTimeout,

--- a/test/gitea_test.go
+++ b/test/gitea_test.go
@@ -547,7 +547,6 @@ func TestGiteaConfigMaxKeepRun(t *testing.T) {
 	tgitea.WaitForStatus(t, topts, "heads/"+topts.TargetRefName, "", false)
 
 	waitOpts := twait.Opts{
-		RepoName:        topts.TargetNS,
 		Namespace:       topts.TargetNS,
 		MinNumberStatus: 1, // 1 means 2 🙃
 		PollTimeout:     twait.DefaultTimeout,
@@ -657,7 +656,6 @@ func TestGiteaConfigCancelInProgressAfterPRClosed(t *testing.T) {
 
 	time.Sleep(3 * time.Second) // “Evil does not sleep. It waits.” - Galadriel
 	waitOpts := twait.Opts{
-		RepoName:        topts.TargetRefName,
 		Namespace:       topts.TargetNS,
 		MinNumberStatus: 1,
 		PollTimeout:     twait.DefaultTimeout,
@@ -884,7 +882,6 @@ func TestGiteaConcurrencyOrderedExecution(t *testing.T) {
 	defer f()
 
 	prs, err := twait.UntilPipelineRunsFinished(context.Background(), topts.ParamsRun.Clients, twait.Opts{
-		RepoName:        topts.TargetNS,
 		Namespace:       topts.TargetNS,
 		MinNumberStatus: 3,
 		PollTimeout:     twait.DefaultTimeout,
@@ -1050,7 +1047,6 @@ func TestGiteaOnPullRequestLabels(t *testing.T) {
 	tgitea.AddLabelToIssue(t, topts, "bug")
 
 	waitOpts := twait.Opts{
-		RepoName:        topts.TargetNS,
 		Namespace:       topts.TargetNS,
 		MinNumberStatus: 1, // 1 means 2 🙃
 		PollTimeout:     twait.DefaultTimeout,
@@ -1349,7 +1345,6 @@ func TestGiteaPushToTagGreedy(t *testing.T) {
 	scmOpts.TargetRefName = "refs/tags/v1.0.0"
 	_ = scm.PushFilesToRefGit(t, scmOpts, map[string]string{"README.md": "hello new version from tag"})
 	waitOpts := twait.Opts{
-		RepoName:  topts.TargetNS,
 		Namespace: topts.TargetNS,
 		// 0 means 1 🙃 (we test for >, while we actually should do >=, but i
 		// need to go all over the code to verify it's not going to break

--- a/test/github_config_maxkeepruns_test.go
+++ b/test/github_config_maxkeepruns_test.go
@@ -34,7 +34,6 @@ func TestGithubGHEMaxKeepRuns(t *testing.T) {
 
 	g.Cnx.Clients.Log.Infof("Waiting for PipelineRuns to be created")
 	waitOpts := twait.Opts{
-		RepoName:        g.TargetNamespace,
 		Namespace:       g.TargetNamespace,
 		MinNumberStatus: 2,
 		PollTimeout:     twait.DefaultTimeout,

--- a/test/github_gitops_commands_prefix_test.go
+++ b/test/github_gitops_commands_prefix_test.go
@@ -46,7 +46,6 @@ func TestGithubPullRequestCustomGitOpsCommandPrefix(t *testing.T) {
 
 	g.Cnx.Clients.Log.Infof("Waiting for PipelineRuns to succeed with custom prefix command")
 	waitOpts := twait.Opts{
-		RepoName:        g.TargetNamespace,
 		Namespace:       g.TargetNamespace,
 		MinNumberStatus: 2,
 		PollTimeout:     twait.DefaultTimeout,
@@ -94,7 +93,6 @@ func TestGithubPullRequestCustomPrefixCancel(t *testing.T) {
 	defer g.TearDown(ctx, t)
 
 	waitOpts := twait.Opts{
-		RepoName:        g.TargetNamespace,
 		Namespace:       g.TargetNamespace,
 		MinNumberStatus: 1,
 		PollTimeout:     twait.DefaultTimeout,

--- a/test/github_pullrequest_concurrency_test.go
+++ b/test/github_pullrequest_concurrency_test.go
@@ -206,7 +206,6 @@ func testGithubConcurrency(ctx context.Context, t *testing.T, g tgithub.PRTest, 
 	time.Sleep(5 * time.Second)
 
 	waitOpts := wait.Opts{
-		RepoName:        g.TargetNamespace,
 		Namespace:       g.TargetNamespace,
 		MinNumberStatus: 1,
 		PollTimeout:     wait.DefaultTimeout,

--- a/test/github_pullrequest_rerequest_test.go
+++ b/test/github_pullrequest_rerequest_test.go
@@ -90,7 +90,6 @@ func TestGithubGHEPullRerequest(t *testing.T) {
 
 	g.Cnx.Clients.Log.Infof("Waiting for PipelineRun to succeed")
 	prs, err := twait.UntilPipelineRunsFinished(ctx, g.Cnx.Clients, twait.Opts{
-		RepoName:        g.TargetNamespace,
 		Namespace:       g.TargetNamespace,
 		MinNumberStatus: 1,
 		PollTimeout:     twait.DefaultTimeout,
@@ -141,7 +140,6 @@ func TestGithubGHEPullRerequest(t *testing.T) {
 
 	g.Cnx.Clients.Log.Infof("Waiting for PipelineRun to succeed")
 	_, err = twait.UntilPipelineRunsFinished(ctx, g.Cnx.Clients, twait.Opts{
-		RepoName:        g.TargetNamespace,
 		Namespace:       g.TargetNamespace,
 		MinNumberStatus: 2,
 		PollTimeout:     twait.DefaultTimeout,
@@ -187,7 +185,6 @@ func TestGithubGHEPullRerequest(t *testing.T) {
 
 	g.Cnx.Clients.Log.Infof("Waiting for PipelineRun to succeed (null head_branch resolved from SHA)")
 	prs, err = twait.UntilPipelineRunsFinished(ctx, g.Cnx.Clients, twait.Opts{
-		RepoName:        g.TargetNamespace,
 		Namespace:       g.TargetNamespace,
 		MinNumberStatus: 3,
 		PollTimeout:     twait.DefaultTimeout,

--- a/test/github_pullrequest_retest_test.go
+++ b/test/github_pullrequest_retest_test.go
@@ -41,7 +41,6 @@ func TestGithubGHEPullRequestGitopsCommentRetest(t *testing.T) {
 
 	g.Cnx.Clients.Log.Infof("Waiting for PipelineRun to succeed")
 	waitOpts := twait.Opts{
-		RepoName:        g.TargetNamespace,
 		Namespace:       g.TargetNamespace,
 		MinNumberStatus: 1,
 		PollTimeout:     twait.DefaultTimeout,
@@ -79,7 +78,6 @@ func TestGithubGHEPullRequestGitopsCommentCancel(t *testing.T) {
 		&github.IssueComment{Body: github.Ptr("/test pr-gitops-comment")},
 	)
 	waitOpts := twait.Opts{
-		RepoName:        g.TargetNamespace,
 		Namespace:       g.TargetNamespace,
 		MinNumberStatus: 3,
 		PollTimeout:     twait.DefaultTimeout,
@@ -97,7 +95,6 @@ func TestGithubGHEPullRequestGitopsCommentCancel(t *testing.T) {
 	assert.NilError(t, err)
 
 	cancelWaitOpts := twait.Opts{
-		RepoName:        g.TargetNamespace,
 		Namespace:       g.TargetNamespace,
 		MinNumberStatus: 1,
 		PollTimeout:     90 * time.Second,
@@ -152,7 +149,6 @@ func TestGithubGHERetestWithMultipleFailedPipelineRuns(t *testing.T) {
 	defer g.TearDown(ctx, t)
 
 	_, err := twait.UntilPipelineRunCreated(ctx, g.Cnx.Clients, twait.Opts{
-		RepoName:        g.TargetNamespace,
 		Namespace:       g.TargetNamespace,
 		MinNumberStatus: 1,
 		TargetSHA:       []string{g.SHA},

--- a/test/github_pullrequest_test.go
+++ b/test/github_pullrequest_test.go
@@ -276,7 +276,6 @@ func TestGithubGHECancelInProgress(t *testing.T) {
 
 	g.Cnx.Clients.Log.Infof("Waiting for one pipelinerun to be created")
 	waitOpts := twait.Opts{
-		RepoName:        g.TargetNamespace,
 		Namespace:       g.TargetNamespace,
 		MinNumberStatus: 1,
 		PollTimeout:     twait.DefaultTimeout,
@@ -293,7 +292,6 @@ func TestGithubGHECancelInProgress(t *testing.T) {
 
 	g.Cnx.Clients.Log.Infof("Waiting for the two pipelinerun to be created")
 	waitOpts = twait.Opts{
-		RepoName:        g.TargetNamespace,
 		Namespace:       g.TargetNamespace,
 		MinNumberStatus: 2,
 		PollTimeout:     twait.DefaultTimeout,
@@ -348,7 +346,6 @@ func TestGithubGHECancelInProgressPRClosed(t *testing.T) {
 
 	g.Cnx.Clients.Log.Infof("Waiting for the two pipelinerun to be created")
 	waitOpts := twait.Opts{
-		RepoName:        g.TargetNamespace,
 		Namespace:       g.TargetNamespace,
 		MinNumberStatus: 1,
 		PollTimeout:     twait.DefaultTimeout,
@@ -491,7 +488,6 @@ func TestGithubGHEPullRequestNoPipelineRunCancelledOnPRClosed(t *testing.T) {
 
 	g.Cnx.Clients.Log.Infof("Waiting for the two pipelinerun to be created")
 	waitOpts := twait.Opts{
-		RepoName:        g.TargetNamespace,
 		Namespace:       g.TargetNamespace,
 		MinNumberStatus: 1,
 		PollTimeout:     twait.DefaultTimeout,
@@ -569,7 +565,6 @@ func TestGithubGHECancelInProgressSettingFromConfigMapOnPR(t *testing.T) {
 
 	g.Cnx.Clients.Log.Infof("Waiting for the two pipelinerun to be created")
 	waitOpts := twait.Opts{
-		RepoName:        g.TargetNamespace,
 		Namespace:       g.TargetNamespace,
 		MinNumberStatus: 2,
 		PollTimeout:     twait.DefaultTimeout,
@@ -616,7 +611,6 @@ func TestGithubGHECancelInProgressSettingFromConfigMapOnPush(t *testing.T) {
 
 	g.Cnx.Clients.Log.Infof("Waiting for the two pipelinerun to be created")
 	waitOpts := twait.Opts{
-		RepoName:        g.TargetNamespace,
 		Namespace:       g.TargetNamespace,
 		MinNumberStatus: 2,
 		PollTimeout:     twait.DefaultTimeout,
@@ -730,7 +724,6 @@ func TestGithubGHEPullRequestCelPrefix(t *testing.T) {
 
 	// Wait for PipelineRun to succeed
 	waitOpts := twait.Opts{
-		RepoName:        g.TargetNamespace,
 		Namespace:       g.TargetNamespace,
 		MinNumberStatus: 1,
 		PollTimeout:     twait.DefaultTimeout,

--- a/test/github_pullrequest_test_comment_test.go
+++ b/test/github_pullrequest_test_comment_test.go
@@ -38,7 +38,6 @@ func TestGithubGHEPullRequestTest(t *testing.T) {
 
 	g.Cnx.Clients.Log.Infof("Waiting for PipelineRun to succeed")
 	waitOpts := twait.Opts{
-		RepoName:        g.TargetNamespace,
 		Namespace:       g.TargetNamespace,
 		MinNumberStatus: 1,
 		PollTimeout:     twait.DefaultTimeout,
@@ -78,7 +77,6 @@ func TestGithubGHEOnCommentAnnotation(t *testing.T) {
 	twait.Succeeded(ctx, t, g.Cnx, g.Options, sopt)
 
 	waitOpts := twait.Opts{
-		RepoName:        g.TargetNamespace,
 		Namespace:       g.TargetNamespace,
 		MinNumberStatus: 1,
 		PollTimeout:     twait.DefaultTimeout,
@@ -97,6 +95,7 @@ func TestGithubGHEOnCommentAnnotation(t *testing.T) {
 	assert.NilError(t, err)
 
 	err = twait.RegexpMatchingInPodLog(context.Background(), g.Cnx, g.TargetNamespace, fmt.Sprintf("tekton.dev/pipelineRun=%s", lastPR.Name), "step-task", *regexp.MustCompile(fmt.Sprintf(
-		"The event is %s", opscomments.OnCommentEventType.String())), "", 2, nil)
+		"The event is %s", opscomments.OnCommentEventType.String(),
+	)), "", 2, nil)
 	assert.NilError(t, err)
 }

--- a/test/github_push_retest_test.go
+++ b/test/github_push_retest_test.go
@@ -23,7 +23,6 @@ import (
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/pkg/names"
 	"gotest.tools/v3/assert"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -55,7 +54,6 @@ func TestGithubGHEPushRequestGitOpsCommentOnComment(t *testing.T) {
 	assert.NilError(t, err)
 
 	waitOpts := twait.Opts{
-		RepoName:        g.TargetNamespace,
 		Namespace:       g.TargetNamespace,
 		MinNumberStatus: len(g.YamlFiles),
 		PollTimeout:     twait.DefaultTimeout,
@@ -113,20 +111,17 @@ func TestGithubGHEPushRequestGitOpsCommentRetest(t *testing.T) {
 	assert.NilError(t, err)
 
 	waitOpts := twait.Opts{
-		RepoName:        g.TargetNamespace,
 		Namespace:       g.TargetNamespace,
 		MinNumberStatus: 4,
 		PollTimeout:     twait.DefaultTimeout,
 		TargetSHA:       []string{g.SHA},
 	}
 	g.Cnx.Clients.Log.Info("Waiting for PipelineRuns to succeed")
-	_, err = twait.UntilPipelineRunHasReason(ctx, g.Cnx.Clients, tektonv1.PipelineRunReasonSuccessful, waitOpts)
+	prs, err := twait.UntilPipelineRunHasReason(ctx, g.Cnx.Clients, tektonv1.PipelineRunReasonSuccessful, waitOpts)
 	assert.NilError(t, err)
 
 	g.Cnx.Clients.Log.Infof("Check if PipelineRun succeeded")
-	repo, err := g.Cnx.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(g.TargetNamespace).Get(ctx, g.TargetNamespace, metav1.GetOptions{})
-	assert.NilError(t, err)
-	assert.Equal(t, repo.Status[len(repo.Status)-1].Conditions[0].Status, corev1.ConditionTrue)
+	assert.Assert(t, len(prs) >= 4)
 
 	pruns, err = g.Cnx.Clients.Tekton.TektonV1().PipelineRuns(g.TargetNamespace).List(ctx, metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("%s=%s", keys.SHA, g.SHA),
@@ -170,7 +165,6 @@ func TestGithubGHEPushRequestGitOpsCommentCancel(t *testing.T) {
 	assert.NilError(t, err)
 	numberOfStatus := 3
 	waitOpts := twait.Opts{
-		RepoName:        g.TargetNamespace,
 		Namespace:       g.TargetNamespace,
 		MinNumberStatus: numberOfStatus,
 		PollTimeout:     twait.DefaultTimeout,
@@ -307,7 +301,6 @@ func TestGithubGHEPullRequestRetestPullRequestNumberSubstitution(t *testing.T) {
 	g.Logger.Infof("Comment %s has been created", mergedSHA)
 
 	waitOpts := twait.Opts{
-		RepoName:        g.TargetNamespace,
 		Namespace:       g.TargetNamespace,
 		MinNumberStatus: 2,
 		PollTimeout:     twait.DefaultTimeout,

--- a/test/github_scope_token_to_list_of_private_public_repos_test.go
+++ b/test/github_scope_token_to_list_of_private_public_repos_test.go
@@ -26,6 +26,7 @@ import (
 	"gotest.tools/v3/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
 )
 
 func TestGithubPullRequestScopeTokenToListOfRepos(t *testing.T) {
@@ -167,30 +168,23 @@ func verifyGHTokenScope(t *testing.T, remoteTaskURL, remoteTaskName string, data
 
 	runcnx.Clients.Log.Infof("Waiting for PipelineRun to succeed")
 	waitOpts := twait.Opts{
-		RepoName:        targetNS,
 		Namespace:       targetNS,
 		MinNumberStatus: 0,
 		PollTimeout:     twait.DefaultTimeout,
 		TargetSHA:       []string{sha},
 	}
-	_, err = twait.UntilPipelineRunHasReason(ctx, runcnx.Clients, tektonv1.PipelineRunReasonSuccessful, waitOpts)
+	prs, err := twait.UntilPipelineRunHasReason(ctx, runcnx.Clients, tektonv1.PipelineRunReasonSuccessful, waitOpts)
 	assert.NilError(t, err)
+	assert.Assert(t, len(prs) > 0)
 
 	runcnx.Clients.Log.Infof("Check if PipelineRun succeeded")
-	repo, err := runcnx.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(targetNS).Get(ctx, targetNS, metav1.GetOptions{})
-	assert.NilError(t, err)
-	laststatus := repo.Status[len(repo.Status)-1]
-	assert.Equal(t, corev1.ConditionTrue, laststatus.Conditions[0].Status)
-	assert.Equal(t, sha, *laststatus.SHA)
-	assert.Equal(t, sha, filepath.Base(*laststatus.SHAURL))
-	assert.Equal(t, title, *laststatus.Title)
-	assert.Assert(t, *laststatus.LogURL != "")
-
-	pr, err := runcnx.Clients.Tekton.TektonV1().PipelineRuns(targetNS).Get(ctx, laststatus.PipelineRunName, metav1.GetOptions{})
-	assert.NilError(t, err)
+	pr := prs[len(prs)-1]
+	cond := pr.Status.GetCondition(apis.ConditionSucceeded)
+	assert.Assert(t, cond != nil)
+	assert.Equal(t, corev1.ConditionTrue, cond.Status)
 
 	assert.Equal(t, triggertype.PullRequest.String(), pr.Annotations[keys.EventType])
-	assert.Equal(t, repo.GetName(), pr.Annotations[keys.Repository])
+	assert.Equal(t, targetNS, pr.Annotations[keys.Repository])
 	assert.Equal(t, sha, pr.Annotations[keys.SHA])
 	assert.Equal(t, opts.Organization, pr.Annotations[keys.URLOrg])
 	assert.Equal(t, opts.Repo, pr.Annotations[keys.URLRepository])

--- a/test/github_skip_ci_test.go
+++ b/test/github_skip_ci_test.go
@@ -131,7 +131,6 @@ func TestGithubGHESkipCITestCommand(t *testing.T) {
 
 	// Wait for PipelineRun to be created
 	waitOpts := twait.Opts{
-		RepoName:        g.TargetNamespace,
 		Namespace:       g.TargetNamespace,
 		MinNumberStatus: 1,
 		PollTimeout:     twait.DefaultTimeout,

--- a/test/github_tag_gitops_test.go
+++ b/test/github_tag_gitops_test.go
@@ -112,7 +112,6 @@ func TestGithubGHEGitOpsCommentOnTag(t *testing.T) {
 		assert.NilError(t, err)
 
 		waitOpts := twait.Opts{
-			RepoName:        targetNS,
 			Namespace:       targetNS,
 			MinNumberStatus: numberOfPRs,
 			PollTimeout:     twait.DefaultTimeout,

--- a/test/github_tkn_pac_cli_test.go
+++ b/test/github_tkn_pac_cli_test.go
@@ -107,7 +107,6 @@ spec:
 
 	runcnx.Clients.Log.Infof("Waiting for PipelineRun to succeed")
 	waitOpts := twait.Opts{
-		RepoName:        targetNS,
 		Namespace:       targetNS,
 		MinNumberStatus: 1,
 		PollTimeout:     twait.DefaultTimeout,

--- a/test/gitlab_merge_request_retest_pruned_test.go
+++ b/test/gitlab_merge_request_retest_pruned_test.go
@@ -55,7 +55,6 @@ func TestGitlabRetestAfterPipelineRunPruning(t *testing.T) {
 	// Wait for both PipelineRuns to appear
 	topts.ParamsRun.Clients.Log.Infof("Waiting for 2 PipelineRuns to appear")
 	err = twait.UntilMinPRAppeared(ctx, topts.ParamsRun.Clients, twait.Opts{
-		RepoName:    topts.TargetNS,
 		Namespace:   topts.TargetNS,
 		PollTimeout: twait.DefaultTimeout,
 		TargetSHA:   []string{formatting.CleanValueKubernetes(mr.SHA)},
@@ -65,7 +64,6 @@ func TestGitlabRetestAfterPipelineRunPruning(t *testing.T) {
 	// Wait for both PipelineRuns to finish (1 success + 1 failure)
 	topts.ParamsRun.Clients.Log.Infof("Waiting for 2 PipelineRuns to finish")
 	_, err = twait.UntilPipelineRunsFinished(ctx, topts.ParamsRun.Clients, twait.Opts{
-		RepoName:        topts.TargetNS,
 		Namespace:       topts.TargetNS,
 		MinNumberStatus: 2,
 		PollTimeout:     twait.DefaultTimeout,
@@ -145,7 +143,6 @@ func TestGitlabRetestAfterPipelineRunPruning(t *testing.T) {
 	// After /retest, we expect only 1 new PipelineRun (the failed one re-runs)
 	topts.ParamsRun.Clients.Log.Infof("Waiting for retest PipelineRun(s) to appear")
 	err = twait.UntilMinPRAppeared(ctx, topts.ParamsRun.Clients, twait.Opts{
-		RepoName:    topts.TargetNS,
 		Namespace:   topts.TargetNS,
 		PollTimeout: twait.DefaultTimeout,
 		TargetSHA:   []string{formatting.CleanValueKubernetes(mr.SHA)},
@@ -154,7 +151,6 @@ func TestGitlabRetestAfterPipelineRunPruning(t *testing.T) {
 
 	// Wait for the re-run pipeline to finish (it's pipelinerun-exit-1 so it will fail)
 	_, err = twait.UntilPipelineRunHasReason(ctx, topts.ParamsRun.Clients, tektonv1.PipelineRunReasonFailed, twait.Opts{
-		RepoName:        topts.TargetNS,
 		Namespace:       topts.TargetNS,
 		MinNumberStatus: 1,
 		PollTimeout:     twait.DefaultTimeout,
@@ -279,7 +275,6 @@ func TestGitlabRetestAfterPipelineRunPruningFromFork(t *testing.T) {
 
 	topts.ParamsRun.Clients.Log.Infof("Waiting for 2 PipelineRuns to appear for fork MR")
 	err = twait.UntilMinPRAppeared(ctx, topts.ParamsRun.Clients, twait.Opts{
-		RepoName:    topts.TargetNS,
 		Namespace:   topts.TargetNS,
 		PollTimeout: twait.DefaultTimeout,
 		TargetSHA:   []string{formatting.CleanValueKubernetes(mr.SHA)},
@@ -288,7 +283,6 @@ func TestGitlabRetestAfterPipelineRunPruningFromFork(t *testing.T) {
 
 	topts.ParamsRun.Clients.Log.Infof("Waiting for 2 PipelineRuns to finish for fork MR")
 	_, err = twait.UntilPipelineRunsFinished(ctx, topts.ParamsRun.Clients, twait.Opts{
-		RepoName:        topts.TargetNS,
 		Namespace:       topts.TargetNS,
 		MinNumberStatus: 2,
 		PollTimeout:     twait.DefaultTimeout,
@@ -364,7 +358,6 @@ func TestGitlabRetestAfterPipelineRunPruningFromFork(t *testing.T) {
 
 	topts.ParamsRun.Clients.Log.Infof("Waiting for retest PipelineRun(s) to appear for fork MR")
 	err = twait.UntilMinPRAppeared(ctx, topts.ParamsRun.Clients, twait.Opts{
-		RepoName:    topts.TargetNS,
 		Namespace:   topts.TargetNS,
 		PollTimeout: twait.DefaultTimeout,
 		TargetSHA:   []string{formatting.CleanValueKubernetes(mr.SHA)},
@@ -373,7 +366,6 @@ func TestGitlabRetestAfterPipelineRunPruningFromFork(t *testing.T) {
 
 	topts.ParamsRun.Clients.Log.Infof("Waiting for re-run PipelineRun to complete for fork MR")
 	_, err = twait.UntilPipelineRunsFinished(ctx, topts.ParamsRun.Clients, twait.Opts{
-		RepoName:        topts.TargetNS,
 		Namespace:       topts.TargetNS,
 		MinNumberStatus: 1,
 		PollTimeout:     twait.DefaultTimeout,

--- a/test/gitlab_merge_request_test.go
+++ b/test/gitlab_merge_request_test.go
@@ -128,7 +128,6 @@ func TestGitlabOnLabel(t *testing.T) {
 	assert.NilError(t, err)
 
 	waitOpts := twait.Opts{
-		RepoName:        topts.TargetNS,
 		Namespace:       topts.TargetNS,
 		MinNumberStatus: 1,
 		PollTimeout:     twait.DefaultTimeout,
@@ -170,7 +169,6 @@ func TestGitlabOnComment(t *testing.T) {
 	assert.NilError(t, err)
 
 	waitOpts := twait.Opts{
-		RepoName:        topts.TargetNS,
 		Namespace:       topts.TargetNS,
 		MinNumberStatus: 1,
 		PollTimeout:     twait.DefaultTimeout,
@@ -200,7 +198,6 @@ func TestGitlabCancelInProgressOnChange(t *testing.T) {
 
 	topts.ParamsRun.Clients.Log.Infof("Waiting for the pipelinerun to be created")
 	originalPipelineWaitOpts := twait.Opts{
-		RepoName:        topts.TargetNS,
 		Namespace:       topts.TargetNS,
 		MinNumberStatus: 1,
 		PollTimeout:     twait.DefaultTimeout,
@@ -226,7 +223,6 @@ func TestGitlabCancelInProgressOnChange(t *testing.T) {
 
 	topts.ParamsRun.Clients.Log.Infof("Waiting for new pipeline to be created")
 	newPipelineWaitOpts := twait.Opts{
-		RepoName:        topts.TargetNS,
 		Namespace:       topts.TargetNS,
 		MinNumberStatus: 1,
 		PollTimeout:     twait.DefaultTimeout,
@@ -252,7 +248,6 @@ func TestGitlabCancelInProgressOnPRClose(t *testing.T) {
 
 	topts.ParamsRun.Clients.Log.Infof("Waiting for the pipelinerun to be created")
 	waitOpts := twait.Opts{
-		RepoName:        topts.TargetNS,
 		Namespace:       topts.TargetNS,
 		MinNumberStatus: 1,
 		PollTimeout:     twait.DefaultTimeout,
@@ -760,7 +755,6 @@ func TestGitlabMergeRequestVariableSubs(t *testing.T) {
 
 	// Wait for PipelineRun creation
 	waitOpts := twait.Opts{
-		RepoName:        topts.TargetNS,
 		Namespace:       topts.TargetNS,
 		MinNumberStatus: 2,
 		PollTimeout:     twait.DefaultTimeout,

--- a/test/gitlab_oktotest_thread_reply_test.go
+++ b/test/gitlab_oktotest_thread_reply_test.go
@@ -33,7 +33,6 @@ func TestGitlabOpsCommentInThreadReply(t *testing.T) {
 
 	// Wait for PipelineRun to succeed after the MR
 	waitOpts := twait.Opts{
-		RepoName:        topts.TargetNS,
 		Namespace:       topts.TargetNS,
 		MinNumberStatus: 1,
 		PollTimeout:     twait.DefaultTimeout,

--- a/test/gitlab_push_gitops_command_test.go
+++ b/test/gitlab_push_gitops_command_test.go
@@ -45,7 +45,6 @@ func TestGitlabGitOpsCommandTestOnPush(t *testing.T) {
 	assert.NilError(t, err)
 
 	waitOpts := wait.Opts{
-		RepoName:        topts.TargetNS,
 		Namespace:       topts.TargetNS,
 		MinNumberStatus: 1,
 		PollTimeout:     wait.DefaultTimeout,
@@ -110,7 +109,6 @@ func TestGitlabGitOpsCommandCancelOnPush(t *testing.T) {
 
 	numberOfStatus := 2
 	waitOpts := wait.Opts{
-		RepoName:        topts.TargetNS,
 		Namespace:       topts.TargetNS,
 		MinNumberStatus: numberOfStatus,
 		PollTimeout:     wait.DefaultTimeout,
@@ -181,7 +179,6 @@ func TestGitlabGitOpsCommandTestOnTag(t *testing.T) {
 	topts.ParamsRun.Clients.Log.Infof("Commit comment %s has been created", cc.Note)
 
 	waitOpts := wait.Opts{
-		RepoName:        topts.TargetNS,
 		Namespace:       topts.TargetNS,
 		MinNumberStatus: numberOfPRs,
 		PollTimeout:     wait.DefaultTimeout,

--- a/test/pkg/wait/check.go
+++ b/test/pkg/wait/check.go
@@ -40,7 +40,6 @@ func Succeeded(ctx context.Context, t *testing.T, runcnx *params.Run, opts optio
 		targetSHA = []string{sopt.SHA}
 	}
 	waitOpts := Opts{
-		RepoName:        sopt.TargetNS,
 		Namespace:       sopt.TargetNS,
 		MinNumberStatus: minNumberStatus,
 		PollTimeout:     DefaultTimeout,

--- a/test/pkg/wait/wait.go
+++ b/test/pkg/wait/wait.go
@@ -56,12 +56,18 @@ func SortPipelineRunsByCreationMillis(prs []v1.PipelineRun) {
 }
 
 type Opts struct {
-	RepoName        string
 	Namespace       string
 	MinNumberStatus int
 	PollTimeout     time.Duration
 	AdminNS         string
 	TargetSHA       []string
+}
+
+func minNumberStatus(opts Opts) int {
+	if opts.MinNumberStatus < 1 {
+		return 1
+	}
+	return opts.MinNumberStatus
 }
 
 func shaLabelSelector(shas []string) string {
@@ -97,6 +103,7 @@ func UntilMinPRAppeared(ctx context.Context, clients clients.Clients, opts Opts,
 func UntilPipelineRunCreated(ctx context.Context, clients clients.Clients, opts Opts) ([]v1.PipelineRun, error) {
 	ctx, cancel := context.WithTimeout(ctx, opts.PollTimeout)
 	defer cancel()
+	minStatus := minNumberStatus(opts)
 	var matched []v1.PipelineRun
 	return matched, kubeinteraction.PollImmediateWithContext(ctx, opts.PollTimeout, func() (bool, error) {
 		listOpts := metav1.ListOptions{}
@@ -108,8 +115,8 @@ func UntilPipelineRunCreated(ctx context.Context, clients clients.Clients, opts 
 			return true, err
 		}
 
-		clients.Log.Infof("waiting for pipelinerun to be created: selector sha=%v, MinNumberStatus=%d pr.Items=%d", opts.TargetSHA, opts.MinNumberStatus, len(prs.Items))
-		if len(prs.Items) >= opts.MinNumberStatus {
+		clients.Log.Infof("waiting for pipelinerun to be created: selector sha=%v, MinNumberStatus=%d pr.Items=%d", opts.TargetSHA, minStatus, len(prs.Items))
+		if len(prs.Items) >= minStatus {
 			matched = prs.Items
 			SortPipelineRunsByCreationMillis(matched)
 			return true, nil
@@ -119,11 +126,17 @@ func UntilPipelineRunCreated(ctx context.Context, clients clients.Clients, opts 
 }
 
 // UntilPipelineRunsFinished waits until at least MinNumberStatus PipelineRuns
-// have reached a terminal state (Succeeded, Failed, or Cancelled).
+// have reached a terminal state (Succeeded, Failed, or Cancelled) AND have
+// been fully reported by the PaC watcher (state annotation set to completed
+// or failed). The watcher patches the state annotation as its last action,
+// after all status reporting and annotation patching (log-url, check-run-id,
+// ...), so waiting on it guarantees those annotations are present — the same
+// ordering the old Repository.Status-based wait provided.
 // Results are sorted by completion time ascending (oldest first, newest last).
 func UntilPipelineRunsFinished(ctx context.Context, clients clients.Clients, opts Opts) ([]v1.PipelineRun, error) {
 	ctx, cancel := context.WithTimeout(ctx, opts.PollTimeout)
 	defer cancel()
+	minStatus := minNumberStatus(opts)
 	var matched []v1.PipelineRun
 	return matched, kubeinteraction.PollImmediateWithContext(ctx, opts.PollTimeout, func() (bool, error) {
 		listOpts := metav1.ListOptions{}
@@ -137,14 +150,17 @@ func UntilPipelineRunsFinished(ctx context.Context, clients clients.Clients, opt
 
 		var finished []v1.PipelineRun
 		for _, pr := range prs.Items {
-			if cond := pr.Status.GetCondition(apis.ConditionSucceeded); cond != nil && cond.Status != corev1.ConditionUnknown {
+			cond := pr.Status.GetCondition(apis.ConditionSucceeded)
+			state := pr.GetAnnotations()[keys.State]
+			if cond != nil && cond.Status != corev1.ConditionUnknown &&
+				(state == kubeinteraction.StateCompleted || state == kubeinteraction.StateFailed) {
 				finished = append(finished, pr)
 			}
 		}
 
 		clients.Log.Infof("still waiting for %d pipelinerun(s) to finish in %s namespace (finished=%d, total=%d)",
-			opts.MinNumberStatus, opts.Namespace, len(finished), len(prs.Items))
-		if len(finished) >= opts.MinNumberStatus {
+			minStatus, opts.Namespace, len(finished), len(prs.Items))
+		if len(finished) >= minStatus {
 			SortPipelineRunsByCompletionMillis(finished)
 			matched = finished
 			return true, nil
@@ -157,6 +173,7 @@ func UntilPipelineRunsFinished(ctx context.Context, clients clients.Clients, opt
 func UntilPipelineRunHasReason(ctx context.Context, clients clients.Clients, desiredReason v1.PipelineRunReason, opts Opts) ([]v1.PipelineRun, error) {
 	ctx, cancel := context.WithTimeout(ctx, opts.PollTimeout)
 	defer cancel()
+	minStatus := minNumberStatus(opts)
 	var matched []v1.PipelineRun
 	return matched, kubeinteraction.PollImmediateWithContext(ctx, opts.PollTimeout, func() (bool, error) {
 		listOpts := metav1.ListOptions{}
@@ -175,8 +192,8 @@ func UntilPipelineRunHasReason(ctx context.Context, clients clients.Clients, des
 			}
 		}
 
-		clients.Log.Infof("still waiting for %d pipelinerun(s) to have reason %s in %s namespace", opts.MinNumberStatus, desiredReason.String(), opts.Namespace)
-		if len(prsWithReason) >= opts.MinNumberStatus {
+		clients.Log.Infof("still waiting for %d pipelinerun(s) to have reason %s in %s namespace", minStatus, desiredReason.String(), opts.Namespace)
+		if len(prsWithReason) >= minStatus {
 			matched = prsWithReason
 			SortPipelineRunsByCreationMillis(matched)
 			return true, nil

--- a/test/pkg/wait/wait_test.go
+++ b/test/pkg/wait/wait_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
 	paramsclients "github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
 	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
@@ -58,6 +59,16 @@ func makePipelineRunWithStatus(name, sha, reason string, condStatus corev1.Condi
 			},
 		}
 	}
+	return pr
+}
+
+// withState sets the PaC state annotation the watcher patches after it has
+// finished reporting a PipelineRun.
+func withState(pr *pipelinev1.PipelineRun, state string) *pipelinev1.PipelineRun {
+	if pr.Annotations == nil {
+		pr.Annotations = map[string]string{}
+	}
+	pr.Annotations[keys.State] = state
 	return pr
 }
 
@@ -161,6 +172,16 @@ func TestUntilPipelineRunCreated(t *testing.T) {
 			wantCount: 2,
 			wantOrder: []string{"pr-1", "pr-2"},
 		},
+		{
+			name: "zero min status waits for one created pipelinerun",
+			pipelineRuns: []*pipelinev1.PipelineRun{
+				makePipelineRun("pr-1", "sha-1", ""),
+			},
+			targetSHA: []string{"sha-1"},
+			minStatus: 0,
+			wantCount: 1,
+			wantOrder: []string{"pr-1"},
+		},
 	}, UntilPipelineRunCreated)
 }
 
@@ -170,8 +191,8 @@ func TestUntilPipelineRunsFinished(t *testing.T) {
 		{
 			name: "mixed success and failure both returned sorted by completion",
 			pipelineRuns: []*pipelinev1.PipelineRun{
-				makePipelineRunWithStatus("pr-late", "sha-1", "Succeeded", corev1.ConditionTrue, now, now.Add(10*time.Second)),
-				makePipelineRunWithStatus("pr-early", "sha-1", "Failed", corev1.ConditionFalse, now, now.Add(5*time.Second)),
+				withState(makePipelineRunWithStatus("pr-late", "sha-1", "Succeeded", corev1.ConditionTrue, now, now.Add(10*time.Second)), kubeinteraction.StateCompleted),
+				withState(makePipelineRunWithStatus("pr-early", "sha-1", "Failed", corev1.ConditionFalse, now, now.Add(5*time.Second)), kubeinteraction.StateFailed),
 			},
 			targetSHA: []string{"sha-1"},
 			minStatus: 2,
@@ -181,7 +202,7 @@ func TestUntilPipelineRunsFinished(t *testing.T) {
 		{
 			name: "running pipelinerun not counted as finished",
 			pipelineRuns: []*pipelinev1.PipelineRun{
-				makePipelineRunWithStatus("pr-done", "sha-1", "Succeeded", corev1.ConditionTrue, now, now.Add(5*time.Second)),
+				withState(makePipelineRunWithStatus("pr-done", "sha-1", "Succeeded", corev1.ConditionTrue, now, now.Add(5*time.Second)), kubeinteraction.StateCompleted),
 				makePipelineRun("pr-running", "sha-1", ""),
 			},
 			targetSHA: []string{"sha-1"},
@@ -189,10 +210,28 @@ func TestUntilPipelineRunsFinished(t *testing.T) {
 			wantErr:   true,
 		},
 		{
+			name: "terminal condition without watcher state annotation not counted as finished",
+			pipelineRuns: []*pipelinev1.PipelineRun{
+				makePipelineRunWithStatus("pr-not-reported", "sha-1", "Succeeded", corev1.ConditionTrue, now, now.Add(5*time.Second)),
+			},
+			targetSHA: []string{"sha-1"},
+			minStatus: 1,
+			wantErr:   true,
+		},
+		{
+			name: "started state annotation not counted as finished",
+			pipelineRuns: []*pipelinev1.PipelineRun{
+				withState(makePipelineRunWithStatus("pr-started", "sha-1", "Succeeded", corev1.ConditionTrue, now, now.Add(5*time.Second)), kubeinteraction.StateStarted),
+			},
+			targetSHA: []string{"sha-1"},
+			minStatus: 1,
+			wantErr:   true,
+		},
+		{
 			name: "no target sha returns all finished across shas",
 			pipelineRuns: []*pipelinev1.PipelineRun{
-				makePipelineRunWithStatus("pr-b", "sha-2", "Failed", corev1.ConditionFalse, now, now.Add(8*time.Second)),
-				makePipelineRunWithStatus("pr-a", "sha-1", "Succeeded", corev1.ConditionTrue, now, now.Add(3*time.Second)),
+				withState(makePipelineRunWithStatus("pr-b", "sha-2", "Failed", corev1.ConditionFalse, now, now.Add(8*time.Second)), kubeinteraction.StateFailed),
+				withState(makePipelineRunWithStatus("pr-a", "sha-1", "Succeeded", corev1.ConditionTrue, now, now.Add(3*time.Second)), kubeinteraction.StateCompleted),
 			},
 			minStatus: 2,
 			wantCount: 2,
@@ -201,7 +240,7 @@ func TestUntilPipelineRunsFinished(t *testing.T) {
 		{
 			name: "times out when not enough finished",
 			pipelineRuns: []*pipelinev1.PipelineRun{
-				makePipelineRunWithStatus("pr-1", "sha-1", "Succeeded", corev1.ConditionTrue, now, now.Add(5*time.Second)),
+				withState(makePipelineRunWithStatus("pr-1", "sha-1", "Succeeded", corev1.ConditionTrue, now, now.Add(5*time.Second)), kubeinteraction.StateCompleted),
 			},
 			targetSHA: []string{"sha-1"},
 			minStatus: 3,
@@ -210,22 +249,33 @@ func TestUntilPipelineRunsFinished(t *testing.T) {
 		{
 			name: "cancelled pipelinerun counted as finished",
 			pipelineRuns: []*pipelinev1.PipelineRun{
-				makePipelineRunWithStatus("pr-1", "sha-1", "Cancelled", corev1.ConditionFalse, now, now.Add(5*time.Second)),
+				withState(makePipelineRunWithStatus("pr-1", "sha-1", "Cancelled", corev1.ConditionFalse, now, now.Add(5*time.Second)), kubeinteraction.StateCompleted),
 			},
 			targetSHA: []string{"sha-1"},
 			minStatus: 1,
 			wantCount: 1,
+		},
+		{
+			name: "zero min status waits for one finished pipelinerun",
+			pipelineRuns: []*pipelinev1.PipelineRun{
+				withState(makePipelineRunWithStatus("pr-1", "sha-1", "Succeeded", corev1.ConditionTrue, now, now.Add(5*time.Second)), kubeinteraction.StateCompleted),
+			},
+			targetSHA: []string{"sha-1"},
+			minStatus: 0,
+			wantCount: 1,
+			wantOrder: []string{"pr-1"},
 		},
 	}, UntilPipelineRunsFinished)
 }
 
 func TestUntilPipelineRunHasReason(t *testing.T) {
 	tests := []struct {
-		name         string
-		pipelineRuns []*pipelinev1.PipelineRun
-		targetSHA    []string
-		reason       string
-		wantErr      bool
+		name            string
+		pipelineRuns    []*pipelinev1.PipelineRun
+		targetSHA       []string
+		reason          string
+		minNumberStatus int
+		wantErr         bool
 	}{
 		{
 			name: "match by target sha and reason",
@@ -233,42 +283,55 @@ func TestUntilPipelineRunHasReason(t *testing.T) {
 				makePipelineRun("pr-1", "sha-1", "Succeeded"),
 				makePipelineRun("pr-2", "sha-2", "Cancelled"),
 			},
-			targetSHA: []string{"sha-2"},
-			reason:    "Cancelled",
+			targetSHA:       []string{"sha-2"},
+			reason:          "Cancelled",
+			minNumberStatus: 1,
 		},
 		{
 			name: "wrong reason for matching sha",
 			pipelineRuns: []*pipelinev1.PipelineRun{
 				makePipelineRun("pr-1", "sha-2", "Succeeded"),
 			},
-			targetSHA: []string{"sha-2"},
-			reason:    "Cancelled",
-			wantErr:   true,
+			targetSHA:       []string{"sha-2"},
+			reason:          "Cancelled",
+			minNumberStatus: 1,
+			wantErr:         true,
 		},
 		{
 			name: "reason exists on a different sha only",
 			pipelineRuns: []*pipelinev1.PipelineRun{
 				makePipelineRun("pr-1", "sha-1", "Cancelled"),
 			},
-			targetSHA: []string{"sha-2"},
-			reason:    "Cancelled",
-			wantErr:   true,
+			targetSHA:       []string{"sha-2"},
+			reason:          "Cancelled",
+			minNumberStatus: 1,
+			wantErr:         true,
 		},
 		{
 			name: "match without target sha filter",
 			pipelineRuns: []*pipelinev1.PipelineRun{
 				makePipelineRun("pr-1", "sha-1", "Cancelled"),
 			},
-			reason: "Cancelled",
+			reason:          "Cancelled",
+			minNumberStatus: 1,
+		},
+		{
+			name: "zero min status waits for one matching reason",
+			pipelineRuns: []*pipelinev1.PipelineRun{
+				makePipelineRun("pr-1", "sha-1", "Succeeded"),
+			},
+			targetSHA: []string{"sha-1"},
+			reason:    "Succeeded",
 		},
 		{
 			name: "pipelinerun without conditions",
 			pipelineRuns: []*pipelinev1.PipelineRun{
 				makePipelineRun("pr-1", "sha-2", ""),
 			},
-			targetSHA: []string{"sha-2"},
-			reason:    "Cancelled",
-			wantErr:   true,
+			targetSHA:       []string{"sha-2"},
+			reason:          "Cancelled",
+			minNumberStatus: 1,
+			wantErr:         true,
 		},
 	}
 
@@ -278,7 +341,7 @@ func TestUntilPipelineRunHasReason(t *testing.T) {
 			clients := seedAndMakeClients(ctx, t, tt.pipelineRuns)
 			opts := Opts{
 				Namespace:       "test-ns",
-				MinNumberStatus: 1,
+				MinNumberStatus: tt.minNumberStatus,
 				TargetSHA:       tt.targetSHA,
 				PollTimeout:     10 * time.Millisecond,
 			}


### PR DESCRIPTION
## 📝 Description of the Change

Completes the refactoring effort to remove the deprecated `Repository` CR Status field from E2E test wait helpers, finishing work started in 39271f36a

Three remaining gaps are addressed:

**1. Fix zero-minimum wait semantics**

The original helpers compared with `>`, so `MinNumberStatus: 0` meant "wait for at least one". The new PipelineRun-based wait helpers use `>=`, causing zero minimums to return immediately with no results. Added a `minNumberStatus()` helper that normalizes any value below one to one across `UntilPipelineRunCreated`, `UntilPipelineRunsFinished`, and `UntilPipelineRunHasReason`, with unit tests validating the zero-minimum behavior.

**2. Migrate final Status assertions**

Two test files (GitHub push/retest and token-scope tests) still directly fetched and asserted on Repository CR status. These now assert on PipelineRun conditions and annotations instead, reading event type, repository, SHA, org, and URL from annotations rather than deprecated status fields.

**3. Remove unused RepoName field**

The `RepoName` field in `wait.Opts` became dead code after the refactor. Deleted the field and its initializers across E2E test files.

## 🔗 Linked GitHub Issue

(None — internal refactoring)

## 🧪 Testing Strategy

- [x] Unit tests (added zero-minimum behavior tests)
- [x] Integration tests (validated with go test ./test/pkg/wait)
- [x] End-to-end tests (compile check of e2e test package)
- [ ] Manual testing (not applicable)

## 🤖 AI Assistance

- [x] I have used AI assistance for this PR.

AI assistance was used for code review and test validation. All code has been reviewed and validated to meet project standards.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any issues.
- [x] 📖 I have added or updated documentation for any user-facing changes. (Not applicable — internal refactoring)
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [x] 🎁 I have added end-to-end tests where feasible.
- [x] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it. (Not applicable)
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center