### PR TITLE
test: Wait for pipelinerun to be created before cancellation

### DIFF
--- a/test/gitea_gitops_commands_test.go
+++ b/test/gitea_gitops_commands_test.go
@@ -8,7 +8,6 @@ import (
 	"regexp"
 	"strings"
 	"testing"
-	"time"
 
 	forgejo "codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v3"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
@@ -37,17 +36,22 @@ func TestGiteaCancelRun(t *testing.T) {
 	}
 	_, f := tgitea.TestPR(t, topts)
 	defer f()
-	// let pipelineRun start and then cancel it
-	time.Sleep(time.Second * 2)
-	tgitea.PostCommentOnPullRequest(t, topts, "/cancel")
 
+	// wait for the pipelinerun to be created before cancelling it: the
+	// webhook relay can deliver the pull_request event several seconds after
+	// the PR creation, so a fixed sleep would race with the /cancel comment.
 	waitOpts := twait.Opts{
 		Namespace:       topts.TargetNS,
 		MinNumberStatus: 1,
 		PollTimeout:     twait.DefaultTimeout,
 		TargetSHA:       []string{topts.PullRequest.Head.Sha},
 	}
-	_, err := twait.UntilPipelineRunHasReason(context.Background(), topts.ParamsRun.Clients, tektonv1.PipelineRunReasonCancelled, waitOpts)
+	_, err := twait.UntilPipelineRunCreated(context.Background(), topts.ParamsRun.Clients, waitOpts)
+	assert.NilError(t, err)
+
+	tgitea.PostCommentOnPullRequest(t, topts, "/cancel")
+
+	_, err = twait.UntilPipelineRunHasReason(context.Background(), topts.ParamsRun.Clients, tektonv1.PipelineRunReasonCancelled, waitOpts)
 	assert.NilError(t, err)
 
 	tgitea.CheckIfPipelineRunsCancelled(t, topts)


### PR DESCRIPTION
## 📝 Description of the Change

The Gitea cancel run test had a race condition: it used a hardcoded 2-second sleep before sending the cancel comment. When the webhook relay delivered the pull_request event slower than expected, the cancel command would be sent before the pipeline run existed, causing test failures.

This fix replaces the sleep with an explicit wait that polls for the pipeline run to be created first, eliminating the race and making the test more reliable.

## 🔗 Linked GitHub Issue

Fixes #

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [x] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

The test refactoring was done with AI assistance. The change is straightforward — replacing a hardcoded sleep with a proper wait condition — and addresses a clear test flakiness issue.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any issues. For an efficient workflow, I have considered installing [pre-commit](https://pre-commit.com/) and running `pre-commit install` to automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [x] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [x] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center