### PR TITLE
chore: Readd Go module updates in Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,9 +1,20 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
+  - package-ecosystem: gomod
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: weekly
+    commit-message:
+      prefix: "ci"
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
     commit-message:
       prefix: "ci"
     groups:


### PR DESCRIPTION
Added Go module tracking to the Dependabot configuration to keep Go
dependencies updated. Since we can now group these updates together, we
can prevent an excessive number of pull requests.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
