### PR TITLE
fix(gitlab): verify secret write access before token rotation

### DIFF
--- a/docs/content/docs/providers/gitlab.md
+++ b/docs/content/docs/providers/gitlab.md
@@ -371,7 +371,7 @@ When both global and repository settings are present, the repository-level value
 ### How It Works
 
 1. When Pipelines-as-Code sets up the GitLab client (on webhook events and watcher reconciliation loops), it calls the GitLab [token self-introspection API](https://docs.gitlab.com/api/personal_access_tokens/#self-inform) to check the token's expiry. The result is cached per repository (for up to 1 hour, invalidated if the token changes), so repeated events don't each trigger an API call.
-2. If the token expires within 7 days, it calls the [self-rotation API](https://docs.gitlab.com/api/personal_access_tokens/#self-rotate) to rotate it.
+2. If the token expires within 7 days, Pipelines-as-Code first verifies (with a server-side dry-run update) that it can write the Kubernetes Secret referenced in the Repository CR; if not, the rotation is skipped and the old token stays valid. It then calls the [self-rotation API](https://docs.gitlab.com/api/personal_access_tokens/#self-rotate) to rotate the token.
 3. The old token is revoked and a new token (valid for 30 days) is returned.
 4. The new token is written back to the Kubernetes Secret referenced directly in the Repository CR.
 5. A Kubernetes event (`GitLabTokenRotated`) is emitted on the Repository CR.

--- a/pkg/provider/gitlab/token_rotation.go
+++ b/pkg/provider/gitlab/token_rotation.go
@@ -158,6 +158,25 @@ func (v *Provider) rotateToken() (*gitlab.PersonalAccessToken, error) {
 	return nil, fmt.Errorf("rotate token: %w", err)
 }
 
+// verifySecretWriteAccess checks, via a server-side dry-run update with
+// unchanged data, that the controller can actually write the git provider
+// Secret. It is called before rotating the token so that a permission
+// failure aborts the rotation while the old token is still valid — once
+// rotated, the old token is revoked and a failed secret update would lose
+// the new token irrecoverably.
+func (v *Provider) verifySecretWriteAccess(ctx context.Context) error {
+	secretName := v.repo.Spec.GitProvider.Secret.Name
+	secretNS := v.repo.GetNamespace()
+	secret, err := v.run.Clients.Kube.CoreV1().Secrets(secretNS).Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	_, err = v.run.Clients.Kube.CoreV1().Secrets(secretNS).Update(ctx, secret, metav1.UpdateOptions{
+		DryRun: []string{metav1.DryRunAll},
+	})
+	return err
+}
+
 func (v *Provider) updateKubeSecret(ctx context.Context, newToken string) error {
 	if !v.hasGitProviderSecret() {
 		return fmt.Errorf("repository CR has no git_provider.secret configured")
@@ -215,6 +234,14 @@ func (v *Provider) maybeRotateToken(ctx context.Context) (string, error) {
 
 	expiresAt := time.Time(*pat.ExpiresAt)
 	v.Logger.Infof("gitlab token expires at %s (within %v threshold), rotating", expiresAt.Format(time.RFC3339), rotationThreshold)
+
+	// Verify we can write the secret before rotating: once rotated the old
+	// token is revoked, so a permission failure must abort the rotation
+	// while the old token is still valid.
+	if err := v.verifySecretWriteAccess(ctx); err != nil {
+		return "", fmt.Errorf("skipping token rotation, cannot update secret %s/%s (old token untouched): %w",
+			v.repo.GetNamespace(), v.repo.Spec.GitProvider.Secret.Name, err)
+	}
 
 	newPat, err := v.rotateToken()
 	if err != nil {

--- a/pkg/provider/gitlab/token_rotation_test.go
+++ b/pkg/provider/gitlab/token_rotation_test.go
@@ -20,6 +20,8 @@ import (
 	"gotest.tools/v3/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
 	rtesting "knative.dev/pkg/reconciler/testing"
 )
 
@@ -180,6 +182,7 @@ func TestMaybeRotateToken(t *testing.T) {
 		wantSecretUpdate bool
 		wantErrContains  string
 		nilSecretData    bool
+		denySecretWrite  bool
 	}{
 		{
 			name: "token not expiring soon",
@@ -308,6 +311,25 @@ func TestMaybeRotateToken(t *testing.T) {
 			wantNewToken:     true,
 			wantSecretUpdate: true,
 		},
+		{
+			name: "secret write denied aborts rotation before revoking old token",
+			setup: func(t *testing.T, mux *http.ServeMux) {
+				t.Helper()
+				mux.HandleFunc("/personal_access_tokens/self", func(rw http.ResponseWriter, r *http.Request) {
+					if r.Method == http.MethodGet {
+						fmt.Fprintf(rw, `{"id": 1, "active": true, "expires_at": %q}`, expiringIn3Days)
+						return
+					}
+					t.Error("token rotation API must not be called when secret write access is denied")
+				})
+				mux.HandleFunc("/personal_access_tokens/self/rotate", func(_ http.ResponseWriter, _ *http.Request) {
+					t.Error("token rotation API must not be called when secret write access is denied")
+				})
+			},
+			denySecretWrite: true,
+			wantErr:         true,
+			wantErrContains: "old token untouched",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -335,6 +357,12 @@ func TestMaybeRotateToken(t *testing.T) {
 					},
 				},
 			})
+
+			if tt.denySecretWrite {
+				stdata.Kube.PrependReactor("update", "secrets", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+					return true, nil, fmt.Errorf("secrets \"gitlab-token\" is forbidden")
+				})
+			}
 
 			run := &params.Run{
 				Clients: clients.Clients{
@@ -403,8 +431,27 @@ func TestMaybeRotateTokenSecretUpdateFails(t *testing.T) {
 	client, mux, tearDown := thelp.Setup(t)
 	defer tearDown()
 
-	// No secret seeded — the update will fail because the secret doesn't exist
-	stdata, _ := testclient.SeedTestData(t, ctx, testclient.Data{})
+	// Secret exists so the pre-flight dry-run write check passes, but the
+	// real update after rotation fails via the reactor below.
+	stdata, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+		Secret: []*corev1.Secret{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gitlab-token",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{"provider.token": []byte("old-token")},
+			},
+		},
+	})
+	updateCalls := 0
+	stdata.Kube.PrependReactor("update", "secrets", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		updateCalls++
+		if updateCalls > 1 {
+			return true, nil, fmt.Errorf("secrets \"gitlab-token\" is forbidden")
+		}
+		return false, nil, nil
+	})
 
 	run := &params.Run{
 		Clients: clients.Clients{
@@ -462,7 +509,27 @@ func TestSetClientReturnsErrorWhenRotatedTokenCannotBeStored(t *testing.T) {
 	client, mux, tearDown := thelp.Setup(t)
 	defer tearDown()
 
-	stdata, _ := testclient.SeedTestData(t, ctx, testclient.Data{})
+	// Secret exists so the pre-flight dry-run write check passes, but the
+	// real update after rotation fails via the reactor below.
+	stdata, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+		Secret: []*corev1.Secret{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gitlab-token",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{"provider.token": []byte("old-token")},
+			},
+		},
+	})
+	updateCalls := 0
+	stdata.Kube.PrependReactor("update", "secrets", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		updateCalls++
+		if updateCalls > 1 {
+			return true, nil, fmt.Errorf("secrets \"gitlab-token\" is forbidden")
+		}
+		return false, nil, nil
+	})
 	run := &params.Run{
 		Clients: clients.Clients{
 			Kube: stdata.Kube,


### PR DESCRIPTION
## 📝 Description of the Change

The GitLab token auto-rotation feature revoked the old token via the
self-rotate API before making the first Kubernetes API call that could fail
with a permission error. If the subsequent Secret update failed, the old
token was already revoked and the new token was discarded, irrecoverably
destroying the credential.

This change verifies write access upfront: before calling the rotation API,
the controller performs a server-side dry-run update of the git provider
Secret with unchanged data. If the Secret cannot be written, the rotation is
aborted with a clear error while the old token is still valid, so nothing is
lost.

The "How It Works" section of the GitLab provider documentation is updated
to mention the pre-flight check.

## 🔗 Linked GitHub Issue

N/A

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

Unit tests cover the new pre-flight failure path (rotation aborted, the
GitLab rotate API is never called) and the post-rotation Secret update
failure path (dry-run passes, real update fails).

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

The fix was implemented with AI assistance following a security review of
the token rotation code; the code has been reviewed, tested locally with
`make test` and `make lint`.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any issues. For an efficient workflow, I have considered installing [pre-commit](https://pre-commit.com/) and running `pre-commit install` to automate these checks.
- [x] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [x] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center