### PR TITLE
docs: Update controller image path in multi-controller docs

### DIFF
--- a/docs/content/docs/operations/multi-controller.md
+++ b/docs/content/docs/operations/multi-controller.md
@@ -181,5 +181,5 @@ PAC_CONTROLLER_TARGET_NS  Target namespace (default: pipelines-as-code)
 PAC_CONTROLLER_SECRET     Secret name (default: <LABEL>-secret)
 PAC_CONTROLLER_CONFIGMAP  ConfigMap name (default: <LABEL>-configmap)
 PAC_CONTROLLER_SMEE_URL   Smee.io URL for webhook tunneling
-PAC_CONTROLLER_IMAGE      Controller image (default: ghcr.io/tektoncd/pipelines-as-code-controller:stable)
+PAC_CONTROLLER_IMAGE      Controller image (default: ghcr.io/tektoncd/pipelines-as-code/pipelines-as-code-controller:stable)
 ```


### PR DESCRIPTION
## 📝 Description of the Change

The multi-controller documentation referenced an incorrect container image path for the PAC controller. The documentation stated the default image as , but the correct path is  (includes the  path component).

This fix corrects the documentation to reflect the actual image path in the GitHub Container Registry.

## 🔗 Linked GitHub Issue

Fixes #2559

## 🧪 Testing Strategy

- [x] Not Applicable

This is a documentation-only change with no code or functionality affected.

## 🤖 AI Assistance

- [x] I have used AI assistance for this PR.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any issues.
- [x] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes. (N/A - docs only)
- [x] 🎁 I have added end-to-end tests where feasible. (N/A - docs only)
- [x] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it. (N/A - docs only)
- [x] If adding a provider feature, I have filled in the following and updated the provider documentation: (N/A - docs only)