### PR TITLE
feat: pin GitHub host on first authenticated webhook

### DIFF
--- a/config/201-controller-role.yaml
+++ b/config/201-controller-role.yaml
@@ -34,6 +34,15 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "list", "watch"]
+  # update is needed to record authenticated provider hostnames in the
+  # auto-trusted-provider-hostnames annotation. No write happens once an
+  # administrator configures trusted-provider-hostnames. Scoped to the controller
+  # ConfigMaps: add the name of any extra controller ConfigMap here when running
+  # several controllers, see hack/second-controller.py.
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["pipelines-as-code"]
+    verbs: ["update", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/config/302-pac-configmap.yaml
+++ b/config/302-pac-configmap.yaml
@@ -20,6 +20,28 @@ data:
   # The application name, you can customize this label. If using the Github App you will need to customize the label on the github app setting as well.
   application-name: "Pipelines as Code CI"
 
+  # Comma separated list of the hosted VCS hostnames this controller is allowed
+  # to send its Git provider credentials to, for example:
+  #
+  #   trusted-provider-hostnames: "ghe.example.com,gitlab.example.com"
+  #
+  # While this key is empty, the controller manages the policy: the public SaaS
+  # instances (github.com, gitlab.com, bitbucket.org, gitea.com, codeberg.org)
+  # stay trusted and the hostname of every webhook whose signature was verified
+  # is recorded in the auto-trusted-provider-hostnames ConfigMap annotation.
+  #
+  # A non-empty list is authoritative for every hostname, the public ones
+  # included, and the controller stops learning hosts. Listing only your own
+  # instance is how you forbid this controller from talking to public SaaS.
+  #
+  # The allowlist gates the GitHub provider today; the other providers are being
+  # moved onto it.
+  #
+  # Set it explicitly when using incoming webhooks, they carry no signature and
+  # can't be used to establish that trust, and when this ConfigMap is managed by
+  # GitOps tooling that prunes controller-owned annotations.
+  trusted-provider-hostnames: ""
+
   # Whether to automatically create a secret with the token to be use by git-clone
   secret-auto-create: "true"
 

--- a/docs/content/docs/advanced/incoming-webhooks.md
+++ b/docs/content/docs/advanced/incoming-webhooks.md
@@ -283,11 +283,17 @@ Pipelines-as-Code sets the `pull_request_number` parameter to `12345`, so any us
 
 ### Using incoming webhooks with GitHub Enterprise
 
-When using a GitHub App with GitHub Enterprise, you must include the `X-GitHub-Enterprise-Host` header in the incoming webhook
-request. For example:
+Before the first GitHub Enterprise incoming webhook, the controller must have
+processed a signed webhook from that GitHub instance. This records the trusted
+GitHub host in the controller's GitHub App Secret. If discovery has not happened
+yet, the incoming request fails with an initialization error.
+
+The incoming request does not select or override the GitHub API endpoint.
 
 ```shell
-curl -H "X-GitHub-Enterprise-Host: github.example.com" -X POST "https://control.pac.url/incoming?repository=repo&branch=main&secret=very-secure-shared-secret&pipelinerun=target-pipelinerun"
+curl -H "Content-Type: application/json" \
+  -X POST "https://control.pac.url/incoming" \
+  -d '{"repository":"repo","branch":"main","pipelinerun":"target-pipelinerun","secret":"very-secure-shared-secret"}'
 ```
 
 ### Using incoming webhooks with webhook-based providers

--- a/docs/content/docs/advanced/incoming-webhooks.md
+++ b/docs/content/docs/advanced/incoming-webhooks.md
@@ -281,13 +281,33 @@ curl -H "Content-Type: application/json" -X POST "https://control.pac.url/incomi
 Pipelines-as-Code sets the `pull_request_number` parameter to `12345`, so any use of
 `{{pull_request_number}}` in your PipelineRun resolves to that value.
 
-### Using incoming webhooks with GitHub Enterprise
+### Using incoming webhooks with a self-hosted provider
 
-When using a GitHub App with GitHub Enterprise, you must include the `X-GitHub-Enterprise-Host` header in the incoming webhook
-request. For example:
+An incoming webhook carries no provider signature, so the controller cannot
+verify where the request really comes from and will not learn a new provider
+hostname from it. On a self-hosted instance (GitHub Enterprise Server, a
+self-managed GitLab, ...) the hostname must therefore already be trusted, either
+because the controller processed a signed webhook from it earlier, or because an
+administrator listed it in the `trusted-provider-hostnames` key of the
+controller ConfigMap:
+
+```bash
+kubectl -n pipelines-as-code patch configmap pipelines-as-code \
+  --type merge -p '{"data":{"trusted-provider-hostnames":"ghe.example.com"}}'
+```
+
+Setting the key explicitly is the recommended setup: it makes incoming webhooks
+work from the start instead of depending on a previous signed webhook. See
+[Trusted provider hostnames]({{< relref "/docs/operations/settings.md#trusted-provider-hostnames" >}}).
+
+Until then the request is refused with an error naming the host and the exact
+command to run. The incoming request itself can never select or override the
+provider API endpoint.
 
 ```shell
-curl -H "X-GitHub-Enterprise-Host: github.example.com" -X POST "https://control.pac.url/incoming?repository=repo&branch=main&secret=very-secure-shared-secret&pipelinerun=target-pipelinerun"
+curl -H "Content-Type: application/json" \
+  -X POST "https://control.pac.url/incoming" \
+  -d '{"repository":"repo","branch":"main","pipelinerun":"target-pipelinerun","secret":"very-secure-shared-secret"}'
 ```
 
 ### Using incoming webhooks with webhook-based providers

--- a/docs/content/docs/api/configmap.md
+++ b/docs/content/docs/api/configmap.md
@@ -312,6 +312,42 @@ auto-configure-repo-repository-template: "{{repo_owner}}-{{repo_name}}-repo-cr"
 
 ### Security and Authorization
 
+{{< param name="trusted-provider-hostnames" type="string" default="" id="param-trusted-provider-hostnames" >}}
+Comma-separated list of Git provider hostnames that Pipelines-as-Code is allowed to send credentials to.
+
+Pipelines-as-Code derives the provider API host it talks to from webhook data. This allowlist makes sure a crafted payload cannot redirect the controller, and its credentials, to a host an attacker controls.
+
+The key has two states:
+
+- **Controller managed** (the key is empty): the public hostnames `github.com`, `gitlab.com`, `bitbucket.org`, `gitea.com` and `codeberg.org` stay trusted, any other host is refused, and every request the provider itself authenticated adds its hostname to the `pipelinesascode.tekton.dev/auto-trusted-provider-hostnames` annotation. A default installation therefore needs no configuration, and a controller serving several instances learns all of them.
+- **Administrator configured** (the key is non-empty): the list is authoritative for every hostname, public ones included, and the controller stops learning hosts. Listing only `ghe.example.com` is how an administrator says "this controller must never talk to a public SaaS instance".
+
+The configuration key belongs only to administrators; the annotation belongs only to the controller. Keeping them separate makes the policy mode unambiguous even when both contain the same hostname.
+
+A hostname that is not routable on the public internet (loopback, link-local, a private range, or an in-cluster `.svc` name) is never recorded automatically, since a payload must not be able to point the controller at the cloud metadata endpoint or an internal service. List it explicitly to trust it.
+
+Paths that carry no provider signature, such as [incoming webhooks]({{< relref "/docs/advanced/incoming-webhooks.md" >}}), never record a hostname, so set this key explicitly on any self-hosted instance.
+
+A value holding only whitespace or separators counts as unset, so use a real
+hostname rather than a placeholder when you mean to configure the policy.
+
+Removing a hostname from a non-empty list immediately narrows the policy.
+Emptying the key returns to controller-managed mode, where previously learned
+hosts become effective again. To return to a clean managed policy, empty the key
+and delete the `pipelinesascode.tekton.dev/auto-trusted-provider-hostnames`
+annotation.
+
+Today the allowlist gates the GitHub provider; the other providers are being
+moved onto it.
+
+Each controller has its own ConfigMap and therefore its own allowlist.
+
+```yaml
+trusted-provider-hostnames: "ghe.example.com, gitlab.example.com"
+```
+
+{{< /param >}}
+
 {{< param name="remember-ok-to-test" type="boolean" default="false" id="param-remember-ok-to-test" >}}
 Controls whether Pipelines-as-Code remembers a previous `/ok-to-test` approval when new commits are pushed to a pull request. By default, users must issue `/ok-to-test` on each push. Set to `true` to persist the approval across push events.
 

--- a/docs/content/docs/installation/installation.md
+++ b/docs/content/docs/installation/installation.md
@@ -68,6 +68,62 @@ echo https://$(oc get route -n pipelines-as-code pipelines-as-code-controller -o
 
 Kubernetes installation requires additional ingress setup. See the [Kubernetes installation guide]({{< relref "kubernetes" >}}) for details.
 
+## Self-hosted Git providers
+
+Pipelines-as-Code only sends Git provider credentials to hostnames it trusts.
+Until you configure the `trusted-provider-hostnames` key the public hostnames
+(`github.com`, `gitlab.com`, `bitbucket.org`, `gitea.com`, `codeberg.org`) are
+trusted, so a public-SaaS installation needs nothing here.
+
+If your provider is self-hosted (GitHub Enterprise Server, a self-managed
+GitLab, Gitea, Bitbucket Data Center, ...), add its hostname to the
+`trusted-provider-hostnames` key of the `pipelines-as-code` ConfigMap. The
+allowlist gates the GitHub provider today and the other providers are being
+moved onto it, so set it for all of them:
+
+```shell
+kubectl -n pipelines-as-code patch configmap pipelines-as-code \
+  --type merge -p '{"data":{"trusted-provider-hostnames":"ghe.example.com"}}'
+```
+
+The value is a comma-separated list, so a controller serving several self-hosted
+instances can trust them all. Adding a hostname of your own makes the list
+authoritative for every hostname, public ones included, and the controller stops
+learning hosts. Removing a hostname from a non-empty list narrows the policy.
+Emptying the key gives the policy back to the controller and makes previously
+learned hosts effective again.
+
+Until you do, the controller records the hostname of every webhook whose
+signature it verified in the
+`pipelinesascode.tekton.dev/auto-trusted-provider-hostnames` ConfigMap
+annotation, which keeps a zero-configuration install working. That only applies
+to signed webhooks:
+[incoming webhooks]({{< relref "/docs/advanced/incoming-webhooks.md" >}}) carry
+no signature and fail until the hostname is trusted.
+
+Setting the key during installation is therefore recommended, and required if
+you deploy the ConfigMap through GitOps tooling that prunes controller-owned
+annotations. Otherwise the controller must relearn the hostname on every signed
+webhook.
+
+### Upgrading an existing self-hosted installation
+
+Only requests the provider itself authenticated can teach the controller a
+hostname, which in practice means a GitHub App webhook. If your installation
+uses per-repository webhooks rather than a GitHub App, or uses incoming
+webhooks, nothing will ever record your hostname for you and the controller
+refuses it. Set the key before upgrading:
+
+```shell
+kubectl -n pipelines-as-code patch configmap pipelines-as-code \
+  --type merge -p '{"data":{"trusted-provider-hostnames":"ghe.example.com"}}'
+```
+
+The controller logs the exact command to run when it refuses a hostname, so a
+missed instance is visible in the controller log rather than silent.
+
+See [Trusted provider hostnames]({{< relref "/docs/operations/settings.md#trusted-provider-hostnames" >}}).
+
 ## RBAC
 
 RBAC (Role-Based Access Control) governs which users can perform actions in a Kubernetes cluster. Non-`system:admin` users must be explicitly granted permission to create Repository

--- a/docs/content/docs/operations/global-repository-settings.md
+++ b/docs/content/docs/operations/global-repository-settings.md
@@ -80,6 +80,8 @@ In this example, the `repo` Repository CR keeps its concurrency limit of 2 becau
 
 Because the local Repository CR sets `git_provider.type` to `gitlab`, matching the global Repository CR, Pipelines-as-Code uses the Git provider settings (secret, webhook secret) from the global repository. It fetches the referenced secrets from the namespace where the global repository lives.
 
+A namespace-level Repository that inherits `git_provider.secret` cannot set a different `git_provider.url`. Otherwise, someone who controls that Repository could redirect a credential owned by the controller namespace. To use another provider endpoint, configure `git_provider.secret` on the namespace-level Repository as well. This restriction applies to webhook-based providers; GitHub Apps use the controller's GitHub App credentials instead of inheriting this secret.
+
 ## Webhook-Based Provider Global Settings
 
 The `spec.git_provider.type` field identifies which Git provider handles incoming webhooks. You can set it to any of the following values for webhook-based providers (everything except GitHub Apps):

--- a/docs/content/docs/operations/multi-controller.md
+++ b/docs/content/docs/operations/multi-controller.md
@@ -35,6 +35,10 @@ Each GitHub application requires:
 | `PAC_CONTROLLER_SECRET`      | Secret containing GitHub App credentials           | `gh-enterprise-secret` |
 | `PAC_CONTROLLER_CONFIGMAP`   | ConfigMap with application settings                | `gh-enterprise-config` |
 
+Each controller Secret independently records the GitHub host discovered from
+its first signed webhook. This binds each GitHub App identity to one GitHub
+instance without additional configuration.
+
 {{< callout type="info" >}}
 While each GitHub application requires its own controller, only one
 status reconciler ("watcher") component is needed cluster-wide.

--- a/docs/content/docs/operations/multi-controller.md
+++ b/docs/content/docs/operations/multi-controller.md
@@ -35,6 +35,22 @@ Each GitHub application requires:
 | `PAC_CONTROLLER_SECRET`      | Secret containing GitHub App credentials           | `gh-enterprise-secret` |
 | `PAC_CONTROLLER_CONFIGMAP`   | ConfigMap with application settings                | `gh-enterprise-config` |
 
+Each controller has its own ConfigMap and therefore its own
+`trusted-provider-hostnames` allowlist, which binds a controller and its
+credentials to the provider instances it is meant to talk to. Set it in the
+ConfigMap named by `PAC_CONTROLLER_CONFIGMAP` when the controller serves a
+self-hosted instance:
+
+```bash
+kubectl -n pipelines-as-code patch configmap gh-enterprise-config \
+  --type merge -p '{"data":{"trusted-provider-hostnames":"ghe.example.com"}}'
+```
+
+If the key is left empty, the controller records authenticated provider
+hostnames in its ConfigMap's
+`pipelinesascode.tekton.dev/auto-trusted-provider-hostnames` annotation. See
+[Trusted provider hostnames]({{< relref "settings.md#trusted-provider-hostnames" >}}).
+
 {{< callout type="info" >}}
 While each GitHub application requires its own controller, only one
 status reconciler ("watcher") component is needed cluster-wide.
@@ -110,21 +126,23 @@ Usage: second-controller.py [-h] [--configmap CONFIGMAP]
                             [--controller-image CONTROLLER_IMAGE]
                             [--gosmee-image GOSMEE_IMAGE]
                             [--smee-url SMEE_URL] [--namespace NAMESPACE]
+                            [--trusted-provider-hostnames TRUSTED_PROVIDER_HOSTNAMES]
                             [--openshift-route]
                             LABEL
 ```
 
 #### Key Options
 
-| Option                     | Description                                                                   |
-| -------------------------- | ----------------------------------------------------------------------------- |
-| `--configmap`              | ConfigMap name (default: `<LABEL>-configmap`)                                 |
-| `--secret`                 | Secret name (default: `<LABEL>-secret`)                                       |
-| `--ingress-domain`         | Create Ingress with specified domain (Kubernetes)                             |
-| `--openshift-route`        | Create OpenShift Route instead of Ingress                                     |
-| `--controller-image`       | Custom controller image (use `ko` for local builds)                           |
-| `--smee-url`               | Deploy Gosmee sidecar for webhook tunneling                                   |
-| `--namespace`              | Target namespace (default: `pipelines-as-code`)                               |
+| Option                         | Description                                                            |
+| ------------------------------ | ---------------------------------------------------------------------- |
+| `--configmap`                  | ConfigMap name (default: `<LABEL>-configmap`)                          |
+| `--secret`                     | Secret name (default: `<LABEL>-secret`)                                |
+| `--ingress-domain`             | Create Ingress with specified domain (Kubernetes)                      |
+| `--openshift-route`            | Create OpenShift Route instead of Ingress                              |
+| `--controller-image`           | Custom controller image (use `ko` for local builds)                    |
+| `--smee-url`                   | Deploy Gosmee sidecar for webhook tunneling                            |
+| `--namespace`                  | Target namespace (default: `pipelines-as-code`)                        |
+| `--trusted-provider-hostnames` | Self-hosted provider hostnames this controller may send credentials to |
 
 ### Example Scenarios
 
@@ -136,6 +154,7 @@ The following examples show common deployment patterns.
 # Generate and apply configuration for GitHub Enterprise
 python3 hack/second-controller.py ghe \
   --ingress-domain "ghe.example.com" \
+  --trusted-provider-hostnames "ghe.example.com" \
   --namespace pipelines-as-code | kubectl apply -f -
 ```
 

--- a/docs/content/docs/operations/settings.md
+++ b/docs/content/docs/operations/settings.md
@@ -22,6 +22,42 @@ and their default values.
 For instructions on viewing and applying changes, see
 [Configuration]({{< relref "configuration" >}}).
 
+### Trusted provider hostnames
+
+Pipelines-as-Code only sends Git provider credentials to hostnames it trusts,
+listed in the `trusted-provider-hostnames` key:
+
+```bash
+kubectl -n pipelines-as-code patch configmap pipelines-as-code \
+  --type merge -p '{"data":{"trusted-provider-hostnames":"ghe.example.com"}}'
+```
+
+While the key is empty, the public hostnames (`github.com`, `gitlab.com`,
+`bitbucket.org`, `gitea.com`, `codeberg.org`) stay trusted and every request the
+provider itself authenticated adds its hostname to the
+`pipelinesascode.tekton.dev/auto-trusted-provider-hostnames` annotation. A
+default installation needs no configuration, and a controller serving several
+instances learns all of them.
+
+A non-empty list is authoritative for every hostname, public ones included, and
+the controller stops learning hosts. Listing only your own instance is how you
+say "this controller must never talk to a public SaaS instance".
+
+That automatic trust only covers requests the provider signed:
+[incoming webhooks]({{< relref "/docs/advanced/incoming-webhooks.md" >}}) carry
+no provider signature and fail until the hostname is trusted. Set the key
+explicitly on any self-hosted instance.
+
+Emptying the list returns to controller-managed mode and makes previously
+learned hosts effective again. Delete the auto-trusted annotation as well when
+you want the controller to forget them.
+
+Today the allowlist gates the GitHub provider; the other providers are being
+moved onto it.
+
+See the [ConfigMap Reference]({{< relref "/docs/api/configmap#param-trusted-provider-hostnames" >}})
+for details.
+
 ## Per-repository configuration
 
 Each `Repository` CR can include a `spec.settings` block that overrides selected

--- a/docs/content/docs/providers/github-app.md
+++ b/docs/content/docs/providers/github-app.md
@@ -79,4 +79,38 @@ Finally, install the App on the repositories you want to use with Pipelines-as-C
 
 ## Notes
 
-- Pipelines-as-Code supports GitHub Enterprise with no special configuration required. Pipelines-as-Code automatically detects the header set by GitHub Enterprise and uses the GitHub Enterprise API auth URL instead of the public GitHub API.
+- GitHub.com requires no additional configuration.
+- For GitHub Enterprise Server, Pipelines-as-Code validates the first signed
+  webhook and records its GitHub host in the controller's GitHub App Secret.
+  Later credential requests must match that host. Repository CRs and incoming
+  webhook headers cannot change it.
+
+### GitHub Enterprise host pinning
+
+The trusted GitHub Enterprise host is stored under the `github-host` key in
+the controller Secret (`pipelines-as-code-secret` by default). The key is
+created automatically by the first signed webhook and is never overwritten
+with a different host afterwards.
+
+To set the pin manually (for example before any webhook has been received):
+
+```bash
+kubectl -n pipelines-as-code patch secret pipelines-as-code-secret \
+  --type merge -p '{"stringData":{"github-host":"ghe.example.com"}}'
+```
+
+To reset the pin, for example after migrating to a new GitHub Enterprise
+hostname, remove the key. The next signed webhook re-pins the new host:
+
+```bash
+kubectl -n pipelines-as-code patch secret pipelines-as-code-secret \
+  --type json -p '[{"op":"remove","path":"/data/github-host"}]'
+```
+
+If the controller Secret is managed by GitOps tooling (Argo CD,
+External Secrets Operator, ...), the reconciler will treat the
+controller-written `github-host` key as drift and remove it on every sync.
+For GitHub Enterprise, pre-seed the key in the source-of-truth Secret
+manifest with your GitHub Enterprise hostname (for example
+`github-host: ghe.example.com`), or exclude the key from reconciliation
+(for example with Argo CD `ignoreDifferences`).

--- a/docs/content/docs/providers/github-app.md
+++ b/docs/content/docs/providers/github-app.md
@@ -79,4 +79,67 @@ Finally, install the App on the repositories you want to use with Pipelines-as-C
 
 ## Notes
 
-- Pipelines-as-Code supports GitHub Enterprise with no special configuration required. Pipelines-as-Code automatically detects the header set by GitHub Enterprise and uses the GitHub Enterprise API auth URL instead of the public GitHub API.
+- GitHub.com requires no additional configuration.
+- For a self hosted instance such as GitHub Enterprise Server, the hostname must
+  be trusted by the controller before it will send credentials to it. See
+  [Trusted provider hostnames]({{< relref "/docs/operations/settings.md#trusted-provider-hostnames" >}}).
+
+### Trusting a self hosted GitHub instance
+
+Pipelines-as-Code only sends its Git provider credentials to hostnames it
+trusts, listed in the `trusted-provider-hostnames` key of the controller
+ConfigMap (`pipelines-as-code` by default):
+
+```bash
+kubectl -n pipelines-as-code patch configmap pipelines-as-code \
+  --type merge -p '{"data":{"trusted-provider-hostnames":"ghe.example.com"}}'
+```
+
+The value is a comma separated list, so several instances can be trusted at
+once, which is what you want when a single controller serves more than one self
+hosted provider:
+
+```yaml
+trusted-provider-hostnames: "ghe.example.com, gitlab.example.com"
+```
+
+While the key is empty, the public hostnames (`github.com`, `gitlab.com`,
+`bitbucket.org`, `gitea.com`, `codeberg.org`) stay trusted and the controller
+records the hostname of every webhook whose signature it verified in the
+`pipelinesascode.tekton.dev/auto-trusted-provider-hostnames` ConfigMap
+annotation. This keeps a default installation working without configuration,
+and a controller serving several instances learns all of them.
+
+A non-empty list is authoritative for every hostname, public ones included, and
+the controller stops learning hosts. Listing only `ghe.example.com` is how you
+make sure the controller never talks to `github.com`.
+
+The automatic trust only covers webhooks GitHub signed:
+[incoming webhooks]({{< relref "/docs/advanced/incoming-webhooks.md" >}}) carry
+no signature and will fail until the hostname is trusted. Setting the key
+explicitly is therefore the recommended setup for any self hosted instance.
+
+A hostname that is not routable on the public internet (loopback, a private
+range, or an in-cluster `.svc` name) is never recorded automatically: list it
+explicitly to trust it.
+
+If a hostname is not trusted, the controller refuses the request and logs the
+exact command to run:
+
+```text
+refusing to use credentials with the "ghe.example.com" host: it is not listed in
+the "trusted-provider-hostnames" key of the pipelines-as-code/pipelines-as-code
+ConfigMap. Add it with: kubectl -n pipelines-as-code patch configmap ...
+```
+
+After migrating to a new hostname, replace the value with the new one. Removing
+a hostname from a non-empty list immediately stops the controller from talking
+to it. Emptying the key gives the policy back to the controller and makes its
+previously learned hosts effective again; delete the auto-trusted annotation as
+well to forget them.
+
+If the controller ConfigMap is managed by GitOps tooling (Argo CD, the
+OpenShift Pipelines operator through `TektonConfig`, ...), set
+`trusted-provider-hostnames` in the source of truth. Otherwise a reconciler that
+prunes controller-owned annotations makes the controller relearn the hostname
+on every signed webhook.

--- a/go.mod
+++ b/go.mod
@@ -153,7 +153,7 @@ require (
 	go.uber.org/automaxprocs v1.6.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.55.0 // indirect
-	golang.org/x/net v0.57.0 // indirect
+	golang.org/x/net v0.57.0
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/term v0.45.0
 	golang.org/x/time v0.15.0 // indirect

--- a/hack/second-controller.py
+++ b/hack/second-controller.py
@@ -111,6 +111,17 @@ def parse_arguments():
     )
 
     parser.add_argument(
+        "--trusted-provider-hostnames",
+        help=(
+            "comma separated hostnames of the git providers this controller is "
+            "allowed to send credentials to, e.g. ghe.example.com. Once set, the "
+            "list is authoritative and the public instances are trusted only if "
+            "they are listed too"
+        ),
+        default=os.environ.get("PAC_TRUSTED_PROVIDER_HOSTNAMES", ""),
+    )
+
+    parser.add_argument(
         "--openshift-route",
         help="add an openshift route to the controller",
         action="store_true",
@@ -166,9 +177,54 @@ with open("config/302-pac-configmap.yaml", "r", encoding="utf-8") as f:
     configmap = yaml.load(f, Loader=yaml.FullLoader)
     configmap["metadata"]["name"] = args.configmap
     configmap["metadata"]["namespace"] = args.namespace
+    if args.trusted_provider_hostnames:
+        configmap.setdefault("data", {})["trusted-provider-hostnames"] = (
+            args.trusted_provider_hostnames
+        )
+
+# The controller Role in config/201-controller-role.yaml scopes ConfigMap writes
+# to the default ConfigMap name, so a second controller needs its own Role to be
+# able to record a trusted provider hostname in its own ConfigMap.
+role = {
+    "apiVersion": "rbac.authorization.k8s.io/v1",
+    "kind": "Role",
+    "metadata": {
+        "name": f"{args.label}-controller-role",
+        "namespace": args.namespace,
+    },
+    "rules": [
+        {
+            "apiGroups": [""],
+            "resources": ["configmaps"],
+            "resourceNames": [args.configmap],
+            "verbs": ["update", "patch"],
+        }
+    ],
+}
+
+rolebinding = {
+    "apiVersion": "rbac.authorization.k8s.io/v1",
+    "kind": "RoleBinding",
+    "metadata": {
+        "name": f"{args.label}-controller-binding",
+        "namespace": args.namespace,
+    },
+    "subjects": [
+        {
+            "kind": "ServiceAccount",
+            "name": "pipelines-as-code-controller",
+            "namespace": args.namespace,
+        }
+    ],
+    "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": f"{args.label}-controller-role",
+    },
+}
 
 # re-encode as YAML to stdout
-for obj in [controller, service, configmap]:
+for obj in [controller, service, configmap, role, rolebinding]:
     print("---")
     yaml.dump(obj, sys.stdout, default_flow_style=False)
 

--- a/pkg/adapter/incoming.go
+++ b/pkg/adapter/incoming.go
@@ -177,7 +177,7 @@ func (l *listener) detectIncoming(ctx context.Context, event *info.Event, req *h
 		gh := github.New()
 		gh.Run = l.run
 		ns := info.GetNS(ctx)
-		ip := app.NewInstallation(req, l.run, repo, gh, ns)
+		ip := app.NewInstallation(l.run, repo, gh, ns)
 		enterpriseURL, token, installationID, err := ip.GetAndUpdateInstallationID(ctx)
 		if err != nil {
 			return false, nil, err

--- a/pkg/adapter/incoming.go
+++ b/pkg/adapter/incoming.go
@@ -181,7 +181,7 @@ func (l *listener) detectIncoming(ctx context.Context, event *info.Event, req *h
 			gh.SetPacInfo(&pacInfo)
 		}
 		ns := info.GetNS(ctx)
-		ip := app.NewInstallation(req, l.run, repo, gh, ns)
+		ip := app.NewInstallation(l.run, repo, gh, ns)
 		enterpriseURL, token, installationID, err := ip.GetAndUpdateInstallationID(ctx)
 		if err != nil {
 			return false, nil, err

--- a/pkg/adapter/incoming_test.go
+++ b/pkg/adapter/incoming_test.go
@@ -23,6 +23,8 @@ import (
 	"gotest.tools/v3/env"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ktesting "k8s.io/client-go/testing"
 	rtesting "knative.dev/pkg/reconciler/testing"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
@@ -1132,6 +1134,216 @@ func TestIncomingGitHubAppScopesTokenThroughClientSetup(t *testing.T) {
 
 	_, hasRepoIDs := capturedBody["repository_ids"]
 	assert.Assert(t, !hasRepoIDs, "repository_ids should not be present for incoming name-scoped token")
+}
+
+func TestDetectIncomingRejectsUnconfiguredGitHubHost(t *testing.T) {
+	const (
+		namespace  = "default"
+		repository = "incoming-repo"
+		secret     = "shared-secret"
+	)
+
+	requests := 0
+	server := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requests++
+	}))
+	defer server.Close()
+
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = info.StoreCurrentControllerName(ctx, "default")
+	ctx = info.StoreNS(ctx, "pipelines-as-code")
+
+	seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+		Secret: []*corev1.Secret{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      info.DefaultPipelinesAscodeSecretName,
+				Namespace: "pipelines-as-code",
+			},
+			Data: map[string][]byte{
+				"github-application-id": []byte("12345"),
+				"github-private-key":    []byte(fakePrivateKey),
+			},
+		}},
+		Repositories: []*v1alpha1.Repository{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      repository,
+				Namespace: namespace,
+			},
+			Spec: v1alpha1.RepositorySpec{
+				URL: server.URL + "/owner/repo",
+				Incomings: &[]v1alpha1.Incoming{{
+					Targets: []string{"main"},
+					Secret: v1alpha1.Secret{
+						Name: "incoming-secret",
+					},
+				}},
+			},
+		}},
+	})
+	run := &params.Run{
+		Clients: clients.Clients{
+			Kube:           seedData.Kube,
+			PipelineAsCode: seedData.PipelineAsCode,
+		},
+		Info: info.Info{
+			Controller: &info.ControllerInfo{Secret: info.DefaultPipelinesAscodeSecretName},
+		},
+	}
+	l := &listener{
+		run:    run,
+		logger: zap.NewNop().Sugar(),
+		kint: &kubernetestint.KinterfaceTest{
+			GetSecretResult: map[string]string{"incoming-secret": secret},
+		},
+	}
+	payload := fmt.Sprintf(`{"repository":%q,"namespace":%q,"branch":"main","pipelinerun":"pr","secret":%q}`, repository, namespace, secret)
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/incoming", strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+
+	_, _, err := l.detectIncoming(ctx, info.NewEvent(), req, []byte(payload))
+	assert.ErrorContains(t, err, "has not been authenticated yet")
+	assert.Equal(t, requests, 0)
+}
+
+func TestDetectIncomingHandlesGitHubAppInstallation(t *testing.T) {
+	const (
+		namespace  = "default"
+		systemNS   = "pipelines-as-code"
+		repository = "incoming-repo"
+		secret     = "shared-secret"
+		token      = "installation-token"
+	)
+
+	tests := []struct {
+		name               string
+		installationID     int64
+		wantErrText        string
+		wantDetected       bool
+		wantInstallationID int64
+		wantToken          string
+	}{
+		{
+			name:               "installed",
+			installationID:     44,
+			wantDetected:       true,
+			wantInstallationID: 44,
+			wantToken:          token,
+		},
+		{
+			name:           "zero installation id",
+			installationID: 0,
+			wantErrText:    "GithubApp is not installed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, mux, serverURL, teardown := ghtesthelper.SetupGH()
+			defer teardown()
+			t.Setenv("PAC_GIT_PROVIDER_TOKEN_APIURL", serverURL+"/api/v3")
+			mux.HandleFunc(fmt.Sprintf("/repos/owner/%s/installation", repository), func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = fmt.Fprintf(w, `{"id": %d}`, tt.installationID)
+			})
+			mux.HandleFunc(fmt.Sprintf("/app/installations/%d/access_tokens", tt.installationID), func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = fmt.Fprintf(w, `{"token": %q}`, token)
+			})
+
+			ctx, _ := rtesting.SetupFakeContext(t)
+			ctx = info.StoreCurrentControllerName(ctx, "default")
+			ctx = info.StoreNS(ctx, systemNS)
+			seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+				Secret: []*corev1.Secret{{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      info.DefaultPipelinesAscodeSecretName,
+						Namespace: systemNS,
+					},
+					Data: map[string][]byte{
+						"github-application-id": []byte("12345"),
+						"github-private-key":    []byte(fakePrivateKey),
+					},
+				}},
+				Repositories: []*v1alpha1.Repository{{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      repository,
+						Namespace: namespace,
+					},
+					Spec: v1alpha1.RepositorySpec{
+						URL: "https://github.com/owner/" + repository,
+						Incomings: &[]v1alpha1.Incoming{{
+							Targets: []string{"main"},
+							Secret:  v1alpha1.Secret{Name: "incoming-secret"},
+						}},
+					},
+				}},
+			})
+			run := &params.Run{
+				Clients: clients.Clients{
+					Kube:           seedData.Kube,
+					PipelineAsCode: seedData.PipelineAsCode,
+				},
+				Info: info.Info{
+					Controller: &info.ControllerInfo{Secret: info.DefaultPipelinesAscodeSecretName},
+				},
+			}
+			l := &listener{
+				run:    run,
+				logger: zap.NewNop().Sugar(),
+				kint: &kubernetestint.KinterfaceTest{
+					GetSecretResult: map[string]string{"incoming-secret": secret},
+				},
+			}
+			payload := fmt.Sprintf(`{"repository":%q,"namespace":%q,"branch":"main","pipelinerun":"pr","secret":%q}`, repository, namespace, secret)
+			req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/incoming", strings.NewReader(payload))
+			req.Header.Set("Content-Type", "application/json")
+			event := info.NewEvent()
+
+			got, repo, err := l.detectIncoming(ctx, event, req, []byte(payload))
+			if tt.wantErrText != "" {
+				assert.ErrorContains(t, err, tt.wantErrText)
+				return
+			}
+
+			assert.NilError(t, err)
+			assert.Assert(t, repo != nil)
+			assert.Equal(t, got, tt.wantDetected)
+			assert.Equal(t, event.Provider.Token, tt.wantToken)
+			assert.Equal(t, event.InstallationID, tt.wantInstallationID)
+			assert.Equal(t, event.TargetPipelineRun, "pr")
+			assert.Equal(t, event.URL, "https://github.com/owner/"+repository)
+		})
+	}
+}
+
+func TestDetectIncomingReturnsRepositoryListErrors(t *testing.T) {
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = info.StoreCurrentControllerName(ctx, "default")
+	ctx = info.StoreNS(ctx, "pipelines-as-code")
+	seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{})
+	seedData.PipelineAsCode.PrependReactor("list", "repositories", func(_ ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("list failed")
+	})
+	run := &params.Run{
+		Clients: clients.Clients{
+			Kube:           seedData.Kube,
+			PipelineAsCode: seedData.PipelineAsCode,
+		},
+		Info: info.Info{
+			Controller: &info.ControllerInfo{Secret: info.DefaultPipelinesAscodeSecretName},
+		},
+	}
+	l := &listener{
+		run:    run,
+		logger: zap.NewNop().Sugar(),
+		kint:   &kubernetestint.KinterfaceTest{},
+	}
+	payload := `{"repository":"incoming-repo","branch":"main","pipelinerun":"pr","secret":"shared-secret"}`
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/incoming", strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+
+	got, repo, err := l.detectIncoming(ctx, info.NewEvent(), req, []byte(payload))
+	assert.ErrorContains(t, err, "error getting repo")
+	assert.Assert(t, !got)
+	assert.Assert(t, repo == nil)
 }
 
 func TestApplyIncomingParams(t *testing.T) {

--- a/pkg/adapter/incoming_test.go
+++ b/pkg/adapter/incoming_test.go
@@ -23,12 +23,15 @@ import (
 	"gotest.tools/v3/env"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ktesting "k8s.io/client-go/testing"
 	rtesting "knative.dev/pkg/reconciler/testing"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketcloud"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketdatacenter"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/gitea"
@@ -1110,6 +1113,12 @@ func TestIncomingGitHubAppScopesTokenThroughClientSetup(t *testing.T) {
 				"webhook.secret":        []byte("webhook-secret"),
 			},
 		}},
+		ConfigMap: []*corev1.ConfigMap{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      info.DefaultPipelinesAscodeConfigmapName,
+				Namespace: namespace,
+			},
+		}},
 	})
 
 	run := &params.Run{
@@ -1119,8 +1128,11 @@ func TestIncomingGitHubAppScopesTokenThroughClientSetup(t *testing.T) {
 			Log:            testLog,
 		},
 		Info: info.Info{
-			Controller: &info.ControllerInfo{Secret: secretName},
-			Kube:       &info.KubeOpts{Namespace: namespace},
+			Controller: &info.ControllerInfo{
+				Secret:    secretName,
+				Configmap: info.DefaultPipelinesAscodeConfigmapName,
+			},
+			Kube: &info.KubeOpts{Namespace: namespace},
 		},
 	}
 
@@ -1163,6 +1175,237 @@ func TestIncomingGitHubAppScopesTokenThroughClientSetup(t *testing.T) {
 
 	_, hasRepoIDs := capturedBody["repository_ids"]
 	assert.Assert(t, !hasRepoIDs, "repository_ids should not be present for incoming name-scoped token")
+}
+
+func TestDetectIncomingRejectsUnconfiguredGitHubHost(t *testing.T) {
+	const (
+		namespace  = "default"
+		repository = "incoming-repo"
+		secret     = "shared-secret"
+	)
+
+	requests := 0
+	server := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requests++
+	}))
+	defer server.Close()
+
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = info.StoreCurrentControllerName(ctx, "default")
+	ctx = info.StoreNS(ctx, "pipelines-as-code")
+
+	seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+		Secret: []*corev1.Secret{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      info.DefaultPipelinesAscodeSecretName,
+				Namespace: "pipelines-as-code",
+			},
+			Data: map[string][]byte{
+				"github-application-id": []byte("12345"),
+				"github-private-key":    []byte(fakePrivateKey),
+			},
+		}},
+		ConfigMap: []*corev1.ConfigMap{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      info.DefaultPipelinesAscodeConfigmapName,
+				Namespace: "pipelines-as-code",
+			},
+			Data: map[string]string{
+				settings.TrustedProviderHostnamesKey: "",
+			},
+		}},
+		Repositories: []*v1alpha1.Repository{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      repository,
+				Namespace: namespace,
+			},
+			Spec: v1alpha1.RepositorySpec{
+				URL: server.URL + "/owner/repo",
+				Incomings: &[]v1alpha1.Incoming{{
+					Targets: []string{"main"},
+					Secret: v1alpha1.Secret{
+						Name: "incoming-secret",
+					},
+				}},
+			},
+		}},
+	})
+	run := &params.Run{
+		Clients: clients.Clients{
+			Kube:           seedData.Kube,
+			PipelineAsCode: seedData.PipelineAsCode,
+		},
+		Info: info.Info{
+			Controller: &info.ControllerInfo{
+				Secret:    info.DefaultPipelinesAscodeSecretName,
+				Configmap: info.DefaultPipelinesAscodeConfigmapName,
+			},
+		},
+	}
+	l := &listener{
+		run:    run,
+		logger: zap.NewNop().Sugar(),
+		kint: &kubernetestint.KinterfaceTest{
+			GetSecretResult: map[string]string{"incoming-secret": secret},
+		},
+	}
+	payload := fmt.Sprintf(`{"repository":%q,"namespace":%q,"branch":"main","pipelinerun":"pr","secret":%q}`, repository, namespace, secret)
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/incoming", strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+
+	_, _, err := l.detectIncoming(ctx, info.NewEvent(), req, []byte(payload))
+	assert.ErrorContains(t, err, "refusing to use credentials")
+	assert.Equal(t, requests, 0)
+}
+
+func TestDetectIncomingHandlesGitHubAppInstallation(t *testing.T) {
+	const (
+		namespace  = "default"
+		systemNS   = "pipelines-as-code"
+		repository = "incoming-repo"
+		secret     = "shared-secret"
+		token      = "installation-token"
+	)
+
+	tests := []struct {
+		name               string
+		installationID     int64
+		wantErrText        string
+		wantDetected       bool
+		wantInstallationID int64
+		wantToken          string
+	}{
+		{
+			name:               "installed",
+			installationID:     44,
+			wantDetected:       true,
+			wantInstallationID: 44,
+			wantToken:          token,
+		},
+		{
+			name:           "zero installation id",
+			installationID: 0,
+			wantErrText:    "GithubApp is not installed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, mux, serverURL, teardown := ghtesthelper.SetupGH()
+			defer teardown()
+			t.Setenv("PAC_GIT_PROVIDER_TOKEN_APIURL", serverURL+"/api/v3")
+			mux.HandleFunc(fmt.Sprintf("/repos/owner/%s/installation", repository), func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = fmt.Fprintf(w, `{"id": %d}`, tt.installationID)
+			})
+			mux.HandleFunc(fmt.Sprintf("/app/installations/%d/access_tokens", tt.installationID), func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = fmt.Fprintf(w, `{"token": %q}`, token)
+			})
+
+			ctx, _ := rtesting.SetupFakeContext(t)
+			ctx = info.StoreCurrentControllerName(ctx, "default")
+			ctx = info.StoreNS(ctx, systemNS)
+			seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+				Secret: []*corev1.Secret{{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      info.DefaultPipelinesAscodeSecretName,
+						Namespace: systemNS,
+					},
+					Data: map[string][]byte{
+						"github-application-id": []byte("12345"),
+						"github-private-key":    []byte(fakePrivateKey),
+					},
+				}},
+				ConfigMap: []*corev1.ConfigMap{{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      info.DefaultPipelinesAscodeConfigmapName,
+						Namespace: systemNS,
+					},
+				}},
+				Repositories: []*v1alpha1.Repository{{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      repository,
+						Namespace: namespace,
+					},
+					Spec: v1alpha1.RepositorySpec{
+						URL: "https://github.com/owner/" + repository,
+						Incomings: &[]v1alpha1.Incoming{{
+							Targets: []string{"main"},
+							Secret:  v1alpha1.Secret{Name: "incoming-secret"},
+						}},
+					},
+				}},
+			})
+			run := &params.Run{
+				Clients: clients.Clients{
+					Kube:           seedData.Kube,
+					PipelineAsCode: seedData.PipelineAsCode,
+				},
+				Info: info.Info{
+					Controller: &info.ControllerInfo{
+						Secret:    info.DefaultPipelinesAscodeSecretName,
+						Configmap: info.DefaultPipelinesAscodeConfigmapName,
+					},
+				},
+			}
+			l := &listener{
+				run:    run,
+				logger: zap.NewNop().Sugar(),
+				kint: &kubernetestint.KinterfaceTest{
+					GetSecretResult: map[string]string{"incoming-secret": secret},
+				},
+			}
+			payload := fmt.Sprintf(`{"repository":%q,"namespace":%q,"branch":"main","pipelinerun":"pr","secret":%q}`, repository, namespace, secret)
+			req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/incoming", strings.NewReader(payload))
+			req.Header.Set("Content-Type", "application/json")
+			event := info.NewEvent()
+
+			got, repo, err := l.detectIncoming(ctx, event, req, []byte(payload))
+			if tt.wantErrText != "" {
+				assert.ErrorContains(t, err, tt.wantErrText)
+				return
+			}
+
+			assert.NilError(t, err)
+			assert.Assert(t, repo != nil)
+			assert.Equal(t, got, tt.wantDetected)
+			assert.Equal(t, event.Provider.Token, tt.wantToken)
+			assert.Equal(t, event.InstallationID, tt.wantInstallationID)
+			assert.Equal(t, event.TargetPipelineRun, "pr")
+			assert.Equal(t, event.URL, "https://github.com/owner/"+repository)
+		})
+	}
+}
+
+func TestDetectIncomingReturnsRepositoryListErrors(t *testing.T) {
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = info.StoreCurrentControllerName(ctx, "default")
+	ctx = info.StoreNS(ctx, "pipelines-as-code")
+	seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{})
+	seedData.PipelineAsCode.PrependReactor("list", "repositories", func(_ ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("list failed")
+	})
+	run := &params.Run{
+		Clients: clients.Clients{
+			Kube:           seedData.Kube,
+			PipelineAsCode: seedData.PipelineAsCode,
+		},
+		Info: info.Info{
+			Controller: &info.ControllerInfo{Secret: info.DefaultPipelinesAscodeSecretName},
+		},
+	}
+	l := &listener{
+		run:    run,
+		logger: zap.NewNop().Sugar(),
+		kint:   &kubernetestint.KinterfaceTest{},
+	}
+	payload := `{"repository":"incoming-repo","branch":"main","pipelinerun":"pr","secret":"shared-secret"}`
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/incoming", strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+
+	got, repo, err := l.detectIncoming(ctx, info.NewEvent(), req, []byte(payload))
+	assert.ErrorContains(t, err, "error getting repo")
+	assert.Assert(t, !got)
+	assert.Assert(t, repo == nil)
 }
 
 func TestApplyIncomingParams(t *testing.T) {

--- a/pkg/apis/pipelinesascode/keys/keys.go
+++ b/pkg/apis/pipelinesascode/keys/keys.go
@@ -64,11 +64,11 @@ const (
 	SCMReportingPLRStarted = pipelinesascode.GroupName + "/scm-reporting-plr-started"
 	SecretCreated          = pipelinesascode.GroupName + "/secret-created"
 	CloneURL               = pipelinesascode.GroupName + "/clone-url"
-	// PublicGithubAPIURL default is "https://api.github.com" but it can be overridden by X-GitHub-Enterprise-Host header.
-	PublicGithubAPIURL   = "https://api.github.com"
-	GithubApplicationID  = "github-application-id"
-	GithubPrivateKey     = "github-private-key"
-	ResultsRecordSummary = "results.tekton.dev/recordSummaryAnnotations"
+	PublicGithubAPIURL     = "https://api.github.com"
+	GithubApplicationID    = "github-application-id"
+	GithubPrivateKey       = "github-private-key"
+	GithubHost             = "github-host"
+	ResultsRecordSummary   = "results.tekton.dev/recordSummaryAnnotations"
 
 	SpanContextAnnotation = "tekton.dev/pipelinerunSpanContext"
 )

--- a/pkg/apis/pipelinesascode/keys/keys.go
+++ b/pkg/apis/pipelinesascode/keys/keys.go
@@ -64,7 +64,11 @@ const (
 	SCMReportingPLRStarted = pipelinesascode.GroupName + "/scm-reporting-plr-started"
 	SecretCreated          = pipelinesascode.GroupName + "/secret-created"
 	CloneURL               = pipelinesascode.GroupName + "/clone-url"
-	// PublicGithubAPIURL default is "https://api.github.com" but it can be overridden by X-GitHub-Enterprise-Host header.
+	// AutoTrustedProviderHostnames annotates the controller ConfigMap with the
+	// hostnames the controller learnt on its own, so that it can tell them apart
+	// from the ones an administrator configured deliberately.
+	AutoTrustedProviderHostnames = pipelinesascode.GroupName + "/auto-trusted-provider-hostnames"
+	// PublicGithubAPIURL is the API URL of the public github.com instance.
 	PublicGithubAPIURL   = "https://api.github.com"
 	GithubApplicationID  = "github-application-id"
 	GithubPrivateKey     = "github-private-key"

--- a/pkg/cmd/tknpac/bootstrap/kubestuff.go
+++ b/pkg/cmd/tknpac/bootstrap/kubestuff.go
@@ -3,11 +3,16 @@ package bootstrap
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/google/go-github/v90/github"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/vcshost"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 )
 
 // deleteSecret delete secret first if it exists.
@@ -36,6 +41,70 @@ func createPacSecret(ctx context.Context, run *params.Run, opts *bootstrapOpts, 
 
 	fmt.Fprintf(opts.ioStreams.Out, "🔑 Secret %s has been created in the %s namespace\n", secretName, opts.targetNamespace)
 	return nil
+}
+
+// trustProviderHostname adds the GitHub instance the App was created on to the
+// controller allowlist, so that the controller is allowed to send its
+// credentials there. Seeding it here also closes the trust on first use window
+// immediately: the hostname comes from the user running the bootstrap, not from
+// a webhook payload.
+func trustProviderHostname(ctx context.Context, run *params.Run, opts *bootstrapOpts) error {
+	configMapName := info.DefaultPipelinesAscodeConfigmapName
+	if run.Info.Controller != nil && run.Info.Controller.Configmap != "" {
+		configMapName = run.Info.Controller.Configmap
+	}
+
+	host, err := vcshost.Parse(opts.GithubAPIURL)
+	if err != nil {
+		// The App already exists at this point, so failing the bootstrap would
+		// leave a half provisioned install. Warn loudly instead: skipping a
+		// security setup step must never be silent.
+		warnUntrustedHostname(opts, configMapName, opts.GithubAPIURL, err)
+		return nil //nolint:nilerr
+	}
+
+	host = vcshost.Canonical(host)
+
+	cms := run.Clients.Kube.CoreV1().ConfigMaps(opts.targetNamespace)
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		cm, err := cms.Get(ctx, configMapName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		hosts, err := vcshost.ParseAllowlist(cm.Data[settings.TrustedProviderHostnamesKey])
+		if err != nil {
+			return err
+		}
+		if slices.Contains(hosts, host) {
+			return nil
+		}
+		if cm.Data == nil {
+			cm.Data = map[string]string{}
+		}
+		cm.Data[settings.TrustedProviderHostnamesKey] = vcshost.Join(append(hosts, host))
+		_, err = cms.Update(ctx, cm, metav1.UpdateOptions{})
+		return err
+	})
+	if err != nil {
+		warnUntrustedHostname(opts, configMapName, host, err)
+		return nil //nolint:nilerr
+	}
+
+	fmt.Fprintf(opts.ioStreams.Out, "🔒 Hostname %s has been added to the %q key of the %s ConfigMap\n",
+		host, settings.TrustedProviderHostnamesKey, configMapName)
+	return nil
+}
+
+// warnUntrustedHostname tells the user, with a ready to run command, that the
+// controller will refuse to talk to the instance until they configure it.
+func warnUntrustedHostname(opts *bootstrapOpts, configMapName, host string, cause error) {
+	fmt.Fprintf(opts.ioStreams.ErrOut,
+		"\n⚠️  Could not add %q to the %q key of the %s ConfigMap: %v\n"+
+			"   Pipelines-as-Code refuses to send credentials to a host it does not trust.\n"+
+			"   Run this before using the App:\n"+
+			"   kubectl -n %s patch configmap %s --type merge -p '{\"data\":{\"%s\":\"HOSTNAME\"}}'\n\n",
+		host, settings.TrustedProviderHostnamesKey, configMapName, cause,
+		opts.targetNamespace, configMapName, settings.TrustedProviderHostnamesKey)
 }
 
 func checkPipelinesInstalled(run *params.Run) (bool, error) {

--- a/pkg/cmd/tknpac/bootstrap/kubestuff_test.go
+++ b/pkg/cmd/tknpac/bootstrap/kubestuff_test.go
@@ -1,0 +1,129 @@
+package bootstrap
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
+	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	rtesting "knative.dev/pkg/reconciler/testing"
+)
+
+func TestTrustProviderHostname(t *testing.T) {
+	const namespace = "pipelines-as-code"
+
+	tests := []struct {
+		name string
+		// existingHosts is the value of the trusted-provider-hostnames key the
+		// ConfigMap already holds; noConfigMap skips creating it entirely.
+		existingHosts       string
+		noConfigMap         bool
+		githubAPIURL        string
+		controllerConfigMap string
+		wantHosts           string
+		wantOutSub          string
+		wantErrOutSub       string
+	}{
+		{
+			name:         "adds the hostname to an empty allowlist",
+			githubAPIURL: "https://ghe.example.com",
+			wantHosts:    "ghe.example.com",
+			wantOutSub:   "has been added",
+		},
+		{
+			name:          "appends to the hosts already trusted",
+			existingHosts: "other.example.com",
+			githubAPIURL:  "https://ghe.example.com",
+			wantHosts:     "other.example.com,ghe.example.com",
+			wantOutSub:    "has been added",
+		},
+		{
+			name:          "an already trusted hostname is not duplicated",
+			existingHosts: "ghe.example.com",
+			githubAPIURL:  "https://ghe.example.com",
+			wantHosts:     "ghe.example.com",
+			wantOutSub:    "has been added",
+		},
+		{
+			name:                "targets the configmap of the controller",
+			controllerConfigMap: "ghe-configmap",
+			githubAPIURL:        "https://ghe.example.com",
+			wantHosts:           "ghe.example.com",
+			wantOutSub:          "ghe-configmap",
+		},
+		{
+			// The App exists by the time this runs: a hostname that cannot be
+			// trusted must warn with the corrective command, never fail the
+			// bootstrap and leave a half provisioned install.
+			name:          "an unusable hostname warns instead of failing",
+			githubAPIURL:  "https://user@ghe.example.com",
+			wantHosts:     "",
+			wantErrOutSub: "kubectl -n pipelines-as-code patch configmap",
+		},
+		{
+			name:          "a missing configmap warns instead of failing",
+			noConfigMap:   true,
+			githubAPIURL:  "https://ghe.example.com",
+			wantErrOutSub: "refuses to send credentials to a host it does not trust",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			configMapName := info.DefaultPipelinesAscodeConfigmapName
+			if tt.controllerConfigMap != "" {
+				configMapName = tt.controllerConfigMap
+			}
+			tdata := testclient.Data{}
+			if !tt.noConfigMap {
+				tdata.ConfigMap = []*corev1.ConfigMap{{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      configMapName,
+						Namespace: namespace,
+					},
+					Data: map[string]string{
+						settings.TrustedProviderHostnamesKey: tt.existingHosts,
+					},
+				}}
+			}
+			stdata, _ := testclient.SeedTestData(t, ctx, tdata)
+			run := &params.Run{
+				Clients: clients.Clients{Kube: stdata.Kube},
+			}
+			if tt.controllerConfigMap != "" {
+				run.Info.Controller = &info.ControllerInfo{Configmap: tt.controllerConfigMap}
+			}
+			ios, _, out, errOut := cli.IOTest()
+			opts := &bootstrapOpts{
+				targetNamespace: namespace,
+				GithubAPIURL:    tt.githubAPIURL,
+				ioStreams:       ios,
+			}
+
+			err := trustProviderHostname(ctx, run, opts)
+			assert.NilError(t, err)
+
+			if tt.wantOutSub != "" {
+				assert.Assert(t, strings.Contains(out.String(), tt.wantOutSub),
+					"expected %q in stdout, got %q", tt.wantOutSub, out.String())
+			}
+			if tt.wantErrOutSub != "" {
+				assert.Assert(t, strings.Contains(errOut.String(), tt.wantErrOutSub),
+					"expected %q in stderr, got %q", tt.wantErrOutSub, errOut.String())
+			}
+			if tt.noConfigMap {
+				return
+			}
+			cm, err := stdata.Kube.CoreV1().ConfigMaps(namespace).Get(ctx, configMapName, metav1.GetOptions{})
+			assert.NilError(t, err)
+			assert.Equal(t, cm.Data[settings.TrustedProviderHostnamesKey], tt.wantHosts)
+		})
+	}
+}

--- a/pkg/cmd/tknpac/bootstrap/web.go
+++ b/pkg/cmd/tknpac/bootstrap/web.go
@@ -73,6 +73,10 @@ func startWebServer(ctx context.Context, opts *bootstrapOpts, run *params.Run, j
 		return err
 	}
 
+	if err := trustProviderHostname(ctx, run, opts); err != nil {
+		return err
+	}
+
 	if err := info.UpdateInfoConfigMap(ctx, run, &info.Options{
 		TargetNamespace: opts.targetNamespace,
 		ControllerURL:   opts.RouteName,

--- a/pkg/gitclient/client_setup.go
+++ b/pkg/gitclient/client_setup.go
@@ -46,14 +46,17 @@ func SetupAuthenticatedClient(
 			logger.Errorf("cannot get global repository: %v", err)
 		}
 	}
-	// Determine secret namespace BEFORE merging repos
-	// This preserves the ability to detect when credentials come from global repo
 	secretNS := repo.GetNamespace()
 	inheritedGlobalSecret := false
-	if repo.Spec.GitProvider != nil && repo.Spec.GitProvider.Secret == nil &&
-		globalRepo != nil && globalRepo.Spec.GitProvider != nil && globalRepo.Spec.GitProvider.Secret != nil {
-		secretNS = globalRepo.GetNamespace()
-		inheritedGlobalSecret = true
+	// GitHub Apps use the controller secret, so Repository credential inheritance
+	// is irrelevant to them. For webhook providers, resolve it before merging so
+	// a local endpoint cannot be hidden by the global Repository defaults.
+	if event.InstallationID <= 0 {
+		var err error
+		secretNS, inheritedGlobalSecret, err = secrets.ResolveInheritedSecret(repo, globalRepo)
+		if err != nil {
+			return err
+		}
 	}
 	logger.Debugf("setupAuthenticatedClient: repo=%s/%s secret_namespace=%s", repo.GetNamespace(), repo.GetName(), secretNS)
 	// merge global repo settings into local repo (after determining secret namespace)

--- a/pkg/gitclient/client_setup_test.go
+++ b/pkg/gitclient/client_setup_test.go
@@ -218,6 +218,32 @@ func TestSetupAuthenticatedClientGitHubApp(t *testing.T) {
 	}
 }
 
+func TestSetupAuthenticatedClientGitHubAppIgnoresInheritedProviderSecret(t *testing.T) {
+	t.Parallel()
+
+	ctx, log := setupTestContext(t)
+	repo := createTestRepository(true)
+	repo.Spec.GitProvider.URL = "https://another.example.com"
+	repo.Spec.GitProvider.Secret = nil
+	globalRepo := testnewrepo.NewRepo(testnewrepo.RepoTestcreationOpts{
+		Name:             "global-repo",
+		URL:              "https://github.com/global/repo",
+		InstallNamespace: "default",
+	})
+	globalRepo.Spec.GitProvider = &v1alpha1.GitProvider{
+		URL:    "https://github.com",
+		Secret: &v1alpha1.Secret{Name: "global-secret", Key: "token"},
+	}
+	run := seedTestData(ctx, t, []*v1alpha1.Repository{repo, globalRepo})
+	kint := createTestKintMock(map[string]string{
+		"pipelines-as-code-secret": "github-app-webhook-secret",
+	})
+
+	err := SetupAuthenticatedClient(ctx, createTestProvider(log), kint, run,
+		createTestEvent("pull_request", 12345, "test-secret"), repo, globalRepo, createTestPacInfo(), log)
+	assert.NilError(t, err)
+}
+
 // TestSetupAuthenticatedClient_NonGitHubApp tests non-GitHub App authentication path.
 func TestSetupAuthenticatedClientNonGitHubApp(t *testing.T) {
 	t.Parallel()
@@ -893,6 +919,101 @@ func TestSetupAuthenticatedClientCommentEventTypes(t *testing.T) {
 			} else {
 				assert.NilError(t, err, "%s: %v", tt.description, err)
 			}
+		})
+	}
+}
+
+// A Repository that inherits the shared credential of the global Repository must
+// not also get to choose the host that credential is sent to: the two together
+// let anyone who can create a Repository in any namespace redirect a token owned
+// by the controller namespace.
+func TestSetupAuthenticatedClientRefusesInheritedSecretWithOwnProviderURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		localURL          string
+		globalURL         string
+		localHasOwnSecret bool
+		wantErrSub        string
+	}{
+		{
+			name:       "inheriting the global secret while pointing elsewhere is refused",
+			localURL:   "https://attacker.example",
+			globalURL:  "https://github.com",
+			wantErrSub: "must not be sent to an endpoint chosen by another namespace",
+		},
+		{
+			name:      "inheriting the global secret for the same host is allowed",
+			localURL:  "github.com",
+			globalURL: "https://github.com/",
+		},
+		{
+			name:      "inheriting the global secret without an own url is allowed",
+			localURL:  "",
+			globalURL: "https://github.com",
+		},
+		{
+			name:       "downgrading the inherited credential to cleartext is refused",
+			localURL:   "http://github.com",
+			globalURL:  "https://github.com",
+			wantErrSub: "must not be sent to an endpoint chosen by another namespace",
+		},
+		{
+			name:       "another path on the same shared host is refused",
+			localURL:   "https://git.example.com/other",
+			globalURL:  "https://git.example.com/gitlab",
+			wantErrSub: "must not be sent to an endpoint chosen by another namespace",
+		},
+		{
+			name:      "the api entry point of the same deployment is allowed",
+			localURL:  "https://git.example.com/gitlab/api/v4",
+			globalURL: "https://git.example.com/gitlab",
+		},
+		{
+			name:              "pointing elsewhere with an own secret is allowed",
+			localURL:          "https://ghe.example.com",
+			globalURL:         "https://github.com",
+			localHasOwnSecret: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, log := setupTestContext(t)
+
+			repo := createTestRepository(true)
+			repo.Spec.GitProvider.URL = tt.localURL
+			if !tt.localHasOwnSecret {
+				repo.Spec.GitProvider.Secret = nil
+			}
+
+			globalRepo := testnewrepo.NewRepo(testnewrepo.RepoTestcreationOpts{
+				Name:             "global-repo",
+				URL:              "https://github.com/global/repo",
+				InstallNamespace: "pipelines-as-code",
+			})
+			globalRepo.Spec.GitProvider = &v1alpha1.GitProvider{
+				URL:    tt.globalURL,
+				Secret: &v1alpha1.Secret{Name: "global-secret", Key: "token"},
+			}
+
+			run := seedTestData(ctx, t, []*v1alpha1.Repository{repo, globalRepo})
+			kint := createTestKintMock(map[string]string{
+				"test-secret":   "test-token",
+				"global-secret": "global-token",
+			})
+
+			err := SetupAuthenticatedClient(ctx, createTestProvider(log), kint, run,
+				createTestEvent("pull_request", 0, ""), repo, globalRepo, createTestPacInfo(), log)
+
+			if tt.wantErrSub != "" {
+				assert.ErrorContains(t, err, tt.wantErrSub)
+				return
+			}
+			assert.NilError(t, err)
 		})
 	}
 }

--- a/pkg/hostpolicy/hostpolicy.go
+++ b/pkg/hostpolicy/hostpolicy.go
@@ -1,0 +1,316 @@
+// Package hostpolicy decides which hosted VCS instances a controller is allowed
+// to send credentials to.
+//
+// Pipelines-as-Code derives the API host it talks to from data that originates,
+// directly or indirectly, from a webhook payload. Without a check, whoever can
+// reach the controller endpoint could make it send its Git provider credentials
+// to a host they control. This package is the single gate that prevents it.
+//
+// The policy lives in the controller ConfigMap and works in two states:
+//
+//   - Administrator configured: the list is authoritative for every host, public
+//     ones included. The controller never writes to the ConfigMap, and an
+//     administrator can express "this controller must never talk to a public
+//     SaaS instance". Administrators own the
+//     settings.TrustedProviderHostnamesKey value exclusively.
+//   - Controller managed: the controller has no configured policy. The public
+//     SaaS hostnames stay trusted, any other host is refused, and each request
+//     the provider itself authenticated appends its host to the
+//     keys.AutoTrustedProviderHostnames annotation (trust on first use), so that
+//     a default install needs no configuration and a controller serving several
+//     instances learns all of them.
+//
+// A non-empty administrator allowlist selects administrator configured mode. An
+// empty allowlist selects controller managed mode. Keeping the two lists under
+// separate keys gives each value a single owner and avoids inferring ownership
+// by comparing their contents.
+//
+// Trust on first use appends rather than replaces, so a controller serving
+// several instances, or several providers, learns all of them instead of being
+// pinned to whichever one happened to send the first webhook.
+//
+// The policy only covers hosts the controller did not choose. A caller that
+// picked the host itself, from its own configuration rather than from a payload
+// or a Repository CR, installs its client through
+// github.Provider.UsePreauthenticatedClient and never reaches this package: the
+// end to end harness is the one caller that does.
+package hostpolicy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/vcshost"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+)
+
+// Trusted validates rawHost against the allowlist and returns its normalised
+// hostname.
+//
+// It never writes, so it is the function to use on every path that the provider
+// has not authenticated, and on every path authenticated by a secret a tenant
+// controls, such as a per Repository webhook secret: letting those record a host
+// would hand any namespace user a write primitive on the controller wide policy.
+func Trusted(ctx context.Context, run *params.Run, rawHost string) (string, error) {
+	host, err := vcshost.Parse(rawHost)
+	if err != nil {
+		return "", err
+	}
+
+	namespace := info.GetNS(ctx)
+	configMapName := controllerConfigMap(run)
+	policy, err := readPolicy(ctx, run.Clients.Kube, namespace, configMapName)
+	if err != nil {
+		return "", err
+	}
+	if err := policy.check(host, namespace, configMapName); err != nil {
+		return "", err
+	}
+	return vcshost.Canonical(host), nil
+}
+
+// TrustOnFirstUse validates rawHost against the policy and, while the policy is
+// controller managed, appends rawHost to the controller-owned annotation.
+//
+// Only call it once the provider itself has authenticated the request with a
+// credential the controller owns, for instance after verifying a webhook
+// signature against the GitHub App webhook secret: rawHost joins the policy from
+// that point on. Anything else must use Trusted.
+func TrustOnFirstUse(ctx context.Context, run *params.Run, rawHost string) (string, error) {
+	host, err := vcshost.Parse(rawHost)
+	if err != nil {
+		return "", err
+	}
+	canonical := vcshost.Canonical(host)
+
+	namespace := info.GetNS(ctx)
+	configMapName := controllerConfigMap(run)
+	if run.Clients.Kube == nil {
+		return "", noKubeClientError(namespace, configMapName)
+	}
+	configMaps := run.Clients.Kube.CoreV1().ConfigMaps(namespace)
+
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		configMap, err := configMaps.Get(ctx, configMapName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		policy, err := policyFrom(configMap, namespace, configMapName)
+		if err != nil {
+			return err
+		}
+
+		// A non-empty administrator list is authoritative. The learned hosts are
+		// kept separately and ignored until the administrator empties the list
+		// and deliberately hands the policy back to the controller.
+		if policy.administratorConfigured() {
+			return policy.check(host, namespace, configMapName)
+		}
+
+		// A public instance is trusted for as long as the policy is controller
+		// managed, so recording it would buy nothing and would make every stock
+		// install fight its GitOps reconciler over a value it does not need.
+		if vcshost.IsPublic(host) || slices.Contains(policy.autoTrusted, canonical) {
+			return nil
+		}
+
+		// A payload must never be able to point the controller at an address
+		// that is only reachable from inside the cluster or the cloud instance,
+		// such as the metadata endpoint. An administrator may still list one
+		// explicitly, which is how a private instance is trusted on purpose.
+		if vcshost.IsPrivate(host) {
+			return NotTrustedError(namespace, configMapName, host, reasonPrivate)
+		}
+
+		if configMap.Annotations == nil {
+			configMap.Annotations = map[string]string{}
+		}
+		autoTrusted := append(slices.Clone(policy.autoTrusted), canonical)
+		configMap.Annotations[keys.AutoTrustedProviderHostnames] = vcshost.Join(autoTrusted)
+		if _, err := configMaps.Update(ctx, configMap, metav1.UpdateOptions{}); err != nil {
+			return err
+		}
+		logPolicyChange(run, namespace, configMapName, canonical, autoTrusted)
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return canonical, nil
+}
+
+// controllerConfigMap returns the ConfigMap holding this controller policy. Each
+// controller has its own, so a second controller can never widen the policy of
+// the first one.
+func controllerConfigMap(run *params.Run) string {
+	if run.Info.Controller != nil && run.Info.Controller.Configmap != "" {
+		return run.Info.Controller.Configmap
+	}
+	return info.DefaultPipelinesAscodeConfigmapName
+}
+
+// logPolicyChange makes a trust on first use write visible: it changes a
+// security policy, so an administrator must be able to find out when, and to
+// what, without diffing the ConfigMap.
+func logPolicyChange(run *params.Run, namespace, configMapName, host string, autoTrusted []string) {
+	if run.Clients.Log == nil {
+		return
+	}
+	run.Clients.Log.Warnf(
+		"trusted provider hostnames: learnt %q from an authenticated request and added it to the %q annotation of the %s/%s ConfigMap, "+
+			"which now trusts %s on top of the public instances. Set the %q key explicitly to take the policy over.",
+		host, keys.AutoTrustedProviderHostnames, namespace, configMapName, vcshost.Join(autoTrusted), settings.TrustedProviderHostnamesKey,
+	)
+}
+
+// policy is the trust policy of one controller, as stored in its ConfigMap.
+type policy struct {
+	// allowlist is the administrator configured list of trusted hostnames.
+	allowlist []string
+	// autoTrusted is the list of hostnames the controller recorded itself.
+	autoTrusted []string
+}
+
+// administratorConfigured reports whether the policy belongs to an
+// administrator rather than to the controller.
+//
+// Any non-empty administrator list is exhaustive. Learned hosts live under a
+// different key and therefore never make administrator intent ambiguous.
+func (p policy) administratorConfigured() bool {
+	return len(p.allowlist) > 0
+}
+
+// check applies the policy to host.
+//
+// An administrator configured list is exhaustive: a public SaaS instance that is
+// not on it is refused, which is how "this controller must never talk to
+// github.com" is expressed. While the policy is still controller managed the
+// public instances stay trusted on top of whatever was learnt, so that a
+// controller serving several providers keeps working.
+func (p policy) check(host, namespace, configMapName string) error {
+	if p.administratorConfigured() {
+		if !vcshost.Allowed(p.allowlist, host) {
+			return NotTrustedError(namespace, configMapName, host, reasonNotListed)
+		}
+		return nil
+	}
+	if vcshost.IsPublic(host) || vcshost.Allowed(p.autoTrusted, host) {
+		return nil
+	}
+	return NotTrustedError(namespace, configMapName, host, reasonUnconfigured)
+}
+
+func readPolicy(ctx context.Context, kube kubernetes.Interface, namespace, configMapName string) (policy, error) {
+	// Without a Kubernetes client the policy cannot be read, and a policy that
+	// cannot be read must never be assumed to be permissive.
+	if kube == nil {
+		return policy{}, noKubeClientError(namespace, configMapName)
+	}
+	configMap, err := kube.CoreV1().ConfigMaps(namespace).Get(ctx, configMapName, metav1.GetOptions{})
+	if err != nil {
+		return policy{}, err
+	}
+	return policyFrom(configMap, namespace, configMapName)
+}
+
+func policyFrom(configMap *corev1.ConfigMap, namespace, configMapName string) (policy, error) {
+	allowlist, err := vcshost.ParseAllowlist(configMap.Data[settings.TrustedProviderHostnamesKey])
+	if err != nil {
+		return policy{}, InvalidAllowlistError(namespace, configMapName, err)
+	}
+	// A corrupted annotation must never widen the policy: forget the learned
+	// hosts and retain only the public defaults until a valid authenticated
+	// request records them again.
+	autoTrusted, err := vcshost.ParseAllowlist(configMap.Annotations[keys.AutoTrustedProviderHostnames])
+	if err != nil {
+		autoTrusted = nil
+	}
+	return policy{allowlist: allowlist, autoTrusted: autoTrusted}, nil
+}
+
+// Reasons a host was refused, used to build an error an administrator can act on.
+const (
+	reasonNotListed = iota
+	reasonUnconfigured
+	reasonPrivate
+)
+
+// NotTrustedError explains, with a ready to run command, how to trust a host.
+func NotTrustedError(namespace, configMapName, host string, reason int) error {
+	var why string
+	switch reason {
+	case reasonUnconfigured:
+		why = fmt.Sprintf("it is not a public instance and no authenticated request has made it known yet, "+
+			"so it must be listed in the %q key of the %s/%s ConfigMap",
+			settings.TrustedProviderHostnamesKey, namespace, configMapName)
+	case reasonPrivate:
+		why = fmt.Sprintf("it is not routable on the public internet, so it cannot be trusted automatically "+
+			"and must be listed in the %q key of the %s/%s ConfigMap",
+			settings.TrustedProviderHostnamesKey, namespace, configMapName)
+	default:
+		why = fmt.Sprintf("it is not listed in the %q key of the %s/%s ConfigMap",
+			settings.TrustedProviderHostnamesKey, namespace, configMapName)
+	}
+	return fmt.Errorf(
+		"refusing to use credentials with the %q host: %s. "+
+			"Add it with: kubectl -n %s patch configmap %s --type merge -p '{\"data\":{\"%s\":\"%s\"}}'",
+		host, why, namespace, configMapName, settings.TrustedProviderHostnamesKey, host,
+	)
+}
+
+// noKubeClientError reports that the policy cannot be read at all, which is
+// never allowed to read as permissive.
+func noKubeClientError(namespace, configMapName string) error {
+	return fmt.Errorf(
+		"cannot read the %q key of the %s/%s ConfigMap: no Kubernetes client is configured",
+		settings.TrustedProviderHostnamesKey, namespace, configMapName,
+	)
+}
+
+// InvalidAllowlistError is returned when the configured allowlist cannot be parsed.
+func InvalidAllowlistError(namespace, configMapName string, err error) error {
+	return fmt.Errorf("the %q key of the %s/%s ConfigMap is invalid: %w",
+		settings.TrustedProviderHostnamesKey, namespace, configMapName, err)
+}
+
+// TrustedURL validates the host component of rawURL against the allowlist and
+// returns the URL rebuilt on the canonical hostname, keeping the path and query.
+//
+// GitHub derives its API endpoint from a bare hostname, but GitLab, Gitea and
+// Bitbucket Data Center are routinely served under a path prefix
+// (https://example.com/gitlab), which rebuilding a URL from the hostname alone
+// would silently drop. Those providers keep their own URL and use this function
+// as their gate.
+//
+// The returned URL always carries the hostname the allowlist actually approved,
+// never the one the caller passed in: the two can differ, and a caller dialling
+// the raw value would defeat the check. See the vcshost package documentation.
+func TrustedURL(ctx context.Context, run *params.Run, rawURL string) (string, error) {
+	parsed, err := vcshost.SplitURL(rawURL)
+	if err != nil {
+		if errors.Is(err, vcshost.ErrURLUnsafeComponents) {
+			return "", fmt.Errorf("provider URL must not contain credentials, a query or a fragment")
+		}
+		return "", fmt.Errorf("invalid provider URL")
+	}
+	if !strings.EqualFold(parsed.Scheme, "https") {
+		return "", fmt.Errorf("provider URL scheme must be https, got %q", parsed.Scheme)
+	}
+	host, err := Trusted(ctx, run, parsed.Host)
+	if err != nil {
+		return "", err
+	}
+	parsed.Scheme = "https"
+	parsed.Host = host
+	return parsed.String(), nil
+}

--- a/pkg/hostpolicy/hostpolicy_test.go
+++ b/pkg/hostpolicy/hostpolicy_test.go
@@ -1,0 +1,580 @@
+package hostpolicy
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
+	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stesting "k8s.io/client-go/testing"
+	rtesting "knative.dev/pkg/reconciler/testing"
+)
+
+const (
+	testNamespace     = "pipelines-as-code"
+	testConfigMapName = "pipelines-as-code"
+)
+
+// newRun returns a Run backed by a fake client holding a controller ConfigMap
+// with the given allowlist. When withConfigMap is false no ConfigMap is seeded.
+func newRun(t *testing.T, allowlist string, withConfigMap bool) (*params.Run, *testclient.Clients) {
+	t.Helper()
+	ctx, _ := rtesting.SetupFakeContext(t)
+	data := testclient.Data{}
+	if withConfigMap {
+		configMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testConfigMapName,
+				Namespace: testNamespace,
+			},
+			Data: map[string]string{},
+		}
+		if allowlist != "" {
+			configMap.Data[settings.TrustedProviderHostnamesKey] = allowlist
+		}
+		data.ConfigMap = []*corev1.ConfigMap{configMap}
+	}
+	seedData, _ := testclient.SeedTestData(t, ctx, data)
+	run := &params.Run{
+		Clients: clients.Clients{Kube: seedData.Kube},
+		Info: info.Info{
+			Controller: &info.ControllerInfo{Configmap: testConfigMapName},
+		},
+	}
+	return run, &seedData
+}
+
+func TestTrusted(t *testing.T) {
+	tests := []struct {
+		name        string
+		allowlist   string
+		autoTrusted string
+		host        string
+		want        string
+		wantErrSub  string
+	}{
+		{
+			name: "public github is trusted without any configuration",
+			host: "github.com",
+			want: "github.com",
+		},
+		{
+			name: "api.github.com folds into github.com",
+			host: "api.github.com",
+			want: "github.com",
+		},
+		{
+			name: "public gitlab is trusted without any configuration",
+			host: "gitlab.com",
+			want: "gitlab.com",
+		},
+		{
+			name:       "a configured allowlist is authoritative for the public instances too",
+			allowlist:  "ghe.example.com",
+			host:       "github.com",
+			wantErrSub: "is not listed in",
+		},
+		{
+			name:      "a public instance listed explicitly stays trusted",
+			allowlist: "ghe.example.com,github.com",
+			host:      "github.com",
+			want:      "github.com",
+		},
+		{
+			name:       "self hosted host is refused when the allowlist is empty",
+			host:       "ghe.example.com",
+			wantErrSub: "no authenticated request has made it known yet",
+		},
+		{
+			name:        "controller learned self hosted host is trusted",
+			autoTrusted: "ghe.example.com",
+			host:        "ghe.example.com",
+			want:        "ghe.example.com",
+		},
+		{
+			name:      "listed self hosted host is trusted",
+			allowlist: "ghe.example.com",
+			host:      "ghe.example.com",
+			want:      "ghe.example.com",
+		},
+		{
+			name:      "one of several listed hosts is trusted",
+			allowlist: "ghe.example.com,gitlab.example.com",
+			host:      "gitlab.example.com",
+			want:      "gitlab.example.com",
+		},
+		{
+			name:       "unlisted host is refused",
+			allowlist:  "ghe.example.com",
+			host:       "attacker.example.com",
+			wantErrSub: "is not listed in",
+		},
+		{
+			name:       "lookalike host is refused",
+			allowlist:  "ghe.example.com",
+			host:       "ghe.example.com.evil.example",
+			wantErrSub: "is not listed in",
+		},
+		{
+			name:       "invalid host is refused",
+			host:       "http://ghe.example.com",
+			wantErrSub: "scheme must be https",
+		},
+		{
+			name:       "invalid allowlist is reported",
+			allowlist:  "https://ghe.example.com/owner",
+			host:       "ghe.example.com",
+			wantErrSub: "is invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			ctx = info.StoreNS(ctx, testNamespace)
+			run, _ := newRunWithPolicy(t, tt.allowlist, tt.autoTrusted)
+
+			got, err := Trusted(ctx, run, tt.host)
+			if tt.wantErrSub != "" {
+				assert.ErrorContains(t, err, tt.wantErrSub)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, got, tt.want)
+		})
+	}
+}
+
+// Trusted must never write: it is used on paths carrying no provider signature.
+func TestTrustedNeverWrites(t *testing.T) {
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = info.StoreNS(ctx, testNamespace)
+	run, seedData := newRun(t, "", true)
+
+	_, err := Trusted(ctx, run, "ghe.example.com")
+	assert.ErrorContains(t, err, "refusing to use credentials")
+
+	configMap, err := seedData.Kube.CoreV1().ConfigMaps(testNamespace).Get(ctx, testConfigMapName, metav1.GetOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, configMap.Data[settings.TrustedProviderHostnamesKey], "",
+		"an unauthenticated request must never populate the allowlist")
+	_, recorded := configMap.Annotations[keys.AutoTrustedProviderHostnames]
+	assert.Assert(t, !recorded, "an unauthenticated request must never record a learned host")
+}
+
+func TestTrustedConfigMapGetError(t *testing.T) {
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = info.StoreNS(ctx, testNamespace)
+	run, _ := newRun(t, "", false)
+
+	_, err := Trusted(ctx, run, "ghe.example.com")
+	assert.ErrorContains(t, err, `configmaps "pipelines-as-code" not found`)
+}
+
+func TestTrustOnFirstUse(t *testing.T) {
+	tests := []struct {
+		name            string
+		allowlist       string
+		host            string
+		want            string
+		wantAllowlist   string
+		wantAutoTrusted string
+		wantErrSub      string
+	}{
+		{
+			name:            "first authenticated host is recorded",
+			host:            "ghe.example.com",
+			want:            "ghe.example.com",
+			wantAutoTrusted: "ghe.example.com",
+		},
+		{
+			name:          "administrator listed host is accepted without being learned",
+			allowlist:     "ghe.example.com",
+			host:          "ghe.example.com",
+			want:          "ghe.example.com",
+			wantAllowlist: "ghe.example.com",
+		},
+		{
+			name:            "host is normalized before being recorded",
+			host:            "https://GHE.Example.COM",
+			want:            "ghe.example.com",
+			wantAutoTrusted: "ghe.example.com",
+		},
+		{
+			name:          "a configured allowlist is authoritative for the public instances too",
+			allowlist:     "ghe.example.com",
+			host:          "github.com",
+			wantAllowlist: "ghe.example.com",
+			wantErrSub:    "is not listed in",
+		},
+		{
+			name:          "public github stays trusted without being recorded",
+			host:          "github.com",
+			want:          "github.com",
+			wantAllowlist: "",
+		},
+		{
+			name:          "a private address is never recorded automatically",
+			host:          "gitea.gitea.svc",
+			wantAllowlist: "",
+			wantErrSub:    "not routable on the public internet",
+		},
+		{
+			name:          "a private address listed explicitly is trusted",
+			allowlist:     "gitea.gitea.svc",
+			host:          "gitea.gitea.svc",
+			want:          "gitea.gitea.svc",
+			wantAllowlist: "gitea.gitea.svc",
+		},
+		{
+			name:          "a configured allowlist refuses an unlisted host",
+			allowlist:     "ghe.example.com",
+			host:          "attacker.example.com",
+			wantAllowlist: "ghe.example.com",
+			wantErrSub:    "is not listed in",
+		},
+		{
+			name:          "invalid allowlist is reported and left untouched",
+			allowlist:     "https://ghe.example.com/owner",
+			host:          "ghe.example.com",
+			wantAllowlist: "https://ghe.example.com/owner",
+			wantErrSub:    "is invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			ctx = info.StoreNS(ctx, testNamespace)
+			run, seedData := newRun(t, tt.allowlist, true)
+
+			got, err := TrustOnFirstUse(ctx, run, tt.host)
+			if tt.wantErrSub != "" {
+				assert.ErrorContains(t, err, tt.wantErrSub)
+			} else {
+				assert.NilError(t, err)
+				assert.Equal(t, got, tt.want)
+			}
+
+			configMap, err := seedData.Kube.CoreV1().ConfigMaps(testNamespace).Get(ctx, testConfigMapName, metav1.GetOptions{})
+			assert.NilError(t, err)
+			assert.Equal(t, configMap.Data[settings.TrustedProviderHostnamesKey], tt.wantAllowlist)
+			assert.Equal(t, configMap.Annotations[keys.AutoTrustedProviderHostnames], tt.wantAutoTrusted)
+		})
+	}
+}
+
+// An administrator configured allowlist is authoritative: the controller must
+// not write to the ConfigMap at all, so that GitOps tooling sees no drift.
+func TestTrustOnFirstUseDoesNotWriteWhenConfigured(t *testing.T) {
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = info.StoreNS(ctx, testNamespace)
+	run, seedData := newRun(t, "ghe.example.com", true)
+
+	updated := false
+	seedData.Kube.PrependReactor("update", "configmaps", func(k8stesting.Action) (bool, runtime.Object, error) {
+		updated = true
+		return false, nil, nil
+	})
+
+	got, err := TrustOnFirstUse(ctx, run, "ghe.example.com")
+	assert.NilError(t, err)
+	assert.Equal(t, got, "ghe.example.com")
+	assert.Assert(t, !updated, "the ConfigMap must not be written when the allowlist is configured")
+}
+
+func TestTrustOnFirstUseRetriesConflict(t *testing.T) {
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = info.StoreNS(ctx, testNamespace)
+	run, seedData := newRun(t, "", true)
+
+	conflicts := 1
+	seedData.Kube.PrependReactor("update", "configmaps", func(k8stesting.Action) (bool, runtime.Object, error) {
+		if conflicts > 0 {
+			conflicts--
+			return true, nil, apierrors.NewConflict(
+				schema.GroupResource{Resource: "configmaps"}, testConfigMapName, errors.New("conflict"),
+			)
+		}
+		return false, nil, nil
+	})
+
+	got, err := TrustOnFirstUse(ctx, run, "ghe.example.com")
+	assert.NilError(t, err)
+	assert.Equal(t, got, "ghe.example.com")
+
+	configMap, err := seedData.Kube.CoreV1().ConfigMaps(testNamespace).Get(ctx, testConfigMapName, metav1.GetOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, configMap.Data[settings.TrustedProviderHostnamesKey], "")
+	assert.Equal(t, configMap.Annotations[keys.AutoTrustedProviderHostnames], "ghe.example.com")
+}
+
+// An administrator may have configured a list while a controller request was
+// starting. The configured value wins and the request is refused.
+func TestTrustOnFirstUseRejectsConcurrentDifferentHost(t *testing.T) {
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = info.StoreNS(ctx, testNamespace)
+	run, seedData := newRun(t, "", true)
+
+	raced := false
+	seedData.Kube.PrependReactor("get", "configmaps", func(k8stesting.Action) (bool, runtime.Object, error) {
+		if raced {
+			return false, nil, nil
+		}
+		raced = true
+		return true, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: testConfigMapName, Namespace: testNamespace},
+			Data: map[string]string{
+				settings.TrustedProviderHostnamesKey: "other.example.com",
+			},
+		}, nil
+	})
+
+	_, err := TrustOnFirstUse(ctx, run, "ghe.example.com")
+	assert.ErrorContains(t, err, "is not listed in")
+}
+
+func TestTrustOnFirstUseInvalidHost(t *testing.T) {
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = info.StoreNS(ctx, testNamespace)
+	run, _ := newRun(t, "", true)
+
+	_, err := TrustOnFirstUse(ctx, run, "http://ghe.example.com")
+	assert.ErrorContains(t, err, "scheme must be https")
+}
+
+// The controller must always read the ConfigMap named in its own
+// ControllerInfo, so that a second controller keeps its own allowlist.
+func TestTrustedUsesControllerConfigMap(t *testing.T) {
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = info.StoreNS(ctx, testNamespace)
+	seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+		ConfigMap: []*corev1.ConfigMap{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "pipelines-as-code", Namespace: testNamespace},
+				Data:       map[string]string{settings.TrustedProviderHostnamesKey: "first.example.com"},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "second-configmap", Namespace: testNamespace},
+				Data:       map[string]string{settings.TrustedProviderHostnamesKey: "second.example.com"},
+			},
+		},
+	})
+	run := &params.Run{
+		Clients: clients.Clients{Kube: seedData.Kube},
+		Info: info.Info{
+			Controller: &info.ControllerInfo{Configmap: "second-configmap"},
+		},
+	}
+
+	got, err := Trusted(ctx, run, "second.example.com")
+	assert.NilError(t, err)
+	assert.Equal(t, got, "second.example.com")
+
+	_, err = Trusted(ctx, run, "first.example.com")
+	assert.ErrorContains(t, err, "is not listed in")
+}
+
+// The error must tell the administrator exactly how to fix the situation.
+func TestNotTrustedErrorIsActionable(t *testing.T) {
+	err := NotTrustedError(testNamespace, testConfigMapName, "ghe.example.com", reasonUnconfigured)
+	assert.ErrorContains(t, err, "ghe.example.com")
+	assert.ErrorContains(t, err, settings.TrustedProviderHostnamesKey)
+	assert.ErrorContains(t, err, "kubectl -n pipelines-as-code patch configmap pipelines-as-code")
+}
+
+// newRunWithPolicy seeds a controller ConfigMap whose administrator list and
+// controller-learned annotation are set independently.
+func newRunWithPolicy(t *testing.T, allowlist, autoTrusted string) (*params.Run, *testclient.Clients) {
+	t.Helper()
+	ctx, _ := rtesting.SetupFakeContext(t)
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        testConfigMapName,
+			Namespace:   testNamespace,
+			Annotations: map[string]string{},
+		},
+		Data: map[string]string{},
+	}
+	if allowlist != "" {
+		configMap.Data[settings.TrustedProviderHostnamesKey] = allowlist
+	}
+	if autoTrusted != "" {
+		configMap.Annotations[keys.AutoTrustedProviderHostnames] = autoTrusted
+	}
+	seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{ConfigMap: []*corev1.ConfigMap{configMap}})
+	run := &params.Run{
+		Clients: clients.Clients{Kube: seedData.Kube},
+		Info:    info.Info{Controller: &info.ControllerInfo{Configmap: testConfigMapName}},
+	}
+	return run, &seedData
+}
+
+// A controller serving several instances, or several providers, must learn all
+// of them instead of being pinned to whichever one sent the first webhook.
+func TestTrustOnFirstUseAppends(t *testing.T) {
+	tests := []struct {
+		name            string
+		allowlist       string
+		autoTrusted     string
+		host            string
+		wantAllowlist   string
+		wantAutoTrusted string
+		wantErrSub      string
+	}{
+		{
+			name:            "a second self hosted instance is appended, not substituted",
+			autoTrusted:     "ghe.example.com",
+			host:            "gitlab.example.com",
+			wantAutoTrusted: "ghe.example.com,gitlab.example.com",
+		},
+		{
+			name:            "a public instance stays trusted alongside a learnt one",
+			autoTrusted:     "ghe.example.com",
+			host:            "github.com",
+			wantAutoTrusted: "ghe.example.com",
+		},
+		{
+			name:            "an administrator configured list is never appended to",
+			allowlist:       "ghe.example.com",
+			host:            "gitlab.example.com",
+			wantAllowlist:   "ghe.example.com",
+			wantAutoTrusted: "",
+			wantErrSub:      "is not listed in",
+		},
+		{
+			name:            "a configured list is authoritative even when it matches a learned host",
+			allowlist:       "ghe.example.com",
+			autoTrusted:     "ghe.example.com",
+			host:            "gitlab.example.com",
+			wantAllowlist:   "ghe.example.com",
+			wantAutoTrusted: "ghe.example.com",
+			wantErrSub:      "is not listed in",
+		},
+		{
+			name:            "a corrupted learned annotation is replaced safely",
+			autoTrusted:     "not a hostname!!",
+			host:            "gitlab.example.com",
+			wantAutoTrusted: "gitlab.example.com",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			ctx = info.StoreNS(ctx, testNamespace)
+			run, seedData := newRunWithPolicy(t, tt.allowlist, tt.autoTrusted)
+
+			_, err := TrustOnFirstUse(ctx, run, tt.host)
+			if tt.wantErrSub != "" {
+				assert.ErrorContains(t, err, tt.wantErrSub)
+			} else {
+				assert.NilError(t, err)
+			}
+
+			configMap, err := seedData.Kube.CoreV1().ConfigMaps(testNamespace).Get(ctx, testConfigMapName, metav1.GetOptions{})
+			assert.NilError(t, err)
+			assert.Equal(t, configMap.Data[settings.TrustedProviderHostnamesKey], tt.wantAllowlist)
+			assert.Equal(t, configMap.Annotations[keys.AutoTrustedProviderHostnames], tt.wantAutoTrusted)
+		})
+	}
+}
+
+// TrustedURL must hand back a URL built on the hostname the allowlist approved,
+// never the one it was given: the two can differ, and a caller dialling the raw
+// value would defeat the check entirely.
+func TestTrustedURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		allowlist  string
+		rawURL     string
+		want       string
+		wantErrSub string
+	}{
+		{
+			name:      "a path prefix is preserved",
+			allowlist: "git.example.com",
+			rawURL:    "https://git.example.com/gitlab",
+			want:      "https://git.example.com/gitlab",
+		},
+		{
+			name:      "the host is replaced by the canonical one",
+			allowlist: "",
+			rawURL:    "https://API.GitHub.com/foo",
+			want:      "https://github.com/foo",
+		},
+		{
+			// strings.ToLower folds the Turkish dotted capital I onto an ASCII
+			// i, but a resolver reads it as xn--github-qyd.com. The policy must
+			// see, and refuse, the name that would really be dialled.
+			name:       "a unicode lookalike of github.com is refused",
+			rawURL:     "https://GİTHUB.com/owner/repo",
+			wantErrSub: "refusing to use credentials",
+		},
+		{
+			name:       "cleartext is refused",
+			allowlist:  "git.example.com",
+			rawURL:     "http://git.example.com/gitlab",
+			wantErrSub: "scheme must be https",
+		},
+		{
+			name:       "userinfo redirection is refused",
+			allowlist:  "git.example.com",
+			rawURL:     "https://git.example.com@attacker.example/gitlab",
+			wantErrSub: "must not contain credentials",
+		},
+		{
+			name:       "an untrusted host is refused",
+			allowlist:  "git.example.com",
+			rawURL:     "https://attacker.example/gitlab",
+			wantErrSub: "refusing to use credentials",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			ctx = info.StoreNS(ctx, testNamespace)
+			run, _ := newRun(t, tt.allowlist, true)
+
+			got, err := TrustedURL(ctx, run, tt.rawURL)
+			if tt.wantErrSub != "" {
+				assert.ErrorContains(t, err, tt.wantErrSub)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, got, tt.want)
+		})
+	}
+}
+
+// Emptying the administrator list deliberately returns to managed mode. Hosts
+// learned before the administrator took over remain available in that mode.
+func TestEmptyingConfiguredListRestoresManagedPolicy(t *testing.T) {
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = info.StoreNS(ctx, testNamespace)
+	run, seedData := newRunWithPolicy(t, "corp.example.com", "ghe.example.com")
+
+	_, err := Trusted(ctx, run, "ghe.example.com")
+	assert.ErrorContains(t, err, "is not listed in")
+
+	configMaps := seedData.Kube.CoreV1().ConfigMaps(testNamespace)
+	configMap, err := configMaps.Get(ctx, testConfigMapName, metav1.GetOptions{})
+	assert.NilError(t, err)
+	delete(configMap.Data, settings.TrustedProviderHostnamesKey)
+	_, err = configMaps.Update(ctx, configMap, metav1.UpdateOptions{})
+	assert.NilError(t, err)
+
+	_, err = Trusted(ctx, run, "ghe.example.com")
+	assert.NilError(t, err)
+	_, err = Trusted(ctx, run, "github.com")
+	assert.NilError(t, err)
+}

--- a/pkg/params/settings/config.go
+++ b/pkg/params/settings/config.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/configutil"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/vcshost"
 	"go.uber.org/zap"
 )
 
@@ -25,6 +26,11 @@ const (
 	CustomConsoleNamespaceURLKey = "custom-console-url-namespace"
 
 	SecretGhAppTokenRepoScopedKey = "secret-github-app-token-scoped" //nolint: gosec
+
+	// TrustedProviderHostnamesKey is the ConfigMap key holding the comma
+	// separated list of hosted VCS hostnames this controller is allowed to send
+	// credentials to.
+	TrustedProviderHostnamesKey = "trusted-provider-hostnames"
 
 	// DefaultAPIRetryMaxAttempts is the fallback number of attempts (initial
 	// request included) used when api-retry-max-attempts is unset or invalid.
@@ -60,6 +66,17 @@ type Settings struct {
 	AutoConfigureNewGitHubRepo          bool   `default:"false"                                json:"auto-configure-new-github-repo"`
 	AutoConfigureRepoNamespaceTemplate  string `json:"auto-configure-repo-namespace-template"`
 	AutoConfigureRepoRepositoryTemplate string `json:"auto-configure-repo-repository-template"`
+
+	// TrustedProviderHostnames is the comma separated allowlist of hosted VCS
+	// hostnames this controller may send credentials to.
+	//
+	// It is here so that the value is validated on every ConfigMap change and
+	// surfaced with the rest of the settings. The security gate in
+	// pkg/hostpolicy deliberately does NOT read this field: it reads the
+	// ConfigMap live, because the informer cache may lag behind an administrator
+	// narrowing the allowlist, and because trust on first use has to update the
+	// learned-host annotation under a read-modify-write it can retry on conflict.
+	TrustedProviderHostnames string `json:"trusted-provider-hostnames"`
 
 	SecretAutoCreation               bool   `default:"true"                             json:"secret-auto-create"`
 	SecretGHAppRepoScoped            bool   `default:"true"                             json:"secret-github-app-token-scoped"`
@@ -122,7 +139,20 @@ func DefaultValidators() map[string]func(string) error {
 		"CustomConsoleURL":           isValidURL,
 		"CustomConsolePRTaskLog":     startWithHTTPorHTTPS,
 		"CustomConsolePRDetail":      startWithHTTPorHTTPS,
+		"TrustedProviderHostnames":   isValidTrustedProviderHostnames,
 	}
+}
+
+// isValidTrustedProviderHostnames validates the hosted VCS allowlist. An empty
+// value is accepted and means the allowlist has not been configured yet.
+func isValidTrustedProviderHostnames(raw string) error {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	if _, err := vcshost.ParseAllowlist(raw); err != nil {
+		return fmt.Errorf("invalid value for %s: %w", TrustedProviderHostnamesKey, err)
+	}
+	return nil
 }
 
 func SyncConfig(logger *zap.SugaredLogger, setting *Settings, config map[string]string, validators map[string]func(string) error) error {

--- a/pkg/params/settings/config_test.go
+++ b/pkg/params/settings/config_test.go
@@ -150,6 +150,13 @@ func TestSyncConfig(t *testing.T) {
 			},
 			expectedError: "custom validation failed for field CustomConsolePRTaskLog: invalid value, must start with http:// or https://",
 		},
+		{
+			name: "invalid value trusted provider hostnames",
+			configMap: map[string]string{
+				"trusted-provider-hostnames": "ghe.example.com, https://user@bad.example.com",
+			},
+			expectedError: "custom validation failed for field TrustedProviderHostnames: invalid value for trusted-provider-hostnames",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -171,6 +178,47 @@ func TestSyncConfig(t *testing.T) {
 			if !reflect.DeepEqual(test, tc.expectedStruct) {
 				t.Errorf("failure, actual and expected struct:\nActual: %#v\nExpected: %#v", test, tc.expectedStruct)
 			}
+		})
+	}
+}
+
+func TestIsValidTrustedProviderHostnames(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr string
+	}{
+		{
+			name:  "empty value means not configured",
+			value: "  ",
+		},
+		{
+			name:  "valid comma separated hostnames",
+			value: "ghe.example.com, gitlab.example.com",
+		},
+		{
+			name:  "https url spelling of a hostname",
+			value: "https://ghe.example.com",
+		},
+		{
+			name:    "hostname with a path is refused",
+			value:   "ghe.example.com/api/v3",
+			wantErr: "invalid value for trusted-provider-hostnames",
+		},
+		{
+			name:    "hostname with credentials is refused",
+			value:   "https://user@ghe.example.com",
+			wantErr: "invalid value for trusted-provider-hostnames",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := isValidTrustedProviderHostnames(tt.value)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			assert.NilError(t, err)
 		})
 	}
 }

--- a/pkg/provider/github/app/token.go
+++ b/pkg/provider/github/app/token.go
@@ -3,11 +3,9 @@ package app
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"net/url"
 	"strings"
 
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/github"
@@ -15,19 +13,14 @@ import (
 )
 
 type Install struct {
-	request   *http.Request
 	run       *params.Run
 	repo      *v1alpha1.Repository
 	ghClient  *github.Provider
 	namespace string
 }
 
-func NewInstallation(req *http.Request, run *params.Run, repo *v1alpha1.Repository, gh *github.Provider, namespace string) *Install {
-	if req == nil {
-		req = &http.Request{}
-	}
+func NewInstallation(run *params.Run, repo *v1alpha1.Repository, gh *github.Provider, namespace string) *Install {
 	return &Install{
-		request:   req,
 		run:       run,
 		repo:      repo,
 		ghClient:  gh,
@@ -41,16 +34,13 @@ func NewInstallation(req *http.Request, run *params.Run, repo *v1alpha1.Reposito
 func (ip *Install) GetAndUpdateInstallationID(ctx context.Context) (string, string, int64, error) {
 	logger := logging.FromContext(ctx)
 
-	// Generate a JWT token for authentication
-	jwtToken, err := ip.ghClient.GenerateJWT(ctx, ip.namespace, ip.run.Clients.Kube)
-	if err != nil {
-		return "", "", 0, err
-	}
-
 	// Get owner and repo from the repository URL
 	repoURL, err := url.Parse(ip.repo.Spec.URL)
 	if err != nil {
 		return "", "", 0, fmt.Errorf("failed to parse repository URL: %w", err)
+	}
+	if repoURL.Scheme != "https" || repoURL.User != nil {
+		return "", "", 0, fmt.Errorf("GitHub repository URL must use https without userinfo")
 	}
 	pathParts := strings.Split(strings.Trim(repoURL.Path, "/"), "/")
 	if len(pathParts) != 2 {
@@ -61,17 +51,25 @@ func (ip *Install) GetAndUpdateInstallationID(ctx context.Context) (string, stri
 	if owner == "" || repoName == "" {
 		return "", "", 0, fmt.Errorf("invalid repository URL: owner or repo name is empty")
 	}
-
-	if ip.ghClient.APIURL == nil {
-		return "", "", 0, fmt.Errorf("github client APIURL is nil")
+	endpoint, err := github.TrustedAPIEndpointForRepository(ctx, ip.run, ip.repo.Spec.URL)
+	if err != nil {
+		return "", "", 0, err
 	}
-	apiURL := *ip.ghClient.APIURL
-	enterpriseHost := ""
-	if repoURL.Host != "" && repoURL.Host != "github.com" {
-		enterpriseHost = repoURL.Host
-		if apiURL == keys.PublicGithubAPIURL {
-			apiURL = fmt.Sprintf("https://%s/api/v3", strings.TrimSuffix(enterpriseHost, "/"))
-		}
+	testAPIURL, err := github.AppTokenTestAPIURL()
+	if err != nil {
+		return "", "", 0, err
+	}
+
+	// Generate a JWT only after the repository has been checked against the
+	// controller-owned GitHub endpoint.
+	jwtToken, err := ip.ghClient.GenerateJWT(ctx, ip.namespace, ip.run.Clients.Kube)
+	if err != nil {
+		return "", "", 0, err
+	}
+
+	apiURL := endpoint.BaseURL
+	if testAPIURL != "" {
+		apiURL = strings.TrimSuffix(testAPIURL, "/api/v3")
 	}
 
 	client, _, _ := github.MakeClient(ctx, apiURL, jwtToken)
@@ -95,13 +93,13 @@ func (ip *Install) GetAndUpdateInstallationID(ctx context.Context) (string, stri
 	}
 
 	installationID := *installation.ID
-	token, err := ip.ghClient.GetAppToken(ctx, ip.run.Clients.Kube, enterpriseHost, installationID, ip.namespace)
+	token, err := ip.ghClient.GetAppToken(ctx, ip.run.Clients.Kube, endpoint.BaseURL, installationID, ip.namespace)
 	if err != nil {
 		logger.Warnf("Could not get a token for installation ID %d: %v", installationID, err)
 		// Return with the installation ID even if token generation fails,
 		// as some operations might only need the ID.
-		return enterpriseHost, "", installationID, nil
+		return endpoint.BaseURL, "", installationID, nil
 	}
 
-	return enterpriseHost, token, installationID, nil
+	return endpoint.BaseURL, token, installationID, nil
 }

--- a/pkg/provider/github/app/token.go
+++ b/pkg/provider/github/app/token.go
@@ -3,11 +3,9 @@ package app
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"net/url"
 	"strings"
 
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/github"
@@ -15,19 +13,14 @@ import (
 )
 
 type Install struct {
-	request   *http.Request
 	run       *params.Run
 	repo      *v1alpha1.Repository
 	ghClient  *github.Provider
 	namespace string
 }
 
-func NewInstallation(req *http.Request, run *params.Run, repo *v1alpha1.Repository, gh *github.Provider, namespace string) *Install {
-	if req == nil {
-		req = &http.Request{}
-	}
+func NewInstallation(run *params.Run, repo *v1alpha1.Repository, gh *github.Provider, namespace string) *Install {
 	return &Install{
-		request:   req,
 		run:       run,
 		repo:      repo,
 		ghClient:  gh,
@@ -41,16 +34,13 @@ func NewInstallation(req *http.Request, run *params.Run, repo *v1alpha1.Reposito
 func (ip *Install) GetAndUpdateInstallationID(ctx context.Context) (string, string, int64, error) {
 	logger := logging.FromContext(ctx)
 
-	// Generate a JWT token for authentication
-	jwtToken, err := ip.ghClient.GenerateJWT(ctx, ip.namespace, ip.run.Clients.Kube)
-	if err != nil {
-		return "", "", 0, err
-	}
-
 	// Get owner and repo from the repository URL
 	repoURL, err := url.Parse(ip.repo.Spec.URL)
 	if err != nil {
 		return "", "", 0, fmt.Errorf("failed to parse repository URL: %w", err)
+	}
+	if repoURL.Scheme != "https" || repoURL.User != nil {
+		return "", "", 0, fmt.Errorf("GitHub repository URL must use https without userinfo")
 	}
 	pathParts := strings.Split(strings.Trim(repoURL.Path, "/"), "/")
 	if len(pathParts) != 2 {
@@ -61,17 +51,20 @@ func (ip *Install) GetAndUpdateInstallationID(ctx context.Context) (string, stri
 	if owner == "" || repoName == "" {
 		return "", "", 0, fmt.Errorf("invalid repository URL: owner or repo name is empty")
 	}
-
-	if ip.ghClient.APIURL == nil {
-		return "", "", 0, fmt.Errorf("github client APIURL is nil")
+	endpoint, err := github.TrustedAPIEndpointForRepository(ctx, ip.run, ip.repo.Spec.URL)
+	if err != nil {
+		return "", "", 0, err
 	}
-	apiURL := *ip.ghClient.APIURL
-	enterpriseHost := ""
-	if repoURL.Host != "" && repoURL.Host != "github.com" {
-		enterpriseHost = repoURL.Host
-		if apiURL == keys.PublicGithubAPIURL {
-			apiURL = fmt.Sprintf("https://%s/api/v3", strings.TrimSuffix(enterpriseHost, "/"))
-		}
+	apiURL, err := endpoint.BaseURLForClient()
+	if err != nil {
+		return "", "", 0, err
+	}
+
+	// Generate a JWT only after the repository has been checked against the
+	// controller-owned GitHub endpoint.
+	jwtToken, err := ip.ghClient.GenerateJWT(ctx, ip.namespace, ip.run.Clients.Kube)
+	if err != nil {
+		return "", "", 0, err
 	}
 
 	client, _, _, err := ip.ghClient.MakeClient(ctx, apiURL, jwtToken)
@@ -98,13 +91,13 @@ func (ip *Install) GetAndUpdateInstallationID(ctx context.Context) (string, stri
 	}
 
 	installationID := *installation.ID
-	token, err := ip.ghClient.GetAppToken(ctx, ip.run.Clients.Kube, enterpriseHost, installationID, ip.namespace)
+	token, err := ip.ghClient.GetAppToken(ctx, ip.run.Clients.Kube, endpoint.BaseURL, installationID, ip.namespace)
 	if err != nil {
 		logger.Warnf("Could not get a token for installation ID %d: %v", installationID, err)
 		// Return with the installation ID even if token generation fails,
 		// as some operations might only need the ID.
-		return enterpriseHost, "", installationID, nil
+		return endpoint.BaseURL, "", installationID, nil
 	}
 
-	return enterpriseHost, token, installationID, nil
+	return endpoint.BaseURL, token, installationID, nil
 }

--- a/pkg/provider/github/app/token_test.go
+++ b/pkg/provider/github/app/token_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/github"
 	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
 	ghtesthelper "github.com/openshift-pipelines/pipelines-as-code/pkg/test/github"
@@ -162,9 +161,11 @@ func TestGenerateJWT(t *testing.T) {
 
 // Test_GetAndUpdateInstallationID tests we properly obtain the list of repos for a GitHub App and find a matching repo.
 func TestGetAndUpdateInstallationID(t *testing.T) {
+	enterpriseSecret := validSecret.DeepCopy()
+	enterpriseSecret.Data["github-host"] = []byte("matched")
 	tdata := testclient.Data{
 		Namespaces: []*corev1.Namespace{testNamespace},
-		Secret:     []*corev1.Secret{validSecret},
+		Secret:     []*corev1.Secret{enterpriseSecret},
 	}
 	wantToken := "GOODTOKEN"
 	wantID := 120
@@ -198,9 +199,6 @@ func TestGetAndUpdateInstallationID(t *testing.T) {
 			Kube:           stdata.Kube,
 		},
 		Info: info.Info{
-			Pac: &info.PacOpts{
-				Settings: settings.Settings{},
-			},
 			Controller: &info.ControllerInfo{Secret: validSecret.GetName()},
 		},
 	}
@@ -211,7 +209,6 @@ func TestGetAndUpdateInstallationID(t *testing.T) {
 	gh.Run = run
 	jwtToken, err := gh.GenerateJWT(ctx, testNamespace.GetName(), stdata.Kube)
 	assert.NilError(t, err)
-	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "http://localhost", strings.NewReader(""))
 	repo := &v1alpha1.Repository{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "repo",
@@ -258,7 +255,7 @@ func TestGetAndUpdateInstallationID(t *testing.T) {
 			`{"total_count": 2,"repositories": [{"id":1,"html_url": "https://matched/%s/incoming"},{"id":2,"html_url": "https://anotherrepo/that/would/failit"}]}`,
 			orgName)
 	})
-	ip := NewInstallation(req, run, repo, gprovider, testNamespace.GetName())
+	ip := NewInstallation(run, repo, gprovider, testNamespace.GetName())
 	_, token, installationID, err := ip.GetAndUpdateInstallationID(ctx)
 	assert.NilError(t, err)
 	assert.Equal(t, installationID, int64(wantID))
@@ -266,7 +263,7 @@ func TestGetAndUpdateInstallationID(t *testing.T) {
 	assert.Equal(t, token, wantToken)
 }
 
-func TestGetAndUpdateInstallationIDIgnoresEnterpriseHostHeader(t *testing.T) {
+func TestGetAndUpdateInstallationIDUsesConfiguredPublicEndpoint(t *testing.T) {
 	tdata := testclient.Data{
 		Namespaces: []*corev1.Namespace{testNamespace},
 		Secret:     []*corev1.Secret{validSecret},
@@ -289,9 +286,6 @@ func TestGetAndUpdateInstallationIDIgnoresEnterpriseHostHeader(t *testing.T) {
 			Kube:           stdata.Kube,
 		},
 		Info: info.Info{
-			Pac: &info.PacOpts{
-				Settings: settings.Settings{},
-			},
 			Controller: &info.ControllerInfo{Secret: validSecret.GetName()},
 		},
 	}
@@ -326,9 +320,7 @@ func TestGetAndUpdateInstallationIDIgnoresEnterpriseHostHeader(t *testing.T) {
 	gprovider.SetGithubClient(fakeghclient)
 	t.Setenv("PAC_GIT_PROVIDER_TOKEN_APIURL", serverURL+"/api/v3")
 
-	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "http://localhost", strings.NewReader(""))
-	req.Header.Set("X-GitHub-Enterprise-Host", "127.0.0.1:1")
-	ip := NewInstallation(req, run, repo, gprovider, testNamespace.GetName())
+	ip := NewInstallation(run, repo, gprovider, testNamespace.GetName())
 	enterpriseURL, token, installationID, err := ip.GetAndUpdateInstallationID(ctx)
 	assert.NilError(t, err)
 	assert.Equal(t, enterpriseURL, "")
@@ -345,9 +337,11 @@ func testMethod(t *testing.T, r *http.Request) {
 }
 
 func TestGetAndUpdateInstallationIDFallbacks(t *testing.T) {
+	enterpriseSecret := validSecret.DeepCopy()
+	enterpriseSecret.Data["github-host"] = []byte("matched")
 	tdata := testclient.Data{
 		Namespaces: []*corev1.Namespace{testNamespace},
-		Secret:     []*corev1.Secret{validSecret},
+		Secret:     []*corev1.Secret{enterpriseSecret},
 	}
 	wantToken := "GOODTOKEN"
 	orgName := "org"
@@ -387,7 +381,7 @@ func TestGetAndUpdateInstallationIDFallbacks(t *testing.T) {
 			wantErr:            false,
 			wantInstallationID: orgID,
 			wantToken:          wantToken,
-			wantEnterpriseHost: "matched",
+			wantEnterpriseHost: "https://matched",
 		},
 		{
 			name:    "repo and org installation fail, user installation succeeds",
@@ -412,7 +406,7 @@ func TestGetAndUpdateInstallationIDFallbacks(t *testing.T) {
 			wantErr:            false,
 			wantInstallationID: userID,
 			wantToken:          wantToken,
-			wantEnterpriseHost: "matched",
+			wantEnterpriseHost: "https://matched",
 		},
 		{
 			name:    "all installations fail",
@@ -459,9 +453,6 @@ func TestGetAndUpdateInstallationIDFallbacks(t *testing.T) {
 					Kube:           stdata.Kube,
 				},
 				Info: info.Info{
-					Pac: &info.PacOpts{
-						Settings: settings.Settings{},
-					},
 					Controller: &info.ControllerInfo{Secret: validSecret.GetName()},
 				},
 			}
@@ -488,7 +479,7 @@ func TestGetAndUpdateInstallationIDFallbacks(t *testing.T) {
 			gprovider.SetGithubClient(fakeghclient)
 			t.Setenv("PAC_GIT_PROVIDER_TOKEN_APIURL", serverURL)
 
-			ip := NewInstallation(httptest.NewRequestWithContext(ctx, http.MethodGet, "http://localhost", strings.NewReader("")), run, repo, gprovider, testNamespace.GetName())
+			ip := NewInstallation(run, repo, gprovider, testNamespace.GetName())
 			enterpriseHost, token, installationID, err := ip.GetAndUpdateInstallationID(ctx)
 
 			if tt.wantErr {
@@ -503,6 +494,258 @@ func TestGetAndUpdateInstallationIDFallbacks(t *testing.T) {
 			assert.Equal(t, installationID, tt.wantInstallationID)
 			assert.Equal(t, token, tt.wantToken)
 			assert.Equal(t, enterpriseHost, tt.wantEnterpriseHost)
+		})
+	}
+}
+
+func TestGetAndUpdateInstallationIDRejectsUnconfiguredRepositoryHost(t *testing.T) {
+	requests := 0
+	server := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requests++
+	}))
+	defer server.Close()
+
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = info.StoreNS(ctx, testNamespace.GetName())
+	seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+		Secret: []*corev1.Secret{validSecret},
+	})
+	run := &params.Run{
+		Clients: clients.Clients{
+			Kube: seedData.Kube,
+		},
+		Info: info.Info{
+			Controller: &info.ControllerInfo{Secret: validSecret.GetName()},
+		},
+	}
+	repo := &v1alpha1.Repository{
+		Spec: v1alpha1.RepositorySpec{
+			URL: server.URL + "/owner/repo",
+		},
+	}
+
+	ip := NewInstallation(run, repo, github.New(), testNamespace.GetName())
+	enterpriseURL, token, installationID, err := ip.GetAndUpdateInstallationID(ctx)
+	assert.ErrorContains(t, err, "has not been authenticated yet")
+	assert.Equal(t, enterpriseURL, "")
+	assert.Equal(t, token, "")
+	assert.Equal(t, installationID, int64(0))
+	assert.Equal(t, requests, 0)
+}
+
+func TestGetAndUpdateInstallationIDRejectsInvalidRepositoryURLs(t *testing.T) {
+	tests := []struct {
+		name        string
+		repoURL     string
+		wantErrText string
+	}{
+		{
+			name:        "parse error",
+			repoURL:     "https://github.com/%zz/repo",
+			wantErrText: "failed to parse repository URL",
+		},
+		{
+			name:        "http scheme",
+			repoURL:     "http://github.com/owner/repo",
+			wantErrText: "must use https without userinfo",
+		},
+		{
+			name:        "userinfo",
+			repoURL:     "https://user@github.com/owner/repo",
+			wantErrText: "must use https without userinfo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			ctx = info.StoreNS(ctx, testNamespace.GetName())
+			seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+				Secret: []*corev1.Secret{validSecret},
+			})
+			run := &params.Run{
+				Clients: clients.Clients{
+					Kube: seedData.Kube,
+				},
+				Info: info.Info{
+					Controller: &info.ControllerInfo{Secret: validSecret.GetName()},
+				},
+			}
+			repo := &v1alpha1.Repository{
+				Spec: v1alpha1.RepositorySpec{
+					URL: tt.repoURL,
+				},
+			}
+
+			ip := NewInstallation(run, repo, github.New(), testNamespace.GetName())
+			enterpriseURL, token, installationID, err := ip.GetAndUpdateInstallationID(ctx)
+			assert.ErrorContains(t, err, tt.wantErrText)
+			assert.Equal(t, enterpriseURL, "")
+			assert.Equal(t, token, "")
+			assert.Equal(t, installationID, int64(0))
+		})
+	}
+}
+
+func TestGetAndUpdateInstallationIDReturnsSetupErrors(t *testing.T) {
+	tests := []struct {
+		name        string
+		secret      *corev1.Secret
+		envAPIURL   string
+		wantErrText string
+	}{
+		{
+			name: "missing controller secret",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "different-secret",
+					Namespace: testNamespace.GetName(),
+				},
+			},
+			wantErrText: "not found",
+		},
+		{
+			name:        "invalid token api url",
+			secret:      validSecret,
+			envAPIURL:   "https://example.com",
+			wantErrText: "PAC_GIT_PROVIDER_TOKEN_APIURL must target a loopback IP address",
+		},
+		{
+			name: "invalid application id",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      info.DefaultPipelinesAscodeSecretName,
+					Namespace: testNamespace.GetName(),
+				},
+				Data: map[string][]byte{
+					"github-application-id": []byte("invalid"),
+					"github-private-key":    []byte(fakePrivateKey),
+				},
+			},
+			wantErrText: "could not parse the github application_id number",
+		},
+		{
+			name: "invalid private key",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      info.DefaultPipelinesAscodeSecretName,
+					Namespace: testNamespace.GetName(),
+				},
+				Data: map[string][]byte{
+					"github-application-id": []byte("12345"),
+					"github-private-key":    []byte("not-a-private-key"),
+				},
+			},
+			wantErrText: "failed to parse private key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envAPIURL != "" {
+				t.Setenv("PAC_GIT_PROVIDER_TOKEN_APIURL", tt.envAPIURL)
+			}
+			ctx, _ := rtesting.SetupFakeContext(t)
+			ctx = info.StoreNS(ctx, testNamespace.GetName())
+			seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+				Secret: []*corev1.Secret{tt.secret},
+			})
+			run := &params.Run{
+				Clients: clients.Clients{
+					Kube: seedData.Kube,
+				},
+				Info: info.Info{
+					Controller: &info.ControllerInfo{Secret: info.DefaultPipelinesAscodeSecretName},
+				},
+			}
+			gh := github.New()
+			gh.Run = run
+			repo := &v1alpha1.Repository{
+				Spec: v1alpha1.RepositorySpec{
+					URL: "https://github.com/owner/repo",
+				},
+			}
+
+			ip := NewInstallation(run, repo, gh, testNamespace.GetName())
+			enterpriseURL, token, installationID, err := ip.GetAndUpdateInstallationID(ctx)
+			assert.ErrorContains(t, err, tt.wantErrText)
+			assert.Equal(t, enterpriseURL, "")
+			assert.Equal(t, token, "")
+			assert.Equal(t, installationID, int64(0))
+		})
+	}
+}
+
+func TestGetAndUpdateInstallationIDHandlesInstallationAndTokenErrors(t *testing.T) {
+	tests := []struct {
+		name               string
+		repoInstallation   string
+		wantErrText        string
+		wantEnterpriseURL  string
+		wantToken          string
+		wantInstallationID int64
+	}{
+		{
+			name:             "installation has no id",
+			repoInstallation: `{}`,
+			wantErrText:      "github App installation found but contained no ID",
+		},
+		{
+			name:               "token request fails",
+			repoInstallation:   `{"id": 99}`,
+			wantEnterpriseURL:  "",
+			wantToken:          "",
+			wantInstallationID: 99,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, mux, serverURL, teardown := ghtesthelper.SetupGH()
+			defer teardown()
+			t.Setenv("PAC_GIT_PROVIDER_TOKEN_APIURL", serverURL+"/api/v3")
+			mux.HandleFunc("/repos/owner/repo/installation", func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = fmt.Fprint(w, tt.repoInstallation)
+			})
+			if tt.wantInstallationID != 0 {
+				mux.HandleFunc(fmt.Sprintf("/app/installations/%d/access_tokens", tt.wantInstallationID), func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusInternalServerError)
+				})
+			}
+
+			ctx, _ := rtesting.SetupFakeContext(t)
+			ctx = info.StoreNS(ctx, testNamespace.GetName())
+			seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+				Secret: []*corev1.Secret{validSecret},
+			})
+			logger, _ := logger.GetLogger()
+			run := &params.Run{
+				Clients: clients.Clients{
+					Log:  logger,
+					Kube: seedData.Kube,
+				},
+				Info: info.Info{
+					Controller: &info.ControllerInfo{Secret: validSecret.GetName()},
+				},
+			}
+			gh := github.New()
+			gh.Run = run
+			repo := &v1alpha1.Repository{
+				Spec: v1alpha1.RepositorySpec{
+					URL: "https://github.com/owner/repo",
+				},
+			}
+
+			ip := NewInstallation(run, repo, gh, testNamespace.GetName())
+			enterpriseURL, token, installationID, err := ip.GetAndUpdateInstallationID(ctx)
+			if tt.wantErrText != "" {
+				assert.ErrorContains(t, err, tt.wantErrText)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, enterpriseURL, tt.wantEnterpriseURL)
+			assert.Equal(t, token, tt.wantToken)
+			assert.Equal(t, installationID, tt.wantInstallationID)
 		})
 	}
 }

--- a/pkg/provider/github/app/token_test.go
+++ b/pkg/provider/github/app/token_test.go
@@ -55,6 +55,28 @@ var validSecret = &corev1.Secret{
 	},
 }
 
+const testConfigMapName = "pipelines-as-code"
+
+// trustedHostsConfigMapSlice returns the controller ConfigMap of a fresh
+// install, where no trusted hostname has been recorded yet.
+func trustedHostsConfigMapSlice() []*corev1.ConfigMap {
+	return []*corev1.ConfigMap{trustedHostsConfigMap("")}
+}
+
+// trustedHostsConfigMap returns the controller ConfigMap holding the allowlist
+// of the hosted VCS instances the controller may send credentials to.
+func trustedHostsConfigMap(hosts string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testConfigMapName,
+			Namespace: testNamespace.GetName(),
+		},
+		Data: map[string]string{
+			settings.TrustedProviderHostnamesKey: hosts,
+		},
+	}
+}
+
 func TestGenerateJWT(t *testing.T) {
 	namespaceWhereSecretNotInstalled := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -165,6 +187,7 @@ func TestGetAndUpdateInstallationID(t *testing.T) {
 	tdata := testclient.Data{
 		Namespaces: []*corev1.Namespace{testNamespace},
 		Secret:     []*corev1.Secret{validSecret},
+		ConfigMap:  []*corev1.ConfigMap{trustedHostsConfigMap("matched")},
 	}
 	wantToken := "GOODTOKEN"
 	wantID := 120
@@ -198,10 +221,7 @@ func TestGetAndUpdateInstallationID(t *testing.T) {
 			Kube:           stdata.Kube,
 		},
 		Info: info.Info{
-			Pac: &info.PacOpts{
-				Settings: settings.Settings{},
-			},
-			Controller: &info.ControllerInfo{Secret: validSecret.GetName()},
+			Controller: &info.ControllerInfo{Secret: validSecret.GetName(), Configmap: testConfigMapName},
 		},
 	}
 	ctx = info.StoreCurrentControllerName(ctx, "default")
@@ -211,7 +231,6 @@ func TestGetAndUpdateInstallationID(t *testing.T) {
 	gh.Run = run
 	jwtToken, err := gh.GenerateJWT(ctx, testNamespace.GetName(), stdata.Kube)
 	assert.NilError(t, err)
-	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "http://localhost", strings.NewReader(""))
 	repo := &v1alpha1.Repository{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "repo",
@@ -258,7 +277,7 @@ func TestGetAndUpdateInstallationID(t *testing.T) {
 			`{"total_count": 2,"repositories": [{"id":1,"html_url": "https://matched/%s/incoming"},{"id":2,"html_url": "https://anotherrepo/that/would/failit"}]}`,
 			orgName)
 	})
-	ip := NewInstallation(req, run, repo, gprovider, testNamespace.GetName())
+	ip := NewInstallation(run, repo, gprovider, testNamespace.GetName())
 	_, token, installationID, err := ip.GetAndUpdateInstallationID(ctx)
 	assert.NilError(t, err)
 	assert.Equal(t, installationID, int64(wantID))
@@ -266,10 +285,11 @@ func TestGetAndUpdateInstallationID(t *testing.T) {
 	assert.Equal(t, token, wantToken)
 }
 
-func TestGetAndUpdateInstallationIDIgnoresEnterpriseHostHeader(t *testing.T) {
+func TestGetAndUpdateInstallationIDUsesConfiguredPublicEndpoint(t *testing.T) {
 	tdata := testclient.Data{
 		Namespaces: []*corev1.Namespace{testNamespace},
 		Secret:     []*corev1.Secret{validSecret},
+		ConfigMap:  trustedHostsConfigMapSlice(),
 	}
 	wantToken := "GOODTOKEN"
 	wantID := int64(120)
@@ -289,10 +309,7 @@ func TestGetAndUpdateInstallationIDIgnoresEnterpriseHostHeader(t *testing.T) {
 			Kube:           stdata.Kube,
 		},
 		Info: info.Info{
-			Pac: &info.PacOpts{
-				Settings: settings.Settings{},
-			},
-			Controller: &info.ControllerInfo{Secret: validSecret.GetName()},
+			Controller: &info.ControllerInfo{Secret: validSecret.GetName(), Configmap: testConfigMapName},
 		},
 	}
 	ctx = info.StoreCurrentControllerName(ctx, "default")
@@ -326,9 +343,7 @@ func TestGetAndUpdateInstallationIDIgnoresEnterpriseHostHeader(t *testing.T) {
 	gprovider.SetGithubClient(fakeghclient)
 	t.Setenv("PAC_GIT_PROVIDER_TOKEN_APIURL", serverURL+"/api/v3")
 
-	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "http://localhost", strings.NewReader(""))
-	req.Header.Set("X-GitHub-Enterprise-Host", "127.0.0.1:1")
-	ip := NewInstallation(req, run, repo, gprovider, testNamespace.GetName())
+	ip := NewInstallation(run, repo, gprovider, testNamespace.GetName())
 	enterpriseURL, token, installationID, err := ip.GetAndUpdateInstallationID(ctx)
 	assert.NilError(t, err)
 	assert.Equal(t, enterpriseURL, "")
@@ -348,6 +363,7 @@ func TestGetAndUpdateInstallationIDFallbacks(t *testing.T) {
 	tdata := testclient.Data{
 		Namespaces: []*corev1.Namespace{testNamespace},
 		Secret:     []*corev1.Secret{validSecret},
+		ConfigMap:  []*corev1.ConfigMap{trustedHostsConfigMap("matched")},
 	}
 	wantToken := "GOODTOKEN"
 	orgName := "org"
@@ -388,7 +404,7 @@ func TestGetAndUpdateInstallationIDFallbacks(t *testing.T) {
 			wantErr:            false,
 			wantInstallationID: orgID,
 			wantToken:          wantToken,
-			wantEnterpriseHost: "matched",
+			wantEnterpriseHost: "https://matched",
 		},
 		{
 			name:    "repo and org installation fail, user installation succeeds",
@@ -413,7 +429,7 @@ func TestGetAndUpdateInstallationIDFallbacks(t *testing.T) {
 			wantErr:            false,
 			wantInstallationID: userID,
 			wantToken:          wantToken,
-			wantEnterpriseHost: "matched",
+			wantEnterpriseHost: "https://matched",
 		},
 		{
 			name:    "all installations fail",
@@ -440,14 +456,6 @@ func TestGetAndUpdateInstallationIDFallbacks(t *testing.T) {
 			wantErr:             true,
 			expectedErrorString: "invalid repository URL path",
 		},
-		{
-			name:                "invalid enterprise API URL",
-			repoURL:             fmt.Sprintf("https://github.com/%s/%s", orgName, repoName),
-			apiURL:              "%",
-			setupMux:            func(_ *http.ServeMux, _ string) {},
-			wantErr:             true,
-			expectedErrorString: "failed to create github enterprise client",
-		},
 	}
 
 	for _, tt := range tests {
@@ -468,10 +476,7 @@ func TestGetAndUpdateInstallationIDFallbacks(t *testing.T) {
 					Kube:           stdata.Kube,
 				},
 				Info: info.Info{
-					Pac: &info.PacOpts{
-						Settings: settings.Settings{},
-					},
-					Controller: &info.ControllerInfo{Secret: validSecret.GetName()},
+					Controller: &info.ControllerInfo{Secret: validSecret.GetName(), Configmap: testConfigMapName},
 				},
 			}
 			ctx = info.StoreCurrentControllerName(ctx, "default")
@@ -501,7 +506,7 @@ func TestGetAndUpdateInstallationIDFallbacks(t *testing.T) {
 			gprovider.SetGithubClient(fakeghclient)
 			t.Setenv("PAC_GIT_PROVIDER_TOKEN_APIURL", serverURL)
 
-			ip := NewInstallation(httptest.NewRequestWithContext(ctx, http.MethodGet, "http://localhost", strings.NewReader("")), run, repo, gprovider, testNamespace.GetName())
+			ip := NewInstallation(run, repo, gprovider, testNamespace.GetName())
 			enterpriseHost, token, installationID, err := ip.GetAndUpdateInstallationID(ctx)
 
 			if tt.wantErr {
@@ -516,6 +521,262 @@ func TestGetAndUpdateInstallationIDFallbacks(t *testing.T) {
 			assert.Equal(t, installationID, tt.wantInstallationID)
 			assert.Equal(t, token, tt.wantToken)
 			assert.Equal(t, enterpriseHost, tt.wantEnterpriseHost)
+		})
+	}
+}
+
+func TestGetAndUpdateInstallationIDRejectsUnconfiguredRepositoryHost(t *testing.T) {
+	requests := 0
+	server := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requests++
+	}))
+	defer server.Close()
+
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = info.StoreNS(ctx, testNamespace.GetName())
+	seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+		ConfigMap: trustedHostsConfigMapSlice(),
+		Secret:    []*corev1.Secret{validSecret},
+	})
+	run := &params.Run{
+		Clients: clients.Clients{
+			Kube: seedData.Kube,
+		},
+		Info: info.Info{
+			Controller: &info.ControllerInfo{Secret: validSecret.GetName(), Configmap: testConfigMapName},
+		},
+	}
+	repo := &v1alpha1.Repository{
+		Spec: v1alpha1.RepositorySpec{
+			URL: server.URL + "/owner/repo",
+		},
+	}
+
+	ip := NewInstallation(run, repo, github.New(), testNamespace.GetName())
+	enterpriseURL, token, installationID, err := ip.GetAndUpdateInstallationID(ctx)
+	assert.ErrorContains(t, err, "refusing to use credentials")
+	assert.Equal(t, enterpriseURL, "")
+	assert.Equal(t, token, "")
+	assert.Equal(t, installationID, int64(0))
+	assert.Equal(t, requests, 0)
+}
+
+func TestGetAndUpdateInstallationIDRejectsInvalidRepositoryURLs(t *testing.T) {
+	tests := []struct {
+		name        string
+		repoURL     string
+		wantErrText string
+	}{
+		{
+			name:        "parse error",
+			repoURL:     "https://github.com/%zz/repo",
+			wantErrText: "failed to parse repository URL",
+		},
+		{
+			name:        "http scheme",
+			repoURL:     "http://github.com/owner/repo",
+			wantErrText: "must use https without userinfo",
+		},
+		{
+			name:        "userinfo",
+			repoURL:     "https://user@github.com/owner/repo",
+			wantErrText: "must use https without userinfo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			ctx = info.StoreNS(ctx, testNamespace.GetName())
+			seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+				ConfigMap: trustedHostsConfigMapSlice(),
+				Secret:    []*corev1.Secret{validSecret},
+			})
+			run := &params.Run{
+				Clients: clients.Clients{
+					Kube: seedData.Kube,
+				},
+				Info: info.Info{
+					Controller: &info.ControllerInfo{Secret: validSecret.GetName(), Configmap: testConfigMapName},
+				},
+			}
+			repo := &v1alpha1.Repository{
+				Spec: v1alpha1.RepositorySpec{
+					URL: tt.repoURL,
+				},
+			}
+
+			ip := NewInstallation(run, repo, github.New(), testNamespace.GetName())
+			enterpriseURL, token, installationID, err := ip.GetAndUpdateInstallationID(ctx)
+			assert.ErrorContains(t, err, tt.wantErrText)
+			assert.Equal(t, enterpriseURL, "")
+			assert.Equal(t, token, "")
+			assert.Equal(t, installationID, int64(0))
+		})
+	}
+}
+
+func TestGetAndUpdateInstallationIDReturnsSetupErrors(t *testing.T) {
+	tests := []struct {
+		name        string
+		secret      *corev1.Secret
+		envAPIURL   string
+		wantErrText string
+	}{
+		{
+			name: "missing controller secret",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "different-secret",
+					Namespace: testNamespace.GetName(),
+				},
+			},
+			wantErrText: "not found",
+		},
+		{
+			name:        "invalid token api url",
+			secret:      validSecret,
+			envAPIURL:   "https://example.com",
+			wantErrText: "PAC_GIT_PROVIDER_TOKEN_APIURL must target a loopback IP address",
+		},
+		{
+			name: "invalid application id",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      info.DefaultPipelinesAscodeSecretName,
+					Namespace: testNamespace.GetName(),
+				},
+				Data: map[string][]byte{
+					"github-application-id": []byte("invalid"),
+					"github-private-key":    []byte(fakePrivateKey),
+				},
+			},
+			wantErrText: "could not parse the github application_id number",
+		},
+		{
+			name: "invalid private key",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      info.DefaultPipelinesAscodeSecretName,
+					Namespace: testNamespace.GetName(),
+				},
+				Data: map[string][]byte{
+					"github-application-id": []byte("12345"),
+					"github-private-key":    []byte("not-a-private-key"),
+				},
+			},
+			wantErrText: "failed to parse private key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envAPIURL != "" {
+				t.Setenv("PAC_GIT_PROVIDER_TOKEN_APIURL", tt.envAPIURL)
+			}
+			ctx, _ := rtesting.SetupFakeContext(t)
+			ctx = info.StoreNS(ctx, testNamespace.GetName())
+			seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+				ConfigMap: trustedHostsConfigMapSlice(),
+				Secret:    []*corev1.Secret{tt.secret},
+			})
+			run := &params.Run{
+				Clients: clients.Clients{
+					Kube: seedData.Kube,
+				},
+				Info: info.Info{
+					Controller: &info.ControllerInfo{Secret: info.DefaultPipelinesAscodeSecretName, Configmap: testConfigMapName},
+				},
+			}
+			gh := github.New()
+			gh.Run = run
+			repo := &v1alpha1.Repository{
+				Spec: v1alpha1.RepositorySpec{
+					URL: "https://github.com/owner/repo",
+				},
+			}
+
+			ip := NewInstallation(run, repo, gh, testNamespace.GetName())
+			enterpriseURL, token, installationID, err := ip.GetAndUpdateInstallationID(ctx)
+			assert.ErrorContains(t, err, tt.wantErrText)
+			assert.Equal(t, enterpriseURL, "")
+			assert.Equal(t, token, "")
+			assert.Equal(t, installationID, int64(0))
+		})
+	}
+}
+
+func TestGetAndUpdateInstallationIDHandlesInstallationAndTokenErrors(t *testing.T) {
+	tests := []struct {
+		name               string
+		repoInstallation   string
+		wantErrText        string
+		wantEnterpriseURL  string
+		wantToken          string
+		wantInstallationID int64
+	}{
+		{
+			name:             "installation has no id",
+			repoInstallation: `{}`,
+			wantErrText:      "github App installation found but contained no ID",
+		},
+		{
+			name:               "token request fails",
+			repoInstallation:   `{"id": 99}`,
+			wantEnterpriseURL:  "",
+			wantToken:          "",
+			wantInstallationID: 99,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, mux, serverURL, teardown := ghtesthelper.SetupGH()
+			defer teardown()
+			t.Setenv("PAC_GIT_PROVIDER_TOKEN_APIURL", serverURL+"/api/v3")
+			mux.HandleFunc("/repos/owner/repo/installation", func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = fmt.Fprint(w, tt.repoInstallation)
+			})
+			if tt.wantInstallationID != 0 {
+				mux.HandleFunc(fmt.Sprintf("/app/installations/%d/access_tokens", tt.wantInstallationID), func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusInternalServerError)
+				})
+			}
+
+			ctx, _ := rtesting.SetupFakeContext(t)
+			ctx = info.StoreNS(ctx, testNamespace.GetName())
+			seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+				ConfigMap: trustedHostsConfigMapSlice(),
+				Secret:    []*corev1.Secret{validSecret},
+			})
+			logger, _ := logger.GetLogger()
+			run := &params.Run{
+				Clients: clients.Clients{
+					Log:  logger,
+					Kube: seedData.Kube,
+				},
+				Info: info.Info{
+					Controller: &info.ControllerInfo{Secret: validSecret.GetName(), Configmap: testConfigMapName},
+				},
+			}
+			gh := github.New()
+			gh.Run = run
+			repo := &v1alpha1.Repository{
+				Spec: v1alpha1.RepositorySpec{
+					URL: "https://github.com/owner/repo",
+				},
+			}
+
+			ip := NewInstallation(run, repo, gh, testNamespace.GetName())
+			enterpriseURL, token, installationID, err := ip.GetAndUpdateInstallationID(ctx)
+			if tt.wantErrText != "" {
+				assert.ErrorContains(t, err, tt.wantErrText)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, enterpriseURL, tt.wantEnterpriseURL)
+			assert.Equal(t, token, tt.wantToken)
+			assert.Equal(t, installationID, tt.wantInstallationID)
 		})
 	}
 }

--- a/pkg/provider/github/endpoints.go
+++ b/pkg/provider/github/endpoints.go
@@ -1,0 +1,175 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+)
+
+type APIEndpoint struct {
+	APIURL         string
+	BaseURL        string
+	RepositoryHost string
+}
+
+func AppTokenTestAPIURL() (string, error) {
+	rawURL := strings.TrimSpace(os.Getenv("PAC_GIT_PROVIDER_TOKEN_APIURL"))
+	if rawURL == "" {
+		return "", nil
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" ||
+		parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" || parsed.RawPath != "" {
+		return "", fmt.Errorf("PAC_GIT_PROVIDER_TOKEN_APIURL must be a loopback HTTP(S) URL")
+	}
+	if ip := net.ParseIP(parsed.Hostname()); ip == nil || !ip.IsLoopback() {
+		return "", fmt.Errorf("PAC_GIT_PROVIDER_TOKEN_APIURL must target a loopback IP address")
+	}
+	path := strings.TrimSuffix(parsed.Path, "/")
+	if path != "" && path != "/api/v3" {
+		return "", fmt.Errorf("PAC_GIT_PROVIDER_TOKEN_APIURL must not contain a path other than /api/v3")
+	}
+	parsed.Path = path
+	return strings.TrimSuffix(parsed.String(), "/"), nil
+}
+
+func ResolveAPIEndpoint(rawHost string) (APIEndpoint, error) {
+	host, err := parseGitHubHost(rawHost)
+	if err != nil {
+		return APIEndpoint{}, err
+	}
+
+	switch strings.ToLower(host) {
+	case "api.github.com", "github.com":
+		return APIEndpoint{
+			APIURL:         keys.PublicGithubAPIURL,
+			RepositoryHost: "github.com",
+		}, nil
+	default:
+		baseURL := "https://" + host
+		return APIEndpoint{
+			APIURL:         baseURL + "/api/v3",
+			BaseURL:        baseURL,
+			RepositoryHost: host,
+		}, nil
+	}
+}
+
+func parseGitHubHost(rawURL string) (string, error) {
+	if rawURL == "" {
+		return "", fmt.Errorf("GitHub host is empty")
+	}
+	if !strings.HasPrefix(rawURL, "https://") && !strings.HasPrefix(rawURL, "http://") {
+		rawURL = "https://" + rawURL
+	}
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil || parsedURL.Host == "" {
+		return "", fmt.Errorf("invalid GitHub host")
+	}
+	if parsedURL.Scheme != "https" {
+		return "", fmt.Errorf("GitHub host scheme must be https")
+	}
+	if parsedURL.User != nil || parsedURL.RawQuery != "" || parsedURL.Fragment != "" {
+		return "", fmt.Errorf("invalid GitHub host")
+	}
+	if path := strings.TrimSuffix(parsedURL.EscapedPath(), "/"); path != "" {
+		return "", fmt.Errorf("invalid GitHub host")
+	}
+	return strings.ToLower(parsedURL.Host), nil
+}
+
+func pinGitHubHost(ctx context.Context, run *params.Run, endpoint APIEndpoint) (APIEndpoint, error) {
+	namespace := info.GetNS(ctx)
+	secretName := run.Info.Controller.Secret
+	secretsClient := run.Clients.Kube.CoreV1().Secrets(namespace)
+	trustedEndpoint := endpoint
+
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		secret, err := secretsClient.Get(ctx, secretName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		pinnedHost := strings.TrimSpace(string(secret.Data[keys.GithubHost]))
+		if pinnedHost != "" {
+			pinnedEndpoint, err := ResolveAPIEndpoint(pinnedHost)
+			if err != nil {
+				return fmt.Errorf("controller secret %s/%s has an invalid %s value: %w", namespace, secretName, keys.GithubHost, err)
+			}
+			if pinnedEndpoint.RepositoryHost != endpoint.RepositoryHost {
+				return fmt.Errorf("authenticated GitHub host %q conflicts with controller-pinned host %q", endpoint.RepositoryHost, pinnedEndpoint.RepositoryHost)
+			}
+			trustedEndpoint = pinnedEndpoint
+			return nil
+		}
+
+		if secret.Data == nil {
+			secret.Data = map[string][]byte{}
+		}
+		secret.Data[keys.GithubHost] = []byte(endpoint.RepositoryHost)
+		if _, err := secretsClient.Update(ctx, secret, metav1.UpdateOptions{}); err != nil {
+			return err
+		}
+		trustedEndpoint = endpoint
+		return nil
+	})
+	if err != nil {
+		return APIEndpoint{}, fmt.Errorf("failed to pin authenticated GitHub host: %w", err)
+	}
+	return trustedEndpoint, nil
+}
+
+func TrustedAPIEndpointForRepository(ctx context.Context, run *params.Run, repositoryURL string) (APIEndpoint, error) {
+	parsedURL, err := url.Parse(repositoryURL)
+	if err != nil || parsedURL.Scheme != "https" || parsedURL.Host == "" || parsedURL.User != nil {
+		return APIEndpoint{}, fmt.Errorf("invalid GitHub repository URL")
+	}
+	repositoryEndpoint, err := ResolveAPIEndpoint(parsedURL.Host)
+	if err != nil {
+		return APIEndpoint{}, err
+	}
+	return trustedAPIEndpoint(ctx, run.Clients.Kube, info.GetNS(ctx), run.Info.Controller.Secret, repositoryEndpoint)
+}
+
+func trustedAPIEndpoint(ctx context.Context, kube kubernetes.Interface, namespace, secretName string, requestedEndpoint APIEndpoint) (APIEndpoint, error) {
+	secret, err := kube.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		return APIEndpoint{}, err
+	}
+	pinnedHost := strings.TrimSpace(string(secret.Data[keys.GithubHost]))
+	if pinnedHost == "" {
+		if requestedEndpoint.RepositoryHost == "github.com" {
+			return requestedEndpoint, nil
+		}
+		return APIEndpoint{}, fmt.Errorf("GitHub Enterprise host %q has not been authenticated yet; deliver a signed GitHub webhook before using GitHub App credentials", requestedEndpoint.RepositoryHost)
+	}
+	pinnedEndpoint, err := ResolveAPIEndpoint(pinnedHost)
+	if err != nil {
+		return APIEndpoint{}, fmt.Errorf("controller secret %s/%s has an invalid %s value: %w", namespace, secretName, keys.GithubHost, err)
+	}
+	if pinnedEndpoint.RepositoryHost != requestedEndpoint.RepositoryHost {
+		return APIEndpoint{}, fmt.Errorf("requested GitHub host %q does not match controller-pinned GitHub host %q", requestedEndpoint.RepositoryHost, pinnedEndpoint.RepositoryHost)
+	}
+	return pinnedEndpoint, nil
+}
+
+func trustedAPIEndpointForHost(ctx context.Context, kube kubernetes.Interface, namespace, secretName, rawHost string) (APIEndpoint, error) {
+	if rawHost == "" {
+		rawHost = "github.com"
+	}
+	requestedEndpoint, err := ResolveAPIEndpoint(rawHost)
+	if err != nil {
+		return APIEndpoint{}, err
+	}
+	return trustedAPIEndpoint(ctx, kube, namespace, secretName, requestedEndpoint)
+}

--- a/pkg/provider/github/endpoints.go
+++ b/pkg/provider/github/endpoints.go
@@ -1,0 +1,166 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/hostpolicy"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/vcshost"
+)
+
+// APIEndpoint holds the API locations to use for a given GitHub host.
+type APIEndpoint struct {
+	APIURL         string
+	BaseURL        string
+	RepositoryHost string
+}
+
+func AppTokenTestAPIURL() (string, error) {
+	rawURL := strings.TrimSpace(os.Getenv("PAC_GIT_PROVIDER_TOKEN_APIURL"))
+	if rawURL == "" {
+		return "", nil
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" ||
+		parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" || parsed.RawPath != "" {
+		return "", fmt.Errorf("PAC_GIT_PROVIDER_TOKEN_APIURL must be a loopback HTTP(S) URL")
+	}
+	if ip := net.ParseIP(parsed.Hostname()); ip == nil || !ip.IsLoopback() {
+		return "", fmt.Errorf("PAC_GIT_PROVIDER_TOKEN_APIURL must target a loopback IP address")
+	}
+	path := strings.TrimSuffix(parsed.Path, "/")
+	if path != "" && path != "/api/v3" {
+		return "", fmt.Errorf("PAC_GIT_PROVIDER_TOKEN_APIURL must not contain a path other than /api/v3")
+	}
+	parsed.Path = path
+	return strings.TrimSuffix(parsed.String(), "/"), nil
+}
+
+// BaseURLForClient returns the base URL a client must be built against.
+//
+// It is the endpoint base URL, except when the loopback override the unit tests
+// use is set: authentication and API then live on two different servers, and
+// every caller has to prefer the override the same way.
+func (e APIEndpoint) BaseURLForClient() (string, error) {
+	testAPIURL, err := AppTokenTestAPIURL()
+	if err != nil {
+		return "", err
+	}
+	if testAPIURL != "" {
+		return strings.TrimSuffix(testAPIURL, "/api/v3"), nil
+	}
+	return e.BaseURL, nil
+}
+
+// resolveUntrustedAPIEndpoint maps a GitHub hostname to the API endpoints to
+// use. It performs NO trust check and is deliberately unexported: every caller
+// must feed it a hostname returned by hostpolicy, never a hostname taken from a
+// payload, a header or a Repository CR. Passing raw input here reopens the
+// credential exfiltration hole this package exists to close.
+func resolveUntrustedAPIEndpoint(rawHost string) (APIEndpoint, error) {
+	host, err := vcshost.Parse(rawHost)
+	if err != nil {
+		return APIEndpoint{}, err
+	}
+	return apiEndpointFor("https", host), nil
+}
+
+// apiEndpointFor builds the endpoint of an already validated hostname.
+//
+// The public instance answers on its own API host and has no base URL, while a
+// self hosted one serves the API under /api/v3 of the host itself, so the two
+// shapes differ and every caller has to produce the same pair. scheme is only
+// honoured for a self hosted instance: github.com is always https.
+func apiEndpointFor(scheme, host string) APIEndpoint {
+	if vcshost.Canonical(host) == vcshost.PublicGitHub {
+		return APIEndpoint{
+			APIURL:         keys.PublicGithubAPIURL,
+			RepositoryHost: vcshost.PublicGitHub,
+		}
+	}
+	baseURL := strings.ToLower(scheme) + "://" + host
+	return APIEndpoint{
+		APIURL:         baseURL + "/api/v3",
+		BaseURL:        baseURL,
+		RepositoryHost: host,
+	}
+}
+
+// trustedAPIEndpointForHost resolves rawHost through the controller allowlist.
+// Use it on paths that carry no provider signature.
+func trustedAPIEndpointForHost(ctx context.Context, run *params.Run, rawHost string) (APIEndpoint, error) {
+	if rawHost == "" {
+		rawHost = vcshost.PublicGitHub
+	}
+	host, err := hostpolicy.Trusted(ctx, run, rawHost)
+	if err != nil {
+		return APIEndpoint{}, err
+	}
+	return resolveUntrustedAPIEndpoint(host)
+}
+
+// TrustedAPIEndpointForRepository resolves the endpoint for a Repository CR URL
+// through the controller allowlist.
+func TrustedAPIEndpointForRepository(ctx context.Context, run *params.Run, repositoryURL string) (APIEndpoint, error) {
+	parsedURL, err := vcshost.SplitURL(repositoryURL)
+	// SplitURL reads a value with no scheme as https, which is what an
+	// administrator typing a hostname means. A repository URL is not typed by
+	// hand though, GitHub always writes it in full, so it has to carry its own
+	// https scheme and anything else is not a repository URL.
+	if err != nil || !strings.Contains(repositoryURL, "://") || parsedURL.Scheme != "https" {
+		return APIEndpoint{}, fmt.Errorf("invalid GitHub repository URL")
+	}
+	return trustedAPIEndpointForHost(ctx, run, parsedURL.Host)
+}
+
+// authenticatedAPIEndpoint resolves the endpoint of a request that has already
+// been authenticated by GitHub, recording the host when the controller has no
+// allowlist configured yet.
+func authenticatedAPIEndpoint(ctx context.Context, run *params.Run, rawHost string) (APIEndpoint, error) {
+	host, err := hostpolicy.TrustOnFirstUse(ctx, run, rawHost)
+	if err != nil {
+		return APIEndpoint{}, err
+	}
+	return resolveUntrustedAPIEndpoint(host)
+}
+
+// trustedAPIEndpointForProviderURL resolves the endpoint for a provider URL that
+// came from a Repository CR through the controller allowlist.
+//
+// The value can be a bare hostname, a base URL or an API URL, since that is what
+// administrators have always been able to put in spec.git_provider.url, so only
+// its host is validated and the endpoint is rebuilt from the hostname the
+// allowlist approved rather than from the string that was supplied.
+//
+// The scheme is carried over rather than forced to https: a self hosted instance
+// reachable over plain http has always been supported here, and refusing it
+// would break those installs without making the credential any harder to
+// redirect, which is what the allowlist is for.
+func trustedAPIEndpointForProviderURL(ctx context.Context, run *params.Run, rawURL string) (APIEndpoint, error) {
+	if strings.TrimSpace(rawURL) == "" {
+		return trustedAPIEndpointForHost(ctx, run, vcshost.PublicGitHub)
+	}
+	parsed, err := vcshost.SplitURL(rawURL)
+	if err != nil {
+		if errors.Is(err, vcshost.ErrURLUnsafeComponents) {
+			return APIEndpoint{}, fmt.Errorf("provider URL must not contain credentials, a query or a fragment")
+		}
+		return APIEndpoint{}, fmt.Errorf("invalid provider URL %q", rawURL)
+	}
+	if !strings.EqualFold(parsed.Scheme, "https") && !strings.EqualFold(parsed.Scheme, "http") {
+		return APIEndpoint{}, fmt.Errorf("invalid provider URL %q: unsupported scheme %q", rawURL, parsed.Scheme)
+	}
+
+	host, err := hostpolicy.Trusted(ctx, run, parsed.Host)
+	if err != nil {
+		return APIEndpoint{}, err
+	}
+	return apiEndpointFor(parsed.Scheme, host), nil
+}

--- a/pkg/provider/github/endpoints.go
+++ b/pkg/provider/github/endpoints.go
@@ -1,0 +1,181 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+)
+
+type APIEndpoint struct {
+	APIURL         string
+	BaseURL        string
+	RepositoryHost string
+}
+
+func AppTokenTestAPIURL() (string, error) {
+	rawURL := strings.TrimSpace(os.Getenv("PAC_GIT_PROVIDER_TOKEN_APIURL"))
+	if rawURL == "" {
+		return "", nil
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" ||
+		parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" || parsed.RawPath != "" {
+		return "", fmt.Errorf("PAC_GIT_PROVIDER_TOKEN_APIURL must be a loopback HTTP(S) URL")
+	}
+	if ip := net.ParseIP(parsed.Hostname()); ip == nil || !ip.IsLoopback() {
+		return "", fmt.Errorf("PAC_GIT_PROVIDER_TOKEN_APIURL must target a loopback IP address")
+	}
+	path := strings.TrimSuffix(parsed.Path, "/")
+	if path != "" && path != "/api/v3" {
+		return "", fmt.Errorf("PAC_GIT_PROVIDER_TOKEN_APIURL must not contain a path other than /api/v3")
+	}
+	parsed.Path = path
+	return strings.TrimSuffix(parsed.String(), "/"), nil
+}
+
+func ResolveAPIEndpoint(rawHost string) (APIEndpoint, error) {
+	host, err := parseGitHubHost(rawHost)
+	if err != nil {
+		return APIEndpoint{}, err
+	}
+
+	switch strings.ToLower(host) {
+	case "api.github.com", "github.com":
+		return APIEndpoint{
+			APIURL:         keys.PublicGithubAPIURL,
+			RepositoryHost: "github.com",
+		}, nil
+	default:
+		baseURL := "https://" + host
+		return APIEndpoint{
+			APIURL:         baseURL + "/api/v3",
+			BaseURL:        baseURL,
+			RepositoryHost: host,
+		}, nil
+	}
+}
+
+func parseGitHubHost(rawURL string) (string, error) {
+	if rawURL == "" {
+		return "", fmt.Errorf("GitHub host is empty")
+	}
+	if !strings.HasPrefix(rawURL, "https://") && !strings.HasPrefix(rawURL, "http://") {
+		rawURL = "https://" + rawURL
+	}
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil || parsedURL.Host == "" {
+		return "", fmt.Errorf("invalid GitHub host")
+	}
+	if parsedURL.Scheme != "https" {
+		return "", fmt.Errorf("GitHub host scheme must be https")
+	}
+	if parsedURL.User != nil || parsedURL.RawQuery != "" || parsedURL.Fragment != "" {
+		return "", fmt.Errorf("invalid GitHub host")
+	}
+	if path := strings.TrimSuffix(parsedURL.EscapedPath(), "/"); path != "" {
+		return "", fmt.Errorf("invalid GitHub host")
+	}
+	return strings.ToLower(parsedURL.Host), nil
+}
+
+func pinGitHubHost(ctx context.Context, run *params.Run, endpoint APIEndpoint) (APIEndpoint, error) {
+	namespace := info.GetNS(ctx)
+	secretName := run.Info.Controller.Secret
+	secretsClient := run.Clients.Kube.CoreV1().Secrets(namespace)
+	trustedEndpoint := endpoint
+
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		secret, err := secretsClient.Get(ctx, secretName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		pinnedHost := strings.TrimSpace(string(secret.Data[keys.GithubHost]))
+		if pinnedHost != "" {
+			pinnedEndpoint, err := ResolveAPIEndpoint(pinnedHost)
+			if err != nil {
+				return fmt.Errorf("controller secret %s/%s has an invalid %s value: %w", namespace, secretName, keys.GithubHost, err)
+			}
+			if pinnedEndpoint.RepositoryHost != endpoint.RepositoryHost {
+				return fmt.Errorf("authenticated GitHub host %q conflicts with controller-pinned host %q", endpoint.RepositoryHost, pinnedEndpoint.RepositoryHost)
+			}
+			trustedEndpoint = pinnedEndpoint
+			return nil
+		}
+
+		// github.com is implicitly trusted and never pinned.
+		if endpoint.RepositoryHost == "github.com" {
+			trustedEndpoint = endpoint
+			return nil
+		}
+
+		if secret.Data == nil {
+			secret.Data = map[string][]byte{}
+		}
+		secret.Data[keys.GithubHost] = []byte(endpoint.RepositoryHost)
+		if _, err := secretsClient.Update(ctx, secret, metav1.UpdateOptions{}); err != nil {
+			return err
+		}
+		trustedEndpoint = endpoint
+		return nil
+	})
+	if err != nil {
+		return APIEndpoint{}, fmt.Errorf("failed to pin authenticated GitHub host: %w", err)
+	}
+	return trustedEndpoint, nil
+}
+
+func TrustedAPIEndpointForRepository(ctx context.Context, run *params.Run, repositoryURL string) (APIEndpoint, error) {
+	parsedURL, err := url.Parse(repositoryURL)
+	if err != nil || parsedURL.Scheme != "https" || parsedURL.Host == "" || parsedURL.User != nil || parsedURL.RawQuery != "" || parsedURL.Fragment != "" {
+		return APIEndpoint{}, fmt.Errorf("invalid GitHub repository URL")
+	}
+	repositoryEndpoint, err := ResolveAPIEndpoint(parsedURL.Host)
+	if err != nil {
+		return APIEndpoint{}, err
+	}
+	return trustedAPIEndpoint(ctx, run.Clients.Kube, info.GetNS(ctx), run.Info.Controller.Secret, repositoryEndpoint)
+}
+
+func trustedAPIEndpoint(ctx context.Context, kube kubernetes.Interface, namespace, secretName string, requestedEndpoint APIEndpoint) (APIEndpoint, error) {
+	secret, err := kube.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		return APIEndpoint{}, err
+	}
+	pinnedHost := strings.TrimSpace(string(secret.Data[keys.GithubHost]))
+	if pinnedHost == "" {
+		if requestedEndpoint.RepositoryHost == "github.com" {
+			return requestedEndpoint, nil
+		}
+		return APIEndpoint{}, fmt.Errorf("GitHub Enterprise host %q has not been authenticated yet; deliver a signed GitHub webhook before using GitHub App credentials", requestedEndpoint.RepositoryHost)
+	}
+	pinnedEndpoint, err := ResolveAPIEndpoint(pinnedHost)
+	if err != nil {
+		return APIEndpoint{}, fmt.Errorf("controller secret %s/%s has an invalid %s value: %w", namespace, secretName, keys.GithubHost, err)
+	}
+	if pinnedEndpoint.RepositoryHost != requestedEndpoint.RepositoryHost {
+		return APIEndpoint{}, fmt.Errorf("requested GitHub host %q does not match controller-pinned GitHub host %q", requestedEndpoint.RepositoryHost, pinnedEndpoint.RepositoryHost)
+	}
+	return pinnedEndpoint, nil
+}
+
+func trustedAPIEndpointForHost(ctx context.Context, kube kubernetes.Interface, namespace, secretName, rawHost string) (APIEndpoint, error) {
+	if rawHost == "" {
+		rawHost = "github.com"
+	}
+	requestedEndpoint, err := ResolveAPIEndpoint(rawHost)
+	if err != nil {
+		return APIEndpoint{}, err
+	}
+	return trustedAPIEndpoint(ctx, kube, namespace, secretName, requestedEndpoint)
+}

--- a/pkg/provider/github/endpoints_test.go
+++ b/pkg/provider/github/endpoints_test.go
@@ -1,0 +1,566 @@
+package github
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+	rtesting "knative.dev/pkg/reconciler/testing"
+)
+
+func TestResolveAPIEndpoint(t *testing.T) {
+	tests := []struct {
+		name       string
+		rawHost    string
+		want       APIEndpoint
+		wantErrSub string
+	}{
+		{
+			name:    "public API host",
+			rawHost: "api.github.com",
+			want: APIEndpoint{
+				APIURL:         "https://api.github.com",
+				RepositoryHost: "github.com",
+			},
+		},
+		{
+			name:    "public repository host",
+			rawHost: "https://github.com",
+			want: APIEndpoint{
+				APIURL:         "https://api.github.com",
+				RepositoryHost: "github.com",
+			},
+		},
+		{
+			name:    "enterprise host",
+			rawHost: "github.example.com",
+			want: APIEndpoint{
+				APIURL:         "https://github.example.com/api/v3",
+				BaseURL:        "https://github.example.com",
+				RepositoryHost: "github.example.com",
+			},
+		},
+		{
+			name:       "invalid path",
+			rawHost:    "https://github.example.com/attacker",
+			wantErrSub: "invalid GitHub host",
+		},
+		{
+			name:       "insecure scheme",
+			rawHost:    "http://github.example.com",
+			wantErrSub: "scheme must be https",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveAPIEndpoint(tt.rawHost)
+			if tt.wantErrSub != "" {
+				assert.ErrorContains(t, err, tt.wantErrSub)
+				return
+			}
+			assert.NilError(t, err)
+			assert.DeepEqual(t, got, tt.want)
+		})
+	}
+}
+
+func TestParseGitHubHost(t *testing.T) {
+	tests := []struct {
+		name       string
+		rawHost    string
+		want       string
+		wantErrSub string
+	}{
+		{
+			name:       "empty host",
+			wantErrSub: "GitHub host is empty",
+		},
+		{
+			name:       "unparsable URL",
+			rawHost:    "https://github.example.com/%zz",
+			wantErrSub: "invalid GitHub host",
+		},
+		{
+			name:       "missing host",
+			rawHost:    "https://",
+			wantErrSub: "invalid GitHub host",
+		},
+		{
+			name:       "http scheme",
+			rawHost:    "http://github.example.com",
+			wantErrSub: "scheme must be https",
+		},
+		{
+			name:       "userinfo is rejected",
+			rawHost:    "https://token@github.example.com",
+			wantErrSub: "invalid GitHub host",
+		},
+		{
+			name:       "query is rejected",
+			rawHost:    "https://github.example.com?token=secret",
+			wantErrSub: "invalid GitHub host",
+		},
+		{
+			name:       "fragment is rejected",
+			rawHost:    "https://github.example.com#token",
+			wantErrSub: "invalid GitHub host",
+		},
+		{
+			name:       "path is rejected",
+			rawHost:    "https://github.example.com/owner",
+			wantErrSub: "invalid GitHub host",
+		},
+		{
+			name:    "normalizes case",
+			rawHost: "https://GitHub.Example.COM/",
+			want:    "github.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseGitHubHost(tt.rawHost)
+			if tt.wantErrSub != "" {
+				assert.ErrorContains(t, err, tt.wantErrSub)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, got, tt.want)
+		})
+	}
+}
+
+func TestAppTokenTestAPIURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		rawURL     string
+		want       string
+		wantErrSub string
+	}{
+		{
+			name: "unset",
+		},
+		{
+			name:   "loopback test server",
+			rawURL: "http://127.0.0.1:1234/api/v3",
+			want:   "http://127.0.0.1:1234/api/v3",
+		},
+		{
+			name:       "remote host",
+			rawURL:     "https://attacker.example/api/v3",
+			wantErrSub: "must target a loopback IP address",
+		},
+		{
+			name:       "unexpected path",
+			rawURL:     "http://127.0.0.1:1234/credentials",
+			wantErrSub: "must not contain a path other than /api/v3",
+		},
+		{
+			name:       "malformed URL",
+			rawURL:     "http://127.0.0.1:1234/%zz",
+			wantErrSub: "must be a loopback HTTP(S) URL",
+		},
+		{
+			name:       "userinfo is rejected",
+			rawURL:     "http://user@127.0.0.1:1234/api/v3",
+			wantErrSub: "must be a loopback HTTP(S) URL",
+		},
+		{
+			name:       "query is rejected",
+			rawURL:     "http://127.0.0.1:1234/api/v3?token=secret",
+			wantErrSub: "must be a loopback HTTP(S) URL",
+		},
+		{
+			name:       "fragment is rejected",
+			rawURL:     "http://127.0.0.1:1234/api/v3#token",
+			wantErrSub: "must be a loopback HTTP(S) URL",
+		},
+		{
+			name:       "scheme is rejected",
+			rawURL:     "ftp://127.0.0.1:1234/api/v3",
+			wantErrSub: "must be a loopback HTTP(S) URL",
+		},
+		{
+			name:   "trailing slash is trimmed",
+			rawURL: "http://127.0.0.1:1234/api/v3/",
+			want:   "http://127.0.0.1:1234/api/v3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("PAC_GIT_PROVIDER_TOKEN_APIURL", tt.rawURL)
+			got, err := AppTokenTestAPIURL()
+			if tt.wantErrSub != "" {
+				assert.ErrorContains(t, err, tt.wantErrSub)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestPinGitHubHost(t *testing.T) {
+	const (
+		namespace  = "pipelines-as-code"
+		secretName = "pipelines-as-code-secret"
+	)
+
+	tests := []struct {
+		name       string
+		pinnedHost string
+		eventHost  string
+		wantHost   string
+		wantErrSub string
+	}{
+		{
+			name:      "first authenticated host is pinned",
+			eventHost: "github.example.com",
+			wantHost:  "github.example.com",
+		},
+		{
+			name:       "same pinned host is accepted",
+			pinnedHost: "github.example.com",
+			eventHost:  "github.example.com",
+			wantHost:   "github.example.com",
+		},
+		{
+			name:       "different host is rejected",
+			pinnedHost: "github.example.com",
+			eventHost:  "attacker.example.com",
+			wantErrSub: "conflicts with controller-pinned host",
+		},
+		{
+			name:       "invalid pinned host is rejected",
+			pinnedHost: "https://github.example.com/owner",
+			eventHost:  "github.example.com",
+			wantErrSub: "has an invalid github-host value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			ctx = info.StoreNS(ctx, namespace)
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: namespace,
+				},
+				Data: map[string][]byte{},
+			}
+			if tt.pinnedHost != "" {
+				secret.Data[keys.GithubHost] = []byte(tt.pinnedHost)
+			}
+			seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+				Secret: []*corev1.Secret{secret},
+			})
+			run := &params.Run{
+				Clients: clients.Clients{Kube: seedData.Kube},
+				Info: info.Info{
+					Controller: &info.ControllerInfo{Secret: secretName},
+				},
+			}
+			endpoint, err := ResolveAPIEndpoint(tt.eventHost)
+			assert.NilError(t, err)
+
+			got, err := pinGitHubHost(ctx, run, endpoint)
+			if tt.wantErrSub != "" {
+				assert.ErrorContains(t, err, tt.wantErrSub)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, got.RepositoryHost, tt.wantHost)
+			updated, err := seedData.Kube.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
+			assert.NilError(t, err)
+			assert.Equal(t, string(updated.Data[keys.GithubHost]), tt.wantHost)
+		})
+	}
+}
+
+func TestPinGitHubHostSecretGetError(t *testing.T) {
+	const (
+		namespace  = "pipelines-as-code"
+		secretName = "pipelines-as-code-secret"
+	)
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = info.StoreNS(ctx, namespace)
+	seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{})
+	run := &params.Run{
+		Clients: clients.Clients{Kube: seedData.Kube},
+		Info: info.Info{
+			Controller: &info.ControllerInfo{Secret: secretName},
+		},
+	}
+	endpoint, err := ResolveAPIEndpoint("github.example.com")
+	assert.NilError(t, err)
+
+	_, err = pinGitHubHost(ctx, run, endpoint)
+	assert.ErrorContains(t, err, "failed to pin authenticated GitHub host")
+	assert.ErrorContains(t, err, `secrets "pipelines-as-code-secret" not found`)
+}
+
+func simulateSecretUpdateConflict(t *testing.T, kube *fakekubeclientset.Clientset, namespace, secretName, pinnedHost, message string, conflicts *int) {
+	t.Helper()
+	kube.PrependReactor("update", "secrets", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		if *conflicts == 0 {
+			*conflicts++
+			secret, err := kube.Tracker().Get(corev1.SchemeGroupVersion.WithResource("secrets"), namespace, secretName)
+			assert.NilError(t, err)
+			concurrentSecret, ok := secret.(*corev1.Secret)
+			assert.Assert(t, ok)
+			concurrentSecret = concurrentSecret.DeepCopy()
+			if concurrentSecret.Data == nil {
+				concurrentSecret.Data = map[string][]byte{}
+			}
+			concurrentSecret.Data[keys.GithubHost] = []byte(pinnedHost)
+			assert.NilError(t, kube.Tracker().Update(corev1.SchemeGroupVersion.WithResource("secrets"), concurrentSecret, namespace))
+			return true, nil, apierrors.NewConflict(
+				schema.GroupResource{Resource: "secrets"},
+				secretName,
+				errors.New(message),
+			)
+		}
+		return false, nil, nil
+	})
+}
+
+func TestPinGitHubHostRetriesConflict(t *testing.T) {
+	const (
+		namespace  = "pipelines-as-code"
+		secretName = "pipelines-as-code-secret"
+	)
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = info.StoreNS(ctx, namespace)
+	seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+		Secret: []*corev1.Secret{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: namespace,
+			},
+		}},
+	})
+	run := &params.Run{
+		Clients: clients.Clients{Kube: seedData.Kube},
+		Info: info.Info{
+			Controller: &info.ControllerInfo{Secret: secretName},
+		},
+	}
+	conflicts := 0
+	simulateSecretUpdateConflict(t, seedData.Kube, namespace, secretName, "github.example.com", "simulated update conflict", &conflicts)
+	endpoint, err := ResolveAPIEndpoint("github.example.com")
+	assert.NilError(t, err)
+
+	got, err := pinGitHubHost(ctx, run, endpoint)
+	assert.NilError(t, err)
+	assert.Equal(t, got.RepositoryHost, "github.example.com")
+	assert.Equal(t, conflicts, 1)
+	updated, err := seedData.Kube.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, string(updated.Data[keys.GithubHost]), "github.example.com")
+}
+
+func TestPinGitHubHostRejectsConcurrentDifferentHost(t *testing.T) {
+	const (
+		namespace  = "pipelines-as-code"
+		secretName = "pipelines-as-code-secret"
+	)
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = info.StoreNS(ctx, namespace)
+	seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+		Secret: []*corev1.Secret{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: namespace,
+			},
+		}},
+	})
+	run := &params.Run{
+		Clients: clients.Clients{Kube: seedData.Kube},
+		Info: info.Info{
+			Controller: &info.ControllerInfo{Secret: secretName},
+		},
+	}
+	conflicts := 0
+	simulateSecretUpdateConflict(t, seedData.Kube, namespace, secretName, "other.example.com", "simulated concurrent pin", &conflicts)
+	endpoint, err := ResolveAPIEndpoint("github.example.com")
+	assert.NilError(t, err)
+
+	_, err = pinGitHubHost(ctx, run, endpoint)
+	assert.ErrorContains(t, err, `conflicts with controller-pinned host "other.example.com"`)
+	assert.Equal(t, conflicts, 1)
+	updated, err := seedData.Kube.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, string(updated.Data[keys.GithubHost]), "other.example.com")
+}
+
+func TestTrustedAPIEndpointForRepository(t *testing.T) {
+	const (
+		namespace  = "pipelines-as-code"
+		secretName = "pipelines-as-code-secret"
+	)
+	tests := []struct {
+		name          string
+		pinnedHost    string
+		repositoryURL string
+		wantHost      string
+		wantErrSub    string
+	}{
+		{
+			name:          "public GitHub works before pinning",
+			repositoryURL: "https://github.com/owner/repo",
+			wantHost:      "github.com",
+		},
+		{
+			name:          "enterprise requires prior authenticated webhook",
+			repositoryURL: "https://github.example.com/owner/repo",
+			wantErrSub:    "has not been authenticated yet",
+		},
+		{
+			name:          "matching enterprise pin",
+			pinnedHost:    "github.example.com",
+			repositoryURL: "https://github.example.com/owner/repo",
+			wantHost:      "github.example.com",
+		},
+		{
+			name:          "repository conflicts with pin",
+			pinnedHost:    "github.example.com",
+			repositoryURL: "https://attacker.example.com/owner/repo",
+			wantErrSub:    "requested GitHub host",
+		},
+		{
+			name:          "invalid repository URL",
+			repositoryURL: "https://token@github.example.com/owner/repo",
+			wantErrSub:    "invalid GitHub repository URL",
+		},
+		{
+			name:          "invalid pinned host is rejected",
+			pinnedHost:    "https://github.example.com/owner",
+			repositoryURL: "https://github.example.com/owner/repo",
+			wantErrSub:    "has an invalid github-host value",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			ctx = info.StoreNS(ctx, namespace)
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: namespace,
+				},
+				Data: map[string][]byte{},
+			}
+			if tt.pinnedHost != "" {
+				secret.Data[keys.GithubHost] = []byte(tt.pinnedHost)
+			}
+			seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+				Secret: []*corev1.Secret{secret},
+			})
+			run := &params.Run{
+				Clients: clients.Clients{Kube: seedData.Kube},
+				Info: info.Info{
+					Controller: &info.ControllerInfo{Secret: secretName},
+				},
+			}
+
+			got, err := TrustedAPIEndpointForRepository(ctx, run, tt.repositoryURL)
+			if tt.wantErrSub != "" {
+				assert.ErrorContains(t, err, tt.wantErrSub)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, got.RepositoryHost, tt.wantHost)
+		})
+	}
+}
+
+func TestTrustedAPIEndpointForRepositorySecretGetError(t *testing.T) {
+	const (
+		namespace  = "pipelines-as-code"
+		secretName = "pipelines-as-code-secret"
+	)
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = info.StoreNS(ctx, namespace)
+	seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{})
+	run := &params.Run{
+		Clients: clients.Clients{Kube: seedData.Kube},
+		Info: info.Info{
+			Controller: &info.ControllerInfo{Secret: secretName},
+		},
+	}
+
+	_, err := TrustedAPIEndpointForRepository(ctx, run, "https://github.com/owner/repo")
+	assert.ErrorContains(t, err, `secrets "pipelines-as-code-secret" not found`)
+}
+
+func TestTrustedAPIEndpointForHost(t *testing.T) {
+	const (
+		namespace  = "pipelines-as-code"
+		secretName = "pipelines-as-code-secret"
+	)
+	tests := []struct {
+		name       string
+		pinnedHost string
+		rawHost    string
+		wantHost   string
+		wantErrSub string
+	}{
+		{
+			name:     "empty host defaults to public GitHub",
+			wantHost: "github.com",
+		},
+		{
+			name:       "invalid host is rejected",
+			rawHost:    "http://github.example.com",
+			wantErrSub: "scheme must be https",
+		},
+		{
+			name:       "matching enterprise pin",
+			pinnedHost: "github.example.com",
+			rawHost:    "github.example.com",
+			wantHost:   "github.example.com",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			ctx = info.StoreNS(ctx, namespace)
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: namespace,
+				},
+				Data: map[string][]byte{},
+			}
+			if tt.pinnedHost != "" {
+				secret.Data[keys.GithubHost] = []byte(tt.pinnedHost)
+			}
+			seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+				Secret: []*corev1.Secret{secret},
+			})
+
+			got, err := trustedAPIEndpointForHost(ctx, seedData.Kube, namespace, secretName, tt.rawHost)
+			if tt.wantErrSub != "" {
+				assert.ErrorContains(t, err, tt.wantErrSub)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, got.RepositoryHost, tt.wantHost)
+		})
+	}
+}

--- a/pkg/provider/github/endpoints_test.go
+++ b/pkg/provider/github/endpoints_test.go
@@ -1,0 +1,374 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
+	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	rtesting "knative.dev/pkg/reconciler/testing"
+)
+
+func TestResolveUntrustedAPIEndpoint(t *testing.T) {
+	tests := []struct {
+		name       string
+		rawHost    string
+		want       APIEndpoint
+		wantErrSub string
+	}{
+		{
+			name:    "public API host",
+			rawHost: "api.github.com",
+			want: APIEndpoint{
+				APIURL:         "https://api.github.com",
+				RepositoryHost: "github.com",
+			},
+		},
+		{
+			name:    "public repository host",
+			rawHost: "https://github.com",
+			want: APIEndpoint{
+				APIURL:         "https://api.github.com",
+				RepositoryHost: "github.com",
+			},
+		},
+		{
+			name:    "enterprise host",
+			rawHost: "github.example.com",
+			want: APIEndpoint{
+				APIURL:         "https://github.example.com/api/v3",
+				BaseURL:        "https://github.example.com",
+				RepositoryHost: "github.example.com",
+			},
+		},
+		{
+			name:       "invalid path",
+			rawHost:    "https://github.example.com/attacker",
+			wantErrSub: "must not contain a path",
+		},
+		{
+			name:       "insecure scheme",
+			rawHost:    "http://github.example.com",
+			wantErrSub: "scheme must be https",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveUntrustedAPIEndpoint(tt.rawHost)
+			if tt.wantErrSub != "" {
+				assert.ErrorContains(t, err, tt.wantErrSub)
+				return
+			}
+			assert.NilError(t, err)
+			assert.DeepEqual(t, got, tt.want)
+		})
+	}
+}
+
+func TestAppTokenTestAPIURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		rawURL     string
+		want       string
+		wantErrSub string
+	}{
+		{
+			name: "unset",
+		},
+		{
+			name:   "loopback test server",
+			rawURL: "http://127.0.0.1:1234/api/v3",
+			want:   "http://127.0.0.1:1234/api/v3",
+		},
+		{
+			name:       "remote host",
+			rawURL:     "https://attacker.example/api/v3",
+			wantErrSub: "must target a loopback IP address",
+		},
+		{
+			name:       "unexpected path",
+			rawURL:     "http://127.0.0.1:1234/credentials",
+			wantErrSub: "must not contain a path other than /api/v3",
+		},
+		{
+			name:       "malformed URL",
+			rawURL:     "http://127.0.0.1:1234/%zz",
+			wantErrSub: "must be a loopback HTTP(S) URL",
+		},
+		{
+			name:       "userinfo is rejected",
+			rawURL:     "http://user@127.0.0.1:1234/api/v3",
+			wantErrSub: "must be a loopback HTTP(S) URL",
+		},
+		{
+			name:       "query is rejected",
+			rawURL:     "http://127.0.0.1:1234/api/v3?token=secret",
+			wantErrSub: "must be a loopback HTTP(S) URL",
+		},
+		{
+			name:       "fragment is rejected",
+			rawURL:     "http://127.0.0.1:1234/api/v3#token",
+			wantErrSub: "must be a loopback HTTP(S) URL",
+		},
+		{
+			name:       "scheme is rejected",
+			rawURL:     "ftp://127.0.0.1:1234/api/v3",
+			wantErrSub: "must be a loopback HTTP(S) URL",
+		},
+		{
+			name:   "trailing slash is trimmed",
+			rawURL: "http://127.0.0.1:1234/api/v3/",
+			want:   "http://127.0.0.1:1234/api/v3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("PAC_GIT_PROVIDER_TOKEN_APIURL", tt.rawURL)
+			got, err := AppTokenTestAPIURL()
+			if tt.wantErrSub != "" {
+				assert.ErrorContains(t, err, tt.wantErrSub)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// emptyAllowlistConfigMap returns the controller ConfigMap of a fresh install,
+// where no trusted hostname has been recorded yet.
+func emptyAllowlistConfigMap() []*corev1.ConfigMap {
+	return []*corev1.ConfigMap{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pipelines-as-code",
+			Namespace: "pipelinesascode",
+		},
+	}}
+}
+
+// newTestRun returns a Run whose controller ConfigMap holds the given allowlist.
+func newTestRun(t *testing.T, allowlist string) *params.Run {
+	t.Helper()
+	ctx, _ := rtesting.SetupFakeContext(t)
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pipelines-as-code",
+			Namespace: "pipelines-as-code",
+		},
+		Data: map[string]string{},
+	}
+	if allowlist != "" {
+		configMap.Data[settings.TrustedProviderHostnamesKey] = allowlist
+	}
+	seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+		ConfigMap: []*corev1.ConfigMap{configMap},
+	})
+	return &params.Run{
+		Clients: clients.Clients{Kube: seedData.Kube},
+		Info: info.Info{
+			Controller: &info.ControllerInfo{Configmap: "pipelines-as-code"},
+		},
+	}
+}
+
+func TestTrustedAPIEndpointForRepository(t *testing.T) {
+	tests := []struct {
+		name          string
+		allowlist     string
+		repositoryURL string
+		want          APIEndpoint
+		wantErrSub    string
+	}{
+		{
+			name:          "public GitHub needs no allowlist",
+			repositoryURL: "https://github.com/owner/repo",
+			want: APIEndpoint{
+				APIURL:         "https://api.github.com",
+				RepositoryHost: "github.com",
+			},
+		},
+		{
+			name:          "self hosted needs a trusted host",
+			repositoryURL: "https://github.example.com/owner/repo",
+			wantErrSub:    "refusing to use credentials",
+		},
+		{
+			name:          "trusted self hosted repository",
+			allowlist:     "github.example.com",
+			repositoryURL: "https://github.example.com/owner/repo",
+			want: APIEndpoint{
+				APIURL:         "https://github.example.com/api/v3",
+				BaseURL:        "https://github.example.com",
+				RepositoryHost: "github.example.com",
+			},
+		},
+		{
+			name:          "untrusted repository host is refused",
+			allowlist:     "github.example.com",
+			repositoryURL: "https://attacker.example.com/owner/repo",
+			wantErrSub:    "is not listed in",
+		},
+		{
+			name:          "userinfo is rejected",
+			repositoryURL: "https://token@github.example.com/owner/repo",
+			wantErrSub:    "invalid GitHub repository URL",
+		},
+		{
+			name:          "query string is rejected",
+			repositoryURL: "https://github.com/owner/repo?x=y",
+			wantErrSub:    "invalid GitHub repository URL",
+		},
+		{
+			name:          "fragment is rejected",
+			repositoryURL: "https://github.com/owner/repo#section",
+			wantErrSub:    "invalid GitHub repository URL",
+		},
+		{
+			name:          "http scheme is rejected",
+			repositoryURL: "http://github.com/owner/repo",
+			wantErrSub:    "invalid GitHub repository URL",
+		},
+		{
+			name:          "invalid allowlist is reported",
+			allowlist:     "https://github.example.com/owner",
+			repositoryURL: "https://github.example.com/owner/repo",
+			wantErrSub:    "is invalid",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			ctx = info.StoreNS(ctx, "pipelines-as-code")
+			run := newTestRun(t, tt.allowlist)
+
+			got, err := TrustedAPIEndpointForRepository(ctx, run, tt.repositoryURL)
+			if tt.wantErrSub != "" {
+				assert.ErrorContains(t, err, tt.wantErrSub)
+				return
+			}
+			assert.NilError(t, err)
+			assert.DeepEqual(t, got, tt.want)
+		})
+	}
+}
+
+func TestTrustedAPIEndpointForHost(t *testing.T) {
+	tests := []struct {
+		name       string
+		allowlist  string
+		rawHost    string
+		wantHost   string
+		wantErrSub string
+	}{
+		{
+			name:     "empty host defaults to public GitHub",
+			wantHost: "github.com",
+		},
+		{
+			name:       "insecure scheme is rejected",
+			rawHost:    "http://github.example.com",
+			wantErrSub: "scheme must be https",
+		},
+		{
+			name:      "trusted self hosted host",
+			allowlist: "github.example.com",
+			rawHost:   "github.example.com",
+			wantHost:  "github.example.com",
+		},
+		{
+			name:       "untrusted self hosted host",
+			rawHost:    "github.example.com",
+			wantErrSub: "refusing to use credentials",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			ctx = info.StoreNS(ctx, "pipelines-as-code")
+			run := newTestRun(t, tt.allowlist)
+
+			got, err := trustedAPIEndpointForHost(ctx, run, tt.rawHost)
+			if tt.wantErrSub != "" {
+				assert.ErrorContains(t, err, tt.wantErrSub)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, got.RepositoryHost, tt.wantHost)
+		})
+	}
+}
+
+func TestAuthenticatedAPIEndpoint(t *testing.T) {
+	tests := []struct {
+		name            string
+		allowlist       string
+		rawHost         string
+		wantHost        string
+		wantAllowlist   string
+		wantAutoTrusted string
+		wantErrSub      string
+	}{
+		{
+			name:            "first authenticated self hosted webhook is recorded",
+			rawHost:         "github.example.com",
+			wantHost:        "github.example.com",
+			wantAutoTrusted: "github.example.com",
+		},
+		{
+			name:          "public GitHub stays trusted without being recorded",
+			rawHost:       "github.com",
+			wantHost:      "github.com",
+			wantAllowlist: "",
+		},
+		{
+			name:          "an allowlist without the public host refuses public GitHub",
+			allowlist:     "github.example.com",
+			rawHost:       "github.com",
+			wantAllowlist: "github.example.com",
+			wantErrSub:    "is not listed in",
+		},
+		{
+			name:          "a private address is never recorded automatically",
+			rawHost:       "gitea.gitea.svc",
+			wantAllowlist: "",
+			wantErrSub:    "not routable on the public internet",
+		},
+		{
+			name:          "a configured allowlist refuses another host",
+			allowlist:     "github.example.com",
+			rawHost:       "attacker.example.com",
+			wantAllowlist: "github.example.com",
+			wantErrSub:    "is not listed in",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			ctx = info.StoreNS(ctx, "pipelines-as-code")
+			run := newTestRun(t, tt.allowlist)
+
+			got, err := authenticatedAPIEndpoint(ctx, run, tt.rawHost)
+			if tt.wantErrSub != "" {
+				assert.ErrorContains(t, err, tt.wantErrSub)
+			} else {
+				assert.NilError(t, err)
+				assert.Equal(t, got.RepositoryHost, tt.wantHost)
+			}
+
+			configMap, err := run.Clients.Kube.CoreV1().ConfigMaps("pipelines-as-code").Get(
+				ctx, "pipelines-as-code", metav1.GetOptions{},
+			)
+			assert.NilError(t, err)
+			assert.Equal(t, configMap.Data[settings.TrustedProviderHostnamesKey], tt.wantAllowlist)
+			assert.Equal(t, configMap.Annotations[keys.AutoTrustedProviderHostnames], tt.wantAutoTrusted)
+		})
+	}
+}

--- a/pkg/provider/github/endpoints_test.go
+++ b/pkg/provider/github/endpoints_test.go
@@ -1,0 +1,611 @@
+package github
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+	rtesting "knative.dev/pkg/reconciler/testing"
+)
+
+func TestResolveAPIEndpoint(t *testing.T) {
+	tests := []struct {
+		name       string
+		rawHost    string
+		want       APIEndpoint
+		wantErrSub string
+	}{
+		{
+			name:    "public API host",
+			rawHost: "api.github.com",
+			want: APIEndpoint{
+				APIURL:         "https://api.github.com",
+				RepositoryHost: "github.com",
+			},
+		},
+		{
+			name:    "public repository host",
+			rawHost: "https://github.com",
+			want: APIEndpoint{
+				APIURL:         "https://api.github.com",
+				RepositoryHost: "github.com",
+			},
+		},
+		{
+			name:    "enterprise host",
+			rawHost: "github.example.com",
+			want: APIEndpoint{
+				APIURL:         "https://github.example.com/api/v3",
+				BaseURL:        "https://github.example.com",
+				RepositoryHost: "github.example.com",
+			},
+		},
+		{
+			name:       "invalid path",
+			rawHost:    "https://github.example.com/attacker",
+			wantErrSub: "invalid GitHub host",
+		},
+		{
+			name:       "insecure scheme",
+			rawHost:    "http://github.example.com",
+			wantErrSub: "scheme must be https",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveAPIEndpoint(tt.rawHost)
+			if tt.wantErrSub != "" {
+				assert.ErrorContains(t, err, tt.wantErrSub)
+				return
+			}
+			assert.NilError(t, err)
+			assert.DeepEqual(t, got, tt.want)
+		})
+	}
+}
+
+func TestParseGitHubHost(t *testing.T) {
+	tests := []struct {
+		name       string
+		rawHost    string
+		want       string
+		wantErrSub string
+	}{
+		{
+			name:       "empty host",
+			wantErrSub: "GitHub host is empty",
+		},
+		{
+			name:       "unparsable URL",
+			rawHost:    "https://github.example.com/%zz",
+			wantErrSub: "invalid GitHub host",
+		},
+		{
+			name:       "missing host",
+			rawHost:    "https://",
+			wantErrSub: "invalid GitHub host",
+		},
+		{
+			name:       "http scheme",
+			rawHost:    "http://github.example.com",
+			wantErrSub: "scheme must be https",
+		},
+		{
+			name:       "userinfo is rejected",
+			rawHost:    "https://token@github.example.com",
+			wantErrSub: "invalid GitHub host",
+		},
+		{
+			name:       "query is rejected",
+			rawHost:    "https://github.example.com?token=secret",
+			wantErrSub: "invalid GitHub host",
+		},
+		{
+			name:       "fragment is rejected",
+			rawHost:    "https://github.example.com#token",
+			wantErrSub: "invalid GitHub host",
+		},
+		{
+			name:       "path is rejected",
+			rawHost:    "https://github.example.com/owner",
+			wantErrSub: "invalid GitHub host",
+		},
+		{
+			name:    "normalizes case",
+			rawHost: "https://GitHub.Example.COM/",
+			want:    "github.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseGitHubHost(tt.rawHost)
+			if tt.wantErrSub != "" {
+				assert.ErrorContains(t, err, tt.wantErrSub)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, got, tt.want)
+		})
+	}
+}
+
+func TestAppTokenTestAPIURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		rawURL     string
+		want       string
+		wantErrSub string
+	}{
+		{
+			name: "unset",
+		},
+		{
+			name:   "loopback test server",
+			rawURL: "http://127.0.0.1:1234/api/v3",
+			want:   "http://127.0.0.1:1234/api/v3",
+		},
+		{
+			name:       "remote host",
+			rawURL:     "https://attacker.example/api/v3",
+			wantErrSub: "must target a loopback IP address",
+		},
+		{
+			name:       "unexpected path",
+			rawURL:     "http://127.0.0.1:1234/credentials",
+			wantErrSub: "must not contain a path other than /api/v3",
+		},
+		{
+			name:       "malformed URL",
+			rawURL:     "http://127.0.0.1:1234/%zz",
+			wantErrSub: "must be a loopback HTTP(S) URL",
+		},
+		{
+			name:       "userinfo is rejected",
+			rawURL:     "http://user@127.0.0.1:1234/api/v3",
+			wantErrSub: "must be a loopback HTTP(S) URL",
+		},
+		{
+			name:       "query is rejected",
+			rawURL:     "http://127.0.0.1:1234/api/v3?token=secret",
+			wantErrSub: "must be a loopback HTTP(S) URL",
+		},
+		{
+			name:       "fragment is rejected",
+			rawURL:     "http://127.0.0.1:1234/api/v3#token",
+			wantErrSub: "must be a loopback HTTP(S) URL",
+		},
+		{
+			name:       "scheme is rejected",
+			rawURL:     "ftp://127.0.0.1:1234/api/v3",
+			wantErrSub: "must be a loopback HTTP(S) URL",
+		},
+		{
+			name:   "trailing slash is trimmed",
+			rawURL: "http://127.0.0.1:1234/api/v3/",
+			want:   "http://127.0.0.1:1234/api/v3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("PAC_GIT_PROVIDER_TOKEN_APIURL", tt.rawURL)
+			got, err := AppTokenTestAPIURL()
+			if tt.wantErrSub != "" {
+				assert.ErrorContains(t, err, tt.wantErrSub)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestPinGitHubHost(t *testing.T) {
+	const (
+		namespace  = "pipelines-as-code"
+		secretName = "pipelines-as-code-secret"
+	)
+
+	tests := []struct {
+		name       string
+		pinnedHost string
+		eventHost  string
+		wantHost   string
+		wantErrSub string
+	}{
+		{
+			name:      "first authenticated host is pinned",
+			eventHost: "github.example.com",
+			wantHost:  "github.example.com",
+		},
+		{
+			name:       "same pinned host is accepted",
+			pinnedHost: "github.example.com",
+			eventHost:  "github.example.com",
+			wantHost:   "github.example.com",
+		},
+		{
+			name:       "different host is rejected",
+			pinnedHost: "github.example.com",
+			eventHost:  "attacker.example.com",
+			wantErrSub: "conflicts with controller-pinned host",
+		},
+		{
+			name:       "invalid pinned host is rejected",
+			pinnedHost: "https://github.example.com/owner",
+			eventHost:  "github.example.com",
+			wantErrSub: "has an invalid github-host value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			ctx = info.StoreNS(ctx, namespace)
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: namespace,
+				},
+				Data: map[string][]byte{},
+			}
+			if tt.pinnedHost != "" {
+				secret.Data[keys.GithubHost] = []byte(tt.pinnedHost)
+			}
+			seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+				Secret: []*corev1.Secret{secret},
+			})
+			run := &params.Run{
+				Clients: clients.Clients{Kube: seedData.Kube},
+				Info: info.Info{
+					Controller: &info.ControllerInfo{Secret: secretName},
+				},
+			}
+			endpoint, err := ResolveAPIEndpoint(tt.eventHost)
+			assert.NilError(t, err)
+
+			got, err := pinGitHubHost(ctx, run, endpoint)
+			if tt.wantErrSub != "" {
+				assert.ErrorContains(t, err, tt.wantErrSub)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, got.RepositoryHost, tt.wantHost)
+			updated, err := seedData.Kube.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
+			assert.NilError(t, err)
+			assert.Equal(t, string(updated.Data[keys.GithubHost]), tt.wantHost)
+		})
+	}
+}
+
+func TestPinGitHubHostSkipsPublicGitHub(t *testing.T) {
+	const (
+		namespace  = "pipelines-as-code"
+		secretName = "pipelines-as-code-secret"
+	)
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = info.StoreNS(ctx, namespace)
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{},
+	}
+	seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+		Secret: []*corev1.Secret{secret},
+	})
+	run := &params.Run{
+		Clients: clients.Clients{Kube: seedData.Kube},
+		Info: info.Info{
+			Controller: &info.ControllerInfo{Secret: secretName},
+		},
+	}
+	endpoint, err := ResolveAPIEndpoint("github.com")
+	assert.NilError(t, err)
+
+	got, err := pinGitHubHost(ctx, run, endpoint)
+	assert.NilError(t, err)
+	assert.Equal(t, got.RepositoryHost, "github.com")
+	updated, err := seedData.Kube.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
+	assert.NilError(t, err)
+	_, hasKey := updated.Data[keys.GithubHost]
+	assert.Assert(t, !hasKey, "github.com should not be pinned to the controller secret")
+}
+
+func TestPinGitHubHostSecretGetError(t *testing.T) {
+	const (
+		namespace  = "pipelines-as-code"
+		secretName = "pipelines-as-code-secret"
+	)
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = info.StoreNS(ctx, namespace)
+	seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{})
+	run := &params.Run{
+		Clients: clients.Clients{Kube: seedData.Kube},
+		Info: info.Info{
+			Controller: &info.ControllerInfo{Secret: secretName},
+		},
+	}
+	endpoint, err := ResolveAPIEndpoint("github.example.com")
+	assert.NilError(t, err)
+
+	_, err = pinGitHubHost(ctx, run, endpoint)
+	assert.ErrorContains(t, err, "failed to pin authenticated GitHub host")
+	assert.ErrorContains(t, err, `secrets "pipelines-as-code-secret" not found`)
+}
+
+func simulateSecretUpdateConflict(t *testing.T, kube *fakekubeclientset.Clientset, namespace, secretName, pinnedHost, message string, conflicts *int) {
+	t.Helper()
+	kube.PrependReactor("update", "secrets", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		if *conflicts == 0 {
+			*conflicts++
+			secret, err := kube.Tracker().Get(corev1.SchemeGroupVersion.WithResource("secrets"), namespace, secretName)
+			assert.NilError(t, err)
+			concurrentSecret, ok := secret.(*corev1.Secret)
+			assert.Assert(t, ok)
+			concurrentSecret = concurrentSecret.DeepCopy()
+			if concurrentSecret.Data == nil {
+				concurrentSecret.Data = map[string][]byte{}
+			}
+			concurrentSecret.Data[keys.GithubHost] = []byte(pinnedHost)
+			assert.NilError(t, kube.Tracker().Update(corev1.SchemeGroupVersion.WithResource("secrets"), concurrentSecret, namespace))
+			return true, nil, apierrors.NewConflict(
+				schema.GroupResource{Resource: "secrets"},
+				secretName,
+				errors.New(message),
+			)
+		}
+		return false, nil, nil
+	})
+}
+
+func TestPinGitHubHostRetriesConflict(t *testing.T) {
+	const (
+		namespace  = "pipelines-as-code"
+		secretName = "pipelines-as-code-secret"
+	)
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = info.StoreNS(ctx, namespace)
+	seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+		Secret: []*corev1.Secret{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: namespace,
+			},
+		}},
+	})
+	run := &params.Run{
+		Clients: clients.Clients{Kube: seedData.Kube},
+		Info: info.Info{
+			Controller: &info.ControllerInfo{Secret: secretName},
+		},
+	}
+	conflicts := 0
+	simulateSecretUpdateConflict(t, seedData.Kube, namespace, secretName, "github.example.com", "simulated update conflict", &conflicts)
+	endpoint, err := ResolveAPIEndpoint("github.example.com")
+	assert.NilError(t, err)
+
+	got, err := pinGitHubHost(ctx, run, endpoint)
+	assert.NilError(t, err)
+	assert.Equal(t, got.RepositoryHost, "github.example.com")
+	assert.Equal(t, conflicts, 1)
+	updated, err := seedData.Kube.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, string(updated.Data[keys.GithubHost]), "github.example.com")
+}
+
+func TestPinGitHubHostRejectsConcurrentDifferentHost(t *testing.T) {
+	const (
+		namespace  = "pipelines-as-code"
+		secretName = "pipelines-as-code-secret"
+	)
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = info.StoreNS(ctx, namespace)
+	seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+		Secret: []*corev1.Secret{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: namespace,
+			},
+		}},
+	})
+	run := &params.Run{
+		Clients: clients.Clients{Kube: seedData.Kube},
+		Info: info.Info{
+			Controller: &info.ControllerInfo{Secret: secretName},
+		},
+	}
+	conflicts := 0
+	simulateSecretUpdateConflict(t, seedData.Kube, namespace, secretName, "other.example.com", "simulated concurrent pin", &conflicts)
+	endpoint, err := ResolveAPIEndpoint("github.example.com")
+	assert.NilError(t, err)
+
+	_, err = pinGitHubHost(ctx, run, endpoint)
+	assert.ErrorContains(t, err, `conflicts with controller-pinned host "other.example.com"`)
+	assert.Equal(t, conflicts, 1)
+	updated, err := seedData.Kube.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, string(updated.Data[keys.GithubHost]), "other.example.com")
+}
+
+func TestTrustedAPIEndpointForRepository(t *testing.T) {
+	const (
+		namespace  = "pipelines-as-code"
+		secretName = "pipelines-as-code-secret"
+	)
+	tests := []struct {
+		name          string
+		pinnedHost    string
+		repositoryURL string
+		wantHost      string
+		wantErrSub    string
+	}{
+		{
+			name:          "public GitHub works before pinning",
+			repositoryURL: "https://github.com/owner/repo",
+			wantHost:      "github.com",
+		},
+		{
+			name:          "enterprise requires prior authenticated webhook",
+			repositoryURL: "https://github.example.com/owner/repo",
+			wantErrSub:    "has not been authenticated yet",
+		},
+		{
+			name:          "matching enterprise pin",
+			pinnedHost:    "github.example.com",
+			repositoryURL: "https://github.example.com/owner/repo",
+			wantHost:      "github.example.com",
+		},
+		{
+			name:          "repository conflicts with pin",
+			pinnedHost:    "github.example.com",
+			repositoryURL: "https://attacker.example.com/owner/repo",
+			wantErrSub:    "requested GitHub host",
+		},
+		{
+			name:          "invalid repository URL",
+			repositoryURL: "https://token@github.example.com/owner/repo",
+			wantErrSub:    "invalid GitHub repository URL",
+		},
+		{
+			name:          "query string is rejected",
+			repositoryURL: "https://github.com/owner/repo?x=y",
+			wantErrSub:    "invalid GitHub repository URL",
+		},
+		{
+			name:          "fragment is rejected",
+			repositoryURL: "https://github.com/owner/repo#section",
+			wantErrSub:    "invalid GitHub repository URL",
+		},
+		{
+			name:          "invalid pinned host is rejected",
+			pinnedHost:    "https://github.example.com/owner",
+			repositoryURL: "https://github.example.com/owner/repo",
+			wantErrSub:    "has an invalid github-host value",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			ctx = info.StoreNS(ctx, namespace)
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: namespace,
+				},
+				Data: map[string][]byte{},
+			}
+			if tt.pinnedHost != "" {
+				secret.Data[keys.GithubHost] = []byte(tt.pinnedHost)
+			}
+			seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+				Secret: []*corev1.Secret{secret},
+			})
+			run := &params.Run{
+				Clients: clients.Clients{Kube: seedData.Kube},
+				Info: info.Info{
+					Controller: &info.ControllerInfo{Secret: secretName},
+				},
+			}
+
+			got, err := TrustedAPIEndpointForRepository(ctx, run, tt.repositoryURL)
+			if tt.wantErrSub != "" {
+				assert.ErrorContains(t, err, tt.wantErrSub)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, got.RepositoryHost, tt.wantHost)
+		})
+	}
+}
+
+func TestTrustedAPIEndpointForRepositorySecretGetError(t *testing.T) {
+	const (
+		namespace  = "pipelines-as-code"
+		secretName = "pipelines-as-code-secret"
+	)
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = info.StoreNS(ctx, namespace)
+	seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{})
+	run := &params.Run{
+		Clients: clients.Clients{Kube: seedData.Kube},
+		Info: info.Info{
+			Controller: &info.ControllerInfo{Secret: secretName},
+		},
+	}
+
+	_, err := TrustedAPIEndpointForRepository(ctx, run, "https://github.com/owner/repo")
+	assert.ErrorContains(t, err, `secrets "pipelines-as-code-secret" not found`)
+}
+
+func TestTrustedAPIEndpointForHost(t *testing.T) {
+	const (
+		namespace  = "pipelines-as-code"
+		secretName = "pipelines-as-code-secret"
+	)
+	tests := []struct {
+		name       string
+		pinnedHost string
+		rawHost    string
+		wantHost   string
+		wantErrSub string
+	}{
+		{
+			name:     "empty host defaults to public GitHub",
+			wantHost: "github.com",
+		},
+		{
+			name:       "invalid host is rejected",
+			rawHost:    "http://github.example.com",
+			wantErrSub: "scheme must be https",
+		},
+		{
+			name:       "matching enterprise pin",
+			pinnedHost: "github.example.com",
+			rawHost:    "github.example.com",
+			wantHost:   "github.example.com",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			ctx = info.StoreNS(ctx, namespace)
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: namespace,
+				},
+				Data: map[string][]byte{},
+			}
+			if tt.pinnedHost != "" {
+				secret.Data[keys.GithubHost] = []byte(tt.pinnedHost)
+			}
+			seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+				Secret: []*corev1.Secret{secret},
+			})
+
+			got, err := trustedAPIEndpointForHost(ctx, seedData.Kube, namespace, secretName, tt.rawHost)
+			if tt.wantErrSub != "" {
+				assert.ErrorContains(t, err, tt.wantErrSub)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, got.RepositoryHost, tt.wantHost)
+		})
+	}
+}

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -322,6 +322,22 @@ func (v *Provider) checkWebhookSecretValidity(ctx context.Context, cw clockwork.
 }
 
 func (v *Provider) SetClient(ctx context.Context, run *params.Run, event *info.Event, repo *v1alpha1.Repository, eventsEmitter *events.EventEmitter) error {
+	if event.InstallationID <= 0 && event.EventType != "incoming" && event.Request != nil &&
+		event.Request.Header.Get("X-GitHub-Enterprise-Host") != "" {
+		if err := v.Validate(ctx, run, event); err != nil {
+			return err
+		}
+		endpoint, err := githubEndpointFromPayload(
+			event.Request.Header.Get("X-GitHub-Enterprise-Host"),
+			string(event.Request.Payload),
+		)
+		if err != nil {
+			return err
+		}
+		event.Provider.URL = endpoint.BaseURL
+		event.GHEURL = endpoint.BaseURL
+	}
+
 	client, providerName, apiURL := MakeClient(ctx, event.Provider.URL, event.Provider.Token)
 	v.providerName = providerName
 	v.Run = run
@@ -369,7 +385,7 @@ func (v *Provider) SetClient(ctx context.Context, run *params.Run, event *info.E
 			// look up extra repos from the configmap first.  When no additional repos
 			// are configured, scope the token to only the triggering repo.
 			ns := info.GetNS(ctx)
-			scopedToken, err := v.GetAppToken(ctx, run.Clients.Kube, event.Provider.URL, event.InstallationID, ns)
+			scopedToken, err := v.GetAppToken(ctx, run.Clients.Kube, event.GHEURL, event.InstallationID, ns)
 			if err != nil {
 				return fmt.Errorf("failed to scope token to triggering repository: %w", err)
 			}
@@ -793,7 +809,7 @@ func (v *Provider) CreateToken(ctx context.Context, repository []string, event *
 		v.RepositoryIDs = uniqueRepositoryID(v.RepositoryIDs, infoData.GetID())
 	}
 	ns := info.GetNS(ctx)
-	token, err := v.GetAppToken(ctx, v.Run.Clients.Kube, event.Provider.URL, event.InstallationID, ns)
+	token, err := v.GetAppToken(ctx, v.Run.Clients.Kube, event.GHEURL, event.InstallationID, ns)
 	if err != nil {
 		return "", err
 	}
@@ -1188,12 +1204,24 @@ func (v *Provider) GenerateJWT(ctx context.Context, ns string, kube kubernetes.I
 // Fetch the app slug used for identifying the application.
 func (v *Provider) fetchAppSlug(ctx context.Context, apiURL string) (string, error) {
 	ns := info.GetNS(ctx)
+	endpoint, err := trustedAPIEndpointForHost(ctx, v.Run.Clients.Kube, ns, v.Run.Info.Controller.Secret, apiURL)
+	if err != nil {
+		return "", err
+	}
+	reqTokenURL, err := AppTokenTestAPIURL()
+	if err != nil {
+		return "", err
+	}
 	tokenString, err := v.GenerateJWT(ctx, ns, v.Run.Clients.Kube)
 	if err != nil {
 		return "", err
 	}
 
-	client, _, _ := MakeClient(ctx, apiURL, tokenString)
+	trustedAPIURL := endpoint.BaseURL
+	if reqTokenURL != "" {
+		trustedAPIURL = strings.TrimSuffix(reqTokenURL, "/api/v3")
+	}
+	client, _, _ := MakeClient(ctx, trustedAPIURL, tokenString)
 	app, _, err := client.Apps.Get(ctx, "")
 	if err != nil {
 		return "", fmt.Errorf("failed to get app info: %w", err)

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -75,6 +75,10 @@ type Provider struct {
 	clock              clockwork.Clock
 	graphQLClient      *graphQLClient
 	checkRunsCache     checkRunsCache
+	// clientFromCaller records that the client was built by the caller from a
+	// credential the caller owns, which exempts it from the trusted hostname
+	// gate in SetClient. See UsePreauthenticatedClient.
+	clientFromCaller bool
 }
 
 type skippedRun struct {
@@ -115,6 +119,22 @@ func (v *Provider) Client() *github.Client {
 
 func (v *Provider) SetGithubClient(client *github.Client) {
 	v.ghClient = client
+}
+
+// UsePreauthenticatedClient installs a client the caller built itself and opts
+// the provider out of the trusted hostname gate in SetClient.
+//
+// The gate exists to stop a credential the controller owns from being sent to a
+// host that a payload, or a Repository CR sharing a token from another
+// namespace, asked for. It is the origin of the host that matters: a caller that
+// picked the URL itself, the end to end harness taking it from its own
+// configuration, has already made that decision and there is nothing left here
+// to protect, whether the token is its own or one it minted from the App. It
+// follows that the URL must never come from a payload. Nothing in the controller
+// may use this.
+func (v *Provider) UsePreauthenticatedClient(client *github.Client) {
+	v.ghClient = client
+	v.clientFromCaller = true
 }
 
 func (v *Provider) SetPacInfo(pacInfo *info.PacOpts) {
@@ -267,12 +287,16 @@ func MakeClient(ctx context.Context, apiURL, token string, retryOpts ...*retryht
 
 	providerName := "github"
 	var err error
-	if apiURL != "" && apiURL != apiPublicURL {
+	// keys.PublicGithubAPIURL carries no trailing slash while apiPublicURL does,
+	// and both reach here: comparing them literally would build an enterprise
+	// client for the public instance and append /api/v3 to api.github.com.
+	if apiURL != "" && strings.TrimSuffix(apiURL, "/") != strings.TrimSuffix(apiPublicURL, "/") {
 		providerName = "github-enterprise"
-		uploadURL := apiURL + "/api/uploads"
+		uploadBaseURL := strings.TrimSuffix(strings.TrimSuffix(apiURL, "/"), "/api/v3")
+		uploadURL := uploadBaseURL + "/api/uploads"
 		client, err = github.NewClient(github.WithHTTPClient(tc), github.WithEnterpriseURLs(apiURL, uploadURL))
 		if err != nil {
-			return nil, providerName, nil, fmt.Errorf("failed to create github enterprise client for %s: %w", apiURL, err)
+			return nil, "", nil, fmt.Errorf("failed to configure GitHub Enterprise client: %w", err)
 		}
 	} else {
 		client, err = github.NewClient(github.WithHTTPClient(tc))
@@ -351,6 +375,46 @@ func (v *Provider) checkWebhookSecretValidity(ctx context.Context, cw clockwork.
 }
 
 func (v *Provider) SetClient(ctx context.Context, run *params.Run, event *info.Event, repo *v1alpha1.Repository, eventsEmitter *events.EventEmitter) error {
+	if event.InstallationID <= 0 && event.EventType != "incoming" && event.Request != nil &&
+		event.Request.Header.Get("X-GitHub-Enterprise-Host") != "" {
+		if err := v.Validate(ctx, run, event); err != nil {
+			return err
+		}
+		endpoint, err := trustedGitHubEndpointFromPayload(
+			ctx,
+			run,
+			event.Request.Header.Get("X-GitHub-Enterprise-Host"),
+			string(event.Request.Payload),
+		)
+		if err != nil {
+			return err
+		}
+		event.Provider.URL = endpoint.BaseURL
+		event.GHEURL = endpoint.BaseURL
+	} else if v.ghClient == nil && !v.clientFromCaller {
+		// event.Provider.URL comes from the Repository CR, which is not enough
+		// to trust it: with a global Repository sharing a token from the
+		// controller namespace, the CR and the credential do not have the same
+		// owner, so a tenant could point an administrator's token at a host of
+		// their choosing. Resolve it through the allowlist and rebuild the
+		// endpoint from the hostname the allowlist approved.
+		//
+		// An empty URL is gated too: it means github.com, which an authoritative
+		// allowlist is entitled to refuse.
+		//
+		// The gate applies exactly when the client built below is the one that
+		// will carry the token. A client that is already installed, which is how
+		// the unit tests inject their fake, is left alone: the URL then reaches
+		// nothing. A caller that installed its own client through
+		// UsePreauthenticatedClient is skipped for a different reason: it owns
+		// the credential, so there is nothing here to protect.
+		endpoint, err := trustedAPIEndpointForProviderURL(ctx, run, event.Provider.URL)
+		if err != nil {
+			return err
+		}
+		event.Provider.URL = endpoint.BaseURL
+	}
+
 	client, providerName, apiURL, err := v.MakeClient(ctx, event.Provider.URL, event.Provider.Token)
 	if err != nil {
 		return err
@@ -401,7 +465,7 @@ func (v *Provider) SetClient(ctx context.Context, run *params.Run, event *info.E
 			// look up extra repos from the configmap first.  When no additional repos
 			// are configured, scope the token to only the triggering repo.
 			ns := info.GetNS(ctx)
-			scopedToken, err := v.GetAppToken(ctx, run.Clients.Kube, event.Provider.URL, event.InstallationID, ns)
+			scopedToken, err := v.GetAppToken(ctx, run.Clients.Kube, event.GHEURL, event.InstallationID, ns)
 			if err != nil {
 				return fmt.Errorf("failed to scope token to triggering repository: %w", err)
 			}
@@ -868,7 +932,7 @@ func (v *Provider) CreateToken(ctx context.Context, repository []string, event *
 		v.RepositoryIDs = uniqueRepositoryID(v.RepositoryIDs, infoData.GetID())
 	}
 	ns := info.GetNS(ctx)
-	token, err := v.GetAppToken(ctx, v.Run.Clients.Kube, event.Provider.URL, event.InstallationID, ns)
+	token, err := v.GetAppToken(ctx, v.Run.Clients.Kube, event.GHEURL, event.InstallationID, ns)
 	if err != nil {
 		return "", err
 	}
@@ -1264,12 +1328,21 @@ func (v *Provider) GenerateJWT(ctx context.Context, ns string, kube kubernetes.I
 // Fetch the app slug used for identifying the application.
 func (v *Provider) fetchAppSlug(ctx context.Context, apiURL string) (string, error) {
 	ns := info.GetNS(ctx)
+	// apiURL is whatever SetClient settled on, which is an API URL rather than a
+	// bare hostname on a self hosted instance, so it needs the URL aware gate.
+	endpoint, err := trustedAPIEndpointForProviderURL(ctx, v.Run, apiURL)
+	if err != nil {
+		return "", err
+	}
+	trustedAPIURL, err := endpoint.BaseURLForClient()
+	if err != nil {
+		return "", err
+	}
 	tokenString, err := v.GenerateJWT(ctx, ns, v.Run.Clients.Kube)
 	if err != nil {
 		return "", err
 	}
-
-	client, _, _, err := v.MakeClient(ctx, apiURL, tokenString)
+	client, _, _, err := v.MakeClient(ctx, trustedAPIURL, tokenString)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/provider/github/github_test.go
+++ b/pkg/provider/github/github_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1263,6 +1264,86 @@ func TestGithubSetClient(t *testing.T) {
 	}
 }
 
+func TestGithubSetClientUsesSignedEnterpriseEndpoint(t *testing.T) {
+	const webhookSecret = "webhook-secret"
+	payload := []byte(`{"repository":{"html_url":"https://ghe.example.com/owner/repo"}}`)
+
+	tests := []struct {
+		name           string
+		enterpriseHost string
+		webhookSecret  string
+		signingSecret  string
+		wantErrSub     string
+	}{
+		{
+			name:           "matching signed enterprise host",
+			enterpriseHost: "ghe.example.com",
+			webhookSecret:  webhookSecret,
+			signingSecret:  webhookSecret,
+		},
+		{
+			name:           "forged enterprise host",
+			enterpriseHost: "attacker.example",
+			webhookSecret:  webhookSecret,
+			signingSecret:  webhookSecret,
+			wantErrSub:     `does not match signed repository host "ghe.example.com"`,
+		},
+		{
+			name:           "signature validation fails before endpoint derivation",
+			enterpriseHost: "ghe.example.com",
+			webhookSecret:  webhookSecret,
+			signingSecret:  "wrong-secret",
+			wantErrSub:     "payload signature check failed",
+		},
+		{
+			name:           "missing webhook secret fails before endpoint derivation",
+			enterpriseHost: "ghe.example.com",
+			signingSecret:  webhookSecret,
+			wantErrSub:     "no webhook secret has been set",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := info.NewEvent()
+			event.EventType = "pull_request"
+			event.Provider.Token = "pat"
+			event.Provider.WebhookSecret = tt.webhookSecret
+			event.Request = &info.Request{
+				Header:  http.Header{},
+				Payload: payload,
+			}
+			event.Request.Header.Set(github.SHA256SignatureHeader, githubSHA256Signature(tt.signingSecret, payload))
+			event.Request.Header.Set("X-GitHub-Enterprise-Host", tt.enterpriseHost)
+
+			testLogger, _ := logger.GetLogger()
+			run := &params.Run{
+				Clients: clients.Clients{Log: testLogger},
+			}
+			provider := &Provider{
+				Logger:  testLogger,
+				pacInfo: &info.PacOpts{},
+			}
+			err := provider.SetClient(
+				context.Background(),
+				run,
+				event,
+				&v1alpha1.Repository{Spec: v1alpha1.RepositorySpec{Settings: &v1alpha1.Settings{}}},
+				nil,
+			)
+			if tt.wantErrSub != "" {
+				assert.ErrorContains(t, err, tt.wantErrSub)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, "https://ghe.example.com", event.Provider.URL)
+			assert.Equal(t, "https://ghe.example.com", event.GHEURL)
+			assert.Equal(t, "ghe.example.com", provider.Client().BaseURL.Host)
+			assert.Equal(t, "/api/v3/", provider.Client().BaseURL.Path)
+		})
+	}
+}
+
 func TestSetClientFallbackScopesToken(t *testing.T) {
 	testNamespace := "pipelinesascode"
 	secretName := "pipelines-as-code-secret"
@@ -1278,6 +1359,7 @@ func TestSetClientFallbackScopesToken(t *testing.T) {
 				Data: map[string][]byte{
 					"github-application-id": []byte("12345"),
 					"github-private-key":    []byte(fakePrivateKey),
+					"github-host":           []byte("github.example.com"),
 				},
 			},
 		},
@@ -1321,6 +1403,7 @@ func TestSetClientFallbackScopesToken(t *testing.T) {
 			event := info.NewEvent()
 			event.InstallationID = testInstallationID
 			event.Provider.Token = initialToken
+			event.GHEURL = "https://github.example.com"
 
 			testLog, _ := logger.GetLogger()
 			v := Provider{
@@ -1880,6 +1963,63 @@ func TestCreateToken(t *testing.T) {
 	if err != nil {
 		assert.ErrorContains(t, err, "could not refresh installation id 1234567's token")
 	}
+}
+
+func TestCreateTokenUsesEventGHEURLForAppToken(t *testing.T) {
+	const (
+		namespace      = "pipelinesascode"
+		secretName     = "pipelines-as-code-secret"
+		scopedToken    = "ghs_scoped_token"
+		enterpriseHost = "github.example.com"
+	)
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = info.StoreNS(ctx, namespace)
+	ctx = info.StoreCurrentControllerName(ctx, "default")
+	logger, _ := logger.GetLogger()
+	seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+		Secret: []*corev1.Secret{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: namespace,
+			},
+			Data: map[string][]byte{
+				"github-application-id": []byte("12345"),
+				"github-private-key":    []byte(fakePrivateKey),
+				"github-host":           []byte(enterpriseHost),
+			},
+		}},
+	})
+	fakeclient, mux, serverURL, teardown := ghtesthelper.SetupGH()
+	defer teardown()
+	tokenRequests := 0
+	mux.HandleFunc(fmt.Sprintf("/app/installations/%d/access_tokens", testInstallationID), func(w http.ResponseWriter, _ *http.Request) {
+		tokenRequests++
+		_, _ = fmt.Fprintf(w, `{"token":%q,"expires_at":"2099-01-01T00:00:00Z"}`, scopedToken)
+	})
+	t.Setenv("PAC_GIT_PROVIDER_TOKEN_APIURL", serverURL+"/api/v3")
+
+	provider := &Provider{
+		Logger:   logger,
+		ghClient: fakeclient,
+		Run: &params.Run{
+			Clients: clients.Clients{
+				Kube: seedData.Kube,
+				Log:  logger,
+			},
+			Info: info.Info{
+				Controller: &info.ControllerInfo{Secret: secretName},
+			},
+		},
+	}
+	event := info.NewEvent()
+	event.Provider.URL = "https://github.com"
+	event.GHEURL = "https://" + enterpriseHost
+	event.InstallationID = testInstallationID
+
+	token, err := provider.CreateToken(ctx, []string{"owner/missing"}, event)
+	assert.NilError(t, err)
+	assert.Equal(t, scopedToken, token)
+	assert.Equal(t, 1, tokenRequests)
 }
 
 func TestGetPullRequest(t *testing.T) {
@@ -2623,61 +2763,90 @@ func TestFetchAppSlug(t *testing.T) {
 		name             string
 		privateKey       []byte
 		applicationID    int64
-		setupMux         func(mux *http.ServeMux)
+		apiURL           string
+		pinnedHost       string
+		tokenAPIURL      string
+		setupMux         func(mux *http.ServeMux, requests *atomic.Int32)
 		wantSlug         string
 		wantErrSubstring string
+		wantRequests     int32
 	}{
 		{
 			name:          "success fetch app slug",
 			privateKey:    []byte(fakePrivateKey),
 			applicationID: testAppID,
-			setupMux: func(mux *http.ServeMux) {
+			setupMux: func(mux *http.ServeMux, requests *atomic.Int32) {
 				mux.HandleFunc("/app", func(w http.ResponseWriter, _ *http.Request) {
+					requests.Add(1)
 					_, _ = fmt.Fprintf(w, `{"slug": "%s", "name": "My GitHub App"}`, validSlug)
 				})
 			},
-			wantSlug: validSlug,
+			wantSlug:     validSlug,
+			wantRequests: 1,
 		},
 		{
 			name:          "app endpoint returns 404",
 			privateKey:    []byte(fakePrivateKey),
 			applicationID: testAppID,
-			setupMux: func(mux *http.ServeMux) {
+			setupMux: func(mux *http.ServeMux, requests *atomic.Int32) {
 				mux.HandleFunc("/app", func(w http.ResponseWriter, _ *http.Request) {
+					requests.Add(1)
 					w.WriteHeader(http.StatusNotFound)
 					_, _ = fmt.Fprint(w, `{"message": "Not Found"}`)
 				})
 			},
 			wantErrSubstring: "failed to get app info",
+			wantRequests:     1,
 		},
 		{
 			name:             "invalid private key",
 			privateKey:       []byte("invalid-key"),
 			applicationID:    testAppID,
-			setupMux:         func(_ *http.ServeMux) {},
+			setupMux:         func(_ *http.ServeMux, _ *atomic.Int32) {},
 			wantErrSubstring: "failed to parse private key",
 		},
 		{
 			name:          "app returns empty slug",
 			privateKey:    []byte(fakePrivateKey),
 			applicationID: testAppID,
-			setupMux: func(mux *http.ServeMux) {
+			setupMux: func(mux *http.ServeMux, requests *atomic.Int32) {
 				mux.HandleFunc("/app", func(w http.ResponseWriter, _ *http.Request) {
+					requests.Add(1)
 					_, _ = fmt.Fprint(w, `{"slug": "", "name": "My GitHub App"}`)
 				})
 			},
-			wantSlug: "",
+			wantSlug:     "",
+			wantRequests: 1,
 		},
 		{
 			name:          "app endpoint returns malformed JSON",
 			privateKey:    []byte(fakePrivateKey),
 			applicationID: testAppID,
-			setupMux: func(mux *http.ServeMux) {
+			setupMux: func(mux *http.ServeMux, requests *atomic.Int32) {
 				mux.HandleFunc("/app", func(w http.ResponseWriter, _ *http.Request) {
+					requests.Add(1)
 					_, _ = fmt.Fprint(w, `{invalid json`)
 				})
 			},
 			wantErrSubstring: "failed to get app info",
+			wantRequests:     1,
+		},
+		{
+			name:             "rejects untrusted app URL before sending JWT",
+			privateKey:       []byte(fakePrivateKey),
+			applicationID:    testAppID,
+			apiURL:           "https://attacker.example",
+			pinnedHost:       "ghe.example.com",
+			setupMux:         func(_ *http.ServeMux, _ *atomic.Int32) {},
+			wantErrSubstring: "does not match controller-pinned GitHub host",
+		},
+		{
+			name:             "rejects invalid app token test URL",
+			privateKey:       []byte(fakePrivateKey),
+			applicationID:    testAppID,
+			tokenAPIURL:      "https://example.com/api/v3",
+			setupMux:         func(_ *http.ServeMux, _ *atomic.Int32) {},
+			wantErrSubstring: "PAC_GIT_PROVIDER_TOKEN_APIURL must target a loopback IP address",
 		},
 	}
 
@@ -2686,8 +2855,9 @@ func TestFetchAppSlug(t *testing.T) {
 			_, mux, serverURL, teardown := ghtesthelper.SetupGH()
 			defer teardown()
 
+			var requests atomic.Int32
 			if tt.setupMux != nil {
-				tt.setupMux(mux)
+				tt.setupMux(mux, &requests)
 			}
 
 			// Set up context with namespace
@@ -2712,6 +2882,9 @@ func TestFetchAppSlug(t *testing.T) {
 					"github-private-key":    tt.privateKey,
 				},
 			}
+			if tt.pinnedHost != "" {
+				testSecret.Data[keys.GithubHost] = []byte(tt.pinnedHost)
+			}
 
 			// Set up test data with kubernetes client
 			tdata := testclient.Data{
@@ -2733,17 +2906,24 @@ func TestFetchAppSlug(t *testing.T) {
 					},
 				},
 			}
+			tokenAPIURL := tt.tokenAPIURL
+			if tokenAPIURL == "" {
+				tokenAPIURL = serverURL + "/api/v3"
+			}
+			t.Setenv("PAC_GIT_PROVIDER_TOKEN_APIURL", tokenAPIURL)
 
-			slug, err := provider.fetchAppSlug(ctx, serverURL)
+			slug, err := provider.fetchAppSlug(ctx, tt.apiURL)
 
 			if tt.wantErrSubstring != "" {
 				assert.Assert(t, err != nil, "expected error but got none")
 				assert.ErrorContains(t, err, tt.wantErrSubstring)
+				assert.Equal(t, tt.wantRequests, requests.Load())
 				return
 			}
 
 			assert.NilError(t, err)
 			assert.Equal(t, slug, tt.wantSlug)
+			assert.Equal(t, tt.wantRequests, requests.Load())
 		})
 	}
 }

--- a/pkg/provider/github/github_test.go
+++ b/pkg/provider/github/github_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1182,10 +1183,11 @@ func TestGithubSetClient(t *testing.T) {
 	tests := []struct {
 		name           string
 		event          *info.Event
+		allowlist      string
 		expectedURL    string
 		isGHE          bool
 		installationID int64
-		wantErr        string
+		wantErrSub     string
 	}{
 		{
 			name: "api url set",
@@ -1194,9 +1196,19 @@ func TestGithubSetClient(t *testing.T) {
 					URL: "foo.com",
 				},
 			},
+			allowlist:      "foo.com",
 			expectedURL:    "https://foo.com",
 			isGHE:          true,
 			installationID: 0,
+		},
+		{
+			name: "a repository url that is not trusted is refused",
+			event: &info.Event{
+				Provider: &info.Provider{
+					URL: "attacker.example",
+				},
+			},
+			wantErrSub: "refusing to use credentials",
 		},
 		{
 			name:           "default to public github",
@@ -1211,7 +1223,7 @@ func TestGithubSetClient(t *testing.T) {
 					URL: "%",
 				},
 			},
-			wantErr: "failed to create github enterprise client",
+			wantErrSub: "invalid provider URL",
 		},
 	}
 	for _, tt := range tests {
@@ -1220,11 +1232,9 @@ func TestGithubSetClient(t *testing.T) {
 			ctx, _ := rtesting.SetupFakeContext(t)
 			core, observer := zapobserver.New(zap.InfoLevel)
 			testLog := zap.New(core).Sugar()
-			fakeRun := &params.Run{
-				Clients: clients.Clients{
-					Log: testLog,
-				},
-			}
+			ctx = info.StoreNS(ctx, "pipelines-as-code")
+			fakeRun := newTestRun(t, tt.allowlist)
+			fakeRun.Clients.Log = testLog
 			v := Provider{
 				Logger:  testLog,
 				pacInfo: &info.PacOpts{},
@@ -1235,8 +1245,8 @@ func TestGithubSetClient(t *testing.T) {
 				},
 			}
 			err := v.SetClient(ctx, fakeRun, tt.event, repo, nil)
-			if tt.wantErr != "" {
-				assert.ErrorContains(t, err, tt.wantErr)
+			if tt.wantErrSub != "" {
+				assert.ErrorContains(t, err, tt.wantErrSub)
 				return
 			}
 			assert.NilError(t, err)
@@ -1244,6 +1254,7 @@ func TestGithubSetClient(t *testing.T) {
 			assert.Assert(t, strings.HasPrefix(v.Client().BaseURL(), "https://"))
 			if tt.isGHE {
 				assert.Assert(t, strings.HasSuffix(v.Client().BaseURL(), "/api/v3/"))
+				assert.Equal(t, "https://foo.com/api/uploads/", v.Client().UploadURL())
 			} else {
 				assert.Equal(t, keys.PublicGithubAPIURL+"/", v.Client().BaseURL())
 			}
@@ -1278,9 +1289,181 @@ func TestGithubSetClient(t *testing.T) {
 	}
 }
 
+func TestMakeClientEnterpriseURLs(t *testing.T) {
+	tests := []struct {
+		name   string
+		apiURL string
+	}{
+		{name: "enterprise base URL", apiURL: "https://ghe.example.com"},
+		{name: "enterprise API URL", apiURL: "https://ghe.example.com/api/v3"},
+		{name: "enterprise API URL with trailing slash", apiURL: "https://ghe.example.com/api/v3/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, providerName, _, err := MakeClient(t.Context(), tt.apiURL, "token")
+			assert.NilError(t, err)
+			assert.Equal(t, providerName, "github-enterprise")
+			assert.Equal(t, client.BaseURL(), "https://ghe.example.com/api/v3/")
+			assert.Equal(t, client.UploadURL(), "https://ghe.example.com/api/uploads/")
+		})
+	}
+}
+
+// TestGithubSetClientPreauthenticatedClient checks that a caller which picked
+// the host itself, the end to end harness being the one that does, keeps the URL
+// it asked for instead of being sent through the allowlist of a controller it is
+// not.
+func TestGithubSetClientPreauthenticatedClient(t *testing.T) {
+	const untrustedHost = "ghe.example.com"
+
+	tests := []struct {
+		name             string
+		preauthenticated bool
+		wantErrSub       string
+	}{
+		{
+			name:       "an untrusted host is refused when the provider builds the client",
+			wantErrSub: "refusing to use credentials",
+		},
+		{
+			name:             "an untrusted host is kept when the caller built the client",
+			preauthenticated: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			ctx = info.StoreNS(ctx, "pipelines-as-code")
+			core, _ := zapobserver.New(zap.InfoLevel)
+			testLog := zap.New(core).Sugar()
+			fakeRun := newTestRun(t, "")
+			fakeRun.Clients.Log = testLog
+
+			v := Provider{Logger: testLog, pacInfo: &info.PacOpts{}}
+			event := &info.Event{Provider: &info.Provider{URL: untrustedHost, Token: "token"}}
+
+			if tt.preauthenticated {
+				client, _, _, err := v.MakeClient(ctx, untrustedHost, "token")
+				assert.NilError(t, err)
+				v.UsePreauthenticatedClient(client)
+			}
+
+			err := v.SetClient(ctx, fakeRun, event, nil, nil)
+			if tt.wantErrSub != "" {
+				assert.ErrorContains(t, err, tt.wantErrSub)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, untrustedHost, event.Provider.URL)
+			assert.Equal(t, "https://"+untrustedHost, *v.APIURL)
+			assert.Equal(t, "https://"+untrustedHost+"/api/v3/", v.Client().BaseURL())
+		})
+	}
+}
+
+func TestGithubSetClientUsesSignedEnterpriseEndpoint(t *testing.T) {
+	const webhookSecret = "webhook-secret"
+	payload := []byte(`{"repository":{"html_url":"https://ghe.example.com/owner/repo"}}`)
+
+	tests := []struct {
+		name           string
+		allowlist      string
+		enterpriseHost string
+		webhookSecret  string
+		signingSecret  string
+		wantErrSub     string
+	}{
+		{
+			name:           "matching signed enterprise host",
+			allowlist:      "ghe.example.com",
+			enterpriseHost: "ghe.example.com",
+			webhookSecret:  webhookSecret,
+			signingSecret:  webhookSecret,
+		},
+		{
+			// The signature here is checked against a secret the tenant owns, so
+			// it must not be enough on its own to reach an arbitrary host.
+			name:           "signed enterprise host outside the controller allowlist",
+			allowlist:      "other.example.com",
+			enterpriseHost: "ghe.example.com",
+			webhookSecret:  webhookSecret,
+			signingSecret:  webhookSecret,
+			wantErrSub:     "refusing to use credentials",
+		},
+		{
+			name:           "signed enterprise host with an unconfigured allowlist",
+			enterpriseHost: "ghe.example.com",
+			webhookSecret:  webhookSecret,
+			signingSecret:  webhookSecret,
+			wantErrSub:     "no authenticated request has made it known yet",
+		},
+		{
+			name:           "forged enterprise host",
+			enterpriseHost: "attacker.example",
+			webhookSecret:  webhookSecret,
+			signingSecret:  webhookSecret,
+			wantErrSub:     `does not match signed repository host "ghe.example.com"`,
+		},
+		{
+			name:           "signature validation fails before endpoint derivation",
+			enterpriseHost: "ghe.example.com",
+			webhookSecret:  webhookSecret,
+			signingSecret:  "wrong-secret",
+			wantErrSub:     "payload signature check failed",
+		},
+		{
+			name:           "missing webhook secret fails before endpoint derivation",
+			enterpriseHost: "ghe.example.com",
+			signingSecret:  webhookSecret,
+			wantErrSub:     "no webhook secret has been set",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := info.NewEvent()
+			event.EventType = "pull_request"
+			event.Provider.Token = "pat"
+			event.Provider.WebhookSecret = tt.webhookSecret
+			event.Request = &info.Request{
+				Header:  http.Header{},
+				Payload: payload,
+			}
+			event.Request.Header.Set(github.SHA256SignatureHeader, githubSHA256Signature(tt.signingSecret, payload))
+			event.Request.Header.Set("X-GitHub-Enterprise-Host", tt.enterpriseHost)
+
+			testLogger, _ := logger.GetLogger()
+			run := newTestRun(t, tt.allowlist)
+			run.Clients.Log = testLogger
+			ctx := info.StoreNS(context.Background(), "pipelines-as-code")
+			provider := &Provider{
+				Logger:  testLogger,
+				pacInfo: &info.PacOpts{},
+			}
+			err := provider.SetClient(
+				ctx,
+				run,
+				event,
+				&v1alpha1.Repository{Spec: v1alpha1.RepositorySpec{Settings: &v1alpha1.Settings{}}},
+				nil,
+			)
+			if tt.wantErrSub != "" {
+				assert.ErrorContains(t, err, tt.wantErrSub)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, "https://ghe.example.com", event.Provider.URL)
+			assert.Equal(t, "https://ghe.example.com", event.GHEURL)
+			assert.Equal(t, "https://ghe.example.com/api/v3/", provider.Client().BaseURL())
+		})
+	}
+}
+
 func TestSetClientFallbackScopesToken(t *testing.T) {
 	testNamespace := "pipelinesascode"
 	secretName := "pipelines-as-code-secret"
+	configMapName := "pipelines-as-code"
 
 	ctx, _ := rtesting.SetupFakeContext(t)
 	seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
@@ -1293,6 +1476,17 @@ func TestSetClientFallbackScopesToken(t *testing.T) {
 				Data: map[string][]byte{
 					"github-application-id": []byte("12345"),
 					"github-private-key":    []byte(fakePrivateKey),
+				},
+			},
+		},
+		ConfigMap: []*corev1.ConfigMap{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configMapName,
+					Namespace: testNamespace,
+				},
+				Data: map[string]string{
+					settings.TrustedProviderHostnamesKey: "github.example.com",
 				},
 			},
 		},
@@ -1336,6 +1530,8 @@ func TestSetClientFallbackScopesToken(t *testing.T) {
 			event := info.NewEvent()
 			event.InstallationID = testInstallationID
 			event.Provider.Token = initialToken
+			event.GHEURL = "https://github.example.com"
+			event.Provider.URL = "https://github.example.com"
 
 			testLog, _ := logger.GetLogger()
 			v := Provider{
@@ -1351,7 +1547,7 @@ func TestSetClientFallbackScopesToken(t *testing.T) {
 					Kube: seedData.Kube,
 				},
 				Info: info.Info{
-					Controller: &info.ControllerInfo{Secret: secretName},
+					Controller: &info.ControllerInfo{Secret: secretName, Configmap: configMapName},
 				},
 			}
 
@@ -1848,6 +2044,7 @@ func TestCreateToken(t *testing.T) {
 	tdata := testclient.Data{
 		Namespaces: []*corev1.Namespace{testNamespace},
 		Secret:     []*corev1.Secret{validSecret},
+		ConfigMap:  emptyAllowlistConfigMap(),
 	}
 
 	stdata, _ := testclient.SeedTestData(t, ctx, tdata)
@@ -1897,6 +2094,72 @@ func TestCreateToken(t *testing.T) {
 	if err != nil {
 		assert.ErrorContains(t, err, "could not refresh installation id 1234567's token")
 	}
+}
+
+func TestCreateTokenUsesEventGHEURLForAppToken(t *testing.T) {
+	const (
+		namespace      = "pipelinesascode"
+		secretName     = "pipelines-as-code-secret"
+		configMapName  = "pipelines-as-code"
+		scopedToken    = "ghs_scoped_token"
+		enterpriseHost = "github.example.com"
+	)
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = info.StoreNS(ctx, namespace)
+	ctx = info.StoreCurrentControllerName(ctx, "default")
+	logger, _ := logger.GetLogger()
+	seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+		Secret: []*corev1.Secret{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: namespace,
+			},
+			Data: map[string][]byte{
+				"github-application-id": []byte("12345"),
+				"github-private-key":    []byte(fakePrivateKey),
+			},
+		}},
+		ConfigMap: []*corev1.ConfigMap{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      configMapName,
+				Namespace: namespace,
+			},
+			Data: map[string]string{
+				settings.TrustedProviderHostnamesKey: enterpriseHost,
+			},
+		}},
+	})
+	fakeclient, mux, serverURL, teardown := ghtesthelper.SetupGH()
+	defer teardown()
+	tokenRequests := 0
+	mux.HandleFunc(fmt.Sprintf("/app/installations/%d/access_tokens", testInstallationID), func(w http.ResponseWriter, _ *http.Request) {
+		tokenRequests++
+		_, _ = fmt.Fprintf(w, `{"token":%q,"expires_at":"2099-01-01T00:00:00Z"}`, scopedToken)
+	})
+	t.Setenv("PAC_GIT_PROVIDER_TOKEN_APIURL", serverURL+"/api/v3")
+
+	provider := &Provider{
+		Logger:   logger,
+		ghClient: fakeclient,
+		Run: &params.Run{
+			Clients: clients.Clients{
+				Kube: seedData.Kube,
+				Log:  logger,
+			},
+			Info: info.Info{
+				Controller: &info.ControllerInfo{Secret: secretName, Configmap: configMapName},
+			},
+		},
+	}
+	event := info.NewEvent()
+	event.Provider.URL = "https://github.com"
+	event.GHEURL = "https://" + enterpriseHost
+	event.InstallationID = testInstallationID
+
+	token, err := provider.CreateToken(ctx, []string{"owner/missing"}, event)
+	assert.NilError(t, err)
+	assert.Equal(t, scopedToken, token)
+	assert.Equal(t, 1, tokenRequests)
 }
 
 func TestExpandGlobAndAddRepoIDsInvalidPattern(t *testing.T) {
@@ -2648,68 +2911,106 @@ func TestFetchAppSlug(t *testing.T) {
 		privateKey       []byte
 		applicationID    int64
 		apiURL           string
-		setupMux         func(mux *http.ServeMux)
+		pinnedHost       string
+		tokenAPIURL      string
+		setupMux         func(mux *http.ServeMux, requests *atomic.Int32)
 		wantSlug         string
 		wantErrSubstring string
+		wantRequests     int32
 	}{
 		{
 			name:          "success fetch app slug",
 			privateKey:    []byte(fakePrivateKey),
 			applicationID: testAppID,
-			setupMux: func(mux *http.ServeMux) {
+			setupMux: func(mux *http.ServeMux, requests *atomic.Int32) {
 				mux.HandleFunc("/app", func(w http.ResponseWriter, _ *http.Request) {
+					requests.Add(1)
 					_, _ = fmt.Fprintf(w, `{"slug": "%s", "name": "My GitHub App"}`, validSlug)
 				})
 			},
-			wantSlug: validSlug,
+			wantSlug:     validSlug,
+			wantRequests: 1,
 		},
 		{
 			name:          "app endpoint returns 404",
 			privateKey:    []byte(fakePrivateKey),
 			applicationID: testAppID,
-			setupMux: func(mux *http.ServeMux) {
+			setupMux: func(mux *http.ServeMux, requests *atomic.Int32) {
 				mux.HandleFunc("/app", func(w http.ResponseWriter, _ *http.Request) {
+					requests.Add(1)
 					w.WriteHeader(http.StatusNotFound)
 					_, _ = fmt.Fprint(w, `{"message": "Not Found"}`)
 				})
 			},
 			wantErrSubstring: "failed to get app info",
+			wantRequests:     1,
 		},
 		{
 			name:             "invalid private key",
 			privateKey:       []byte("invalid-key"),
 			applicationID:    testAppID,
-			setupMux:         func(_ *http.ServeMux) {},
+			setupMux:         func(_ *http.ServeMux, _ *atomic.Int32) {},
 			wantErrSubstring: "failed to parse private key",
 		},
 		{
 			name:          "app returns empty slug",
 			privateKey:    []byte(fakePrivateKey),
 			applicationID: testAppID,
-			setupMux: func(mux *http.ServeMux) {
+			setupMux: func(mux *http.ServeMux, requests *atomic.Int32) {
 				mux.HandleFunc("/app", func(w http.ResponseWriter, _ *http.Request) {
+					requests.Add(1)
 					_, _ = fmt.Fprint(w, `{"slug": "", "name": "My GitHub App"}`)
 				})
 			},
-			wantSlug: "",
+			wantSlug:     "",
+			wantRequests: 1,
 		},
 		{
 			name:          "app endpoint returns malformed JSON",
 			privateKey:    []byte(fakePrivateKey),
 			applicationID: testAppID,
-			setupMux: func(mux *http.ServeMux) {
+			setupMux: func(mux *http.ServeMux, requests *atomic.Int32) {
 				mux.HandleFunc("/app", func(w http.ResponseWriter, _ *http.Request) {
+					requests.Add(1)
 					_, _ = fmt.Fprint(w, `{invalid json`)
 				})
 			},
 			wantErrSubstring: "failed to get app info",
+			wantRequests:     1,
 		},
 		{
-			name:             "invalid enterprise API URL",
+			name:             "rejects untrusted app URL before sending JWT",
 			privateKey:       []byte(fakePrivateKey),
 			applicationID:    testAppID,
-			apiURL:           "%",
-			wantErrSubstring: "failed to create github enterprise client",
+			apiURL:           "https://attacker.example",
+			pinnedHost:       "ghe.example.com",
+			setupMux:         func(_ *http.ServeMux, _ *atomic.Int32) {},
+			wantErrSubstring: "is not listed in",
+		},
+		{
+			// SetClient hands fetchAppSlug the API URL it settled on, which on a
+			// self hosted instance carries the /api/v3 path.
+			name:          "accepts the api url SetClient produces",
+			privateKey:    []byte(fakePrivateKey),
+			applicationID: testAppID,
+			apiURL:        "https://ghe.example.com/api/v3",
+			pinnedHost:    "ghe.example.com",
+			setupMux: func(mux *http.ServeMux, requests *atomic.Int32) {
+				mux.HandleFunc("/app", func(w http.ResponseWriter, _ *http.Request) {
+					requests.Add(1)
+					_, _ = fmt.Fprintf(w, `{"slug": "%s", "name": "My GitHub App"}`, validSlug)
+				})
+			},
+			wantSlug:     validSlug,
+			wantRequests: 1,
+		},
+		{
+			name:             "rejects invalid app token test URL",
+			privateKey:       []byte(fakePrivateKey),
+			applicationID:    testAppID,
+			tokenAPIURL:      "https://example.com/api/v3",
+			setupMux:         func(_ *http.ServeMux, _ *atomic.Int32) {},
+			wantErrSubstring: "PAC_GIT_PROVIDER_TOKEN_APIURL must target a loopback IP address",
 		},
 	}
 
@@ -2718,8 +3019,9 @@ func TestFetchAppSlug(t *testing.T) {
 			_, mux, serverURL, teardown := ghtesthelper.SetupGH()
 			defer teardown()
 
+			var requests atomic.Int32
 			if tt.setupMux != nil {
-				tt.setupMux(mux)
+				tt.setupMux(mux, &requests)
 			}
 
 			// Set up context with namespace
@@ -2744,11 +3046,22 @@ func TestFetchAppSlug(t *testing.T) {
 					"github-private-key":    tt.privateKey,
 				},
 			}
+			testConfigMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pac-configmap",
+					Namespace: testNamespace.GetName(),
+				},
+				Data: map[string]string{},
+			}
+			if tt.pinnedHost != "" {
+				testConfigMap.Data[settings.TrustedProviderHostnamesKey] = tt.pinnedHost
+			}
 
 			// Set up test data with kubernetes client
 			tdata := testclient.Data{
 				Namespaces: []*corev1.Namespace{testNamespace},
 				Secret:     []*corev1.Secret{testSecret},
+				ConfigMap:  []*corev1.ConfigMap{testConfigMap},
 			}
 			stdata, _ := testclient.SeedTestData(t, ctx, tdata)
 
@@ -2761,25 +3074,29 @@ func TestFetchAppSlug(t *testing.T) {
 				},
 				Info: info.Info{
 					Controller: &info.ControllerInfo{
-						Secret: testSecret.GetName(),
+						Secret:    testSecret.GetName(),
+						Configmap: testConfigMap.GetName(),
 					},
 				},
 			}
-
-			apiURL := serverURL
-			if tt.apiURL != "" {
-				apiURL = tt.apiURL
+			tokenAPIURL := tt.tokenAPIURL
+			if tokenAPIURL == "" {
+				tokenAPIURL = serverURL + "/api/v3"
 			}
-			slug, err := provider.fetchAppSlug(ctx, apiURL)
+			t.Setenv("PAC_GIT_PROVIDER_TOKEN_APIURL", tokenAPIURL)
+
+			slug, err := provider.fetchAppSlug(ctx, tt.apiURL)
 
 			if tt.wantErrSubstring != "" {
 				assert.Assert(t, err != nil, "expected error but got none")
 				assert.ErrorContains(t, err, tt.wantErrSubstring)
+				assert.Equal(t, tt.wantRequests, requests.Load())
 				return
 			}
 
 			assert.NilError(t, err)
 			assert.Equal(t, slug, tt.wantSlug)
+			assert.Equal(t, tt.wantRequests, requests.Load())
 		})
 	}
 }

--- a/pkg/provider/github/parse_payload.go
+++ b/pkg/provider/github/parse_payload.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -61,6 +60,16 @@ func (v *Provider) GetAppIDAndPrivateKey(ctx context.Context, ns string, kube ku
 }
 
 func (v *Provider) GetAppToken(ctx context.Context, kube kubernetes.Interface, gheURL string, installationID int64, ns string) (string, error) {
+	endpoint, err := trustedAPIEndpointForHost(ctx, kube, ns, v.Run.Info.Controller.Secret, gheURL)
+	if err != nil {
+		return "", err
+	}
+	gheURL = endpoint.BaseURL
+
+	reqTokenURL, err := AppTokenTestAPIURL()
+	if err != nil {
+		return "", err
+	}
 	applicationID, privateKey, err := v.GetAppIDAndPrivateKey(ctx, ns, kube)
 	if err != nil {
 		return "", err
@@ -83,7 +92,6 @@ func (v *Provider) GetAppToken(ctx context.Context, kube kubernetes.Interface, g
 
 	// This is a hack when we have auth and api disassociated like in our
 	// unittests since we are using a custom http server with httptest
-	reqTokenURL := os.Getenv("PAC_GIT_PROVIDER_TOKEN_APIURL")
 	if reqTokenURL != "" {
 		itr.BaseURL = reqTokenURL
 		v.APIURL = &reqTokenURL
@@ -149,8 +157,6 @@ func (v *Provider) parseEventType(request *http.Request, event *info.Event) erro
 		return fmt.Errorf("failed to find event type in request header")
 	}
 
-	event.Provider.URL = request.Header.Get("X-GitHub-Enterprise-Host")
-
 	if event.EventType == "push" {
 		event.TriggerTarget = triggertype.Push
 	} else {
@@ -187,33 +193,40 @@ func getInstallationAndRepoIDFromPayload(payload string) (int64, int64, error) {
 	return installationID, repoID, nil
 }
 
-func validateEnterpriseHostMatchesPayload(gheURL, payload string) error {
-	if gheURL == "" {
-		return nil
-	}
-	if !strings.HasPrefix(gheURL, "https://") && !strings.HasPrefix(gheURL, "http://") {
-		gheURL = "https://" + gheURL
-	}
-	enterpriseURL, err := url.Parse(gheURL)
-	if err != nil || enterpriseURL.Host == "" {
-		return fmt.Errorf("invalid X-GitHub-Enterprise-Host header")
-	}
-
+func githubEndpointFromPayload(enterpriseHeader, payload string) (APIEndpoint, error) {
 	var data Payload
 	if err := json.Unmarshal([]byte(payload), &data); err != nil {
-		return err
+		return APIEndpoint{}, err
 	}
 	if data.Repository.HTMLURL == "" {
-		return fmt.Errorf("repository HTML URL is missing in payload, cannot validate enterprise host")
+		return APIEndpoint{}, fmt.Errorf("repository HTML URL is missing in payload, cannot validate enterprise host")
 	}
 	repoURL, err := url.Parse(data.Repository.HTMLURL)
-	if err != nil || repoURL.Host == "" {
-		return fmt.Errorf("invalid repository URL in GitHub payload")
+	if err != nil || repoURL.Scheme != "https" || repoURL.Host == "" || repoURL.User != nil {
+		return APIEndpoint{}, fmt.Errorf("invalid repository URL in GitHub payload")
 	}
-	if !strings.EqualFold(enterpriseURL.Host, repoURL.Host) {
-		return fmt.Errorf("github enterprise host %q does not match repository host %q", enterpriseURL.Host, repoURL.Host)
+	endpoint, err := ResolveAPIEndpoint(repoURL.Host)
+	if err != nil {
+		return APIEndpoint{}, err
 	}
-	return nil
+	if enterpriseHeader != "" {
+		headerEndpoint, err := ResolveAPIEndpoint(enterpriseHeader)
+		if err != nil {
+			return APIEndpoint{}, fmt.Errorf("invalid X-GitHub-Enterprise-Host header: %w", err)
+		}
+		if endpoint.RepositoryHost != headerEndpoint.RepositoryHost {
+			return APIEndpoint{}, fmt.Errorf("GitHub enterprise header host %q does not match signed repository host %q", headerEndpoint.RepositoryHost, endpoint.RepositoryHost)
+		}
+	}
+	return endpoint, nil
+}
+
+func authenticatedGitHubEndpoint(ctx context.Context, run *params.Run, enterpriseHeader, payload string) (APIEndpoint, error) {
+	endpoint, err := githubEndpointFromPayload(enterpriseHeader, payload)
+	if err != nil {
+		return APIEndpoint{}, err
+	}
+	return pinGitHubHost(ctx, run, endpoint)
 }
 
 func (v *Provider) logBlockedGitHubAppTokenMint(request *http.Request, event *info.Event, installationID int64, reason string, err error) {
@@ -273,7 +286,6 @@ func (v *Provider) ParsePayload(ctx context.Context, run *params.Run, request *h
 	if err := v.parseEventType(request, event); err != nil {
 		return nil, err
 	}
-
 	installationIDFrompayload, repoIDFromPayload, err := getInstallationAndRepoIDFromPayload(payload)
 	if err != nil {
 		return nil, err
@@ -284,14 +296,17 @@ func (v *Provider) ParsePayload(ctx context.Context, run *params.Run, request *h
 			v.logGitHubAppTokenMintValidationFailure(request, event, installationIDFrompayload, "webhook-signature-validation-failed", err)
 			return nil, err
 		}
-		if err := validateEnterpriseHostMatchesPayload(event.Provider.URL, payload); err != nil {
+		endpoint, err := authenticatedGitHubEndpoint(ctx, run, request.Header.Get("X-GitHub-Enterprise-Host"), payload)
+		if err != nil {
 			v.logBlockedGitHubAppTokenMint(request, event, installationIDFrompayload, "enterprise-host-validation-failed", err)
 			return nil, err
 		}
 		// TODO: move this out of here when we move al config inside context
-		if event.Provider.Token, err = v.GetAppToken(ctx, run.Clients.Kube, event.Provider.URL, installationIDFrompayload, systemNS); err != nil {
+		if event.Provider.Token, err = v.GetAppToken(ctx, run.Clients.Kube, endpoint.BaseURL, installationIDFrompayload, systemNS); err != nil {
 			return nil, err
 		}
+		event.Provider.URL = endpoint.BaseURL
+		event.GHEURL = endpoint.BaseURL
 	}
 
 	if repoIDFromPayload > 0 {
@@ -317,7 +332,7 @@ func (v *Provider) ParsePayload(ctx context.Context, run *params.Run, request *h
 
 	processedEvent.Event = eventInt
 	processedEvent.InstallationID = installationIDFrompayload
-	processedEvent.GHEURL = event.Provider.URL
+	processedEvent.GHEURL = event.GHEURL
 	processedEvent.Provider.URL = event.Provider.URL
 
 	return processedEvent, nil

--- a/pkg/provider/github/parse_payload.go
+++ b/pkg/provider/github/parse_payload.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -64,6 +63,18 @@ func (v *Provider) GetAppIDAndPrivateKey(ctx context.Context, ns string, kube ku
 }
 
 func (v *Provider) GetAppToken(ctx context.Context, kube kubernetes.Interface, gheURL string, installationID int64, ns string) (string, error) {
+	endpoint, err := trustedAPIEndpointForHost(ctx, v.Run, gheURL)
+	if err != nil {
+		return "", err
+	}
+	gheURL, err = endpoint.BaseURLForClient()
+	if err != nil {
+		return "", err
+	}
+	reqTokenURL, err := AppTokenTestAPIURL()
+	if err != nil {
+		return "", err
+	}
 	applicationID, privateKey, err := v.GetAppIDAndPrivateKey(ctx, ns, kube)
 	if err != nil {
 		return "", err
@@ -86,11 +97,9 @@ func (v *Provider) GetAppToken(ctx context.Context, kube kubernetes.Interface, g
 
 	// This is a hack when we have auth and api disassociated like in our
 	// unittests since we are using a custom http server with httptest
-	reqTokenURL := os.Getenv("PAC_GIT_PROVIDER_TOKEN_APIURL")
 	if reqTokenURL != "" {
 		itr.BaseURL = reqTokenURL
 		v.APIURL = &reqTokenURL
-		gheURL = strings.TrimSuffix(reqTokenURL, "/api/v3")
 	}
 
 	// wrap the installation transport with the retry transport when enabled
@@ -164,8 +173,6 @@ func (v *Provider) parseEventType(request *http.Request, event *info.Event) erro
 		return fmt.Errorf("failed to find event type in request header")
 	}
 
-	event.Provider.URL = request.Header.Get("X-GitHub-Enterprise-Host")
-
 	if event.EventType == "push" {
 		event.TriggerTarget = triggertype.Push
 	} else {
@@ -202,33 +209,59 @@ func getInstallationAndRepoIDFromPayload(payload string) (int64, int64, error) {
 	return installationID, repoID, nil
 }
 
-func validateEnterpriseHostMatchesPayload(gheURL, payload string) error {
-	if gheURL == "" {
-		return nil
-	}
-	if !strings.HasPrefix(gheURL, "https://") && !strings.HasPrefix(gheURL, "http://") {
-		gheURL = "https://" + gheURL
-	}
-	enterpriseURL, err := url.Parse(gheURL)
-	if err != nil || enterpriseURL.Host == "" {
-		return fmt.Errorf("invalid X-GitHub-Enterprise-Host header")
-	}
+// errNoRepositoryInPayload marks a payload that names no repository at all.
+// GitHub App level deliveries (ping, installation, installation_repositories,
+// marketplace_purchase) are legitimately shaped that way, so this is a normal
+// condition and not an attempt at redirecting the controller.
+var errNoRepositoryInPayload = errors.New("payload carries no repository, so it names no host")
 
+func githubEndpointFromPayload(enterpriseHeader, payload string) (APIEndpoint, error) {
 	var data Payload
 	if err := json.Unmarshal([]byte(payload), &data); err != nil {
-		return err
+		return APIEndpoint{}, err
 	}
 	if data.Repository.HTMLURL == "" {
-		return fmt.Errorf("repository HTML URL is missing in payload, cannot validate enterprise host")
+		return APIEndpoint{}, errNoRepositoryInPayload
 	}
 	repoURL, err := url.Parse(data.Repository.HTMLURL)
-	if err != nil || repoURL.Host == "" {
-		return fmt.Errorf("invalid repository URL in GitHub payload")
+	if err != nil || repoURL.Scheme != "https" || repoURL.Host == "" || repoURL.User != nil {
+		return APIEndpoint{}, fmt.Errorf("invalid repository URL in GitHub payload")
 	}
-	if !strings.EqualFold(enterpriseURL.Host, repoURL.Host) {
-		return fmt.Errorf("github enterprise host %q does not match repository host %q", enterpriseURL.Host, repoURL.Host)
+	endpoint, err := resolveUntrustedAPIEndpoint(repoURL.Host)
+	if err != nil {
+		return APIEndpoint{}, err
 	}
-	return nil
+	if enterpriseHeader != "" {
+		headerEndpoint, err := resolveUntrustedAPIEndpoint(enterpriseHeader)
+		if err != nil {
+			return APIEndpoint{}, fmt.Errorf("invalid X-GitHub-Enterprise-Host header: %w", err)
+		}
+		if endpoint.RepositoryHost != headerEndpoint.RepositoryHost {
+			return APIEndpoint{}, fmt.Errorf("GitHub enterprise header host %q does not match signed repository host %q", headerEndpoint.RepositoryHost, endpoint.RepositoryHost)
+		}
+	}
+	return endpoint, nil
+}
+
+func authenticatedGitHubEndpoint(ctx context.Context, run *params.Run, enterpriseHeader, payload string) (APIEndpoint, error) {
+	endpoint, err := githubEndpointFromPayload(enterpriseHeader, payload)
+	if err != nil {
+		return APIEndpoint{}, err
+	}
+	return authenticatedAPIEndpoint(ctx, run, endpoint.RepositoryHost)
+}
+
+// trustedGitHubEndpointFromPayload resolves the endpoint of a webhook whose
+// signature was verified against a per Repository secret. That secret belongs to
+// the tenant, not to the controller, so the host is only checked against the
+// allowlist and never recorded: otherwise any namespace owner could rewrite the
+// controller wide policy.
+func trustedGitHubEndpointFromPayload(ctx context.Context, run *params.Run, enterpriseHeader, payload string) (APIEndpoint, error) {
+	endpoint, err := githubEndpointFromPayload(enterpriseHeader, payload)
+	if err != nil {
+		return APIEndpoint{}, err
+	}
+	return trustedAPIEndpointForHost(ctx, run, endpoint.RepositoryHost)
 }
 
 func (v *Provider) logBlockedGitHubAppTokenMint(request *http.Request, event *info.Event, installationID int64, reason string, err error) {
@@ -288,10 +321,24 @@ func (v *Provider) ParsePayload(ctx context.Context, run *params.Run, request *h
 	if err := v.parseEventType(request, event); err != nil {
 		return nil, err
 	}
-
 	installationIDFrompayload, repoIDFromPayload, err := getInstallationAndRepoIDFromPayload(payload)
 	if err != nil {
 		return nil, err
+	}
+	if isRepositorylessAppEvent(event.EventType) {
+		if _, endpointErr := githubEndpointFromPayload("", payload); errors.Is(endpointErr, errNoRepositoryInPayload) {
+			// These deliveries carry no repository and therefore need neither a
+			// provider endpoint nor an installation token. When an installation ID
+			// identifies this as an App delivery, authenticate it before skipping.
+			if installationIDFrompayload != -1 {
+				if err := validateAppWebhookSignature(ctx, run, event); err != nil {
+					v.logGitHubAppTokenMintValidationFailure(request, event, installationIDFrompayload, "webhook-signature-validation-failed", err)
+					return nil, err
+				}
+			}
+			v.Logger.Debugf("skipping GitHub App %s delivery without a repository", event.EventType)
+			return nil, nil
+		}
 	}
 	if installationIDFrompayload != -1 {
 		var err error
@@ -299,14 +346,17 @@ func (v *Provider) ParsePayload(ctx context.Context, run *params.Run, request *h
 			v.logGitHubAppTokenMintValidationFailure(request, event, installationIDFrompayload, "webhook-signature-validation-failed", err)
 			return nil, err
 		}
-		if err := validateEnterpriseHostMatchesPayload(event.Provider.URL, payload); err != nil {
+		endpoint, err := authenticatedGitHubEndpoint(ctx, run, request.Header.Get("X-GitHub-Enterprise-Host"), payload)
+		if err != nil {
 			v.logBlockedGitHubAppTokenMint(request, event, installationIDFrompayload, "enterprise-host-validation-failed", err)
 			return nil, err
 		}
 		// TODO: move this out of here when we move al config inside context
-		if event.Provider.Token, err = v.GetAppToken(ctx, run.Clients.Kube, event.Provider.URL, installationIDFrompayload, systemNS); err != nil {
+		if event.Provider.Token, err = v.GetAppToken(ctx, run.Clients.Kube, endpoint.BaseURL, installationIDFrompayload, systemNS); err != nil {
 			return nil, err
 		}
+		event.Provider.URL = endpoint.BaseURL
+		event.GHEURL = endpoint.BaseURL
 	}
 
 	if repoIDFromPayload > 0 {
@@ -332,10 +382,19 @@ func (v *Provider) ParsePayload(ctx context.Context, run *params.Run, request *h
 
 	processedEvent.Event = eventInt
 	processedEvent.InstallationID = installationIDFrompayload
-	processedEvent.GHEURL = event.Provider.URL
+	processedEvent.GHEURL = event.GHEURL
 	processedEvent.Provider.URL = event.Provider.URL
 
 	return processedEvent, nil
+}
+
+func isRepositorylessAppEvent(eventType string) bool {
+	switch eventType {
+	case "ping", "installation", "installation_repositories", "marketplace_purchase":
+		return true
+	default:
+		return false
+	}
 }
 
 // getPullRequestsWithCommit lists the all pull requests associated with given commit.

--- a/pkg/provider/github/parse_payload_test.go
+++ b/pkg/provider/github/parse_payload_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -1630,17 +1631,63 @@ func TestAppTokenGeneration(t *testing.T) {
 		},
 	})
 
+	ctxPinnedHost, _ := rtesting.SetupFakeContext(t)
+	pinnedHost, _ := testclient.SeedTestData(t, ctxPinnedHost, testclient.Data{
+		Secret: []*corev1.Secret{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: testNamespace,
+				},
+				Data: map[string][]byte{
+					"github-application-id": []byte("12345"),
+					"github-private-key":    []byte(fakePrivateKey),
+					"webhook.secret":        []byte(webhookSecret),
+					"github-host":           []byte("github.example.com"),
+				},
+			},
+		},
+	})
+
+	ctxGHE, _ := rtesting.SetupFakeContext(t)
+	gheSecret, _ := testclient.SeedTestData(t, ctxGHE, testclient.Data{
+		Secret: []*corev1.Secret{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: testNamespace,
+				},
+				Data: map[string][]byte{
+					"github-application-id": []byte("12345"),
+					"github-private-key":    []byte(fakePrivateKey),
+					"webhook.secret":        []byte(webhookSecret),
+				},
+			},
+		},
+	})
+	ghePayloadEvent := samplePRevent
+	ghePayloadEvent.Installation = &github.Installation{ID: &testInstallationID}
+	gheRepository := *sampleRepo
+	gheRepository.HTMLURL = github.Ptr("https://github.example.com/owner/repo")
+	ghePayloadEvent.Repo = &gheRepository
+	ghePayload, err := json.Marshal(ghePayloadEvent)
+	assert.NilError(t, err)
+
 	tests := []struct {
-		ctx            context.Context
-		ctxNS          string
-		name           string
-		wantErrSubst   string
-		nilClient      bool
-		seedData       testclient.Clients
-		omitSignature  bool
-		enterpriseHost string
-		payload        string
-		wantLogMessage string
+		ctx             context.Context
+		ctxNS           string
+		name            string
+		wantErrSubst    string
+		nilClient       bool
+		seedData        testclient.Clients
+		omitSignature   bool
+		enterpriseHost  string
+		payload         string
+		wantLogMessage  string
+		wantPinnedHost  string
+		wantTokenCalls  int
+		wantProviderURL string
+		wantGHEURL      string
 	}{
 		{
 			name:           "secret not found",
@@ -1665,7 +1712,7 @@ func TestAppTokenGeneration(t *testing.T) {
 			ctxNS:          testNamespace,
 			seedData:       vaildSecret,
 			enterpriseHost: "127.0.0.1:1",
-			wantErrSubst:   `github enterprise host "127.0.0.1:1" does not match repository host "github.com"`,
+			wantErrSubst:   `GitHub enterprise header host "127.0.0.1:1" does not match signed repository host "github.com"`,
 			wantLogMessage: githubAppTokenExfiltrationBlockedLog,
 		},
 		{
@@ -1679,11 +1726,33 @@ func TestAppTokenGeneration(t *testing.T) {
 			wantLogMessage: githubAppTokenExfiltrationBlockedLog,
 		},
 		{
-			ctx:       ctx,
-			name:      "secret found",
-			ctxNS:     testNamespace,
-			seedData:  vaildSecret,
-			nilClient: false,
+			ctx:            ctxPinnedHost,
+			name:           "signed payload conflicts with pinned host",
+			ctxNS:          testNamespace,
+			seedData:       pinnedHost,
+			wantErrSubst:   `authenticated GitHub host "github.com" conflicts with controller-pinned host "github.example.com"`,
+			wantLogMessage: githubAppTokenExfiltrationBlockedLog,
+		},
+		{
+			ctx:            ctx,
+			name:           "secret found",
+			ctxNS:          testNamespace,
+			seedData:       vaildSecret,
+			nilClient:      false,
+			wantPinnedHost: "github.com",
+			wantTokenCalls: 1,
+		},
+		{
+			ctx:             ctxGHE,
+			name:            "authenticated enterprise payload configures event endpoints",
+			ctxNS:           testNamespace,
+			seedData:        gheSecret,
+			enterpriseHost:  "github.example.com",
+			payload:         string(ghePayload),
+			wantPinnedHost:  "github.example.com",
+			wantTokenCalls:  1,
+			wantProviderURL: "https://github.example.com",
+			wantGHEURL:      "https://github.example.com",
 		},
 		{
 			ctx:          ctxInvalidAppID,
@@ -1704,7 +1773,13 @@ func TestAppTokenGeneration(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeghclient, mux, serverURL, teardown := ghtesthelper.SetupGH()
 			defer teardown()
+			tokenCalls := 0
 			mux.HandleFunc(fmt.Sprintf("/app/installations/%d/access_tokens", testInstallationID), func(w http.ResponseWriter, _ *http.Request) {
+				tokenCalls++
+				_, _ = fmt.Fprint(w, "{}")
+			})
+			mux.HandleFunc(fmt.Sprintf("/api/v3/app/installations/%d/access_tokens", testInstallationID), func(w http.ResponseWriter, _ *http.Request) {
+				tokenCalls++
 				_, _ = fmt.Fprint(w, "{}")
 			})
 
@@ -1750,10 +1825,11 @@ func TestAppTokenGeneration(t *testing.T) {
 			tt.ctx = info.StoreCurrentControllerName(tt.ctx, "default")
 			tt.ctx = info.StoreNS(tt.ctx, tt.ctxNS)
 
-			_, err := gprovider.ParsePayload(tt.ctx, run, request, string(jeez))
+			event, err := gprovider.ParsePayload(tt.ctx, run, request, string(jeez))
 			if tt.wantErrSubst != "" {
 				assert.Assert(t, err != nil)
 				assert.ErrorContains(t, err, tt.wantErrSubst)
+				assert.Equal(t, tokenCalls, tt.wantTokenCalls)
 				if tt.wantLogMessage != "" {
 					found := false
 					for _, entry := range observedLogs.All() {
@@ -1767,6 +1843,11 @@ func TestAppTokenGeneration(t *testing.T) {
 				return
 			}
 			assert.NilError(t, err)
+			assert.Equal(t, tokenCalls, tt.wantTokenCalls)
+			if tt.wantProviderURL != "" {
+				assert.Equal(t, tt.wantProviderURL, event.Provider.URL)
+				assert.Equal(t, tt.wantGHEURL, event.GHEURL)
+			}
 			if tt.nilClient {
 				assert.Assert(t, gprovider.Client() == nil)
 				return
@@ -1774,8 +1855,202 @@ func TestAppTokenGeneration(t *testing.T) {
 
 			// Verify client was created successfully for GitHub App
 			assert.Assert(t, gprovider.Client() != nil)
+			if tt.wantPinnedHost != "" {
+				secret, err := tt.seedData.Kube.CoreV1().Secrets(tt.ctxNS).Get(tt.ctx, secretName, metav1.GetOptions{})
+				assert.NilError(t, err)
+				assert.Equal(t, string(secret.Data["github-host"]), tt.wantPinnedHost)
+			}
 		})
 	}
+}
+
+func TestGithubEndpointFromPayload(t *testing.T) {
+	tests := []struct {
+		name           string
+		enterpriseHost string
+		payload        string
+		wantErrSubstr  string
+		wantBaseURL    string
+		wantAPIURL     string
+		wantRepoHost   string
+	}{
+		{
+			name:           "enterprise payload with matching header",
+			enterpriseHost: "ghe.example.com",
+			payload:        `{"repository":{"html_url":"https://ghe.example.com/owner/repo"}}`,
+			wantBaseURL:    "https://ghe.example.com",
+			wantAPIURL:     "https://ghe.example.com/api/v3",
+			wantRepoHost:   "ghe.example.com",
+		},
+		{
+			name:         "public github payload without enterprise header",
+			payload:      `{"repository":{"html_url":"https://github.com/owner/repo"}}`,
+			wantAPIURL:   "https://api.github.com",
+			wantRepoHost: "github.com",
+		},
+		{
+			name:          "invalid json",
+			payload:       `{`,
+			wantErrSubstr: "unexpected end of JSON input",
+		},
+		{
+			name:          "missing repository URL",
+			payload:       `{"repository":{}}`,
+			wantErrSubstr: "repository HTML URL is missing",
+		},
+		{
+			name:          "rejects insecure repository URL",
+			payload:       `{"repository":{"html_url":"http://ghe.example.com/owner/repo"}}`,
+			wantErrSubstr: "invalid repository URL in GitHub payload",
+		},
+		{
+			name:          "rejects repository URL with userinfo",
+			payload:       `{"repository":{"html_url":"https://user@ghe.example.com/owner/repo"}}`,
+			wantErrSubstr: "invalid repository URL in GitHub payload",
+		},
+		{
+			name:           "rejects invalid enterprise header",
+			enterpriseHost: "http://ghe.example.com",
+			payload:        `{"repository":{"html_url":"https://ghe.example.com/owner/repo"}}`,
+			wantErrSubstr:  "invalid X-GitHub-Enterprise-Host header",
+		},
+		{
+			name:           "rejects mismatched enterprise header",
+			enterpriseHost: "other.example.com",
+			payload:        `{"repository":{"html_url":"https://ghe.example.com/owner/repo"}}`,
+			wantErrSubstr:  `does not match signed repository host "ghe.example.com"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			endpoint, err := githubEndpointFromPayload(tt.enterpriseHost, tt.payload)
+			if tt.wantErrSubstr != "" {
+				assert.ErrorContains(t, err, tt.wantErrSubstr)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, tt.wantBaseURL, endpoint.BaseURL)
+			assert.Equal(t, tt.wantAPIURL, endpoint.APIURL)
+			assert.Equal(t, tt.wantRepoHost, endpoint.RepositoryHost)
+		})
+	}
+}
+
+func TestParseEventTypeMissingHeader(t *testing.T) {
+	provider := &Provider{}
+	err := provider.parseEventType(&http.Request{Header: http.Header{}}, info.NewEvent())
+	assert.ErrorContains(t, err, "failed to find event type in request header")
+}
+
+func TestValidateAppWebhookSignatureRequiresControllerSecret(t *testing.T) {
+	const (
+		namespace  = "pipelinesascode"
+		secretName = "pipelines-as-code-secret"
+	)
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = info.StoreNS(ctx, namespace)
+	seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+		Secret: []*corev1.Secret{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: namespace,
+			},
+			Data: map[string][]byte{},
+		}},
+	})
+	payload := []byte(`{"repository":{"html_url":"https://github.com/owner/repo"}}`)
+	event := info.NewEvent()
+	event.Request = &info.Request{
+		Header:  http.Header{},
+		Payload: payload,
+	}
+	event.Request.Header.Set(github.SHA256SignatureHeader, githubSHA256Signature("webhook-secret", payload))
+	run := &params.Run{
+		Clients: clients.Clients{Kube: seedData.Kube},
+		Info: info.Info{
+			Controller: &info.ControllerInfo{Secret: secretName},
+		},
+	}
+
+	err := validateAppWebhookSignature(ctx, run, event)
+	assert.ErrorContains(t, err, "no webhook secret has been set in controller secret")
+}
+
+func TestGetAppTokenRejectsHostOutsidePin(t *testing.T) {
+	const (
+		namespace  = "pipelinesascode"
+		secretName = "pipelines-as-code-secret"
+	)
+	requests := 0
+	server := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requests++
+	}))
+	defer server.Close()
+	t.Setenv("PAC_GIT_PROVIDER_TOKEN_APIURL", server.URL+"/api/v3")
+
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = info.StoreNS(ctx, namespace)
+	seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+		Secret: []*corev1.Secret{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: namespace,
+			},
+			Data: map[string][]byte{
+				"github-host": []byte("github.com"),
+			},
+		}},
+	})
+	run := &params.Run{
+		Clients: clients.Clients{
+			Kube: seedData.Kube,
+		},
+		Info: info.Info{
+			Controller: &info.ControllerInfo{Secret: secretName},
+		},
+	}
+	gprovider := Provider{Run: run}
+
+	_, err := gprovider.GetAppToken(ctx, seedData.Kube, server.URL, 1, namespace)
+	assert.ErrorContains(t, err, "does not match controller-pinned GitHub host")
+	assert.Equal(t, requests, 0)
+}
+
+func TestGetAppTokenRejectsInvalidTokenAPIURL(t *testing.T) {
+	const (
+		namespace  = "pipelinesascode"
+		secretName = "pipelines-as-code-secret"
+	)
+	t.Setenv("PAC_GIT_PROVIDER_TOKEN_APIURL", "https://example.com/api/v3")
+
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = info.StoreNS(ctx, namespace)
+	seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+		Secret: []*corev1.Secret{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: namespace,
+			},
+			Data: map[string][]byte{
+				"github-application-id": []byte("12345"),
+				"github-private-key":    []byte(fakePrivateKey),
+				"github-host":           []byte("github.com"),
+			},
+		}},
+	})
+	run := &params.Run{
+		Clients: clients.Clients{
+			Kube: seedData.Kube,
+		},
+		Info: info.Info{
+			Controller: &info.ControllerInfo{Secret: secretName},
+		},
+	}
+	gprovider := Provider{Run: run}
+
+	_, err := gprovider.GetAppToken(ctx, seedData.Kube, "", 1, namespace)
+	assert.ErrorContains(t, err, "PAC_GIT_PROVIDER_TOKEN_APIURL must target a loopback IP address")
 }
 
 func TestGetAppTokenScopesRepositoryNames(t *testing.T) {

--- a/pkg/provider/github/parse_payload_test.go
+++ b/pkg/provider/github/parse_payload_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strconv"
 	"testing"
 	"time"
@@ -21,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	rtesting "knative.dev/pkg/reconciler/testing"
 
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
@@ -1976,10 +1978,12 @@ func TestAppTokenGeneration(t *testing.T) {
 	ctxNoSecret, _ := rtesting.SetupFakeContext(t)
 	noSecret, _ := testclient.SeedTestData(t, ctxNoSecret, testclient.Data{})
 	secretName := "pipelines-as-code-secret"
+	configMapName := "pipelines-as-code"
 
 	ctx, _ := rtesting.SetupFakeContext(t)
 	webhookSecret := "webhook-secret"
 	vaildSecret, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+		ConfigMap: emptyAllowlistConfigMap(),
 		Secret: []*corev1.Secret{
 			{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1997,6 +2001,7 @@ func TestAppTokenGeneration(t *testing.T) {
 
 	ctxInvalidAppID, _ := rtesting.SetupFakeContext(t)
 	invalidAppID, _ := testclient.SeedTestData(t, ctxInvalidAppID, testclient.Data{
+		ConfigMap: emptyAllowlistConfigMap(),
 		Secret: []*corev1.Secret{
 			{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2014,6 +2019,7 @@ func TestAppTokenGeneration(t *testing.T) {
 
 	ctxInvalidPrivateKey, _ := rtesting.SetupFakeContext(t)
 	invalidPrivateKey, _ := testclient.SeedTestData(t, ctxInvalidPrivateKey, testclient.Data{
+		ConfigMap: emptyAllowlistConfigMap(),
 		Secret: []*corev1.Secret{
 			{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2029,17 +2035,83 @@ func TestAppTokenGeneration(t *testing.T) {
 		},
 	})
 
+	ctxPinnedHost, _ := rtesting.SetupFakeContext(t)
+	pinnedHost, _ := testclient.SeedTestData(t, ctxPinnedHost, testclient.Data{
+		ConfigMap: []*corev1.ConfigMap{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configMapName,
+					Namespace: testNamespace,
+				},
+				Data: map[string]string{
+					settings.TrustedProviderHostnamesKey: "other.example.com",
+				},
+			},
+		},
+		Secret: []*corev1.Secret{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: testNamespace,
+				},
+				Data: map[string][]byte{
+					"github-application-id": []byte("12345"),
+					"github-private-key":    []byte(fakePrivateKey),
+					"webhook.secret":        []byte(webhookSecret),
+				},
+			},
+		},
+	})
+	ctxGHE, _ := rtesting.SetupFakeContext(t)
+	gheSecret, _ := testclient.SeedTestData(t, ctxGHE, testclient.Data{
+		ConfigMap: []*corev1.ConfigMap{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configMapName,
+					Namespace: testNamespace,
+				},
+				Data: map[string]string{},
+			},
+		},
+		Secret: []*corev1.Secret{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: testNamespace,
+				},
+				Data: map[string][]byte{
+					"github-application-id": []byte("12345"),
+					"github-private-key":    []byte(fakePrivateKey),
+					"webhook.secret":        []byte(webhookSecret),
+				},
+			},
+		},
+	})
+	ghePayloadEvent := samplePRevent
+	ghePayloadEvent.Installation = &github.Installation{ID: &testInstallationID}
+	gheRepository := *sampleRepo
+	gheRepository.HTMLURL = github.Ptr("https://github.example.com/owner/repo")
+	ghePayloadEvent.Repo = &gheRepository
+	ghePayload, err := json.Marshal(ghePayloadEvent)
+	assert.NilError(t, err)
+
 	tests := []struct {
-		ctx            context.Context
-		ctxNS          string
-		name           string
-		wantErrSubst   string
-		nilClient      bool
-		seedData       testclient.Clients
-		omitSignature  bool
-		enterpriseHost string
-		payload        string
-		wantLogMessage string
+		ctx             context.Context
+		ctxNS           string
+		name            string
+		wantErrSubst    string
+		nilClient       bool
+		seedData        testclient.Clients
+		omitSignature   bool
+		enterpriseHost  string
+		payload         string
+		wantLogMessage  string
+		wantLearnedHost string
+		wantTokenCalls  int
+		wantProviderURL string
+		wantGHEURL      string
+		wantNilEvent    bool
+		eventType       string
 	}{
 		{
 			name:           "secret not found",
@@ -2064,25 +2136,67 @@ func TestAppTokenGeneration(t *testing.T) {
 			ctxNS:          testNamespace,
 			seedData:       vaildSecret,
 			enterpriseHost: "127.0.0.1:1",
-			wantErrSubst:   `github enterprise host "127.0.0.1:1" does not match repository host "github.com"`,
+			wantErrSubst:   `GitHub enterprise header host "127.0.0.1:1" does not match signed repository host "github.com"`,
 			wantLogMessage: githubAppTokenExfiltrationBlockedLog,
 		},
 		{
-			ctx:            ctx,
-			name:           "enterprise host with missing repository HTML URL",
+			ctx: ctx,
+			// App-level deliveries do not need a provider client and must not use
+			// their unsigned enterprise header to select one.
+			name:           "installation delivery without repository is skipped",
 			ctxNS:          testNamespace,
 			seedData:       vaildSecret,
 			enterpriseHost: "127.0.0.1:1",
 			payload:        fmt.Sprintf(`{"installation":{"id":%d},"repository":{}}`, testInstallationID),
-			wantErrSubst:   "repository HTML URL is missing in payload, cannot validate enterprise host",
+			eventType:      "installation",
+			wantNilEvent:   true,
+		},
+		{
+			ctx:          ctx,
+			name:         "ping delivery without repository is skipped",
+			ctxNS:        testNamespace,
+			seedData:     vaildSecret,
+			payload:      `{"zen":"Keep it logically awesome.","hook_id":1}`,
+			eventType:    "ping",
+			wantNilEvent: true,
+		},
+		{
+			ctx:            ctx,
+			name:           "repository delivery without repository is refused",
+			ctxNS:          testNamespace,
+			seedData:       vaildSecret,
+			payload:        fmt.Sprintf(`{"installation":{"id":%d},"repository":{}}`, testInstallationID),
+			wantErrSubst:   "payload carries no repository",
 			wantLogMessage: githubAppTokenExfiltrationBlockedLog,
 		},
 		{
-			ctx:       ctx,
-			name:      "secret found",
-			ctxNS:     testNamespace,
-			seedData:  vaildSecret,
-			nilClient: false,
+			ctx:            ctxPinnedHost,
+			name:           "signed payload host outside the configured allowlist",
+			ctxNS:          testNamespace,
+			seedData:       pinnedHost,
+			payload:        string(ghePayload),
+			wantErrSubst:   "is not listed in",
+			wantLogMessage: githubAppTokenExfiltrationBlockedLog,
+		},
+		{
+			ctx:            ctx,
+			name:           "secret found",
+			ctxNS:          testNamespace,
+			seedData:       vaildSecret,
+			nilClient:      false,
+			wantTokenCalls: 1,
+		},
+		{
+			ctx:             ctxGHE,
+			name:            "authenticated enterprise payload configures event endpoints",
+			ctxNS:           testNamespace,
+			seedData:        gheSecret,
+			enterpriseHost:  "github.example.com",
+			payload:         string(ghePayload),
+			wantLearnedHost: "github.example.com",
+			wantTokenCalls:  1,
+			wantProviderURL: "https://github.example.com",
+			wantGHEURL:      "https://github.example.com",
 		},
 		{
 			ctx:          ctxInvalidAppID,
@@ -2103,7 +2217,13 @@ func TestAppTokenGeneration(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeghclient, mux, serverURL, teardown := ghtesthelper.SetupGH()
 			defer teardown()
+			tokenCalls := 0
 			mux.HandleFunc(fmt.Sprintf("/app/installations/%d/access_tokens", testInstallationID), func(w http.ResponseWriter, _ *http.Request) {
+				tokenCalls++
+				_, _ = fmt.Fprint(w, "{}")
+			})
+			mux.HandleFunc(fmt.Sprintf("/api/v3/app/installations/%d/access_tokens", testInstallationID), func(w http.ResponseWriter, _ *http.Request) {
+				tokenCalls++
 				_, _ = fmt.Fprint(w, "{}")
 			})
 
@@ -2132,12 +2252,16 @@ func TestAppTokenGeneration(t *testing.T) {
 				},
 
 				Info: info.Info{
-					Controller: &info.ControllerInfo{Secret: secretName},
+					Controller: &info.ControllerInfo{Secret: secretName, Configmap: configMapName},
 				},
 			}
 
 			request := &http.Request{Header: map[string][]string{}}
-			request.Header.Set("X-GitHub-Event", "pull_request")
+			eventType := tt.eventType
+			if eventType == "" {
+				eventType = "pull_request"
+			}
+			request.Header.Set("X-GitHub-Event", eventType)
 			if !tt.omitSignature {
 				request.Header.Set(github.SHA256SignatureHeader, githubSHA256Signature(webhookSecret, jeez))
 			}
@@ -2149,10 +2273,11 @@ func TestAppTokenGeneration(t *testing.T) {
 			tt.ctx = info.StoreCurrentControllerName(tt.ctx, "default")
 			tt.ctx = info.StoreNS(tt.ctx, tt.ctxNS)
 
-			_, err := gprovider.ParsePayload(tt.ctx, run, request, string(jeez))
+			event, err := gprovider.ParsePayload(tt.ctx, run, request, string(jeez))
 			if tt.wantErrSubst != "" {
 				assert.Assert(t, err != nil)
 				assert.ErrorContains(t, err, tt.wantErrSubst)
+				assert.Equal(t, tokenCalls, tt.wantTokenCalls)
 				if tt.wantLogMessage != "" {
 					found := false
 					for _, entry := range observedLogs.All() {
@@ -2166,6 +2291,15 @@ func TestAppTokenGeneration(t *testing.T) {
 				return
 			}
 			assert.NilError(t, err)
+			assert.Equal(t, tokenCalls, tt.wantTokenCalls)
+			if tt.wantNilEvent {
+				assert.Assert(t, event == nil)
+				return
+			}
+			if tt.wantProviderURL != "" {
+				assert.Equal(t, tt.wantProviderURL, event.Provider.URL)
+				assert.Equal(t, tt.wantGHEURL, event.GHEURL)
+			}
 			if tt.nilClient {
 				assert.Assert(t, gprovider.Client() == nil)
 				return
@@ -2173,8 +2307,206 @@ func TestAppTokenGeneration(t *testing.T) {
 
 			// Verify client was created successfully for GitHub App
 			assert.Assert(t, gprovider.Client() != nil)
+			if tt.wantLearnedHost != "" {
+				configMap, err := tt.seedData.Kube.CoreV1().ConfigMaps(tt.ctxNS).Get(tt.ctx, configMapName, metav1.GetOptions{})
+				assert.NilError(t, err)
+				assert.Equal(t, configMap.Data[settings.TrustedProviderHostnamesKey], "")
+				assert.Equal(t, configMap.Annotations[keys.AutoTrustedProviderHostnames], tt.wantLearnedHost)
+			}
 		})
 	}
+}
+
+func TestGithubEndpointFromPayload(t *testing.T) {
+	tests := []struct {
+		name           string
+		enterpriseHost string
+		payload        string
+		wantErrSubstr  string
+		wantBaseURL    string
+		wantAPIURL     string
+		wantRepoHost   string
+	}{
+		{
+			name:           "enterprise payload with matching header",
+			enterpriseHost: "ghe.example.com",
+			payload:        `{"repository":{"html_url":"https://ghe.example.com/owner/repo"}}`,
+			wantBaseURL:    "https://ghe.example.com",
+			wantAPIURL:     "https://ghe.example.com/api/v3",
+			wantRepoHost:   "ghe.example.com",
+		},
+		{
+			name:         "public github payload without enterprise header",
+			payload:      `{"repository":{"html_url":"https://github.com/owner/repo"}}`,
+			wantAPIURL:   "https://api.github.com",
+			wantRepoHost: "github.com",
+		},
+		{
+			name:          "invalid json",
+			payload:       `{`,
+			wantErrSubstr: "unexpected end of JSON input",
+		},
+		{
+			name:          "missing repository URL",
+			payload:       `{"repository":{}}`,
+			wantErrSubstr: "payload carries no repository",
+		},
+		{
+			name:          "rejects insecure repository URL",
+			payload:       `{"repository":{"html_url":"http://ghe.example.com/owner/repo"}}`,
+			wantErrSubstr: "invalid repository URL in GitHub payload",
+		},
+		{
+			name:          "rejects repository URL with userinfo",
+			payload:       `{"repository":{"html_url":"https://user@ghe.example.com/owner/repo"}}`,
+			wantErrSubstr: "invalid repository URL in GitHub payload",
+		},
+		{
+			name:           "rejects invalid enterprise header",
+			enterpriseHost: "http://ghe.example.com",
+			payload:        `{"repository":{"html_url":"https://ghe.example.com/owner/repo"}}`,
+			wantErrSubstr:  "invalid X-GitHub-Enterprise-Host header",
+		},
+		{
+			name:           "rejects mismatched enterprise header",
+			enterpriseHost: "other.example.com",
+			payload:        `{"repository":{"html_url":"https://ghe.example.com/owner/repo"}}`,
+			wantErrSubstr:  `does not match signed repository host "ghe.example.com"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			endpoint, err := githubEndpointFromPayload(tt.enterpriseHost, tt.payload)
+			if tt.wantErrSubstr != "" {
+				assert.ErrorContains(t, err, tt.wantErrSubstr)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, tt.wantBaseURL, endpoint.BaseURL)
+			assert.Equal(t, tt.wantAPIURL, endpoint.APIURL)
+			assert.Equal(t, tt.wantRepoHost, endpoint.RepositoryHost)
+		})
+	}
+}
+
+func TestParseEventTypeMissingHeader(t *testing.T) {
+	provider := &Provider{}
+	err := provider.parseEventType(&http.Request{Header: http.Header{}}, info.NewEvent())
+	assert.ErrorContains(t, err, "failed to find event type in request header")
+}
+
+func TestValidateAppWebhookSignatureRequiresControllerSecret(t *testing.T) {
+	const (
+		namespace  = "pipelinesascode"
+		secretName = "pipelines-as-code-secret"
+	)
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = info.StoreNS(ctx, namespace)
+	seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+		ConfigMap: emptyAllowlistConfigMap(),
+		Secret: []*corev1.Secret{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: namespace,
+			},
+			Data: map[string][]byte{},
+		}},
+	})
+	payload := []byte(`{"repository":{"html_url":"https://github.com/owner/repo"}}`)
+	event := info.NewEvent()
+	event.Request = &info.Request{
+		Header:  http.Header{},
+		Payload: payload,
+	}
+	event.Request.Header.Set(github.SHA256SignatureHeader, githubSHA256Signature("webhook-secret", payload))
+	run := &params.Run{
+		Clients: clients.Clients{Kube: seedData.Kube},
+		Info: info.Info{
+			Controller: &info.ControllerInfo{Secret: secretName},
+		},
+	}
+
+	err := validateAppWebhookSignature(ctx, run, event)
+	assert.ErrorContains(t, err, "no webhook secret has been set in controller secret")
+}
+
+func TestGetAppTokenRejectsUntrustedHost(t *testing.T) {
+	const (
+		namespace     = "pipelinesascode"
+		secretName    = "pipelines-as-code-secret"
+		configMapName = "pipelines-as-code"
+	)
+	requests := 0
+	server := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requests++
+	}))
+	defer server.Close()
+	t.Setenv("PAC_GIT_PROVIDER_TOKEN_APIURL", server.URL+"/api/v3")
+
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = info.StoreNS(ctx, namespace)
+	seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+		ConfigMap: []*corev1.ConfigMap{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      configMapName,
+				Namespace: namespace,
+			},
+			Data: map[string]string{
+				settings.TrustedProviderHostnamesKey: "github.com",
+			},
+		}},
+	})
+	run := &params.Run{
+		Clients: clients.Clients{
+			Kube: seedData.Kube,
+		},
+		Info: info.Info{
+			Controller: &info.ControllerInfo{Secret: secretName, Configmap: configMapName},
+		},
+	}
+	gprovider := Provider{Run: run}
+
+	// The test server host is not in the allowlist: no JWT must ever reach it.
+	_, err := gprovider.GetAppToken(ctx, seedData.Kube, server.URL, 1, namespace)
+	assert.ErrorContains(t, err, "is not listed in")
+	assert.Equal(t, requests, 0)
+}
+
+func TestGetAppTokenRejectsInvalidTokenAPIURL(t *testing.T) {
+	const (
+		namespace  = "pipelinesascode"
+		secretName = "pipelines-as-code-secret"
+	)
+	t.Setenv("PAC_GIT_PROVIDER_TOKEN_APIURL", "https://example.com/api/v3")
+
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = info.StoreNS(ctx, namespace)
+	seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+		ConfigMap: emptyAllowlistConfigMap(),
+		Secret: []*corev1.Secret{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: namespace,
+			},
+			Data: map[string][]byte{
+				"github-application-id": []byte("12345"),
+				"github-private-key":    []byte(fakePrivateKey),
+			},
+		}},
+	})
+	run := &params.Run{
+		Clients: clients.Clients{
+			Kube: seedData.Kube,
+		},
+		Info: info.Info{
+			Controller: &info.ControllerInfo{Secret: secretName},
+		},
+	}
+	gprovider := Provider{Run: run}
+
+	_, err := gprovider.GetAppToken(ctx, seedData.Kube, "", 1, namespace)
+	assert.ErrorContains(t, err, "PAC_GIT_PROVIDER_TOKEN_APIURL must target a loopback IP address")
 }
 
 func TestGetAppTokenScopesRepositoryNames(t *testing.T) {
@@ -2183,6 +2515,7 @@ func TestGetAppTokenScopesRepositoryNames(t *testing.T) {
 
 	ctx, _ := rtesting.SetupFakeContext(t)
 	seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+		ConfigMap: emptyAllowlistConfigMap(),
 		Secret: []*corev1.Secret{
 			{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2239,6 +2572,7 @@ func TestGetAppTokenScopesRepositoryNames(t *testing.T) {
 				RepositoryIDs:   tt.repositoryIDs,
 				RepositoryNames: tt.repositoryNames,
 				Run: &params.Run{
+					Clients: clients.Clients{Kube: seedData.Kube},
 					Info: info.Info{
 						Controller: &info.ControllerInfo{Secret: secretName},
 					},

--- a/pkg/provider/github/parse_payload_test.go
+++ b/pkg/provider/github/parse_payload_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -1630,17 +1631,63 @@ func TestAppTokenGeneration(t *testing.T) {
 		},
 	})
 
+	ctxPinnedHost, _ := rtesting.SetupFakeContext(t)
+	pinnedHost, _ := testclient.SeedTestData(t, ctxPinnedHost, testclient.Data{
+		Secret: []*corev1.Secret{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: testNamespace,
+				},
+				Data: map[string][]byte{
+					"github-application-id": []byte("12345"),
+					"github-private-key":    []byte(fakePrivateKey),
+					"webhook.secret":        []byte(webhookSecret),
+					"github-host":           []byte("github.example.com"),
+				},
+			},
+		},
+	})
+
+	ctxGHE, _ := rtesting.SetupFakeContext(t)
+	gheSecret, _ := testclient.SeedTestData(t, ctxGHE, testclient.Data{
+		Secret: []*corev1.Secret{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: testNamespace,
+				},
+				Data: map[string][]byte{
+					"github-application-id": []byte("12345"),
+					"github-private-key":    []byte(fakePrivateKey),
+					"webhook.secret":        []byte(webhookSecret),
+				},
+			},
+		},
+	})
+	ghePayloadEvent := samplePRevent
+	ghePayloadEvent.Installation = &github.Installation{ID: &testInstallationID}
+	gheRepository := *sampleRepo
+	gheRepository.HTMLURL = github.Ptr("https://github.example.com/owner/repo")
+	ghePayloadEvent.Repo = &gheRepository
+	ghePayload, err := json.Marshal(ghePayloadEvent)
+	assert.NilError(t, err)
+
 	tests := []struct {
-		ctx            context.Context
-		ctxNS          string
-		name           string
-		wantErrSubst   string
-		nilClient      bool
-		seedData       testclient.Clients
-		omitSignature  bool
-		enterpriseHost string
-		payload        string
-		wantLogMessage string
+		ctx             context.Context
+		ctxNS           string
+		name            string
+		wantErrSubst    string
+		nilClient       bool
+		seedData        testclient.Clients
+		omitSignature   bool
+		enterpriseHost  string
+		payload         string
+		wantLogMessage  string
+		wantPinnedHost  string
+		wantTokenCalls  int
+		wantProviderURL string
+		wantGHEURL      string
 	}{
 		{
 			name:           "secret not found",
@@ -1665,7 +1712,7 @@ func TestAppTokenGeneration(t *testing.T) {
 			ctxNS:          testNamespace,
 			seedData:       vaildSecret,
 			enterpriseHost: "127.0.0.1:1",
-			wantErrSubst:   `github enterprise host "127.0.0.1:1" does not match repository host "github.com"`,
+			wantErrSubst:   `GitHub enterprise header host "127.0.0.1:1" does not match signed repository host "github.com"`,
 			wantLogMessage: githubAppTokenExfiltrationBlockedLog,
 		},
 		{
@@ -1679,11 +1726,32 @@ func TestAppTokenGeneration(t *testing.T) {
 			wantLogMessage: githubAppTokenExfiltrationBlockedLog,
 		},
 		{
-			ctx:       ctx,
-			name:      "secret found",
-			ctxNS:     testNamespace,
-			seedData:  vaildSecret,
-			nilClient: false,
+			ctx:            ctxPinnedHost,
+			name:           "signed payload conflicts with pinned host",
+			ctxNS:          testNamespace,
+			seedData:       pinnedHost,
+			wantErrSubst:   `authenticated GitHub host "github.com" conflicts with controller-pinned host "github.example.com"`,
+			wantLogMessage: githubAppTokenExfiltrationBlockedLog,
+		},
+		{
+			ctx:            ctx,
+			name:           "secret found",
+			ctxNS:          testNamespace,
+			seedData:       vaildSecret,
+			nilClient:      false,
+			wantTokenCalls: 1,
+		},
+		{
+			ctx:             ctxGHE,
+			name:            "authenticated enterprise payload configures event endpoints",
+			ctxNS:           testNamespace,
+			seedData:        gheSecret,
+			enterpriseHost:  "github.example.com",
+			payload:         string(ghePayload),
+			wantPinnedHost:  "github.example.com",
+			wantTokenCalls:  1,
+			wantProviderURL: "https://github.example.com",
+			wantGHEURL:      "https://github.example.com",
 		},
 		{
 			ctx:          ctxInvalidAppID,
@@ -1704,7 +1772,13 @@ func TestAppTokenGeneration(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeghclient, mux, serverURL, teardown := ghtesthelper.SetupGH()
 			defer teardown()
+			tokenCalls := 0
 			mux.HandleFunc(fmt.Sprintf("/app/installations/%d/access_tokens", testInstallationID), func(w http.ResponseWriter, _ *http.Request) {
+				tokenCalls++
+				_, _ = fmt.Fprint(w, "{}")
+			})
+			mux.HandleFunc(fmt.Sprintf("/api/v3/app/installations/%d/access_tokens", testInstallationID), func(w http.ResponseWriter, _ *http.Request) {
+				tokenCalls++
 				_, _ = fmt.Fprint(w, "{}")
 			})
 
@@ -1750,10 +1824,11 @@ func TestAppTokenGeneration(t *testing.T) {
 			tt.ctx = info.StoreCurrentControllerName(tt.ctx, "default")
 			tt.ctx = info.StoreNS(tt.ctx, tt.ctxNS)
 
-			_, err := gprovider.ParsePayload(tt.ctx, run, request, string(jeez))
+			event, err := gprovider.ParsePayload(tt.ctx, run, request, string(jeez))
 			if tt.wantErrSubst != "" {
 				assert.Assert(t, err != nil)
 				assert.ErrorContains(t, err, tt.wantErrSubst)
+				assert.Equal(t, tokenCalls, tt.wantTokenCalls)
 				if tt.wantLogMessage != "" {
 					found := false
 					for _, entry := range observedLogs.All() {
@@ -1767,6 +1842,11 @@ func TestAppTokenGeneration(t *testing.T) {
 				return
 			}
 			assert.NilError(t, err)
+			assert.Equal(t, tokenCalls, tt.wantTokenCalls)
+			if tt.wantProviderURL != "" {
+				assert.Equal(t, tt.wantProviderURL, event.Provider.URL)
+				assert.Equal(t, tt.wantGHEURL, event.GHEURL)
+			}
 			if tt.nilClient {
 				assert.Assert(t, gprovider.Client() == nil)
 				return
@@ -1774,8 +1854,202 @@ func TestAppTokenGeneration(t *testing.T) {
 
 			// Verify client was created successfully for GitHub App
 			assert.Assert(t, gprovider.Client() != nil)
+			if tt.wantPinnedHost != "" {
+				secret, err := tt.seedData.Kube.CoreV1().Secrets(tt.ctxNS).Get(tt.ctx, secretName, metav1.GetOptions{})
+				assert.NilError(t, err)
+				assert.Equal(t, string(secret.Data["github-host"]), tt.wantPinnedHost)
+			}
 		})
 	}
+}
+
+func TestGithubEndpointFromPayload(t *testing.T) {
+	tests := []struct {
+		name           string
+		enterpriseHost string
+		payload        string
+		wantErrSubstr  string
+		wantBaseURL    string
+		wantAPIURL     string
+		wantRepoHost   string
+	}{
+		{
+			name:           "enterprise payload with matching header",
+			enterpriseHost: "ghe.example.com",
+			payload:        `{"repository":{"html_url":"https://ghe.example.com/owner/repo"}}`,
+			wantBaseURL:    "https://ghe.example.com",
+			wantAPIURL:     "https://ghe.example.com/api/v3",
+			wantRepoHost:   "ghe.example.com",
+		},
+		{
+			name:         "public github payload without enterprise header",
+			payload:      `{"repository":{"html_url":"https://github.com/owner/repo"}}`,
+			wantAPIURL:   "https://api.github.com",
+			wantRepoHost: "github.com",
+		},
+		{
+			name:          "invalid json",
+			payload:       `{`,
+			wantErrSubstr: "unexpected end of JSON input",
+		},
+		{
+			name:          "missing repository URL",
+			payload:       `{"repository":{}}`,
+			wantErrSubstr: "repository HTML URL is missing",
+		},
+		{
+			name:          "rejects insecure repository URL",
+			payload:       `{"repository":{"html_url":"http://ghe.example.com/owner/repo"}}`,
+			wantErrSubstr: "invalid repository URL in GitHub payload",
+		},
+		{
+			name:          "rejects repository URL with userinfo",
+			payload:       `{"repository":{"html_url":"https://user@ghe.example.com/owner/repo"}}`,
+			wantErrSubstr: "invalid repository URL in GitHub payload",
+		},
+		{
+			name:           "rejects invalid enterprise header",
+			enterpriseHost: "http://ghe.example.com",
+			payload:        `{"repository":{"html_url":"https://ghe.example.com/owner/repo"}}`,
+			wantErrSubstr:  "invalid X-GitHub-Enterprise-Host header",
+		},
+		{
+			name:           "rejects mismatched enterprise header",
+			enterpriseHost: "other.example.com",
+			payload:        `{"repository":{"html_url":"https://ghe.example.com/owner/repo"}}`,
+			wantErrSubstr:  `does not match signed repository host "ghe.example.com"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			endpoint, err := githubEndpointFromPayload(tt.enterpriseHost, tt.payload)
+			if tt.wantErrSubstr != "" {
+				assert.ErrorContains(t, err, tt.wantErrSubstr)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, tt.wantBaseURL, endpoint.BaseURL)
+			assert.Equal(t, tt.wantAPIURL, endpoint.APIURL)
+			assert.Equal(t, tt.wantRepoHost, endpoint.RepositoryHost)
+		})
+	}
+}
+
+func TestParseEventTypeMissingHeader(t *testing.T) {
+	provider := &Provider{}
+	err := provider.parseEventType(&http.Request{Header: http.Header{}}, info.NewEvent())
+	assert.ErrorContains(t, err, "failed to find event type in request header")
+}
+
+func TestValidateAppWebhookSignatureRequiresControllerSecret(t *testing.T) {
+	const (
+		namespace  = "pipelinesascode"
+		secretName = "pipelines-as-code-secret"
+	)
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = info.StoreNS(ctx, namespace)
+	seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+		Secret: []*corev1.Secret{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: namespace,
+			},
+			Data: map[string][]byte{},
+		}},
+	})
+	payload := []byte(`{"repository":{"html_url":"https://github.com/owner/repo"}}`)
+	event := info.NewEvent()
+	event.Request = &info.Request{
+		Header:  http.Header{},
+		Payload: payload,
+	}
+	event.Request.Header.Set(github.SHA256SignatureHeader, githubSHA256Signature("webhook-secret", payload))
+	run := &params.Run{
+		Clients: clients.Clients{Kube: seedData.Kube},
+		Info: info.Info{
+			Controller: &info.ControllerInfo{Secret: secretName},
+		},
+	}
+
+	err := validateAppWebhookSignature(ctx, run, event)
+	assert.ErrorContains(t, err, "no webhook secret has been set in controller secret")
+}
+
+func TestGetAppTokenRejectsHostOutsidePin(t *testing.T) {
+	const (
+		namespace  = "pipelinesascode"
+		secretName = "pipelines-as-code-secret"
+	)
+	requests := 0
+	server := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requests++
+	}))
+	defer server.Close()
+	t.Setenv("PAC_GIT_PROVIDER_TOKEN_APIURL", server.URL+"/api/v3")
+
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = info.StoreNS(ctx, namespace)
+	seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+		Secret: []*corev1.Secret{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: namespace,
+			},
+			Data: map[string][]byte{
+				"github-host": []byte("github.com"),
+			},
+		}},
+	})
+	run := &params.Run{
+		Clients: clients.Clients{
+			Kube: seedData.Kube,
+		},
+		Info: info.Info{
+			Controller: &info.ControllerInfo{Secret: secretName},
+		},
+	}
+	gprovider := Provider{Run: run}
+
+	_, err := gprovider.GetAppToken(ctx, seedData.Kube, server.URL, 1, namespace)
+	assert.ErrorContains(t, err, "does not match controller-pinned GitHub host")
+	assert.Equal(t, requests, 0)
+}
+
+func TestGetAppTokenRejectsInvalidTokenAPIURL(t *testing.T) {
+	const (
+		namespace  = "pipelinesascode"
+		secretName = "pipelines-as-code-secret"
+	)
+	t.Setenv("PAC_GIT_PROVIDER_TOKEN_APIURL", "https://example.com/api/v3")
+
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = info.StoreNS(ctx, namespace)
+	seedData, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+		Secret: []*corev1.Secret{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: namespace,
+			},
+			Data: map[string][]byte{
+				"github-application-id": []byte("12345"),
+				"github-private-key":    []byte(fakePrivateKey),
+				"github-host":           []byte("github.com"),
+			},
+		}},
+	})
+	run := &params.Run{
+		Clients: clients.Clients{
+			Kube: seedData.Kube,
+		},
+		Info: info.Info{
+			Controller: &info.ControllerInfo{Secret: secretName},
+		},
+	}
+	gprovider := Provider{Run: run}
+
+	_, err := gprovider.GetAppToken(ctx, seedData.Kube, "", 1, namespace)
+	assert.ErrorContains(t, err, "PAC_GIT_PROVIDER_TOKEN_APIURL must target a loopback IP address")
 }
 
 func TestGetAppTokenScopesRepositoryNames(t *testing.T) {

--- a/pkg/provider/github/scope_test.go
+++ b/pkg/provider/github/scope_test.go
@@ -183,6 +183,7 @@ func TestScopeTokenToListOfRepos(t *testing.T) {
 			tData: testclient.Data{
 				Namespaces: []*corev1.Namespace{testNamespace},
 				Secret:     []*corev1.Secret{validSecret},
+				ConfigMap:  emptyAllowlistConfigMap(),
 			},
 			repository: &v1alpha1.Repository{
 				TypeMeta: metav1.TypeMeta{},
@@ -204,6 +205,7 @@ func TestScopeTokenToListOfRepos(t *testing.T) {
 			tData: testclient.Data{
 				Namespaces: []*corev1.Namespace{testNamespace},
 				Secret:     []*corev1.Secret{validSecret},
+				ConfigMap:  emptyAllowlistConfigMap(),
 				Repositories: []*v1alpha1.Repository{
 					repoData, repoData1,
 				},
@@ -219,6 +221,7 @@ func TestScopeTokenToListOfRepos(t *testing.T) {
 			tData: testclient.Data{
 				Namespaces: []*corev1.Namespace{testNamespace},
 				Secret:     []*corev1.Secret{validSecret},
+				ConfigMap:  emptyAllowlistConfigMap(),
 				Repositories: []*v1alpha1.Repository{
 					repoData,
 				},
@@ -233,6 +236,7 @@ func TestScopeTokenToListOfRepos(t *testing.T) {
 			tData: testclient.Data{
 				Namespaces: []*corev1.Namespace{testNamespace},
 				Secret:     []*corev1.Secret{validSecret},
+				ConfigMap:  emptyAllowlistConfigMap(),
 				Repositories: []*v1alpha1.Repository{
 					repoData, repoData1,
 				},
@@ -248,6 +252,7 @@ func TestScopeTokenToListOfRepos(t *testing.T) {
 			tData: testclient.Data{
 				Namespaces: []*corev1.Namespace{testNamespace},
 				Secret:     []*corev1.Secret{validSecret},
+				ConfigMap:  emptyAllowlistConfigMap(),
 				Repositories: []*v1alpha1.Repository{
 					repoData, repoData1,
 				},
@@ -263,6 +268,7 @@ func TestScopeTokenToListOfRepos(t *testing.T) {
 			tData: testclient.Data{
 				Namespaces: []*corev1.Namespace{testNamespace},
 				Secret:     []*corev1.Secret{validSecret},
+				ConfigMap:  emptyAllowlistConfigMap(),
 				Repositories: []*v1alpha1.Repository{
 					repoData, repoData1,
 				},
@@ -279,6 +285,7 @@ func TestScopeTokenToListOfRepos(t *testing.T) {
 			tData: testclient.Data{
 				Namespaces: []*corev1.Namespace{testNamespace},
 				Secret:     []*corev1.Secret{validSecret},
+				ConfigMap:  emptyAllowlistConfigMap(),
 				Repositories: []*v1alpha1.Repository{
 					repoDataGlobAndExact, repoData1, repoData2, repoData3,
 				},
@@ -294,6 +301,7 @@ func TestScopeTokenToListOfRepos(t *testing.T) {
 			tData: testclient.Data{
 				Namespaces: []*corev1.Namespace{testNamespace},
 				Secret:     []*corev1.Secret{validSecret},
+				ConfigMap:  emptyAllowlistConfigMap(),
 				Repositories: []*v1alpha1.Repository{
 					repoDataInvalidGlob, repoData1,
 				},
@@ -308,6 +316,7 @@ func TestScopeTokenToListOfRepos(t *testing.T) {
 			tData: testclient.Data{
 				Namespaces: []*corev1.Namespace{testNamespace},
 				Secret:     []*corev1.Secret{validSecret},
+				ConfigMap:  emptyAllowlistConfigMap(),
 				Repositories: []*v1alpha1.Repository{
 					repoDataGlobNoMatch, repoData1,
 				},
@@ -322,6 +331,7 @@ func TestScopeTokenToListOfRepos(t *testing.T) {
 			tData: testclient.Data{
 				Namespaces: []*corev1.Namespace{testNamespace},
 				Secret:     []*corev1.Secret{validSecret},
+				ConfigMap:  emptyAllowlistConfigMap(),
 			},
 			repository: &v1alpha1.Repository{
 				TypeMeta: metav1.TypeMeta{},
@@ -342,6 +352,7 @@ func TestScopeTokenToListOfRepos(t *testing.T) {
 			tData: testclient.Data{
 				Namespaces: []*corev1.Namespace{testNamespace},
 				Secret:     []*corev1.Secret{validSecret},
+				ConfigMap:  emptyAllowlistConfigMap(),
 				Repositories: []*v1alpha1.Repository{
 					repoData, repoDataMalformed,
 				},
@@ -368,6 +379,7 @@ func TestScopeTokenToListOfRepos(t *testing.T) {
 			tData: testclient.Data{
 				Namespaces: []*corev1.Namespace{testNamespace},
 				Secret:     []*corev1.Secret{validSecret},
+				ConfigMap:  emptyAllowlistConfigMap(),
 				Repositories: []*v1alpha1.Repository{
 					repoDataMalformedPattern, repoData1,
 				},
@@ -382,6 +394,7 @@ func TestScopeTokenToListOfRepos(t *testing.T) {
 			tData: testclient.Data{
 				Namespaces: []*corev1.Namespace{testNamespace},
 				Secret:     []*corev1.Secret{validSecret},
+				ConfigMap:  emptyAllowlistConfigMap(),
 			},
 			repository: &v1alpha1.Repository{
 				TypeMeta: metav1.TypeMeta{},

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -347,6 +347,24 @@ func (v *Provider) SetClient(ctx context.Context, run *params.Run, runevent *inf
 	return v.setClient(ctx, run, runevent, repo, eventsEmitter, true)
 }
 
+// refuseInheritedCredentialForPayloadHost stops a token that belongs to the
+// controller namespace from being sent to an API host the payload chose.
+//
+// A Repository that omits git_provider.secret inherits the one of the global
+// Repository. If the global Repository also omits git_provider.url, the endpoint
+// falls back to the project URL carried in the webhook, which is unauthenticated
+// at this point: anyone able to create a Repository CR in any namespace could
+// then have the shared token delivered to a host of their choosing.
+func refuseInheritedCredentialForPayloadHost(runevent *info.Event) error {
+	if runevent.Provider == nil || !runevent.Provider.GitProviderSecretFromGlobalRepo {
+		return nil
+	}
+	return fmt.Errorf(
+		"refusing to send the credentials inherited from the global repository to an API host derived from the payload: " +
+			"set git_provider.url on the global repository, or give the repository its own git_provider.secret",
+	)
+}
+
 func (v *Provider) setClient(ctx context.Context, run *params.Run, runevent *info.Event, repo *v1alpha1.Repository, eventsEmitter *events.EventEmitter, rotateToken bool) error {
 	var err error
 	if runevent.Provider.Token == "" {
@@ -365,8 +383,14 @@ func (v *Provider) setClient(ctx context.Context, run *params.Run, runevent *inf
 	case runevent.Provider.URL != "":
 		apiURL = runevent.Provider.URL
 	case v.repoURL != "" && !strings.HasPrefix(v.repoURL, apiPublicURL):
+		if err := refuseInheritedCredentialForPayloadHost(runevent); err != nil {
+			return err
+		}
 		apiURL = strings.ReplaceAll(v.repoURL, v.pathWithNamespace, "")
 	case runevent.URL != "":
+		if err := refuseInheritedCredentialForPayloadHost(runevent); err != nil {
+			return err
+		}
 		burl, err := url.Parse(runevent.URL)
 		if err != nil {
 			return err

--- a/pkg/provider/gitlab/gitlab_test.go
+++ b/pkg/provider/gitlab/gitlab_test.go
@@ -1403,6 +1403,7 @@ func TestSetClientDetectAPIURL(t *testing.T) {
 		repoURL           string // input: v.repoURL
 		pathWithNamespace string // input: v.pathWithNamespace (needed if repoURL is used)
 		eventURL          string // input: event.URL
+		inheritedSecret   bool   // input: event.Provider.GitProviderSecretFromGlobalRepo
 		// Define expected outcomes
 		expectedAPIURL string
 		expectedError  string // Substring expected in the error message, "" for no error
@@ -1461,6 +1462,24 @@ func TestSetClientDetectAPIURL(t *testing.T) {
 			expectedError:     "",
 		},
 		{
+			// The token belongs to the controller namespace, so the API host must
+			// not come from a payload anyone can send.
+			name:              "Error: inherited credential with a payload derived host",
+			providerToken:     "token",
+			providerURL:       "",
+			repoURL:           "https://attacker.example/my/repo",
+			pathWithNamespace: "my/repo",
+			inheritedSecret:   true,
+			expectedError:     "refusing to send the credentials inherited from the global repository",
+		},
+		{
+			name:            "Success: inherited credential with an explicit provider url",
+			providerToken:   "token",
+			providerURL:     "https://gitlab.example.com",
+			inheritedSecret: true,
+			expectedAPIURL:  "https://gitlab.example.com",
+		},
+		{
 			name:          "Error: Invalid URL from event.URL",
 			providerToken: "token",
 			providerURL:   "",
@@ -1501,6 +1520,7 @@ func TestSetClientDetectAPIURL(t *testing.T) {
 			event := info.NewEvent()
 			event.Provider.Token = tc.providerToken
 			event.Provider.URL = tc.providerURL
+			event.Provider.GitProviderSecretFromGlobalRepo = tc.inheritedSecret
 			event.URL = tc.eventURL
 			// Set some default IDs to avoid potential nil pointer issues or side effects
 			// if the GetProject part of SetClient is reached unexpectedly.

--- a/pkg/provider/gitlab/parse_payload.go
+++ b/pkg/provider/gitlab/parse_payload.go
@@ -219,9 +219,8 @@ func (v *Provider) initGitLabClient(ctx context.Context, event *info.Event) (*in
 		ctx, v.run.Info.Controller.GlobalRepository, metav1.GetOptions{},
 	)
 	if err == nil && globalRepo != nil {
-		if repo.Spec.GitProvider != nil && repo.Spec.GitProvider.Secret == nil && globalRepo.Spec.GitProvider != nil && globalRepo.Spec.GitProvider.Secret != nil {
-			secretNS = globalRepo.GetNamespace()
-			inheritedGlobalSecret = true
+		if secretNS, inheritedGlobalSecret, err = secrets.ResolveInheritedSecret(repo, globalRepo); err != nil {
+			return event, err
 		}
 		repo.Spec.Merge(globalRepo.Spec)
 	}

--- a/pkg/reconciler/finalizer.go
+++ b/pkg/reconciler/finalizer.go
@@ -17,11 +17,23 @@ import (
 )
 
 func (r *Reconciler) FinalizeKind(ctx context.Context, pr *tektonv1.PipelineRun) pkgreconciler.Event {
+	finalizeRun := *r.run
+	reconciler := *r
+	reconciler.run = &finalizeRun
+	return reconciler.finalizeKind(ctx, pr)
+}
+
+func (r *Reconciler) finalizeKind(ctx context.Context, pr *tektonv1.PipelineRun) pkgreconciler.Event {
 	logger := logging.FromContext(ctx)
 	state, exist := pr.GetAnnotations()[keys.State]
 	if !exist || state == kubeinteraction.StateCompleted {
 		return nil
 	}
+	controllerInfo, err := controllerInfoForPipelineRun(pr, r.run.Info.Controller)
+	if err != nil {
+		return err
+	}
+	r.run.Info.Controller = controllerInfo
 
 	if state == kubeinteraction.StateQueued || state == kubeinteraction.StateStarted {
 		repoName, ok := pr.GetAnnotations()[keys.Repository]

--- a/pkg/reconciler/finalizer.go
+++ b/pkg/reconciler/finalizer.go
@@ -8,20 +8,39 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/status"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/logging"
 	pkgreconciler "knative.dev/pkg/reconciler"
+	"knative.dev/pkg/system"
 )
 
 func (r *Reconciler) FinalizeKind(ctx context.Context, pr *tektonv1.PipelineRun) pkgreconciler.Event {
+	finalizeRun := *r.run
+	reconciler := *r
+	reconciler.run = &finalizeRun
+	return reconciler.finalizeKind(ctx, pr)
+}
+
+func (r *Reconciler) finalizeKind(ctx context.Context, pr *tektonv1.PipelineRun) pkgreconciler.Event {
 	logger := logging.FromContext(ctx)
+	// Knative hands the reconciler a bare context, and reporting a cancellation
+	// needs a provider client, which reads the trust policy from the controller
+	// ConfigMap. Without the namespace that read targets "" and every deletion
+	// of a running PipelineRun would silently stop reporting.
+	ctx = info.StoreNS(ctx, system.Namespace())
 	state, exist := pr.GetAnnotations()[keys.State]
 	if !exist || state == kubeinteraction.StateCompleted {
 		return nil
 	}
+	controllerInfo, err := controllerInfoForPipelineRun(pr, r.run.Info.Controller)
+	if err != nil {
+		return err
+	}
+	r.run.Info.Controller = controllerInfo
 
 	if state == kubeinteraction.StateQueued || state == kubeinteraction.StateStarted {
 		repoName, ok := pr.GetAnnotations()[keys.Repository]

--- a/pkg/reconciler/finalizer_test.go
+++ b/pkg/reconciler/finalizer_test.go
@@ -68,6 +68,140 @@ func getTestPR(name, state string) *tektonv1.PipelineRun {
 	}
 }
 
+func TestControllerInfoForPipelineRun(t *testing.T) {
+	fallback := &info.ControllerInfo{Name: "default", Secret: "default-secret"}
+	tests := []struct {
+		name       string
+		annotation string
+		fallback   *info.ControllerInfo
+		want       *info.ControllerInfo
+		wantErrSub string
+	}{
+		{
+			name:       "controller annotation",
+			annotation: `{"name":"secondary","configmap":"secondary-config","secret":"secondary-secret","gRepo":"secondary-global"}`,
+			fallback:   fallback,
+			want: &info.ControllerInfo{
+				Name:             "secondary",
+				Configmap:        "secondary-config",
+				Secret:           "secondary-secret",
+				GlobalRepository: "secondary-global",
+			},
+		},
+		{
+			name:     "fallback controller",
+			fallback: fallback,
+			want:     fallback,
+		},
+		{
+			name:     "default controller without fallback",
+			fallback: nil,
+			want: &info.ControllerInfo{
+				Name:             "default",
+				Configmap:        info.DefaultPipelinesAscodeConfigmapName,
+				Secret:           info.DefaultPipelinesAscodeSecretName,
+				GlobalRepository: info.DefaultGlobalRepoName,
+			},
+		},
+		{
+			name:       "invalid annotation",
+			annotation: "{",
+			fallback:   fallback,
+			wantErrSub: "failed to parse controllerInfo",
+		},
+		{
+			name:       "null annotation",
+			annotation: "null",
+			fallback:   fallback,
+			wantErrSub: "value must not be null",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("PAC_CONTROLLER_LABEL", "default")
+			t.Setenv("PAC_CONTROLLER_SECRET", info.DefaultPipelinesAscodeSecretName)
+			t.Setenv("PAC_CONTROLLER_CONFIGMAP", info.DefaultPipelinesAscodeConfigmapName)
+			t.Setenv("PAC_CONTROLLER_GLOBAL_REPOSITORY", info.DefaultGlobalRepoName)
+
+			pr := &tektonv1.PipelineRun{}
+			if tt.annotation != "" {
+				pr.Annotations = map[string]string{keys.ControllerInfo: tt.annotation}
+			}
+			got, err := controllerInfoForPipelineRun(pr, tt.fallback)
+			if tt.wantErrSub != "" {
+				assert.ErrorContains(t, err, tt.wantErrSub)
+				return
+			}
+			assert.NilError(t, err)
+			assert.DeepEqual(t, got, tt.want)
+			if tt.fallback != nil {
+				assert.Assert(t, got != tt.fallback, "controller info must be copied per reconciliation")
+			}
+		})
+	}
+}
+
+func TestFinalizeKindControllerInfoHandling(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotation  string
+		wantErrSub  string
+		wantControl *info.ControllerInfo
+	}{
+		{
+			name:       "invalid controller annotation",
+			annotation: "{",
+			wantErrSub: "failed to parse controllerInfo",
+		},
+		{
+			name:        "controller annotation does not mutate shared run",
+			annotation:  `{"name":"secondary","configmap":"secondary-config","secret":"secondary-secret","gRepo":"secondary-global"}`,
+			wantControl: &info.ControllerInfo{Name: "default", Secret: "default-secret", GlobalRepository: "default-global"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			observer, _ := zapobserver.New(zap.InfoLevel)
+			logger := zap.New(observer).Sugar()
+			controller := &info.ControllerInfo{Name: "default", Secret: "default-secret", GlobalRepository: "default-global"}
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pr",
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						keys.State:          kubeinteraction.StateStarted,
+						keys.ControllerInfo: tt.annotation,
+					},
+				},
+			}
+			r := &Reconciler{
+				run: &params.Run{
+					Clients: clients.Clients{Log: logger},
+					Info: info.Info{
+						Kube:       &info.KubeOpts{Namespace: "global"},
+						Controller: controller,
+						Pac:        info.NewPacOpts(),
+					},
+				},
+			}
+
+			err := r.FinalizeKind(ctx, pr)
+			if tt.wantErrSub != "" {
+				assert.ErrorContains(t, err, tt.wantErrSub)
+			} else {
+				assert.NilError(t, err)
+			}
+			if tt.wantControl != nil {
+				assert.DeepEqual(t, r.run.Info.Controller, tt.wantControl)
+				assert.Assert(t, r.run.Info.Controller == controller, "finalize must keep the shared controller pointer")
+			}
+		})
+	}
+}
+
 func TestReconcilerFinalizeKind(t *testing.T) {
 	observer, _ := zapobserver.New(zap.InfoLevel)
 	fakelogger := zap.New(observer).Sugar()

--- a/pkg/reconciler/finalizer_test.go
+++ b/pkg/reconciler/finalizer_test.go
@@ -3,6 +3,8 @@ package reconciler
 import (
 	"fmt"
 	"net/http"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
@@ -12,6 +14,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
 	queuepkg "github.com/openshift-pipelines/pipelines-as-code/pkg/queue"
 	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
 	ghtesthelper "github.com/openshift-pipelines/pipelines-as-code/pkg/test/github"
@@ -20,9 +23,11 @@ import (
 	"go.uber.org/zap"
 	zapobserver "go.uber.org/zap/zaptest/observer"
 	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/logging"
 	rtesting "knative.dev/pkg/reconciler/testing"
+	"knative.dev/pkg/system"
 )
 
 var (
@@ -68,6 +73,140 @@ func getTestPR(name, state string) *tektonv1.PipelineRun {
 	}
 }
 
+func TestControllerInfoForPipelineRun(t *testing.T) {
+	fallback := &info.ControllerInfo{Name: "default", Secret: "default-secret"}
+	tests := []struct {
+		name       string
+		annotation string
+		fallback   *info.ControllerInfo
+		want       *info.ControllerInfo
+		wantErrSub string
+	}{
+		{
+			name:       "controller annotation",
+			annotation: `{"name":"secondary","configmap":"secondary-config","secret":"secondary-secret","gRepo":"secondary-global"}`,
+			fallback:   fallback,
+			want: &info.ControllerInfo{
+				Name:             "secondary",
+				Configmap:        "secondary-config",
+				Secret:           "secondary-secret",
+				GlobalRepository: "secondary-global",
+			},
+		},
+		{
+			name:     "fallback controller",
+			fallback: fallback,
+			want:     fallback,
+		},
+		{
+			name:     "default controller without fallback",
+			fallback: nil,
+			want: &info.ControllerInfo{
+				Name:             "default",
+				Configmap:        info.DefaultPipelinesAscodeConfigmapName,
+				Secret:           info.DefaultPipelinesAscodeSecretName,
+				GlobalRepository: info.DefaultGlobalRepoName,
+			},
+		},
+		{
+			name:       "invalid annotation",
+			annotation: "{",
+			fallback:   fallback,
+			wantErrSub: "failed to parse controllerInfo",
+		},
+		{
+			name:       "null annotation",
+			annotation: "null",
+			fallback:   fallback,
+			wantErrSub: "value must not be null",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("PAC_CONTROLLER_LABEL", "default")
+			t.Setenv("PAC_CONTROLLER_SECRET", info.DefaultPipelinesAscodeSecretName)
+			t.Setenv("PAC_CONTROLLER_CONFIGMAP", info.DefaultPipelinesAscodeConfigmapName)
+			t.Setenv("PAC_CONTROLLER_GLOBAL_REPOSITORY", info.DefaultGlobalRepoName)
+
+			pr := &tektonv1.PipelineRun{}
+			if tt.annotation != "" {
+				pr.Annotations = map[string]string{keys.ControllerInfo: tt.annotation}
+			}
+			got, err := controllerInfoForPipelineRun(pr, tt.fallback)
+			if tt.wantErrSub != "" {
+				assert.ErrorContains(t, err, tt.wantErrSub)
+				return
+			}
+			assert.NilError(t, err)
+			assert.DeepEqual(t, got, tt.want)
+			if tt.fallback != nil {
+				assert.Assert(t, got != tt.fallback, "controller info must be copied per reconciliation")
+			}
+		})
+	}
+}
+
+func TestFinalizeKindControllerInfoHandling(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotation  string
+		wantErrSub  string
+		wantControl *info.ControllerInfo
+	}{
+		{
+			name:       "invalid controller annotation",
+			annotation: "{",
+			wantErrSub: "failed to parse controllerInfo",
+		},
+		{
+			name:        "controller annotation does not mutate shared run",
+			annotation:  `{"name":"secondary","configmap":"secondary-config","secret":"secondary-secret","gRepo":"secondary-global"}`,
+			wantControl: &info.ControllerInfo{Name: "default", Secret: "default-secret", GlobalRepository: "default-global"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			observer, _ := zapobserver.New(zap.InfoLevel)
+			logger := zap.New(observer).Sugar()
+			controller := &info.ControllerInfo{Name: "default", Secret: "default-secret", GlobalRepository: "default-global"}
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pr",
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						keys.State:          kubeinteraction.StateStarted,
+						keys.ControllerInfo: tt.annotation,
+					},
+				},
+			}
+			r := &Reconciler{
+				run: &params.Run{
+					Clients: clients.Clients{Log: logger},
+					Info: info.Info{
+						Kube:       &info.KubeOpts{Namespace: "global"},
+						Controller: controller,
+						Pac:        info.NewPacOpts(),
+					},
+				},
+			}
+
+			err := r.FinalizeKind(ctx, pr)
+			if tt.wantErrSub != "" {
+				assert.ErrorContains(t, err, tt.wantErrSub)
+			} else {
+				assert.NilError(t, err)
+			}
+			if tt.wantControl != nil {
+				assert.DeepEqual(t, r.run.Info.Controller, tt.wantControl)
+				assert.Assert(t, r.run.Info.Controller == controller, "finalize must keep the shared controller pointer")
+			}
+		})
+	}
+}
+
 func TestReconcilerFinalizeKind(t *testing.T) {
 	observer, _ := zapobserver.New(zap.InfoLevel)
 	fakelogger := zap.New(observer).Sugar()
@@ -77,8 +216,12 @@ func TestReconcilerFinalizeKind(t *testing.T) {
 
 	finalizeTestRepo.Spec.GitProvider.URL = mockServerURL
 
-	// Mock status endpoint
+	// Mock status endpoint. Cancelling a running PipelineRun has to reach the
+	// provider, and the failure to do so is swallowed by the finalizer, so the
+	// call itself is what the test has to observe.
+	var statusesReported atomic.Int32
 	mux.HandleFunc("/repos/org/repo/statuses/123afc", func(rw http.ResponseWriter, _ *http.Request) {
+		statusesReported.Add(1)
 		fmt.Fprint(rw, `{"state":"pending"}`)
 	})
 
@@ -144,8 +287,17 @@ func TestReconcilerFinalizeKind(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, _ := rtesting.SetupFakeContext(t)
 			ctx = logging.WithLogger(ctx, fakelogger)
+			// The controller only sends credentials to hostnames its ConfigMap
+			// trusts, so the mock server has to be listed like any self hosted
+			// instance would be.
 			testData := testclient.Data{
 				Repositories: []*v1alpha1.Repository{finalizeTestRepo},
+				ConfigMap: []*corev1.ConfigMap{{
+					ObjectMeta: metav1.ObjectMeta{Name: "pipelines-as-code", Namespace: system.Namespace()},
+					Data: map[string]string{
+						settings.TrustedProviderHostnamesKey: strings.TrimPrefix(mockServerURL, "http://"),
+					},
+				}},
 			}
 			if tt.globalRepo != nil {
 				testData.Repositories = append(testData.Repositories, tt.globalRepo)
@@ -154,6 +306,9 @@ func TestReconcilerFinalizeKind(t *testing.T) {
 				testData.Repositories = []*v1alpha1.Repository{}
 			}
 			stdata, informers := testclient.SeedTestData(t, ctx, testData)
+			// finalizeKind establishes the controller namespace itself, exactly
+			// as knative hands it a bare context in production. Injecting one
+			// here would hide a regression in that.
 			kinterfaceTest := &testkubernetestint.KinterfaceTest{
 				GetSecretResult: map[string]string{
 					"pac-git-basic-auth-owner-repo": "https://whateveryousayboss",
@@ -163,6 +318,7 @@ func TestReconcilerFinalizeKind(t *testing.T) {
 			cs := &params.Run{
 				Clients: clients.Clients{
 					PipelineAsCode: stdata.PipelineAsCode,
+					Kube:           stdata.Kube,
 					Log:            fakelogger,
 				},
 				Info: info.Info{
@@ -185,8 +341,14 @@ func TestReconcilerFinalizeKind(t *testing.T) {
 					assert.NilError(t, err)
 				}
 			}
+			before := statusesReported.Load()
 			err := r.FinalizeKind(ctx, tt.pipelinerun)
 			assert.NilError(t, err)
+			state := tt.pipelinerun.GetAnnotations()[keys.State]
+			if !tt.skipAddingRepo && (state == kubeinteraction.StateQueued || state == kubeinteraction.StateStarted) {
+				assert.Assert(t, statusesReported.Load() > before,
+					"cancelling a running PipelineRun must report to the provider")
+			}
 
 			// if repo was deleted then no queue will be there
 			if tt.skipAddingRepo {

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -99,6 +99,31 @@ func copyRepositoryForMerge(repo *v1alpha1.Repository) *v1alpha1.Repository {
 
 // ReconcileKind is the main entry point for reconciling PipelineRun resources.
 func (r *Reconciler) ReconcileKind(ctx context.Context, pr *tektonv1.PipelineRun) pkgreconciler.Event {
+	reconcileRun := *r.run
+	reconciler := *r
+	reconciler.run = &reconcileRun
+	return reconciler.reconcileKind(ctx, pr)
+}
+
+func controllerInfoForPipelineRun(pr *tektonv1.PipelineRun, fallback *info.ControllerInfo) (*info.ControllerInfo, error) {
+	if controllerInfo, ok := pr.GetAnnotations()[keys.ControllerInfo]; ok {
+		var parsedControllerInfo *info.ControllerInfo
+		if err := json.Unmarshal([]byte(controllerInfo), &parsedControllerInfo); err != nil {
+			return nil, fmt.Errorf("failed to parse controllerInfo: %w", err)
+		}
+		if parsedControllerInfo == nil {
+			return nil, fmt.Errorf("failed to parse controllerInfo: value must not be null")
+		}
+		return parsedControllerInfo, nil
+	}
+	if fallback != nil {
+		controllerInfo := *fallback
+		return &controllerInfo, nil
+	}
+	return info.GetControllerInfoFromEnvOrDefault(), nil
+}
+
+func (r *Reconciler) reconcileKind(ctx context.Context, pr *tektonv1.PipelineRun) pkgreconciler.Event {
 	ctx = info.StoreNS(ctx, system.Namespace())
 	logger := logging.FromContext(ctx).With("namespace", pr.GetNamespace())
 
@@ -138,15 +163,11 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, pr *tektonv1.PipelineRun
 	//
 	// We always assume the controller is in the same namespace as the original
 	// controller but that may changes
-	if controllerInfo, ok := pr.GetAnnotations()[keys.ControllerInfo]; ok {
-		var parsedControllerInfo *info.ControllerInfo
-		if err := json.Unmarshal([]byte(controllerInfo), &parsedControllerInfo); err != nil {
-			return fmt.Errorf("failed to parse controllerInfo: %w", err)
-		}
-		r.run.Info.Controller = parsedControllerInfo
-	} else {
-		r.run.Info.Controller = info.GetControllerInfoFromEnvOrDefault()
+	controllerInfo, err := controllerInfoForPipelineRun(pr, r.run.Info.Controller)
+	if err != nil {
+		return err
 	}
+	r.run.Info.Controller = controllerInfo
 
 	if secretCreated, ok := pr.GetAnnotations()[keys.SecretCreated]; ok && secretCreated == "false" && pacInfo.SecretAutoCreation {
 		// if secret creation is true then return anyway from createSecretForPipelineRun function

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -116,6 +116,31 @@ func copyRepositoryForMerge(repo *v1alpha1.Repository) *v1alpha1.Repository {
 
 // ReconcileKind is the main entry point for reconciling PipelineRun resources.
 func (r *Reconciler) ReconcileKind(ctx context.Context, pr *tektonv1.PipelineRun) pkgreconciler.Event {
+	reconcileRun := *r.run
+	reconciler := *r
+	reconciler.run = &reconcileRun
+	return reconciler.reconcileKind(ctx, pr)
+}
+
+func controllerInfoForPipelineRun(pr *tektonv1.PipelineRun, fallback *info.ControllerInfo) (*info.ControllerInfo, error) {
+	if controllerInfo, ok := pr.GetAnnotations()[keys.ControllerInfo]; ok {
+		var parsedControllerInfo *info.ControllerInfo
+		if err := json.Unmarshal([]byte(controllerInfo), &parsedControllerInfo); err != nil {
+			return nil, fmt.Errorf("failed to parse controllerInfo: %w", err)
+		}
+		if parsedControllerInfo == nil {
+			return nil, fmt.Errorf("failed to parse controllerInfo: value must not be null")
+		}
+		return parsedControllerInfo, nil
+	}
+	if fallback != nil {
+		controllerInfo := *fallback
+		return &controllerInfo, nil
+	}
+	return info.GetControllerInfoFromEnvOrDefault(), nil
+}
+
+func (r *Reconciler) reconcileKind(ctx context.Context, pr *tektonv1.PipelineRun) pkgreconciler.Event {
 	ctx = info.StoreNS(ctx, system.Namespace())
 	logger := logging.FromContext(ctx).With("namespace", pr.GetNamespace())
 
@@ -155,15 +180,11 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, pr *tektonv1.PipelineRun
 	//
 	// We always assume the controller is in the same namespace as the original
 	// controller but that may changes
-	if controllerInfo, ok := pr.GetAnnotations()[keys.ControllerInfo]; ok {
-		var parsedControllerInfo *info.ControllerInfo
-		if err := json.Unmarshal([]byte(controllerInfo), &parsedControllerInfo); err != nil {
-			return fmt.Errorf("failed to parse controllerInfo: %w", err)
-		}
-		r.run.Info.Controller = parsedControllerInfo
-	} else {
-		r.run.Info.Controller = info.GetControllerInfoFromEnvOrDefault()
+	controllerInfo, err := controllerInfoForPipelineRun(pr, r.run.Info.Controller)
+	if err != nil {
+		return err
 	}
+	r.run.Info.Controller = controllerInfo
 
 	if secretCreated, ok := pr.GetAnnotations()[keys.SecretCreated]; ok && secretCreated == "false" && pacInfo.SecretAutoCreation {
 		// if secret creation is true then return anyway from createSecretForPipelineRun function
@@ -329,10 +350,11 @@ func (r *Reconciler) reportFinalStatus(ctx context.Context, logger *zap.SugaredL
 
 	secretNS := repo.GetNamespace()
 	inheritedGlobalSecret := false
-	if globalRepo, err := r.repoLister.Repositories(r.run.Info.Kube.Namespace).Get(r.run.Info.Controller.GlobalRepository); err == nil && globalRepo != nil {
-		if repo.Spec.GitProvider != nil && repo.Spec.GitProvider.Secret == nil && globalRepo.Spec.GitProvider != nil && globalRepo.Spec.GitProvider.Secret != nil {
-			secretNS = globalRepo.GetNamespace()
-			inheritedGlobalSecret = true
+	if globalRepo, gerr := r.repoLister.Repositories(r.run.Info.Kube.Namespace).Get(r.run.Info.Controller.GlobalRepository); gerr == nil && globalRepo != nil {
+		if event.InstallationID <= 0 {
+			if secretNS, inheritedGlobalSecret, err = secrets.ResolveInheritedSecret(repo, globalRepo); err != nil {
+				return nil, err
+			}
 		}
 		if merged := copyRepositoryForMerge(repo); merged != nil {
 			repo = merged
@@ -555,10 +577,10 @@ func (r *Reconciler) initGitProviderClient(ctx context.Context, logger *zap.Suga
 		// secretNS is needed when git provider is other than Github App.
 		secretNS := repo.GetNamespace()
 		inheritedGlobalSecret := false
-		if globalRepo, err := r.repoLister.Repositories(r.run.Info.Kube.Namespace).Get(r.run.Info.Controller.GlobalRepository); err == nil && globalRepo != nil {
-			if repo.Spec.GitProvider != nil && repo.Spec.GitProvider.Secret == nil && globalRepo.Spec.GitProvider != nil && globalRepo.Spec.GitProvider.Secret != nil {
-				secretNS = globalRepo.GetNamespace()
-				inheritedGlobalSecret = true
+		if globalRepo, gerr := r.repoLister.Repositories(r.run.Info.Kube.Namespace).Get(r.run.Info.Controller.GlobalRepository); gerr == nil && globalRepo != nil {
+			secretNS, inheritedGlobalSecret, err = secrets.ResolveInheritedSecret(repo, globalRepo)
+			if err != nil {
+				return nil, nil, err
 			}
 			if merged := copyRepositoryForMerge(repo); merged != nil {
 				repo = merged

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -477,6 +477,96 @@ func TestUpdatePipelineRunState(t *testing.T) {
 	}
 }
 
+func TestReconcileKindControllerInfoHandling(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotation  string
+		wantErrSub  string
+		wantControl *info.ControllerInfo
+	}{
+		{
+			name:       "invalid controller annotation",
+			annotation: "{",
+			wantErrSub: "failed to parse controllerInfo",
+		},
+		{
+			name:       "null controller annotation",
+			annotation: "null",
+			wantErrSub: "value must not be null",
+		},
+		{
+			name:        "controller annotation does not mutate shared run",
+			annotation:  `{"name":"secondary","configmap":"secondary-config","secret":"secondary-secret","gRepo":"secondary-global"}`,
+			wantControl: &info.ControllerInfo{Name: "default", Secret: "default-secret", GlobalRepository: "default-global"},
+		},
+		{
+			name:        "fallback controller is copied",
+			wantControl: &info.ControllerInfo{Name: "default", Secret: "default-secret", GlobalRepository: "default-global"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			observer, _ := zapobserver.New(zap.InfoLevel)
+			logger := zap.New(observer).Sugar()
+			controller := &info.ControllerInfo{Name: "default", Secret: "default-secret", GlobalRepository: "default-global"}
+			annotations := map[string]string{
+				keys.State:         kubeinteraction.StateStarted,
+				keys.Repository:    "test-repo",
+				keys.SecretCreated: "true",
+			}
+			if tt.annotation != "" {
+				annotations[keys.ControllerInfo] = tt.annotation
+			}
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-pr",
+					Namespace:   "test-ns",
+					Annotations: annotations,
+				},
+			}
+			repo := &v1alpha1.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-repo",
+					Namespace: "test-ns",
+				},
+			}
+			stdata, informers := testclient.SeedTestData(t, ctx, testclient.Data{
+				PipelineRuns: []*tektonv1.PipelineRun{pr},
+				Repositories: []*v1alpha1.Repository{repo},
+			})
+			r := &Reconciler{
+				repoLister: informers.Repository.Lister(),
+				run: &params.Run{
+					Clients: clients.Clients{
+						Tekton: stdata.Pipeline,
+						Log:    logger,
+					},
+					Info: info.Info{
+						Pac: &info.PacOpts{
+							Settings: settings.Settings{},
+						},
+						Kube:       &info.KubeOpts{Namespace: "global"},
+						Controller: controller,
+					},
+				},
+			}
+
+			err := r.ReconcileKind(ctx, pr)
+			if tt.wantErrSub != "" {
+				assert.ErrorContains(t, err, tt.wantErrSub)
+			} else {
+				assert.NilError(t, err)
+			}
+			if tt.wantControl != nil {
+				assert.DeepEqual(t, r.run.Info.Controller, tt.wantControl)
+				assert.Assert(t, r.run.Info.Controller == controller, "reconcile must keep the shared controller pointer")
+			}
+		})
+	}
+}
+
 func TestReconcileKindSCMReportingLogic(t *testing.T) {
 	observer, _ := zapobserver.New(zap.InfoLevel)
 	logger := zap.New(observer).Sugar()
@@ -654,6 +744,7 @@ func TestReconcileKindSCMReportingLogic(t *testing.T) {
 			}
 
 			err := r.ReconcileKind(ctx, tt.pipelineRun)
+			assert.Assert(t, cs.Info.Controller == nil, "reconciliation must not mutate shared controller state")
 
 			// For test cases that should call updatePipelineRunToInProgress,
 			// we expect no error and the state should be updated

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -42,6 +42,7 @@ import (
 	knativeapi "knative.dev/pkg/apis"
 	knativeduckv1 "knative.dev/pkg/apis/duck/v1"
 	rtesting "knative.dev/pkg/reconciler/testing"
+	"knative.dev/pkg/system"
 )
 
 var (
@@ -216,6 +217,9 @@ func TestReconcilerReconcileKind(t *testing.T) {
 				},
 				Spec: v1alpha1.RepositorySpec{
 					URL: randomURL,
+					GitProvider: &v1alpha1.GitProvider{
+						URL: "https://another.example.com",
+					},
 				},
 			}
 			globalRepo := &v1alpha1.Repository{
@@ -226,6 +230,12 @@ func TestReconcilerReconcileKind(t *testing.T) {
 				Spec: v1alpha1.RepositorySpec{
 					Settings: &v1alpha1.Settings{
 						PipelineRunProvenance: "default_branch",
+					},
+					GitProvider: &v1alpha1.GitProvider{
+						URL: "https://github.com",
+						Secret: &v1alpha1.Secret{
+							Name: "global-provider-secret",
+						},
 					},
 				},
 			}
@@ -317,6 +327,7 @@ func TestReconcilerReconcileKind(t *testing.T) {
 			cachedRepo, err := informers.Repository.Lister().Repositories(testRepo.Namespace).Get(testRepo.Name)
 			assert.NilError(t, err)
 			assert.Assert(t, cachedRepo.Spec.Settings == nil, "global settings should not mutate the cached Repository")
+			assert.Assert(t, cachedRepo.Spec.GitProvider.Secret == nil, "global secret should not mutate the cached Repository")
 		})
 	}
 }
@@ -364,7 +375,9 @@ func TestInitGitProviderClientUsesGlobalSecretWithoutMutatingCache(t *testing.T)
 	}
 	stdata, informers := testclient.SeedTestData(t, ctx, testclient.Data{
 		Repositories: []*v1alpha1.Repository{repo, globalRepo},
+		ConfigMap:    []*corev1.ConfigMap{defaultPolicyConfigMap()},
 	})
+	ctx = info.StoreNS(ctx, system.Namespace())
 	kint := &testkubernetestint.KinterfaceTest{
 		GetSecretResult: map[string]string{
 			"global-provider-secret": "test-token",
@@ -515,6 +528,96 @@ func TestUpdatePipelineRunState(t *testing.T) {
 	}
 }
 
+func TestReconcileKindControllerInfoHandling(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotation  string
+		wantErrSub  string
+		wantControl *info.ControllerInfo
+	}{
+		{
+			name:       "invalid controller annotation",
+			annotation: "{",
+			wantErrSub: "failed to parse controllerInfo",
+		},
+		{
+			name:       "null controller annotation",
+			annotation: "null",
+			wantErrSub: "value must not be null",
+		},
+		{
+			name:        "controller annotation does not mutate shared run",
+			annotation:  `{"name":"secondary","configmap":"secondary-config","secret":"secondary-secret","gRepo":"secondary-global"}`,
+			wantControl: &info.ControllerInfo{Name: "default", Secret: "default-secret", GlobalRepository: "default-global"},
+		},
+		{
+			name:        "fallback controller is copied",
+			wantControl: &info.ControllerInfo{Name: "default", Secret: "default-secret", GlobalRepository: "default-global"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			observer, _ := zapobserver.New(zap.InfoLevel)
+			logger := zap.New(observer).Sugar()
+			controller := &info.ControllerInfo{Name: "default", Secret: "default-secret", GlobalRepository: "default-global"}
+			annotations := map[string]string{
+				keys.State:         kubeinteraction.StateStarted,
+				keys.Repository:    "test-repo",
+				keys.SecretCreated: "true",
+			}
+			if tt.annotation != "" {
+				annotations[keys.ControllerInfo] = tt.annotation
+			}
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-pr",
+					Namespace:   "test-ns",
+					Annotations: annotations,
+				},
+			}
+			repo := &v1alpha1.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-repo",
+					Namespace: "test-ns",
+				},
+			}
+			stdata, informers := testclient.SeedTestData(t, ctx, testclient.Data{
+				PipelineRuns: []*tektonv1.PipelineRun{pr},
+				Repositories: []*v1alpha1.Repository{repo},
+			})
+			r := &Reconciler{
+				repoLister: informers.Repository.Lister(),
+				run: &params.Run{
+					Clients: clients.Clients{
+						Tekton: stdata.Pipeline,
+						Log:    logger,
+					},
+					Info: info.Info{
+						Pac: &info.PacOpts{
+							Settings: settings.Settings{},
+						},
+						Kube:       &info.KubeOpts{Namespace: "global"},
+						Controller: controller,
+					},
+				},
+			}
+
+			err := r.ReconcileKind(ctx, pr)
+			if tt.wantErrSub != "" {
+				assert.ErrorContains(t, err, tt.wantErrSub)
+			} else {
+				assert.NilError(t, err)
+			}
+			if tt.wantControl != nil {
+				assert.DeepEqual(t, r.run.Info.Controller, tt.wantControl)
+				assert.Assert(t, r.run.Info.Controller == controller, "reconcile must keep the shared controller pointer")
+			}
+		})
+	}
+}
+
 func TestReconcileKindSCMReportingLogic(t *testing.T) {
 	observer, _ := zapobserver.New(zap.InfoLevel)
 	logger := zap.New(observer).Sugar()
@@ -654,11 +757,20 @@ func TestReconcileKindSCMReportingLogic(t *testing.T) {
 				},
 			}
 
+			// The controller only sends credentials to hostnames its ConfigMap
+			// trusts, so the test server has to be listed like any self hosted
+			// instance would be.
+			testServerHost := strings.TrimPrefix(ghTestServerURL, "http://")
 			testData := testclient.Data{
 				Repositories: []*v1alpha1.Repository{testRepo},
 				PipelineRuns: []*tektonv1.PipelineRun{tt.pipelineRun},
+				ConfigMap: []*corev1.ConfigMap{{
+					ObjectMeta: metav1.ObjectMeta{Name: "pipelines-as-code", Namespace: system.Namespace()},
+					Data:       map[string]string{settings.TrustedProviderHostnamesKey: testServerHost},
+				}},
 			}
 			stdata, informers := testclient.SeedTestData(t, ctx, testData)
+			ctx = info.StoreNS(ctx, system.Namespace())
 
 			// Track if updatePipelineRunToInProgress was called by checking state changes
 			originalState := tt.pipelineRun.GetAnnotations()[keys.State]
@@ -672,6 +784,7 @@ func TestReconcileKindSCMReportingLogic(t *testing.T) {
 			cs := &params.Run{
 				Clients: clients.Clients{
 					Tekton: stdata.Pipeline,
+					Kube:   stdata.Kube,
 					Log:    logger,
 				},
 				Info: info.Info{
@@ -692,6 +805,7 @@ func TestReconcileKindSCMReportingLogic(t *testing.T) {
 			}
 
 			err := r.ReconcileKind(ctx, tt.pipelineRun)
+			assert.Assert(t, cs.Info.Controller == nil, "reconciliation must not mutate shared controller state")
 
 			// For test cases that should call updatePipelineRunToInProgress,
 			// we expect no error and the state should be updated
@@ -852,8 +966,10 @@ func TestCreateSecretForPipelineRun(t *testing.T) {
 			testData := testclient.Data{
 				PipelineRuns: []*tektonv1.PipelineRun{pr},
 				Repositories: []*v1alpha1.Repository{repo},
+				ConfigMap:    []*corev1.ConfigMap{defaultPolicyConfigMap()},
 			}
 			stdata, informers := testclient.SeedTestData(t, ctx, testData)
+			ctx = info.StoreNS(ctx, system.Namespace())
 
 			if tt.simulatePatchErr {
 				stdata.Pipeline.PrependReactor("patch", "pipelineruns", func(_ k8stesting.Action) (bool, runtime.Object, error) {
@@ -873,6 +989,7 @@ func TestCreateSecretForPipelineRun(t *testing.T) {
 				run: &params.Run{
 					Clients: clients.Clients{
 						Tekton: stdata.Pipeline,
+						Kube:   stdata.Kube,
 						Log:    logger,
 					},
 					Info: info.Info{
@@ -957,14 +1074,17 @@ func TestReconcileKindSecretCreationDoesNotLogOnSuccess(t *testing.T) {
 	testData := testclient.Data{
 		PipelineRuns: []*tektonv1.PipelineRun{pr},
 		Repositories: []*v1alpha1.Repository{repo},
+		ConfigMap:    []*corev1.ConfigMap{defaultPolicyConfigMap()},
 	}
 	stdata, informers := testclient.SeedTestData(t, ctx, testData)
+	ctx = info.StoreNS(ctx, system.Namespace())
 
 	r := &Reconciler{
 		repoLister: informers.Repository.Lister(),
 		run: &params.Run{
 			Clients: clients.Clients{
 				Tekton: stdata.Pipeline,
+				Kube:   stdata.Kube,
 				Log:    logger,
 			},
 			Info: info.Info{
@@ -997,4 +1117,79 @@ func TestReconcileKindSecretCreationDoesNotLogOnSuccess(t *testing.T) {
 
 	logEntries := log.FilterMessageSnippet("failed to create secret for pipelineRun").TakeAll()
 	assert.Equal(t, len(logEntries), 0)
+}
+
+// defaultPolicyConfigMap is a controller ConfigMap with no configured allowlist,
+// which is the state every stock install starts in: the public instances are
+// trusted and nothing else is.
+func defaultPolicyConfigMap() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "pipelines-as-code", Namespace: system.Namespace()},
+	}
+}
+
+// The watcher resolves the provider secret on its own, so the guard that stops a
+// tenant Repository from inheriting the shared controller credential while
+// pointing it somewhere else has to apply here too, not only on the adapter path.
+func TestInitGitProviderClientRefusesInheritedSecretWithOwnProviderURL(t *testing.T) {
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = info.StoreNS(ctx, system.Namespace())
+	observer, _ := zapobserver.New(zap.InfoLevel)
+	logger := zap.New(observer).Sugar()
+
+	pr := &tektonv1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pr",
+			Namespace: "test-ns",
+			Annotations: map[string]string{
+				keys.GitProvider:   "github",
+				keys.RepoURL:       "https://github.com/org/repo",
+				keys.URLOrg:        "org",
+				keys.URLRepository: "repo",
+				keys.SHA:           "abc123",
+			},
+		},
+	}
+	repo := &v1alpha1.Repository{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-repo", Namespace: "test-ns"},
+		Spec: v1alpha1.RepositorySpec{
+			URL:         "https://github.com/org/repo",
+			GitProvider: &v1alpha1.GitProvider{URL: "https://gitea.com"},
+		},
+	}
+	globalRepo := &v1alpha1.Repository{
+		ObjectMeta: metav1.ObjectMeta{Name: "global-repo", Namespace: "global"},
+		Spec: v1alpha1.RepositorySpec{
+			GitProvider: &v1alpha1.GitProvider{
+				URL:    "https://github.com",
+				Secret: &v1alpha1.Secret{Name: "global-provider-secret"},
+			},
+		},
+	}
+	stdata, informers := testclient.SeedTestData(t, ctx, testclient.Data{
+		Repositories: []*v1alpha1.Repository{repo, globalRepo},
+		ConfigMap:    []*corev1.ConfigMap{defaultPolicyConfigMap()},
+	})
+	r := &Reconciler{
+		repoLister:   informers.Repository.Lister(),
+		kinteract:    &testkubernetestint.KinterfaceTest{GetSecretResult: map[string]string{"global-provider-secret": "test-token"}},
+		eventEmitter: events.NewEventEmitter(stdata.Kube, logger),
+		run: &params.Run{
+			Clients: clients.Clients{
+				Kube:           stdata.Kube,
+				PipelineAsCode: stdata.PipelineAsCode,
+				Log:            logger,
+			},
+			Info: info.Info{
+				Kube:       &info.KubeOpts{Namespace: "global"},
+				Controller: &info.ControllerInfo{GlobalRepository: "global-repo"},
+				Pac:        info.NewPacOpts(),
+			},
+		},
+	}
+
+	cachedRepo, err := informers.Repository.Lister().Repositories(repo.Namespace).Get(repo.Name)
+	assert.NilError(t, err)
+	_, _, err = r.initGitProviderClient(ctx, logger, cachedRepo, pr)
+	assert.ErrorContains(t, err, "must not be sent to an endpoint chosen by another namespace")
 }

--- a/pkg/secrets/inherit.go
+++ b/pkg/secrets/inherit.go
@@ -1,0 +1,103 @@
+package secrets
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/vcshost"
+)
+
+// ResolveInheritedSecret decides which namespace holds the git_provider secret
+// of repo, and refuses the one combination that is not safe.
+//
+// A Repository that omits git_provider.secret inherits the one of the global
+// Repository, which lives in the controller namespace and is shared by every
+// tenant. If that Repository is also allowed to choose git_provider.url, then
+// whoever can create a Repository in any namespace can have an administrator's
+// token sent to a host, or over a transport, of their choosing. Inheriting the
+// credential and overriding the endpoint it is sent to are only safe apart.
+//
+// Every path that resolves a provider secret must go through here: the adapter
+// and the watcher each used to carry their own copy of this decision, and a
+// guard that only one of them applies is not a guard.
+func ResolveInheritedSecret(repo, globalRepo *v1alpha1.Repository) (string, bool, error) {
+	namespace := repo.GetNamespace()
+	if globalRepo == nil || repo.Spec.GitProvider == nil || repo.Spec.GitProvider.Secret != nil ||
+		globalRepo.Spec.GitProvider == nil || globalRepo.Spec.GitProvider.Secret == nil {
+		return namespace, false, nil
+	}
+	if err := checkInheritedEndpoint(repo, globalRepo); err != nil {
+		return namespace, false, err
+	}
+	return globalRepo.GetNamespace(), true, nil
+}
+
+func checkInheritedEndpoint(repo, globalRepo *v1alpha1.Repository) error {
+	localURL := repo.Spec.GitProvider.URL
+	if localURL == "" {
+		return nil
+	}
+	globalURL := globalRepo.Spec.GitProvider.URL
+	if sameProviderEndpoint(localURL, globalURL) {
+		return nil
+	}
+	return fmt.Errorf(
+		"repository %s/%s sets git_provider.url to %q but inherits its git_provider.secret from the global repository %s/%s: "+
+			"a credential owned by the %s namespace must not be sent to an endpoint chosen by another namespace. "+
+			"Set git_provider.secret on the repository, or drop its git_provider.url",
+		repo.GetNamespace(), repo.GetName(), localURL,
+		globalRepo.GetNamespace(), globalRepo.GetName(), globalRepo.GetNamespace(),
+	)
+}
+
+// sameProviderEndpoint compares two provider URLs by the endpoint they actually
+// reach: the transport, the host, and the path prefix.
+//
+// Downgrading someone else's credential to cleartext hands it to anyone on the
+// path just as effectively as redirecting it would, and GitLab, Gitea and
+// Bitbucket Data Center are routinely served under a path prefix on a shared
+// front end, where another path on the same host is another owner.
+func sameProviderEndpoint(local, global string) bool {
+	localEP := splitProviderURL(local)
+	globalEP := splitProviderURL(global)
+	if localEP.scheme != globalEP.scheme || localEP.host != globalEP.host {
+		return false
+	}
+	// The global endpoint carries the prefix the credential belongs to. Naming no
+	// prefix is only the same endpoint when the global one has none either:
+	// otherwise the token would go to the root of a front end that serves the
+	// deployment under a path, which may well belong to someone else.
+	return localEP.path == globalEP.path
+}
+
+type providerEndpoint struct {
+	scheme string
+	host   string
+	path   string
+}
+
+func splitProviderURL(raw string) providerEndpoint {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return providerEndpoint{}
+	}
+	parsed, err := vcshost.SplitURL(raw)
+	if err != nil {
+		// Unparsable: fall back to comparing the raw strings, which can only
+		// ever be stricter than comparing endpoints.
+		return providerEndpoint{host: raw}
+	}
+	host, err := vcshost.Parse(parsed.Host)
+	if err != nil {
+		return providerEndpoint{host: raw}
+	}
+	// /api/v3 and /api/v4 are the API entry point of a provider served at the
+	// root, not a prefix that tells two deployments apart.
+	path := strings.TrimSuffix(strings.TrimSuffix(strings.TrimRight(parsed.Path, "/"), "/api/v3"), "/api/v4")
+	return providerEndpoint{
+		scheme: strings.ToLower(parsed.Scheme),
+		host:   vcshost.Canonical(host),
+		path:   path,
+	}
+}

--- a/pkg/secrets/inherit_test.go
+++ b/pkg/secrets/inherit_test.go
@@ -1,0 +1,223 @@
+package secrets
+
+import (
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func inheritTestRepo(namespace, name, providerURL string, secret bool) *v1alpha1.Repository {
+	repo := &v1alpha1.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.RepositorySpec{
+			GitProvider: &v1alpha1.GitProvider{
+				URL: providerURL,
+			},
+		},
+	}
+	if secret {
+		repo.Spec.GitProvider.Secret = &v1alpha1.Secret{Name: "provider-secret"}
+	}
+	return repo
+}
+
+func TestResolveInheritedSecret(t *testing.T) {
+	tests := []struct {
+		name          string
+		repo          *v1alpha1.Repository
+		globalRepo    *v1alpha1.Repository
+		wantNamespace string
+		wantInherited bool
+		wantErr       string
+	}{
+		{
+			name:          "no global repository keeps the local namespace",
+			repo:          inheritTestRepo("tenant", "repo", "", false),
+			globalRepo:    nil,
+			wantNamespace: "tenant",
+		},
+		{
+			name:          "own secret is never inherited",
+			repo:          inheritTestRepo("tenant", "repo", "https://ghe.example.com", true),
+			globalRepo:    inheritTestRepo("pipelines-as-code", "global", "https://other.example.com", true),
+			wantNamespace: "tenant",
+		},
+		{
+			name:          "global repository without a secret grants nothing",
+			repo:          inheritTestRepo("tenant", "repo", "", false),
+			globalRepo:    inheritTestRepo("pipelines-as-code", "global", "", false),
+			wantNamespace: "tenant",
+		},
+		{
+			name: "repository without a git provider keeps the local namespace",
+			repo: &v1alpha1.Repository{
+				ObjectMeta: metav1.ObjectMeta{Name: "repo", Namespace: "tenant"},
+			},
+			globalRepo:    inheritTestRepo("pipelines-as-code", "global", "", true),
+			wantNamespace: "tenant",
+		},
+		{
+			name:          "inheriting without an own url is allowed",
+			repo:          inheritTestRepo("tenant", "repo", "", false),
+			globalRepo:    inheritTestRepo("pipelines-as-code", "global", "https://ghe.example.com", true),
+			wantNamespace: "pipelines-as-code",
+			wantInherited: true,
+		},
+		{
+			name:          "inheriting for the same endpoint is allowed",
+			repo:          inheritTestRepo("tenant", "repo", "https://ghe.example.com", false),
+			globalRepo:    inheritTestRepo("pipelines-as-code", "global", "https://ghe.example.com", true),
+			wantNamespace: "pipelines-as-code",
+			wantInherited: true,
+		},
+		{
+			name:          "pointing the inherited credential at another host is refused",
+			repo:          inheritTestRepo("tenant", "repo", "https://attacker.example.com", false),
+			globalRepo:    inheritTestRepo("pipelines-as-code", "global", "https://ghe.example.com", true),
+			wantNamespace: "tenant",
+			wantErr:       "must not be sent to an endpoint chosen by another namespace",
+		},
+		{
+			name:          "downgrading the inherited credential to cleartext is refused",
+			repo:          inheritTestRepo("tenant", "repo", "http://ghe.example.com", false),
+			globalRepo:    inheritTestRepo("pipelines-as-code", "global", "https://ghe.example.com", true),
+			wantNamespace: "tenant",
+			wantErr:       "must not be sent to an endpoint chosen by another namespace",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			namespace, inherited, err := ResolveInheritedSecret(tt.repo, tt.globalRepo)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				assert.Equal(t, inherited, false)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, namespace, tt.wantNamespace)
+			assert.Equal(t, inherited, tt.wantInherited)
+		})
+	}
+}
+
+func TestSameProviderEndpoint(t *testing.T) {
+	tests := []struct {
+		name   string
+		local  string
+		global string
+		want   bool
+	}{
+		{
+			name:   "identical https urls",
+			local:  "https://ghe.example.com",
+			global: "https://ghe.example.com",
+			want:   true,
+		},
+		{
+			name:   "different hosts",
+			local:  "https://attacker.example.com",
+			global: "https://ghe.example.com",
+			want:   false,
+		},
+		{
+			name:   "http downgrade of an https endpoint",
+			local:  "http://ghe.example.com",
+			global: "https://ghe.example.com",
+			want:   false,
+		},
+		{
+			name:   "trailing slash names the same endpoint",
+			local:  "https://ghe.example.com/",
+			global: "https://ghe.example.com",
+			want:   true,
+		},
+		{
+			name:   "host case does not tell endpoints apart",
+			local:  "https://GHE.Example.COM",
+			global: "https://ghe.example.com",
+			want:   true,
+		},
+		{
+			name:   "unicode lookalike host is not the ascii one",
+			local:  "https://ghé.example.com",
+			global: "https://ghe.example.com",
+			want:   false,
+		},
+		{
+			name:   "idna spelling matches its punycode form",
+			local:  "https://ghé.example.com",
+			global: "https://xn--gh-cja.example.com",
+			want:   true,
+		},
+		{
+			name:   "explicit port is another endpoint",
+			local:  "https://ghe.example.com:8443",
+			global: "https://ghe.example.com",
+			want:   false,
+		},
+		{
+			name:   "github api v3 suffix names the root deployment",
+			local:  "https://ghe.example.com/api/v3",
+			global: "https://ghe.example.com",
+			want:   true,
+		},
+		{
+			name:   "gitlab api v4 suffix names the root deployment",
+			local:  "https://gitlab.example.com/api/v4",
+			global: "https://gitlab.example.com",
+			want:   true,
+		},
+		{
+			name:   "same path prefix on a shared front end",
+			local:  "https://front.example.com/gitlab",
+			global: "https://front.example.com/gitlab",
+			want:   true,
+		},
+		{
+			name:   "another path prefix on the same host is another owner",
+			local:  "https://front.example.com/other",
+			global: "https://front.example.com/gitlab",
+			want:   false,
+		},
+		{
+			name:   "naming no prefix when the credential belongs under one",
+			local:  "https://front.example.com",
+			global: "https://front.example.com/gitlab",
+			want:   false,
+		},
+		{
+			name:   "api suffix under a path prefix keeps the prefix",
+			local:  "https://front.example.com/gitlab/api/v4",
+			global: "https://front.example.com/gitlab",
+			want:   true,
+		},
+		{
+			name:   "bare hostname reads as https",
+			local:  "ghe.example.com",
+			global: "https://ghe.example.com",
+			want:   true,
+		},
+		{
+			name:   "unparsable urls only match themselves",
+			local:  "https://user@ghe.example.com",
+			global: "https://ghe.example.com",
+			want:   false,
+		},
+		{
+			name:   "empty urls are the same endpoint",
+			local:  "",
+			global: "",
+			want:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, sameProviderEndpoint(tt.local, tt.global), tt.want)
+		})
+	}
+}

--- a/pkg/vcshost/vcshost.go
+++ b/pkg/vcshost/vcshost.go
@@ -1,0 +1,314 @@
+// Package vcshost parses and normalises hosted VCS hostnames and matches them
+// against an administrator supplied allowlist.
+//
+// It deliberately has no Pipelines-as-Code dependency, which is why it sits
+// outside pkg/provider: the settings package, the secrets package and the
+// provider packages all share the exact same parsing rules without any of them
+// creating an import cycle.
+//
+// Normalisation maps a hostname exactly the way a resolver would, by running the
+// IDNA lookup profile over the raw input before anything else. A hostname that
+// looks like github.com to a human but resolves elsewhere therefore normalises
+// to the name that would really be dialled, and is refused. Callers must still
+// build every URL from the value Parse returns rather than from the raw input,
+// so that policy and DNS can never disagree. See Canonical.
+package vcshost
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/idna"
+)
+
+const (
+	// PublicGitHub is the canonical hostname of the public github.com instance.
+	PublicGitHub = "github.com"
+	// PublicGitLab is the canonical hostname of the public gitlab.com instance.
+	PublicGitLab = "gitlab.com"
+	// PublicBitbucket is the canonical hostname of the public bitbucket.org instance.
+	PublicBitbucket = "bitbucket.org"
+	// PublicGitea is the canonical hostname of the public gitea.com instance.
+	PublicGitea = "gitea.com"
+	// PublicCodeberg is the canonical hostname of the public codeberg.org instance.
+	PublicCodeberg = "codeberg.org"
+)
+
+// Public SaaS instances have well known hostnames that whoever sends a webhook
+// payload cannot point somewhere else. The map also folds the API hostname of an
+// instance onto its canonical hostname, so that api.github.com and github.com
+// are treated as the same instance.
+var publicHosts = map[string]string{
+	PublicGitHub:        PublicGitHub,
+	"api.github.com":    PublicGitHub,
+	PublicGitLab:        PublicGitLab,
+	PublicBitbucket:     PublicBitbucket,
+	"api.bitbucket.org": PublicBitbucket,
+	PublicGitea:         PublicGitea,
+	PublicCodeberg:      PublicCodeberg,
+}
+
+// idnaProfile maps unicode hostnames to their punycode form the same way a
+// resolver would, so that an allowlist entry written in unicode matches the
+// punycode hostname a provider puts in its payloads.
+var idnaProfile = idna.New(idna.MapForLookup(), idna.StrictDomainName(false), idna.BidiRule())
+
+// IsPublic reports whether host is a well known public SaaS instance. The host
+// is expected to have been normalised by Parse first.
+func IsPublic(host string) bool {
+	_, ok := publicHosts[strings.ToLower(host)]
+	return ok
+}
+
+// Canonical returns the canonical hostname for a public SaaS instance, so that
+// api.github.com and github.com are treated as the same instance.
+//
+// Callers must build every URL from this value and never from the hostname they
+// were given: this normalisation is what makes a lookalike hostname collapse
+// onto the host it imitates instead of being dialled as written.
+func Canonical(host string) string {
+	if canonical, ok := publicHosts[strings.ToLower(host)]; ok {
+		return canonical
+	}
+	return strings.ToLower(host)
+}
+
+// privateSuffixes are the DNS suffixes reserved for names that only resolve
+// inside a cluster, a private network or a single machine.
+var privateSuffixes = []string{
+	".localhost",
+	".local",
+	".internal",
+	".intranet",
+	".home.arpa",
+	".svc",
+	".cluster.local",
+}
+
+// IsPrivate reports whether host designates something that is not reachable on
+// the public internet: loopback, link local (which includes the cloud metadata
+// endpoint), a private range, an unqualified name or an in cluster Kubernetes
+// service name. Such a host may well be legitimate, but it must only ever be
+// trusted because an administrator listed it explicitly, never because a webhook
+// payload mentioned it.
+func IsPrivate(host string) bool {
+	hostname := host
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		hostname = h
+	}
+	hostname = strings.ToLower(strings.TrimSuffix(strings.Trim(hostname, "[]"), "."))
+
+	if ip := net.ParseIP(hostname); ip != nil {
+		return ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+			ip.IsPrivate() || ip.IsUnspecified()
+	}
+	// net.ParseIP only accepts the canonical dotted quad, but the C resolver
+	// behind cgo also accepts the inet_aton spellings, where 127.1, 0177.0.0.1
+	// and 0x7f.1 all reach the loopback address. Those never designate a real
+	// hostname, so refuse to learn any of them automatically.
+	if isNumericAddress(hostname) {
+		return true
+	}
+	if !strings.Contains(hostname, ".") {
+		return true
+	}
+	if hostname == "localhost" {
+		return true
+	}
+	for _, suffix := range privateSuffixes {
+		if strings.HasSuffix(hostname, suffix) {
+			return true
+		}
+	}
+	// <service>.<namespace>.svc.<cluster domain>, whatever the cluster domain is.
+	return strings.Contains(hostname, ".svc.")
+}
+
+// isNumericAddress reports whether every label of hostname is a decimal, octal
+// or hexadecimal number, which is what makes inet_aton read it as an IP address
+// rather than as a name.
+func isNumericAddress(hostname string) bool {
+	labels := strings.Split(hostname, ".")
+	for _, label := range labels {
+		if label == "" {
+			return false
+		}
+		digits := label
+		if after, found := strings.CutPrefix(label, "0x"); found {
+			digits = after
+			if digits == "" {
+				return false
+			}
+			for _, r := range digits {
+				if !strings.ContainsRune("0123456789abcdef", r) {
+					return false
+				}
+			}
+			continue
+		}
+		for _, r := range digits {
+			if r < '0' || r > '9' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// ErrURLUnsafeComponents is returned by SplitURL for a URL carrying
+// credentials, a query or a fragment. Callers that speak of a hostname rather
+// than of a URL match on it to word the refusal in their own terms.
+var ErrURLUnsafeComponents = errors.New("provider URL must not contain credentials, a query or a fragment")
+
+// SplitURL parses a provider URL the way an administrator is allowed to write
+// it: bare (ghe.example.com), or with a scheme (https://ghe.example.com/gitlab).
+// A value without a scheme is read as https, which is what every caller wants
+// for a hostname typed by hand.
+//
+// It only parses and rejects a URL that names no host or carries credentials, a
+// query or a fragment, all of which are signs the value was not meant to be a
+// provider endpoint. Deciding which schemes are acceptable is left to the
+// caller: a self hosted instance reachable over plain http is legitimate on the
+// paths that build a client, and refused on the paths that only take a hostname.
+func SplitURL(rawURL string) (*url.URL, error) {
+	raw := strings.TrimSpace(rawURL)
+	if raw == "" {
+		return nil, fmt.Errorf("provider URL is empty")
+	}
+	if !strings.Contains(raw, "://") {
+		raw = "https://" + raw
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Host == "" {
+		return nil, fmt.Errorf("invalid provider URL %q", rawURL)
+	}
+	if parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return nil, ErrURLUnsafeComponents
+	}
+	return parsed, nil
+}
+
+// Parse validates a hostname and returns it normalised. The value may be given
+// bare (ghe.example.com) or as an https URL (https://ghe.example.com). Anything
+// carrying a path, a query, a fragment, credentials or a non https scheme is
+// rejected: those are signs the value did not come from a trusted source.
+func Parse(rawHost string) (string, error) {
+	if strings.TrimSpace(rawHost) == "" {
+		return "", fmt.Errorf("hostname is empty")
+	}
+	parsed, err := SplitURL(rawHost)
+	if err != nil {
+		if errors.Is(err, ErrURLUnsafeComponents) {
+			return "", fmt.Errorf("hostname must not contain credentials, query or fragment")
+		}
+		return "", fmt.Errorf("invalid hostname")
+	}
+	if !strings.EqualFold(parsed.Scheme, "https") {
+		return "", fmt.Errorf("hostname scheme must be https, got %q", parsed.Scheme)
+	}
+	if path := strings.TrimSuffix(parsed.EscapedPath(), "/"); path != "" {
+		return "", fmt.Errorf("hostname must not contain a path")
+	}
+	return normalise(parsed.Hostname(), parsed.Port())
+}
+
+// normalise drops the root label trailing dot, maps the hostname to the punycode
+// form a resolver would look up and lowercases the result, so that two spellings
+// of the same hostname always produce the same string.
+//
+// The IDNA mapping runs on the raw hostname, before any case folding of our own.
+// strings.ToLower applies simple case mapping, which for a handful of runes
+// (U+0130 LATIN CAPITAL LETTER I WITH DOT ABOVE, for one) differs from the full
+// mapping a resolver applies: lowercasing first would classify GITHUB.com spelt
+// with that rune as github.com while net/http dialled xn--github-qyd.com.
+func normalise(hostname, port string) (string, error) {
+	hostname = strings.TrimSuffix(hostname, ".")
+	if hostname == "" {
+		return "", fmt.Errorf("invalid hostname")
+	}
+	isIP := net.ParseIP(hostname) != nil
+	if !isIP {
+		ascii, err := idnaProfile.ToASCII(hostname)
+		if err != nil {
+			return "", fmt.Errorf("invalid hostname %q: %w", hostname, err)
+		}
+		hostname = strings.ToLower(ascii)
+		// The mapping must be a fixed point, otherwise the value we hand back
+		// would still normalise to something else further down the stack.
+		if again, err := idnaProfile.ToASCII(hostname); err != nil || !strings.EqualFold(again, hostname) {
+			return "", fmt.Errorf("hostname %q does not normalise to a stable form", hostname)
+		}
+		if !validDNSHostname(hostname) {
+			return "", fmt.Errorf("hostname %q normalises to an invalid DNS hostname", hostname)
+		}
+	}
+	if port != "" {
+		return net.JoinHostPort(hostname, port), nil
+	}
+	if isIP && strings.Contains(hostname, ":") {
+		return "[" + hostname + "]", nil
+	}
+	return hostname, nil
+}
+
+func validDNSHostname(hostname string) bool {
+	if len(hostname) > 253 {
+		return false
+	}
+	for label := range strings.SplitSeq(hostname, ".") {
+		if len(label) == 0 || len(label) > 63 || label[0] == '-' || label[len(label)-1] == '-' {
+			return false
+		}
+		for _, character := range label {
+			if (character < 'a' || character > 'z') && (character < '0' || character > '9') && character != '-' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// ParseAllowlist splits a comma separated list of hostnames into normalised
+// canonical hostnames. An empty value yields an empty list, which means the
+// allowlist has not been configured.
+func ParseAllowlist(raw string) ([]string, error) {
+	var hosts []string
+	seen := map[string]bool{}
+	for entry := range strings.SplitSeq(raw, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		host, err := Parse(entry)
+		if err != nil {
+			return nil, fmt.Errorf("invalid hostname %q: %w", entry, err)
+		}
+		host = Canonical(host)
+		if seen[host] {
+			continue
+		}
+		seen[host] = true
+		hosts = append(hosts, host)
+	}
+	return hosts, nil
+}
+
+// Allowed reports whether host appears in the allowlist. Both sides are
+// canonicalised so that github.com and api.github.com match each other.
+func Allowed(allowlist []string, host string) bool {
+	canonical := Canonical(host)
+	for _, allowed := range allowlist {
+		if Canonical(allowed) == canonical {
+			return true
+		}
+	}
+	return false
+}
+
+// Join renders an allowlist back into the comma separated ConfigMap value.
+func Join(allowlist []string) string {
+	return strings.Join(allowlist, ",")
+}

--- a/pkg/vcshost/vcshost_test.go
+++ b/pkg/vcshost/vcshost_test.go
@@ -1,0 +1,371 @@
+package vcshost
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name       string
+		rawHost    string
+		want       string
+		wantErrSub string
+	}{
+		{
+			name:       "empty host",
+			wantErrSub: "hostname is empty",
+		},
+		{
+			name:       "unparsable URL",
+			rawHost:    "https://github.example.com/%zz",
+			wantErrSub: "invalid hostname",
+		},
+		{
+			name:       "missing host",
+			rawHost:    "https://",
+			wantErrSub: "invalid hostname",
+		},
+		{
+			name:       "http scheme",
+			rawHost:    "http://github.example.com",
+			wantErrSub: "scheme must be https",
+		},
+		{
+			name:       "userinfo is rejected",
+			rawHost:    "https://token@github.example.com",
+			wantErrSub: "must not contain credentials",
+		},
+		{
+			name:       "query is rejected",
+			rawHost:    "https://github.example.com?token=secret",
+			wantErrSub: "must not contain credentials",
+		},
+		{
+			name:       "fragment is rejected",
+			rawHost:    "https://github.example.com#token",
+			wantErrSub: "must not contain credentials",
+		},
+		{
+			name:       "path is rejected",
+			rawHost:    "https://github.example.com/owner",
+			wantErrSub: "must not contain a path",
+		},
+		{
+			name:    "bare hostname is accepted",
+			rawHost: "github.example.com",
+			want:    "github.example.com",
+		},
+		{
+			name:    "normalizes case and trailing slash",
+			rawHost: "https://GitHub.Example.COM/",
+			want:    "github.example.com",
+		},
+		{
+			name:    "surrounding spaces are trimmed",
+			rawHost: "  github.example.com  ",
+			want:    "github.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Parse(tt.rawHost)
+			if tt.wantErrSub != "" {
+				assert.ErrorContains(t, err, tt.wantErrSub)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, got, tt.want)
+		})
+	}
+}
+
+func TestIsPublic(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		want bool
+	}{
+		{name: "github.com", host: "github.com", want: true},
+		{name: "api.github.com", host: "api.github.com", want: true},
+		{name: "gitlab.com", host: "gitlab.com", want: true},
+		{name: "bitbucket.org", host: "bitbucket.org", want: true},
+		{name: "uppercase is still public", host: "GitHub.com", want: true},
+		{name: "self hosted is not public", host: "github.example.com", want: false},
+		{name: "lookalike is not public", host: "github.com.evil.example", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, IsPublic(tt.host), tt.want)
+		})
+	}
+}
+
+func TestCanonical(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		want string
+	}{
+		{name: "api.github.com folds into github.com", host: "api.github.com", want: "github.com"},
+		{name: "github.com is unchanged", host: "github.com", want: "github.com"},
+		{name: "self hosted is lowercased", host: "GitHub.Example.COM", want: "github.example.com"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, Canonical(tt.host), tt.want)
+		})
+	}
+}
+
+func TestParseAllowlist(t *testing.T) {
+	tests := []struct {
+		name       string
+		raw        string
+		want       []string
+		wantErrSub string
+	}{
+		{
+			name: "empty value yields no host",
+			raw:  "",
+		},
+		{
+			name: "only separators yields no host",
+			raw:  " , , ",
+		},
+		{
+			name: "single host",
+			raw:  "ghe.example.com",
+			want: []string{"ghe.example.com"},
+		},
+		{
+			name: "several hosts with spaces",
+			raw:  "ghe.example.com, gitlab.example.com",
+			want: []string{"ghe.example.com", "gitlab.example.com"},
+		},
+		{
+			name: "https prefixes are normalized",
+			raw:  "https://GHE.example.com",
+			want: []string{"ghe.example.com"},
+		},
+		{
+			name: "duplicates are collapsed",
+			raw:  "ghe.example.com,GHE.EXAMPLE.COM",
+			want: []string{"ghe.example.com"},
+		},
+		{
+			name: "api.github.com is canonicalized",
+			raw:  "api.github.com",
+			want: []string{"github.com"},
+		},
+		{
+			name:       "invalid entry is rejected",
+			raw:        "ghe.example.com,https://evil.example.com/owner",
+			wantErrSub: "invalid hostname",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseAllowlist(tt.raw)
+			if tt.wantErrSub != "" {
+				assert.ErrorContains(t, err, tt.wantErrSub)
+				return
+			}
+			assert.NilError(t, err)
+			assert.DeepEqual(t, got, tt.want)
+		})
+	}
+}
+
+func TestAllowed(t *testing.T) {
+	tests := []struct {
+		name      string
+		allowlist []string
+		host      string
+		want      bool
+	}{
+		{
+			name:      "listed host",
+			allowlist: []string{"ghe.example.com"},
+			host:      "ghe.example.com",
+			want:      true,
+		},
+		{
+			name:      "case is ignored",
+			allowlist: []string{"ghe.example.com"},
+			host:      "GHE.Example.com",
+			want:      true,
+		},
+		{
+			name:      "api.github.com matches github.com",
+			allowlist: []string{"github.com"},
+			host:      "api.github.com",
+			want:      true,
+		},
+		{
+			name:      "unlisted host",
+			allowlist: []string{"ghe.example.com"},
+			host:      "attacker.example.com",
+			want:      false,
+		},
+		{
+			name:      "suffix lookalike does not match",
+			allowlist: []string{"ghe.example.com"},
+			host:      "evil-ghe.example.com",
+			want:      false,
+		},
+		{
+			name: "empty allowlist matches nothing",
+			host: "ghe.example.com",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, Allowed(tt.allowlist, tt.host), tt.want)
+		})
+	}
+}
+
+func TestJoin(t *testing.T) {
+	assert.Equal(t, Join([]string{"ghe.example.com", "gitlab.example.com"}), "ghe.example.com,gitlab.example.com")
+	assert.Equal(t, Join(nil), "")
+}
+
+// Parse must map a hostname to the exact name a resolver would look up, so that
+// the allowlist and DNS can never disagree about which host is being reached.
+func TestParseNormalisation(t *testing.T) {
+	tests := []struct {
+		name    string
+		rawHost string
+		want    string
+		wantErr bool
+	}{
+		{name: "uppercase scheme is accepted", rawHost: "HTTPS://GHE.Example.COM", want: "ghe.example.com"},
+		{name: "uppercase host is lowercased", rawHost: "GHE.EXAMPLE.COM", want: "ghe.example.com"},
+		{name: "root label trailing dot is dropped", rawHost: "ghe.example.com.", want: "ghe.example.com"},
+		{name: "port is kept", rawHost: "ghe.example.com:8443", want: "ghe.example.com:8443"},
+		{name: "unicode is mapped to punycode", rawHost: "ghé.example.com", want: "xn--gh-cja.example.com"},
+		{
+			// strings.ToLower would fold this onto plain "github.com" while
+			// net/http dials xn--github-qyd.com, a registerable domain. Parse
+			// must report the name that is really dialled.
+			name:    "a turkish dotted capital I does not impersonate github.com",
+			rawHost: "GİTHUB.com",
+			want:    "xn--github-qyd.com",
+		},
+		{name: "an already punycoded host is stable", rawHost: "xn--gh-cja.example.com", want: "xn--gh-cja.example.com"},
+		{
+			name:    "unicode mapping cannot introduce a URL path",
+			rawHost: "℀.com",
+			wantErr: true,
+		},
+		{name: "http scheme is refused", rawHost: "http://ghe.example.com", wantErr: true},
+		{name: "userinfo redirection is refused", rawHost: "https://ghe.example.com@evil.example", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Parse(tt.rawHost)
+			if tt.wantErr {
+				assert.Assert(t, err != nil, "expected %q to be refused, got %q", tt.rawHost, got)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, got, tt.want)
+		})
+	}
+}
+
+// A webhook payload must never be able to pin the controller to an address only
+// reachable from inside the cluster or the cloud instance.
+func TestIsPrivate(t *testing.T) {
+	tests := []struct {
+		host string
+		want bool
+	}{
+		{host: "127.0.0.1", want: true},
+		{host: "[::1]", want: true},
+		{host: "169.254.169.254", want: true},
+		{host: "10.0.0.1:8443", want: true},
+		{host: "192.168.1.10", want: true},
+		{host: "localhost", want: true},
+		{host: "gitea", want: true},
+		{host: "gitea.gitea.svc", want: true},
+		{host: "gitea.gitea.svc.cluster.local", want: true},
+		{host: "myservice.cluster.local", want: true},
+		{host: "runner.internal", want: true},
+		{host: "printer.local", want: true},
+		{host: "gitea.home.arpa", want: true},
+		{host: "127.1", want: true},
+		{host: "0177.0.0.1", want: true},
+		{host: "0x7f.1", want: true},
+		{host: "192.168.1", want: true},
+		{host: "github.com", want: false},
+		{host: "ghe.example.com", want: false},
+		{host: "140.82.121.4", want: false},
+		{host: "1password.com", want: false},
+		{host: "svc.example.com", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.host, func(t *testing.T) {
+			assert.Equal(t, IsPrivate(tt.host), tt.want)
+		})
+	}
+}
+
+// Every provider Pipelines-as-Code supports must have its public instance
+// listed, otherwise a stock install of that provider stops working the moment it
+// goes through this gate.
+//
+// The provider list is read from the kubebuilder enum on Repository's provider
+// type rather than hardcoded here, so that adding a provider without deciding
+// what its public hostname is fails this test.
+func TestIsPublicCoversEveryHostedProvider(t *testing.T) {
+	publicInstanceOf := map[string]string{
+		"github":          PublicGitHub,
+		"gitlab":          PublicGitLab,
+		"bitbucket-cloud": PublicBitbucket,
+		"gitea":           PublicGitea,
+		// Forgejo and Bitbucket Data Center have no single public instance:
+		// codeberg.org is the well known Forgejo one and is listed on its own.
+		"forgejo":              "",
+		"bitbucket-datacenter": "",
+	}
+
+	for _, provider := range supportedProviderTypes(t) {
+		host, known := publicInstanceOf[provider]
+		assert.Assert(t, known,
+			"provider %q has no entry in publicInstanceOf: add it here and, if it has a public instance, to publicHosts", provider)
+		if host == "" {
+			continue
+		}
+		assert.Assert(t, IsPublic(host), "%s should be a known public instance", host)
+	}
+
+	// Hostnames that are not a provider type of their own but must still be known.
+	for _, host := range []string{"api.github.com", "api.bitbucket.org", PublicCodeberg} {
+		assert.Assert(t, IsPublic(host), "%s should be a known public instance", host)
+	}
+	assert.Equal(t, Canonical("api.bitbucket.org"), PublicBitbucket)
+}
+
+// supportedProviderTypes reads the provider types from the kubebuilder
+// validation enum that defines them on the Repository CRD.
+func supportedProviderTypes(t *testing.T) []string {
+	t.Helper()
+	const typesFile = "../apis/pipelinesascode/v1alpha1/types.go"
+	source, err := os.ReadFile(typesFile)
+	assert.NilError(t, err)
+	// The Type field of GitProvider is the one enum listing "github".
+	pattern := regexp.MustCompile(`\+kubebuilder:validation:Enum=([a-z;-]*\bgithub\b[a-z;-]*)\s*\n\s*Type string`)
+	match := pattern.FindSubmatch(source)
+	assert.Assert(t, match != nil, "no git provider enum found in %s", typesFile)
+	providers := strings.Split(string(match[1]), ";")
+	assert.Assert(t, len(providers) > 1, "provider enum in %s looks wrong: %v", typesFile, providers)
+	return providers
+}

--- a/test/github_incoming_test.go
+++ b/test/github_incoming_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 	"os"
 	"regexp"
 	"strings"
@@ -18,6 +17,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/configmap"
 	tgithub "github.com/openshift-pipelines/pipelines-as-code/test/pkg/github"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
 	repository "github.com/openshift-pipelines/pipelines-as-code/test/pkg/repository"
@@ -192,6 +192,11 @@ func verifyIncomingWebhook(t *testing.T, randomedString, pipelinerunName string,
 	logmsg := fmt.Sprintf("Testing %s with Github APPS integration on %s with targets %v", label, randomedString, targets)
 	runcnx.Clients.Log.Info(logmsg)
 
+	// An incoming webhook carries no provider signature, so the controller can
+	// never learn this host on its own: it has to be trusted explicitly.
+	defer configmap.TrustProviderHostname(ctx, t, runcnx,
+		tgithub.ControllerConfigMapName(onGHE), *ghprovider.APIURL)()
+
 	var repoinfo *github.Repository
 	var dynamicRepoName string
 
@@ -278,10 +283,6 @@ func verifyIncomingWebhook(t *testing.T, randomedString, pipelinerunName string,
 		assert.NilError(t, err)
 		req.Header.Add("Content-Type", "application/json")
 	}
-	if onGHE {
-		urlParse, _ := url.Parse(*ghprovider.APIURL)
-		req.Header.Add("X-GitHub-Enterprise-Host", urlParse.Host)
-	}
 	assert.NilError(t, err)
 	httpResp, err := client.Do(req)
 	assert.NilError(t, err)
@@ -356,6 +357,11 @@ func TestGithubGHEAppIncomingDefaultBranchProvenance(t *testing.T) {
 	targetBranch := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("incoming-branch")
 
 	runcnx.Clients.Log.Infof("Testing incoming webhook with default_branch provenance on %s", randomedString)
+
+	// An incoming webhook carries no provider signature, so the controller can
+	// never learn this host on its own: it has to be trusted explicitly.
+	defer configmap.TrustProviderHostname(ctx, t, runcnx,
+		tgithub.ControllerConfigMapName(onGHE), *ghprovider.APIURL)()
 
 	repoinfo, resp, err := ghprovider.Client().Repositories.Get(ctx, opts.Organization, opts.Repo)
 	assert.NilError(t, err)
@@ -449,10 +455,6 @@ func TestGithubGHEAppIncomingDefaultBranchProvenance(t *testing.T) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, incomingURL, strings.NewReader(string(jsonData)))
 	assert.NilError(t, err)
 	req.Header.Add("Content-Type", "application/json")
-	if onGHE {
-		urlParse, _ := url.Parse(*ghprovider.APIURL)
-		req.Header.Add("X-GitHub-Enterprise-Host", urlParse.Host)
-	}
 
 	client := &http.Client{}
 	httpResp, err := client.Do(req)

--- a/test/github_trusted_hostnames_test.go
+++ b/test/github_trusted_hostnames_test.go
@@ -1,0 +1,187 @@
+//go:build e2e
+
+package test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/configmap"
+	tgithub "github.com/openshift-pipelines/pipelines-as-code/test/pkg/github"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/secret"
+	twait "github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
+	"github.com/tektoncd/pipeline/pkg/names"
+	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// The trusted provider hostname policy is controller wide, so these tests patch
+// the ConfigMap the GHE controller reads and must not run in parallel with each
+// other or with any other GHE test.
+const gheControllerName = "ghe-controller"
+
+// TestGithubGHETrustOnFirstUse checks that a controller with no configured
+// allowlist records the GHE hostname of a webhook GitHub itself signed, and
+// keeps serving it.
+//
+// The unit tests cover the decision; what only a cluster can tell us is whether
+// the controller is actually allowed to write to its own ConfigMap. Without the
+// RBAC grant that ships with this policy every first webhook from a self hosted
+// instance fails, and nothing else in the suite would notice.
+func TestGithubGHETrustOnFirstUse(t *testing.T) {
+	ctx := context.Background()
+	onGHE := true
+	ctx, runcnx, _, ghprovider, err := tgithub.Setup(ctx, onGHE, false)
+	assert.NilError(t, err)
+
+	configMapName := tgithub.ControllerConfigMapName(onGHE)
+	host := configmap.ProviderHost(t, *ghprovider.APIURL)
+
+	// Hand the policy back to the controller, so that it has to learn the host
+	// again rather than find it already trusted.
+	defer configmap.ResetTrustedProviderHostnames(ctx, t, runcnx, configMapName)()
+	runcnx.Clients.Log.Infof("Cleared the trusted provider hostnames of %s, expecting the controller to learn %s",
+		configMapName, host)
+
+	g := &tgithub.PRTest{
+		Label:     "Github trust on first use",
+		YamlFiles: []string{"testdata/pipelinerun.yaml"},
+		GHE:       true,
+	}
+	g.RunPullRequest(ctx, t)
+	defer g.TearDown(ctx, t)
+
+	// The write happens while the webhook is served, so it has already landed by
+	// the time the PipelineRun succeeded. Poll anyway: the controller retries the
+	// update on conflict, and asserting once would flake on that retry.
+	var allowlist, autoTrusted []string
+	for range 12 {
+		allowlist, autoTrusted = configmap.TrustedProviderHostnames(ctx, t, runcnx, configMapName)
+		if slices.Contains(autoTrusted, host) {
+			break
+		}
+		time.Sleep(5 * time.Second)
+	}
+	assert.Assert(t, !slices.Contains(allowlist, host),
+		"the controller wrote learned host %s into the administrator-owned %q key of the %s ConfigMap, got %v",
+		host, settings.TrustedProviderHostnamesKey, configMapName, allowlist)
+	assert.Assert(t, slices.Contains(autoTrusted, host),
+		"the controller did not record %s in the %s annotation of the %s ConfigMap, got %v. "+
+			"A missing update permission on its own ConfigMap looks exactly like this",
+		host, keys.AutoTrustedProviderHostnames, configMapName, autoTrusted)
+}
+
+// TestGithubGHEUntrustedHostRefused checks that an administrator configured
+// allowlist which leaves the GHE host out stops the controller from using its
+// credentials against it.
+//
+// It drives an incoming webhook, which carries no provider signature and can
+// therefore never be trusted on first use, so the refusal is the policy talking
+// rather than a missing signature. Only a cluster can tell us the gate really
+// sits on the serving path.
+func TestGithubGHEUntrustedHostRefused(t *testing.T) {
+	ctx := context.Background()
+	onGHE := true
+	ctx, runcnx, opts, ghprovider, err := tgithub.Setup(ctx, onGHE, false)
+	assert.NilError(t, err)
+
+	configMapName := tgithub.ControllerConfigMapName(onGHE)
+	host := configmap.ProviderHost(t, *ghprovider.APIURL)
+	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
+
+	repoinfo, resp, err := ghprovider.Client().Repositories.Get(ctx, opts.Organization, opts.Repo)
+	assert.NilError(t, err)
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		t.Errorf("Repository %s not found in %s", opts.Organization, opts.Repo)
+	}
+
+	entries, err := payload.GetEntries(map[string]string{
+		".tekton/pipelinerun-incoming.yaml": "testdata/pipelinerun-incoming.yaml",
+	}, targetNS, targetNS, triggertype.Incoming.String(), map[string]string{})
+	assert.NilError(t, err)
+
+	incoming := &[]v1alpha1.Incoming{
+		{
+			Type:    "webhook-url",
+			Secret:  v1alpha1.Secret{Name: incomingSecretName, Key: "incoming"},
+			Targets: []string{targetNS},
+			Params:  []string{"the_best_superhero_is"},
+		},
+	}
+	assert.NilError(t, tgithub.CreateCRDIncoming(ctx, t, repoinfo, runcnx, incoming, opts, ghprovider, targetNS))
+	assert.NilError(t, secret.Create(ctx, runcnx, map[string]string{"incoming": incomingSecreteValue}, targetNS, incomingSecretName))
+
+	targetRefName := "refs/heads/" + targetNS
+	title := "TestGithubGHEUntrustedHostRefused - " + targetNS
+	sha, vref, err := tgithub.PushFilesToRef(ctx, ghprovider.Client(), title,
+		repoinfo.GetDefaultBranch(), targetRefName, opts.Organization, opts.Repo, entries)
+	assert.NilError(t, err)
+	runcnx.Clients.Log.Infof("Commit %s has been created and pushed to branch %s", sha, vref.GetURL())
+
+	g := tgithub.PRTest{
+		Cnx:             runcnx,
+		Options:         opts,
+		Provider:        ghprovider,
+		TargetNamespace: targetNS,
+		TargetRefName:   targetRefName,
+		PRNumber:        -1,
+		SHA:             sha,
+		Logger:          runcnx.Clients.Log,
+		GHE:             onGHE,
+	}
+	defer g.TearDown(ctx, t)
+
+	// A non-empty administrator list is authoritative. The GHE host is
+	// deliberately left out.
+	defer configmap.ChangeGlobalConfig(ctx, t, runcnx, configMapName, map[string]string{
+		settings.TrustedProviderHostnamesKey: "github.com",
+	})()
+	runcnx.Clients.Log.Infof("Set an authoritative allowlist on %s that leaves %s out", configMapName, host)
+
+	incomingURL := fmt.Sprintf("%s/incoming", opts.ControllerURL)
+	jsonData, err := json.Marshal(map[string]any{
+		"repository":  targetNS,
+		"branch":      targetNS,
+		"pipelinerun": "pipelinerun-incoming",
+		"secret":      incomingSecreteValue,
+		"params":      map[string]string{"the_best_superhero_is": "Superman"},
+	})
+	assert.NilError(t, err)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, incomingURL, strings.NewReader(string(jsonData)))
+	assert.NilError(t, err)
+	req.Header.Add("Content-Type", "application/json")
+
+	httpResp, err := (&http.Client{}).Do(req)
+	assert.NilError(t, err)
+	defer httpResp.Body.Close()
+	runcnx.Clients.Log.Infof("Sent an incoming request to %s for a host that is not trusted", incomingURL)
+
+	numLines := int64(300)
+	sinceSeconds := int64(300)
+	// The controller logs JSON, so the quotes around the hostname reach the log
+	// line escaped. Accept both shapes rather than depend on the encoder.
+	refusal := regexp.MustCompile(
+		`refusing to use credentials with the \\?"` + regexp.QuoteMeta(host) + `\\?" host`,
+	)
+	assert.NilError(t, twait.RegexpMatchingInControllerLog(ctx, runcnx, *refusal, 10, gheControllerName, &numLines, &sinceSeconds),
+		"the controller did not refuse the untrusted host, which means the allowlist is not gating the serving path")
+
+	prs, err := runcnx.Clients.Tekton.TektonV1().PipelineRuns(targetNS).List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", keys.SHA, sha),
+	})
+	assert.NilError(t, err)
+	assert.Assert(t, len(prs.Items) == 0,
+		"a PipelineRun was created for a provider host the allowlist refuses, got %d", len(prs.Items))
+}

--- a/test/pkg/configmap/configmap.go
+++ b/test/pkg/configmap/configmap.go
@@ -2,42 +2,192 @@ package configmap
 
 import (
 	"context"
+	"maps"
+	"slices"
+	"strings"
 	"testing"
 
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
-	"golang.org/x/exp/maps"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/vcshost"
 	"gotest.tools/v3/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	typedv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/util/retry"
 )
 
-func ChangeGlobalConfig(ctx context.Context, t *testing.T, runcnx *params.Run, configMapName string, data map[string]string) func() {
-	ns := info.GetNS(ctx)
-	// grab the old configmap content
-	origCfgmap, err := runcnx.Clients.Kube.CoreV1().ConfigMaps(ns).Get(ctx, configMapName, metav1.GetOptions{})
-	assert.NilError(t, err)
-	newData := map[string]string{}
-	maps.Copy(newData, origCfgmap.Data)
-	maps.Copy(newData, data)
-	newConfigMap := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      configMapName,
-			Namespace: ns,
-		},
-		Data: newData,
-	}
-	_, err = runcnx.Clients.Kube.CoreV1().ConfigMaps(ns).Update(ctx, newConfigMap, metav1.UpdateOptions{})
-	assert.NilError(t, err)
-	return func() {
-		orgNew := &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      configMapName,
-				Namespace: ns,
-			},
-			Data: origCfgmap.Data,
+// update applies mutate to the ConfigMap under a conflict retry.
+//
+// Every helper here reads, mutates and updates rather than replacing the object
+// wholesale: the controller writes to this ConfigMap on its own when it learns a
+// provider hostname, and neither that value nor the labels and annotations it
+// carries may be lost by a test tuning an unrelated key. mutate runs again on
+// each retry, so it must derive everything it writes from the object it is
+// given.
+func update(ctx context.Context, t *testing.T, configMaps typedv1.ConfigMapInterface, configMapName string, mutate func(*corev1.ConfigMap)) {
+	t.Helper()
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current, err := configMaps.Get(ctx, configMapName, metav1.GetOptions{})
+		if err != nil {
+			return err
 		}
-		_, err := runcnx.Clients.Kube.CoreV1().ConfigMaps(ns).Update(ctx, orgNew, metav1.UpdateOptions{})
-		assert.NilError(t, err)
+		if current.Data == nil {
+			current.Data = map[string]string{}
+		}
+		if current.Annotations == nil {
+			current.Annotations = map[string]string{}
+		}
+		mutate(current)
+		_, err = configMaps.Update(ctx, current, metav1.UpdateOptions{})
+		return err
+	})
+	assert.NilError(t, err)
+}
+
+func configMapsFor(ctx context.Context, runcnx *params.Run) typedv1.ConfigMapInterface {
+	return runcnx.Clients.Kube.CoreV1().ConfigMaps(info.GetNS(ctx))
+}
+
+// ChangeGlobalConfig patches keys into the controller ConfigMap and returns a
+// function restoring the previous values.
+func ChangeGlobalConfig(ctx context.Context, t *testing.T, runcnx *params.Run, configMapName string, data map[string]string) func() {
+	t.Helper()
+	configMaps := configMapsFor(ctx, runcnx)
+
+	original := map[string]string{}
+	update(ctx, t, configMaps, configMapName, func(current *corev1.ConfigMap) {
+		clear(original)
+		for key := range data {
+			original[key] = current.Data[key]
+		}
+		maps.Copy(current.Data, data)
+	})
+
+	return func() {
+		update(ctx, t, configMaps, configMapName, func(current *corev1.ConfigMap) {
+			maps.Copy(current.Data, original)
+		})
 	}
+}
+
+// TrustProviderHostname adds the hostname of the provider under test to the
+// controller allowlist, so that an incoming webhook, which carries no provider
+// signature and therefore cannot be trusted on first use, reaches it. It returns
+// a function removing that hostname again.
+//
+// Only the hostname it added is removed on restore; writing the whole key back
+// would otherwise delete another administrator entry added during the test.
+func TrustProviderHostname(ctx context.Context, t *testing.T, runcnx *params.Run, configMapName, providerURL string) func() {
+	t.Helper()
+	host := providerHost(t, providerURL)
+	configMaps := configMapsFor(ctx, runcnx)
+
+	added := false
+	update(ctx, t, configMaps, configMapName, func(current *corev1.ConfigMap) {
+		hosts := splitHosts(current.Data[settings.TrustedProviderHostnamesKey])
+		if added = !slices.Contains(hosts, host); added {
+			current.Data[settings.TrustedProviderHostnamesKey] = strings.Join(append(hosts, host), ",")
+		}
+	})
+
+	if !added {
+		return func() {}
+	}
+
+	return func() {
+		update(ctx, t, configMaps, configMapName, func(current *corev1.ConfigMap) {
+			hosts := slices.DeleteFunc(splitHosts(current.Data[settings.TrustedProviderHostnamesKey]),
+				func(entry string) bool { return entry == host })
+			setOrDelete(current.Data, settings.TrustedProviderHostnamesKey, strings.Join(hosts, ","), len(hosts) > 0)
+		})
+	}
+}
+
+// ProviderHost extracts the hostname of a provider URL the way the controller
+// stores it in the allowlist, so that a test comparing what the controller wrote
+// against the instance it talks to compares equal spellings.
+func ProviderHost(t *testing.T, providerURL string) string {
+	t.Helper()
+	return providerHost(t, providerURL)
+}
+
+// TrustedProviderHostnames returns the administrator allowlist together with the
+// hostnames the controller recorded itself.
+func TrustedProviderHostnames(ctx context.Context, t *testing.T, runcnx *params.Run, configMapName string) (allowlist, autoTrusted []string) {
+	t.Helper()
+	current, err := configMapsFor(ctx, runcnx).Get(ctx, configMapName, metav1.GetOptions{})
+	assert.NilError(t, err)
+	return splitHosts(current.Data[settings.TrustedProviderHostnamesKey]),
+		splitHosts(current.Annotations[keys.AutoTrustedProviderHostnames])
+}
+
+// ResetTrustedProviderHostnames hands the policy back to the controller and
+// forgets what it learned, which is the state a fresh install starts from. It
+// returns a function putting both values back as they were.
+//
+// A test that wants to watch the controller learn a hostname has to start from
+// here: a configured list is authoritative, while an existing learned entry
+// would make the controller skip the write.
+func ResetTrustedProviderHostnames(ctx context.Context, t *testing.T, runcnx *params.Run, configMapName string) func() {
+	t.Helper()
+	configMaps := configMapsFor(ctx, runcnx)
+
+	var originalData, originalAnnotation string
+	var hadData, hadAnnotation bool
+	update(ctx, t, configMaps, configMapName, func(current *corev1.ConfigMap) {
+		originalData, hadData = current.Data[settings.TrustedProviderHostnamesKey]
+		originalAnnotation, hadAnnotation = current.Annotations[keys.AutoTrustedProviderHostnames]
+		delete(current.Data, settings.TrustedProviderHostnamesKey)
+		delete(current.Annotations, keys.AutoTrustedProviderHostnames)
+	})
+
+	return func() {
+		update(ctx, t, configMaps, configMapName, func(current *corev1.ConfigMap) {
+			setOrDelete(current.Data, settings.TrustedProviderHostnamesKey, originalData, hadData)
+			setOrDelete(current.Annotations, keys.AutoTrustedProviderHostnames, originalAnnotation, hadAnnotation)
+		})
+	}
+}
+
+// setOrDelete restores a key to the value it had, which for a key that was not
+// there in the first place means removing it rather than leaving an empty value
+// behind: an empty allowlist and an unset one read the same to the controller,
+// but an empty annotation would not survive a round trip unchanged.
+func setOrDelete(target map[string]string, key, value string, keep bool) {
+	if keep {
+		target[key] = value
+		return
+	}
+	delete(target, key)
+}
+
+// providerHost extracts the hostname of a provider URL the way the controller
+// stores it in the allowlist, so that adding and removing an entry compares
+// equal to what the controller itself would have written.
+func providerHost(t *testing.T, providerURL string) string {
+	t.Helper()
+	parsed, err := vcshost.SplitURL(providerURL)
+	assert.NilError(t, err)
+	host, err := vcshost.Parse(parsed.Host)
+	assert.NilError(t, err)
+	return vcshost.Canonical(host)
+}
+
+// splitHosts parses the comma separated allowlist, dropping the empty entries an
+// unset or trailing separator leaves behind.
+//
+// It does not go through vcshost.ParseAllowlist on purpose: a restore path has
+// to put back whatever it found, and an entry the controller cannot parse must
+// not make a test fail in its teardown.
+func splitHosts(raw string) []string {
+	var hosts []string
+	for entry := range strings.SplitSeq(raw, ",") {
+		if entry = strings.TrimSpace(entry); entry != "" {
+			hosts = append(hosts, entry)
+		}
+	}
+	return hosts
 }

--- a/test/pkg/github/setup.go
+++ b/test/pkg/github/setup.go
@@ -58,7 +58,17 @@ func Setup(ctx context.Context, onGHE, viaDirectWebhook bool) (context.Context, 
 		URL:   config.url,
 	}
 	gprovider.Token = &config.token
-	// TODO: before PR
+	// The harness is not a controller: the API URL comes from its own
+	// configuration rather than from a payload or a Repository CR, so the
+	// trusted hostname policy, which exists to stop a credential the controller
+	// owns from reaching a host a tenant picked, has nothing to protect here.
+	// Build the client from that URL and hand it over, so that SetClient leaves
+	// it alone instead of asking the policy of a controller we are not.
+	client, _, _, err := gprovider.MakeClient(ctx, config.url, config.token)
+	if err != nil {
+		return ctx, nil, options.E2E{}, github.New(), err
+	}
+	gprovider.UsePreauthenticatedClient(client)
 	if err := gprovider.SetClient(ctx, run, event, nil, nil); err != nil {
 		return ctx, nil, options.E2E{}, github.New(), err
 	}
@@ -71,6 +81,23 @@ type envConfig struct {
 	url           string
 	repoOwner     string
 	controllerURL string
+}
+
+// ControllerConfigMapName returns the ConfigMap the controller under test reads
+// its settings from.
+//
+// The GHE tests talk to the second controller, which hack/second-controller.py
+// deploys with a ConfigMap of its own, so a test tuning a controller wide
+// setting has to target that one: patching the default ConfigMap would tune the
+// controller the test is not talking to.
+func ControllerConfigMapName(onGHE bool) string {
+	if !onGHE {
+		return info.DefaultPipelinesAscodeConfigmapName
+	}
+	if name := os.Getenv("TEST_GITHUB_SECOND_CONFIGMAP"); name != "" {
+		return name
+	}
+	return "ghe-configmap"
 }
 
 // setupEnvVars validates and retrieves environment variables based on the test scenario.


### PR DESCRIPTION
## 📝 Description of the Change

Git provider API endpoints can be influenced by webhook payloads and Repository configuration. Without a trust policy, the controller could send provider credentials to a host selected by an attacker.

This change introduces `trusted-provider-hostnames`, an administrator-owned allowlist in the controller ConfigMap:

- When the list is empty, known public provider hosts remain trusted.
- An authenticated GitHub App webhook may teach the controller a publicly routable self-hosted hostname. Learned hosts are kept separately in the `pipelinesascode.tekton.dev/auto-trusted-provider-hostnames` annotation.
- When an administrator configures a non-empty list, it becomes authoritative. The controller stops learning hosts and sends credentials only to listed destinations.
- Private, loopback, link-local, metadata, and in-cluster destinations are never learned automatically.
- Each controller has its own policy and can update only its own ConfigMap.
- Repository resources cannot redirect credentials inherited from a global Repository to another endpoint.
- GitLab refuses to derive an API host from webhook payloads when it is using a globally inherited credential.
- GitHub App deliveries without a repository are skipped without selecting an endpoint or minting an installation token.

### Request flow

```mermaid
flowchart TD
    A[Request needs provider credentials] --> B{Did an administrator configure trusted hostnames?}

    B -- Yes --> C{Is the requested host listed?}
    C -- Yes --> ALLOW[Use the credentials]
    C -- No --> REFUSE[Refuse the request]

    B -- No --> D{Is it a known public provider host?}
    D -- Yes --> ALLOW
    D -- No --> E{Was this host already learned?}
    E -- Yes --> ALLOW
    E -- No --> F{Did the provider authenticate this request?}
    F -- No --> REFUSE
    F -- Yes --> G{Is the host private or internal?}
    G -- Yes --> REFUSE
    G -- No --> RECORD[Record it in the controller-owned annotation]
    RECORD --> ALLOW
```

### Upgrade note

Existing self-hosted installations using per-repository or incoming webhooks should configure `trusted-provider-hostnames` before upgrading. Those requests cannot teach the controller a hostname because they are not authenticated with the controller-owned GitHub App webhook secret.

GitHub.com installations require no additional configuration.

### Tekton Operator follow-up

The Tekton Operator needs a companion update after this PR is merged so it can round-trip the new setting, preserve learned-host annotations, and grant additional controllers access to their own ConfigMaps. This work is tracked in [tektoncd/operator#3946](https://github.com/tektoncd/operator/issues/3946).

## 🔗 Linked GitHub Issue

Jira: [SRVKP-13030](https://redhat.atlassian.net/browse/SRVKP-13030)

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [x] End-to-end tests
- [x] Manual testing
- [ ] Not Applicable

Validated with:

- `make test` — 3,620 tests passed
- `make lint`
- `TestGithubGHETrustOnFirstUse`
- `TestGithubGHEUntrustedHostRefused`

## 🤖 AI Assistance

AI assistance was used for code review, test planning, and documentation. The resulting changes were reviewed and tested locally.

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♻ I have run `make test` and `make lint` locally to check for and fix any issues.
- [x] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [x] 🎁 I have added end-to-end tests where feasible.
- [x] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [x] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [x] GitHub App
  - [x] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [x] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
