### PR TITLE
feat: capture container creation error messages in logs

### DIFF
--- a/pkg/kubeinteraction/status/task_status.go
+++ b/pkg/kubeinteraction/status/task_status.go
@@ -20,6 +20,19 @@ var reasonMessageReplacementRegexp = regexp.MustCompile(`\(image: .*`)
 
 const maxErrorSnippetCharacterLimit = 65535 // This is the maximum size allowed by Github check run logs and may apply to all other providers
 
+func waitingMessage(steps []tektonv1.StepState) string {
+	for _, step := range steps {
+		if step.Waiting == nil || step.Waiting.Message == "" {
+			continue
+		}
+		if step.Waiting.Reason == "" {
+			return step.Waiting.Message
+		}
+		return fmt.Sprintf("%s: %s", step.Waiting.Reason, step.Waiting.Message)
+	}
+	return ""
+}
+
 // GetTaskRunStatusForPipelineTask takes a minimal embedded status child reference and returns the actual TaskRunStatus
 // for the PipelineTask. It returns an error if the child reference's kind isn't TaskRun.
 func GetTaskRunStatusForPipelineTask(ctx context.Context, client versioned.Interface, ns string, childRef tektonv1.ChildStatusReference) (*tektonv1.TaskRunStatus, error) {
@@ -96,8 +109,13 @@ func CollectFailedTasksLogSnippet(ctx context.Context, cs *params.Run, kinteract
 		if task.Status.TaskSpec != nil {
 			ti.DisplayName = task.Status.TaskSpec.DisplayName
 		}
+		if message := waitingMessage(task.Status.Steps); message != "" {
+			ti.LogSnippet = message
+		} else if ti.Message != "" {
+			ti.LogSnippet = ti.Message
+		}
 		// don't check for pod logs into those
-		if ti.Reason == "TaskRunValidationFailed" || ti.Reason == tektonv1.TaskRunReasonCancelled.String() || ti.Reason == tektonv1.TaskRunReasonTimedOut.String() || ti.Reason == tektonv1.TaskRunReasonImagePullFailed.String() {
+		if ti.Reason == "TaskRunValidationFailed" || ti.Reason == tektonv1.TaskRunReasonCancelled.String() || ti.Reason == tektonv1.TaskRunReasonTimedOut.String() || ti.Reason == tektonv1.TaskRunReasonImagePullFailed.String() || ti.Reason == tektonv1.TaskRunReasonCreateContainerConfigError.String() || ti.Reason == tektonv1.TaskRunReasonPodCreationFailed.String() {
 			failureReasons[task.PipelineTaskName] = ti
 			continue
 		} else if ti.Reason != tektonv1.PipelineRunReasonFailed.String() {

--- a/pkg/kubeinteraction/status/task_status_test.go
+++ b/pkg/kubeinteraction/status/task_status_test.go
@@ -117,6 +117,154 @@ func TestCollectFailedTasksLogSnippet(t *testing.T) {
 	}
 }
 
+func TestCollectFailedTasksLogSnippetWaitingReasons(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+
+	tests := []struct {
+		name        string
+		reason      string
+		condMessage string
+		steps       []tektonv1.StepState
+		wantSnippet string
+	}{
+		{
+			name:        "CreateContainerConfigError surfaces step waiting message",
+			reason:      tektonv1.TaskRunReasonCreateContainerConfigError.String(),
+			condMessage: "Failed to create pod due to config error",
+			steps: []tektonv1.StepState{{
+				Name: "step",
+				ContainerState: corev1.ContainerState{
+					Waiting: &corev1.ContainerStateWaiting{
+						Reason:  tektonv1.TaskRunReasonCreateContainerConfigError.String(),
+						Message: `secret "pac-gitauth-test" not found`,
+					},
+				},
+			}},
+			wantSnippet: `CreateContainerConfigError: secret "pac-gitauth-test" not found`,
+		},
+		{
+			// TaskRunValidationFailed/PodCreationFailed happen before any
+			// step/pod is created, so waitingMessage() has nothing to
+			// inspect and we must fall back to the condition message.
+			name:        "no steps falls back to condition message",
+			reason:      "TaskRunValidationFailed",
+			condMessage: "task validation failed: unknown field foo",
+			steps:       nil,
+			wantSnippet: "task validation failed: unknown field foo",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			pr := tektontest.MakePRCompletion(clock, "pipeline", "ns", tektonv1.PipelineRunReasonFailed.String(), nil, map[string]string{}, 10)
+			pr.Status.ChildReferences = []tektonv1.ChildStatusReference{{
+				TypeMeta:         runtime.TypeMeta{Kind: "TaskRun"},
+				Name:             "task",
+				PipelineTaskName: "task",
+			}}
+			taskStatus := tektonv1.TaskRunStatusFields{
+				PodName: "task-pod",
+				Steps:   tt.steps,
+			}
+			stdata, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+				TaskRuns: []*tektonv1.TaskRun{
+					tektontest.MakeTaskRunCompletion(clock, "task", "ns", "pipeline", map[string]string{}, taskStatus, knativeduckv1.Conditions{{
+						Type:    knativeapi.ConditionSucceeded,
+						Status:  corev1.ConditionFalse,
+						Reason:  tt.reason,
+						Message: tt.condMessage,
+					}}, 10),
+				},
+			})
+			cs := &params.Run{Clients: paramclients.Clients{Tekton: stdata.Pipeline}}
+
+			got := CollectFailedTasksLogSnippet(ctx, cs, nil, pr, 1)
+
+			assertv3.Equal(t, len(got), 1)
+			assertv3.Equal(t, got["task"].LogSnippet, tt.wantSnippet)
+		})
+	}
+}
+
+func TestWaitingMessage(t *testing.T) {
+	tests := []struct {
+		name  string
+		steps []tektonv1.StepState
+		want  string
+	}{
+		{
+			name:  "no steps",
+			steps: nil,
+			want:  "",
+		},
+		{
+			name: "step not waiting",
+			steps: []tektonv1.StepState{{
+				Name: "step",
+			}},
+			want: "",
+		},
+		{
+			name: "waiting with empty message",
+			steps: []tektonv1.StepState{{
+				Name: "step",
+				ContainerState: corev1.ContainerState{
+					Waiting: &corev1.ContainerStateWaiting{
+						Reason: "ImagePullBackOff",
+					},
+				},
+			}},
+			want: "",
+		},
+		{
+			name: "waiting with message and no reason",
+			steps: []tektonv1.StepState{{
+				Name: "step",
+				ContainerState: corev1.ContainerState{
+					Waiting: &corev1.ContainerStateWaiting{
+						Message: "something went wrong",
+					},
+				},
+			}},
+			want: "something went wrong",
+		},
+		{
+			name: "waiting with reason and message",
+			steps: []tektonv1.StepState{{
+				Name: "step",
+				ContainerState: corev1.ContainerState{
+					Waiting: &corev1.ContainerStateWaiting{
+						Reason:  "CreateContainerConfigError",
+						Message: `secret "pac-gitauth-test" not found`,
+					},
+				},
+			}},
+			want: `CreateContainerConfigError: secret "pac-gitauth-test" not found`,
+		},
+		{
+			name: "skips non waiting steps until waiting one",
+			steps: []tektonv1.StepState{
+				{Name: "first"},
+				{
+					Name: "second",
+					ContainerState: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{
+							Reason:  "ErrImagePull",
+							Message: "image not found",
+						},
+					},
+				},
+			},
+			want: "ErrImagePull: image not found",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertv3.Equal(t, waitingMessage(tt.steps), tt.want)
+		})
+	}
+}
+
 func TestCollectFailedTasksLogSnippetUTF8SafeTruncation(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 

--- a/test/gitea_missing_secret_error_test.go
+++ b/test/gitea_missing_secret_error_test.go
@@ -1,0 +1,27 @@
+//go:build e2e
+
+package test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
+	tgitea "github.com/openshift-pipelines/pipelines-as-code/test/pkg/gitea"
+)
+
+func TestGiteaCreateContainerConfigErrorSnippet(t *testing.T) {
+	topts := &tgitea.TestOpts{
+		TargetEvent: triggertype.PullRequest.String(),
+		YAMLFiles: map[string]string{
+			".tekton/pr.yaml": "testdata/pipelinerun-missing-secret.yaml",
+		},
+		ExpectEvents:   false,
+		CheckForStatus: "failure",
+	}
+	_, cleanup := tgitea.TestPR(t, topts)
+	defer cleanup()
+
+	topts.Regexp = regexp.MustCompile(`CreateContainerConfigError.*missing-step-secret`)
+	tgitea.WaitForPullRequestCommentMatch(t, topts)
+}

--- a/test/testdata/pipelinerun-missing-secret.yaml
+++ b/test/testdata/pipelinerun-missing-secret.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: "\\ .PipelineName //"
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
+    pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
+spec:
+  timeouts:
+    pipeline: 1m
+  pipelineSpec:
+    tasks:
+      - name: missing-secret
+        taskSpec:
+          steps:
+            - name: task
+              image: registry.access.redhat.com/ubi10/ubi-micro
+              env:
+                - name: SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: missing-step-secret
+                      key: secret
+              script: echo "$SECRET"


### PR DESCRIPTION
## 📝 Description of the Change

When tasks fail due to secret or configuration issues, users previously only saw a generic failure reason code. This PR captures and displays the actual error messages from container initialization failures (e.g., "secret not found"), making it much easier to diagnose configuration problems in pipeline runs.

The changes:
- Extract error messages from waiting container states when pod creation fails
- Display these messages in the pipeline failure output for better debugging
- Extend the non-retryable failure reasons to include container creation and pod creation errors

This addresses a common pain point where users had to dig into logs to understand why their tasks were failing due to missing or incorrect configuration.

The captured messages go through the existing secret-hiding mechanism (`secrets.ReplaceSecretsInText` applied in `pkg/reconciler/status.go` on the failure snippet), so any secret values attached to the PipelineRun are masked before being posted to the provider.

When creating a pipelinerun that has missing secret instead of a generic error we have

<img width="1784" height="1254" alt="image" src="https://github.com/user-attachments/assets/ec85fc26-0ce8-4e2d-aaf3-85d9fe8b01c1" />


## 🔗 Linked GitHub Issue

Fixes #2751

Relates to [SRVKP-12208](https://redhat.atlassian.net/browse/SRVKP-12208)
Relates to [SRVKP-12882](https://redhat.atlassian.net/browse/SRVKP-12882)


## 🧪 Testing Strategy

- [x] Unit tests
- [x] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

> [!NOTE]
> AI assistance was used for code generation and testing.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any issues.
- [x] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [x] 🎁 I have added end-to-end tests where feasible.
- [x] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
