### PR TITLE
fix: graceful shutdown of controller listener

### DIFF
--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -141,16 +141,34 @@ func (l *listener) Start(ctx context.Context) error {
 		}
 		serverTLSConfig.Certificates = []tls.Certificate{cert}
 		srv.TLSConfig = serverTLSConfig
-
-		if err := srv.ListenAndServeTLS("", ""); err != nil {
-			return err
-		}
-	} else {
-		if err := srv.ListenAndServe(); err != nil {
-			return err
-		}
 	}
-	return nil
+
+	// Shut the server down gracefully when the context is cancelled
+	// (SIGTERM/SIGINT via knative signals), so the process exits cleanly
+	// instead of being killed at the end of the pod grace period.
+	errCh := make(chan error, 1)
+	go func() {
+		var err error
+		if enabled {
+			err = srv.ListenAndServeTLS("", "")
+		} else {
+			err = srv.ListenAndServe()
+		}
+		errCh <- err
+	}()
+
+	select {
+	case err := <-errCh:
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return err
+		}
+		return nil
+	case <-ctx.Done():
+		l.logger.Info("shutting down listener")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		return srv.Shutdown(shutdownCtx)
+	}
 }
 
 func (l listener) handleEvent(ctx context.Context) http.HandlerFunc {

--- a/pkg/adapter/adapter_test.go
+++ b/pkg/adapter/adapter_test.go
@@ -4,9 +4,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/google/go-github/v85/github"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
@@ -20,6 +23,7 @@ import (
 	tektontest "github.com/openshift-pipelines/pipelines-as-code/pkg/test/tekton"
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/env"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -253,5 +257,72 @@ func TestWhichProvider(t *testing.T) {
 			}
 			assert.NilError(t, err)
 		})
+	}
+}
+
+func TestStartGracefulShutdown(t *testing.T) {
+	// pick a free port for the listener
+	var lc net.ListenConfig
+	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	assert.NilError(t, err)
+	tcpAddr, ok := ln.Addr().(*net.TCPAddr)
+	assert.Assert(t, ok, "expected *net.TCPAddr")
+	port := strconv.Itoa(tcpAddr.Port)
+	assert.NilError(t, ln.Close())
+
+	defer env.PatchAll(t, map[string]string{
+		"SYSTEM_NAMESPACE":    "pipelinesascode",
+		"PAC_CONTROLLER_PORT": port,
+	})()
+
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	cs, _ := testclient.SeedTestData(t, ctx, testclient.Data{})
+	log, _ := logger.GetLogger()
+	l := &listener{
+		logger: log,
+		run: &params.Run{
+			Clients: clients.Clients{Kube: cs.Kube, Log: log},
+			Info: info.Info{
+				Pac:        &info.PacOpts{Settings: settings.Settings{}},
+				Kube:       &info.KubeOpts{Namespace: "pipelinesascode"},
+				Controller: &info.ControllerInfo{Configmap: "pipelines-as-code"},
+			},
+		},
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- l.Start(ctx)
+	}()
+
+	// wait until the http server is up before cancelling the context
+	liveURL := "http://127.0.0.1:" + port + "/live"
+	httpClient := &http.Client{Timeout: 2 * time.Second}
+	up := false
+	for range 50 {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, liveURL, nil)
+		assert.NilError(t, err)
+		resp, err := httpClient.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+			up = resp.StatusCode == http.StatusOK
+			if up {
+				break
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	assert.Assert(t, up, "listener never became ready on %s", liveURL)
+
+	cancel()
+
+	select {
+	case err := <-errCh:
+		assert.NilError(t, err, "Start should return cleanly on context cancellation")
+	case <-time.After(15 * time.Second):
+		t.Fatal("listener did not shut down after context cancellation")
 	}
 }


### PR DESCRIPTION
## 📝 Description of the Change

The controller's HTTP listener ignored context cancellation, causing the process to hang indefinitely on SIGTERM. Previously, `srv.ListenAndServe()` blocked forever without checking the context, forcing Kubernetes to forcibly terminate the pod with SIGKILL at the end of the grace period instead of allowing a clean shutdown.

This fix runs the server in a separate goroutine and monitors the context for cancellation signals. When the context is cancelled (SIGTERM/SIGINT from knative), the server is gracefully shut down with a 10-second timeout, allowing in-flight requests to complete. This enables the process to exit cleanly and allows Go runtime cleanup hooks (e.g., coverage data flushing via GOCOVERDIR) to execute before the process terminates.

## 🔗 Linked GitHub Issue

Fixes #

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

Added `TestStartGracefulShutdown` which verifies the listener starts correctly and terminates cleanly when the context is cancelled—this test fails on the previous code.

## 🤖 AI Assistance

- [x] I have not used any AI assistance for this PR.
- [ ] I have used AI assistance for this PR.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any issues. For an efficient workflow, I have considered installing [pre-commit](https://pre-commit.com/) and running `pre-commit install` to automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [x] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center