### PR TITLE
fix(e2e): wait for push pipelinerun in gitea params test

### DIFF
--- a/test/gitea_params_test.go
+++ b/test/gitea_params_test.go
@@ -60,7 +60,17 @@ func TestGiteaParamsStandardCheckForPushAndPullEvent(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Assert(t, resp.StatusCode < 400, resp)
 	assert.Assert(t, merged)
-	tgitea.WaitForStatus(t, topts, topts.PullRequest.Head.Sha, "", false)
+
+	// wait for both the pull_request and the push (from the merge)
+	// pipelineruns to succeed, the merge push event can take a while to be
+	// delivered so we cannot just wait on the PR head sha status.
+	waitOpts := twait.Opts{
+		Namespace:       topts.TargetNS,
+		MinNumberStatus: 2, // 1 means 2 🙃
+		PollTimeout:     twait.DefaultTimeout,
+	}
+	_, err = twait.UntilPipelineRunHasReason(context.Background(), topts.ParamsRun.Clients, tektonv1.PipelineRunReasonSuccessful, waitOpts)
+	assert.NilError(t, err)
 	time.Sleep(5 * time.Second)
 
 	// get standard parameter info for pull_request

--- a/test/pkg/bitbucketcloud/crd.go
+++ b/test/pkg/bitbucketcloud/crd.go
@@ -23,7 +23,8 @@ func CreateCRD(ctx context.Context, t *testing.T, bprovider bitbucketcloud.Provi
 		&bitbucket.RepositoryOptions{
 			Owner:    opts.Organization,
 			RepoSlug: opts.Repo,
-		})
+		},
+	)
 	assert.NilError(t, err, "failed to get repository %s/%s: %v", opts.Organization, opts.Repo, err)
 
 	links := &types.Links{}

--- a/test/pkg/gitea/test.go
+++ b/test/pkg/gitea/test.go
@@ -30,6 +30,7 @@ import (
 	"gotest.tools/v3/golden"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
 )
 
 type TestOpts struct {
@@ -629,15 +630,24 @@ func GetStandardParams(t *testing.T, topts *TestOpts, eventType string) (repoURL
 		for i, pr := range prs.Items {
 			names[i] = pr.Name
 		}
-		assert.Equal(t, len(prs.Items), 1, "should have only one "+eventType+" pipelinerun", names)
+		if len(prs.Items) > 1 {
+			t.Fatalf("should have only one %s pipelinerun, got %d: %v", eventType, len(prs.Items), names)
+		}
 
-		if prs.Items[0].Status.Status.Conditions[0].Reason == "Succeeded" || prs.Items[0].Status.Status.Conditions[0].Reason == "Failed" {
-			break
+		// the pipelinerun may not have been created yet (e.g., the webhook
+		// event is still in flight) or may not have status conditions yet,
+		// keep retrying until it is finished.
+		if len(prs.Items) == 1 {
+			if cond := prs.Items[0].Status.GetCondition(apis.ConditionSucceeded); cond != nil {
+				if cond.Reason == "Succeeded" || cond.Reason == "Failed" {
+					break
+				}
+			}
+		}
+		if i == 20 {
+			t.Fatalf("%s pipelinerun has not finished, something is fishy", eventType)
 		}
 		time.Sleep(5 * time.Second)
-		if i == 20 {
-			t.Fatalf("pipelinerun has not finished, something is fishy")
-		}
 	}
 	numLines := int64(10)
 	out, err := tlogs.GetPodLog(context.Background(),


### PR DESCRIPTION
## 📝 Description of the Change

Fixes e2e test flakiness in Gitea params test by properly waiting for push pipelinerun completion. The test merges a pull request and checks that the merge kicked off a second pipeline. Previously, it only waited on something that was already finished from the initial pull request run, so if the merge notification was delayed (which happens when test infrastructure is busy), the test would fail despite nothing actually being broken.

### Changes Made

- Wait for both pipelineruns (pull request and push) to succeed after the merge
- Make GetStandardParams retry while the pipelinerun is missing or still warming up instead of failing immediately
- Improve test reliability by being patient with timing-dependent operations

## 🔗 Linked GitHub Issue

## 🧪 Testing Strategy

- [x] End-to-end tests
- [x] Manual testing

## 🤖 AI Assistance

- [x] I have used AI assistance for this PR.

AI-assisted-by: Cursor

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits).
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any issues.
- [x] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [x] 🎁 I have added end-to-end tests where feasible.
- [x] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.