### PR TITLE
fix(provider): use provider logger in gitlab setClient

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,10 @@
 - Targets arm64 and amd64 architectures
 - Uses `ko` for building container images in development
 
+## Provider Logging
+
+In provider code (`pkg/provider/`), always use the provider's own logger (`v.Logger`) for logging — never `run.Clients.Log`. The provider logger carries standard context variables (provider, repository, event-id) that `run.Clients.Log` lacks. This applies to all providers: GitHub, GitLab, Bitbucket, Bitbucket Data Center, and Gitea.
+
 ## Code Quality Workflow
 
 ### After Editing Code

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -278,18 +278,18 @@ func (v *Provider) setClient(ctx context.Context, run *params.Run, runevent *inf
 
 	switch {
 	case runevent.Provider.GitProviderSecretFromGlobalRepo:
-		run.Clients.Log.Debugf("gitlab token auto-rotation skipped: git_provider.secret is inherited from global Repository secret namespace=%s", runevent.Provider.GitProviderSecretNamespace)
+		v.Logger.Debugf("gitlab token auto-rotation skipped: git_provider.secret is inherited from global Repository secret namespace=%s", runevent.Provider.GitProviderSecretNamespace)
 	case !rotateToken:
-		run.Clients.Log.Debugf("gitlab token auto-rotation skipped: client initialized before webhook validation")
+		v.Logger.Debugf("gitlab token auto-rotation skipped: client initialized before webhook validation")
 	case v.isTokenAutoRotationEnabled():
 		if newToken, rotateErr := v.maybeRotateToken(ctx); rotateErr != nil {
 			switch {
 			case errors.Is(rotateErr, errMissingSelfRotateScope):
-				run.Clients.Log.Debugf("gitlab token auto-rotation: %v", rotateErr)
+				v.Logger.Debugf("gitlab token auto-rotation: %v", rotateErr)
 			case errors.Is(rotateErr, errTokenRotatedSecretUpdateFailed):
 				return fmt.Errorf("gitlab token auto-rotation failed: %w", rotateErr)
 			default:
-				run.Clients.Log.Warnf("gitlab token auto-rotation check failed: %v", rotateErr)
+				v.Logger.Warnf("gitlab token auto-rotation check failed: %v", rotateErr)
 			}
 		} else if newToken != "" {
 			v.gitlabClient, err = gitlab.NewClient(newToken, gitlab.WithBaseURL(apiURL))


### PR DESCRIPTION
## 📝 Description of the Change
The token auto-rotation logging in the GitLab provider's setClient was still using run.Clients.Log instead of the provider's own logger. This logger lacks the standard context variables (provider, repository, event-id) that v.Logger carries.

Follow-up-to: https://github.com/tektoncd/pipelines-as-code/pull/2827

## 🔗 Linked GitHub Issue
N/A

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

AI assistance can be used for various tasks, such as code generation,
documentation, or testing.

Please indicate whether you have used AI assistance
for this PR and provide details if applicable.

- [x] I have not used any AI assistance for this PR.
- [ ] I have used AI assistance for this PR.

> [!IMPORTANT]
>
> **Slop will be simply rejected**, if you are using AI assistance you need to make sure you
> understand the code generated and that it meets the project's standards. you
> need at least know how to run the code and deploy it (if needed). See
> [startpaac](https://github.com/openshift-pipelines/startpaac) to make it easy
> to deploy and test your code changes.
>
> If the **majority of the code** in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Claude <noreply@anthropic.com>

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
