### PR TITLE
Security: Fix CVE-2026-42505 - update Go to 1.26.5 (release-v0.49.x)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift-pipelines/pipelines-as-code
 
-go 1.26.4
+go 1.26.5
 
 require (
 	codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v3 v3.0.0


### PR DESCRIPTION
## Summary

This PR fixes **CVE-2026-42505** by upgrading Go from 1.26.4 to 1.26.5 on the release-v0.49.x branch.

### CVE Details
- **CVE ID**: CVE-2026-42505 (GO-2026-5856)
- **Package**: crypto/tls (Go standard library)
- **Severity**: Medium
- **Impact**: Invoking Encrypted Client Hello (ECH) privacy leak in crypto/tls
- **Vulnerable versions**: Go < 1.26.5
- **Fixed version**: Go 1.26.5

### Fix Summary
Updated go.mod to use Go 1.26.5. No application code changes required. go mod tidy and go mod verify pass clean.

### Post-fix Verification
Re-ran govulncheck with GOTOOLCHAIN=go1.26.5 — CVE-2026-42505 / GO-2026-5856 no longer reported.

### Breaking Changes
None — patch version bump within same minor line (1.26.x).

### Risk Assessment
Low — backward compatible patch version bump.

Resolves: CVE-2026-42505

---
Generated by CVE Fixer Workflow