### PR TITLE
chore: add bitbucket cloud secret in e2e

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -110,6 +110,7 @@ jobs:
       TEST_BITBUCKET_CLOUD_E2E_REPOSITORY: cboudjna/pac-e2e-tests
       TEST_BITBUCKET_CLOUD_TOKEN: ${{ secrets.BITBUCKET_CLOUD_TOKEN }}
       TEST_BITBUCKET_CLOUD_USER: cboudjna@redhat.com
+      TEST_BITBUCKET_CLOUD_WEBHOOK_SECRET: ${{ secrets.BITBUCKET_CLOUD_WEBHOOK_SECRET }}
 
       # Bitbucket Data Center
       TEST_BITBUCKET_DATA_CENTER_API_URL: ${{ secrets.BITBUCKET_DATA_CENTER_API_URL }}
@@ -291,6 +292,7 @@ jobs:
           TEST_BITBUCKET_CLOUD_E2E_REPOSITORY: cboudjna/pac-e2e-tests
           TEST_BITBUCKET_CLOUD_TOKEN: ${{ secrets.BITBUCKET_CLOUD_TOKEN }}
           TEST_BITBUCKET_CLOUD_USER: cboudjna
+          TEST_BITBUCKET_CLOUD_WEBHOOK_SECRET: ${{ secrets.BITBUCKET_CLOUD_WEBHOOK_SECRET }}
 
           # Bitbucket Data Center
           TEST_BITBUCKET_DATA_CENTER_API_URL: ${{ secrets.BITBUCKET_DATA_CENTER_API_URL }}
@@ -365,6 +367,7 @@ jobs:
         env:
           TEST_PROVIDER: ${{ matrix.provider }}
           TEST_BITBUCKET_CLOUD_TOKEN: ${{ secrets.BITBUCKET_CLOUD_TOKEN }}
+          TEST_BITBUCKET_CLOUD_WEBHOOK_SECRET: ${{ secrets.BITBUCKET_CLOUD_WEBHOOK_SECRET }}
           TEST_EL_WEBHOOK_SECRET: ${{ secrets.WEBHOOK_SECRET }}
           TEST_GITHUB_REPO_INSTALLATION_ID: ${{ vars.INSTALLATION_ID }}
           TEST_GITHUB_TOKEN: ${{ secrets.GH_APPS_TOKEN }}

--- a/test/pkg/bitbucketcloud/crd.go
+++ b/test/pkg/bitbucketcloud/crd.go
@@ -44,12 +44,14 @@ func CreateCRD(ctx context.Context, t *testing.T, bprovider bitbucketcloud.Provi
 	token, _ := os.LookupEnv("TEST_BITBUCKET_CLOUD_TOKEN")
 	apiURL, _ := os.LookupEnv("TEST_BITBUCKET_CLOUD_API_URL")
 	apiUser, _ := os.LookupEnv("TEST_BITBUCKET_CLOUD_USER")
-	err = secret.Create(ctx, run, map[string]string{"token": token}, targetNS, "webhook-token")
+	webhookSecret, _ := os.LookupEnv("TEST_BITBUCKET_CLOUD_WEBHOOK_SECRET")
+	err = secret.Create(ctx, run, map[string]string{"token": token, "webhook-secret": webhookSecret}, targetNS, "webhook-token")
 	assert.NilError(t, err)
 	repository.Spec.GitProvider = &v1alpha1.GitProvider{
-		URL:    apiURL,
-		User:   apiUser,
-		Secret: &v1alpha1.Secret{Name: "webhook-token", Key: "token"},
+		URL:           apiURL,
+		User:          apiUser,
+		Secret:        &v1alpha1.Secret{Name: "webhook-token", Key: "token"},
+		WebhookSecret: &v1alpha1.Secret{Name: "webhook-token", Key: "webhook-secret"},
 	}
 
 	err = pacrepo.CreateRepo(ctx, targetNS, run, repository)

--- a/test/pkg/bitbucketcloud/setup.go
+++ b/test/pkg/bitbucketcloud/setup.go
@@ -22,12 +22,14 @@ func Setup(ctx context.Context) (*params.Run, options.E2E, bitbucketcloud.Provid
 	bitbucketCloudToken := os.Getenv("TEST_BITBUCKET_CLOUD_TOKEN")
 	bitbucketWSOwner := os.Getenv("TEST_BITBUCKET_CLOUD_E2E_REPOSITORY")
 	bitbucketCloudAPIURL := os.Getenv("TEST_BITBUCKET_CLOUD_API_URL")
+	bitbucketCloudWebhookSecret := os.Getenv("TEST_BITBUCKET_CLOUD_WEBHOOK_SECRET")
 
 	if err := setup.RequireEnvs(
 		"TEST_BITBUCKET_CLOUD_USER",
 		"TEST_BITBUCKET_CLOUD_TOKEN",
 		"TEST_BITBUCKET_CLOUD_E2E_REPOSITORY",
 		"TEST_BITBUCKET_CLOUD_API_URL",
+		"TEST_BITBUCKET_CLOUD_WEBHOOK_SECRET",
 	); err != nil {
 		return nil, options.E2E{}, bitbucketcloud.Provider{}, err
 	}
@@ -46,9 +48,10 @@ func Setup(ctx context.Context) (*params.Run, options.E2E, bitbucketcloud.Provid
 	bbc.SetLogger(run.Clients.Log)
 	event := info.NewEvent()
 	event.Provider = &info.Provider{
-		Token: bitbucketCloudToken,
-		URL:   bitbucketCloudAPIURL,
-		User:  bitbucketCloudUser,
+		Token:         bitbucketCloudToken,
+		URL:           bitbucketCloudAPIURL,
+		User:          bitbucketCloudUser,
+		WebhookSecret: bitbucketCloudWebhookSecret,
 	}
 	if err := bbc.SetClient(ctx, run, event, nil, nil); err != nil {
 		return nil, options.E2E{}, bitbucketcloud.Provider{}, err

--- a/test/pkg/configfile/config.go
+++ b/test/pkg/configfile/config.go
@@ -67,6 +67,7 @@ type BitbucketCloudConfig struct {
 	APIURL        string `env:"TEST_BITBUCKET_CLOUD_API_URL"        json:"api_url"        yaml:"api_url"`
 	User          string `env:"TEST_BITBUCKET_CLOUD_USER"           json:"user"           yaml:"user"`
 	Token         string `env:"TEST_BITBUCKET_CLOUD_TOKEN"          json:"token"          yaml:"token"`
+	Secret        string `env:"TEST_BITBUCKET_CLOUD_SECRET"         json:"secret"         yaml:"secret"`
 	E2ERepository string `env:"TEST_BITBUCKET_CLOUD_E2E_REPOSITORY" json:"e2e_repository" yaml:"e2e_repository"`
 }
 


### PR DESCRIPTION
## 📝 Description of the Change
this adds new secert TEST_BITBUCKET_CLOUD_WEBHOOK_SECRET for bitbucket cloud webhook validation.

## 🔗 Linked GitHub Issue

Fixes #

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [x] Not Applicable

## 🤖 AI Assistance

AI assistance can be used for various tasks, such as code generation,
documentation, or testing.

Please indicate whether you have used AI assistance
for this PR and provide details if applicable.

- [x] I have not used any AI assistance for this PR.
- [ ] I have used AI assistance for this PR.

> [!IMPORTANT]
>
> **Slop will be simply rejected**, if you are using AI assistance you need to make sure you
> understand the code generated and that it meets the project's standards. you
> need at least know how to run the code and deploy it (if needed). See
> [startpaac](https://github.com/openshift-pipelines/startpaac) to make it easy
> to deploy and test your code changes.
>
> If the **majority of the code** in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Claude <noreply@anthropic.com>

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
