### PR TITLE
ci: collect e2e coverage and upload to codecov

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -12,6 +12,16 @@ coverage:
       # See https://docs.codecov.io/docs/commit-status#disabling-a-status.
       default: false
 
+flag_management:
+  individual_flags:
+    - name: unit-tests
+      carryforward: false
+    # The e2e workflow is path-filtered and does not run on every PR;
+    # carryforward reuses the last e2e report instead of showing a
+    # coverage drop when it did not run.
+    - name: e2e
+      carryforward: true
+
 ignore:
   - "**/zz_generated*.go"
   - "**/*.pb.go"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -46,6 +46,8 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
+      # for codecov OIDC upload of e2e coverage
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -357,6 +359,11 @@ jobs:
             kubectl -n pipelines-as-code rollout status deployment/pipelines-as-code-$name --timeout=120s
           done
 
+      - name: Instrument PAC with coverage
+        id: coverage-deploy
+        run: |
+          ./hack/dev/e2e-coverage.sh deploy
+
       # Adjusted step-level conditions based on the new job-level logic
       - name: Run E2E Tests
         # This step runs for schedule, PR target (if job started), or workflow_dispatch (if job started)
@@ -402,6 +409,37 @@ jobs:
         if: ${{ always() }}
         run: |
           ./hack/gh-workflow-ci.sh output_logs
+
+      # Coverage collection scales the deployments down (SIGTERM flushes the
+      # counters), so it must run after all the log gathering steps.
+      - name: Collect e2e coverage
+        id: coverage-collect
+        if: ${{ always() && steps.coverage-deploy.outcome == 'success' }}
+        env:
+          OUTPUT_DIR: /tmp/e2e-coverage
+        run: |
+          ./hack/dev/e2e-coverage.sh collect
+          ./hack/dev/e2e-coverage.sh report
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload e2e coverage artifact
+        if: ${{ always() && steps.coverage-collect.outcome == 'success' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-e2e-${{ matrix.provider }}
+          path: /tmp/e2e-coverage/e2e-coverage.txt
+
+      - name: Upload e2e coverage to Codecov
+        if: ${{ always() && steps.coverage-collect.outcome == 'success' }}
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: /tmp/e2e-coverage/e2e-coverage.txt
+          flags: e2e
+          use_oidc: true
+          disable_search: true
+          fail_ci_if_error: false
+          override_commit: ${{ steps.coverage-collect.outputs.sha }}
+          override_pr: ${{ github.event.pull_request.number }}
 
       - name: Upload artifacts
         if: ${{ always() }}

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,16 @@ test-e2e:  ## run e2e tests
 	env GODEBUG=asynctimerchan=1 \
 		$(GO) test $(DEFAULT_GO_TEST_FLAGS) $(GO_TEST_FLAGS) -timeout $(TIMEOUT_E2E)  -failfast -count=1 -tags=e2e ./test
 
+.PHONY: e2e-coverage-deploy
+e2e-coverage-deploy: ## redeploy PAC on local kind with coverage instrumentation
+	@./hack/dev/e2e-coverage.sh deploy
+
+.PHONY: e2e-coverage
+e2e-coverage: ## run e2e tests (E2E_TEST=TestName to filter) and collect coverage from the cluster
+	$(MAKE) test-e2e GO_TEST_FLAGS="$(GO_TEST_FLAGS) $(if $(E2E_TEST),-run $(E2E_TEST))" || true
+	@./hack/dev/e2e-coverage.sh collect
+	@./hack/dev/e2e-coverage.sh report
+
 .PHONY: html-coverage
 html-coverage: ## generate html coverage
 	@mkdir -p tmp

--- a/hack/dev/e2e-coverage.sh
+++ b/hack/dev/e2e-coverage.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# Collect Go binary coverage from PAC components running on a kind/k8s
+# cluster reachable via the current kubeconfig, while running e2e tests
+# against it. No assumption about how the cluster was set up (startpaac,
+# manual kind, ...): the registry is auto-detected from the running
+# deployment and node access goes through a privileged helper pod.
+#
+# Usage:
+#   ./hack/dev/e2e-coverage.sh deploy     # redeploy instrumented PAC via ko (+GOCOVERDIR)
+#   ./hack/dev/e2e-coverage.sh collect    # flush + gather coverage from the cluster
+#   ./hack/dev/e2e-coverage.sh report     # textfmt + html report (merges unit if present)
+#   ./hack/dev/e2e-coverage.sh clean      # remove coverage dirs (node + local)
+#
+# Typical flow:
+#   ./hack/dev/e2e-coverage.sh deploy
+#   make test-e2e GO_TEST_FLAGS="-run TestGiteaPush"   # or any e2e run
+#   ./hack/dev/e2e-coverage.sh collect
+#   ./hack/dev/e2e-coverage.sh report
+#
+# Environment:
+#   KO_DOCKER_REPO  registry for ko builds (default: auto-detected from the
+#                   running controller deployment image)
+#   KO_EXTRA_FLAGS  extra flags for ko apply (e.g. --insecure-registry)
+#   COMPONENTS      space-separated list (default: "controller watcher webhook")
+#   OUTPUT_DIR      local output dir (default: ./tmp/e2e-coverage)
+set -euo pipefail
+
+COMPONENTS=${COMPONENTS:-"controller watcher webhook"}
+OUTPUT_DIR=${OUTPUT_DIR:-./tmp/e2e-coverage}
+KO_EXTRA_FLAGS=${KO_EXTRA_FLAGS:-}
+NAMESPACE=pipelines-as-code
+NODE_COVER_DIR=/tmp/gocover
+HELPER_POD=gocover-helper
+
+info() { echo -e "\033[1;32m>>>\033[0m $*"; }
+die() {
+	echo -e "\033[1;31mERROR:\033[0m $*" >&2
+	exit 1
+}
+
+# Privileged helper pod mounting the node's coverage dir; all node-side
+# operations go through it so this works wherever the kind node runs
+# (local docker, remote host, ...).
+helper_up() {
+	kubectl -n ${NAMESPACE} get pod ${HELPER_POD} >/dev/null 2>&1 && return
+	kubectl -n ${NAMESPACE} apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${HELPER_POD}
+spec:
+  terminationGracePeriodSeconds: 0
+  containers:
+    - name: helper
+      image: busybox
+      command: ["sleep", "infinity"]
+      securityContext:
+        privileged: true
+      volumeMounts:
+        - name: host-tmp
+          mountPath: /host-tmp
+  volumes:
+    - name: host-tmp
+      hostPath:
+        path: /tmp
+        type: Directory
+EOF
+	kubectl -n ${NAMESPACE} wait --for=condition=Ready pod/${HELPER_POD} --timeout=120s
+}
+
+helper_exec() {
+	kubectl -n ${NAMESPACE} exec ${HELPER_POD} -- sh -c "$*"
+}
+
+helper_down() {
+	kubectl -n ${NAMESPACE} delete pod ${HELPER_POD} --ignore-not-found --wait=false
+}
+
+component_config() {
+	case $1 in
+	controller) echo config/400-controller.yaml ;;
+	watcher) echo config/500-watcher.yaml ;;
+	webhook) echo config/600-webhook.yaml ;;
+	*) die "unknown component: $1" ;;
+	esac
+}
+
+detect_registry() {
+	local image
+	image=$(kubectl -n ${NAMESPACE} get deployment pipelines-as-code-controller \
+		-o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null) ||
+		die "cannot read controller deployment; is PAC installed in ${NAMESPACE}?"
+	echo "${image%%/*}"
+}
+
+deploy() {
+	command -v ko >/dev/null || die "ko is required (https://ko.build)"
+	if [[ -z ${KO_DOCKER_REPO:-} ]]; then
+		KO_DOCKER_REPO=$(detect_registry)
+		info "Auto-detected registry: ${KO_DOCKER_REPO}"
+	fi
+	export KO_DOCKER_REPO
+
+	local node_arch platform
+	node_arch=$(kubectl get nodes -o jsonpath='{.items[0].status.nodeInfo.architecture}')
+	platform="linux/${node_arch}"
+	info "Building for node platform: ${platform}"
+
+	info "Redeploying PAC with coverage instrumentation (GOFLAGS=-cover)"
+	for component in ${COMPONENTS}; do
+		# shellcheck disable=SC2086
+		env GOFLAGS=-cover ko apply -f "$(component_config "${component}")" \
+			--platform="${platform}" -B --sbom=none ${KO_EXTRA_FLAGS}
+	done
+
+	info "Creating coverage dirs on the node"
+	helper_up
+	for component in ${COMPONENTS}; do
+		# distroless nonroot UID; a root-owned dir would be unwritable
+		helper_exec "mkdir -p /host-tmp/gocover/${component} && chown 65532:65532 /host-tmp/gocover/${component} && chmod 0770 /host-tmp/gocover/${component}"
+	done
+
+	info "Patching deployments with GOCOVERDIR + hostPath volume"
+	for component in ${COMPONENTS}; do
+		kubectl -n ${NAMESPACE} patch deployment "pipelines-as-code-${component}" --type=strategic -p "{
+      \"spec\": {\"template\": {\"spec\": {
+        \"terminationGracePeriodSeconds\": 90,
+        \"containers\": [{\"name\": \"pac-${component}\",
+          \"env\": [{\"name\": \"GOCOVERDIR\", \"value\": \"/coverage\"}],
+          \"volumeMounts\": [{\"name\": \"gocover\", \"mountPath\": \"/coverage\"}]}],
+        \"volumes\": [{\"name\": \"gocover\", \"hostPath\": {\"path\": \"${NODE_COVER_DIR}/${component}\", \"type\": \"Directory\"}}]
+      }}}}"
+	done
+
+	for component in ${COMPONENTS}; do
+		kubectl -n ${NAMESPACE} rollout status "deployment/pipelines-as-code-${component}" --timeout=120s
+	done
+	info "Done. Run your e2e tests, then: $0 collect"
+}
+
+collect() {
+	info "Scaling down instrumented deployments (SIGTERM flushes coverage)"
+	for component in ${COMPONENTS}; do
+		kubectl -n ${NAMESPACE} scale deployment "pipelines-as-code-${component}" --replicas=0
+	done
+	for component in ${COMPONENTS}; do
+		kubectl -n ${NAMESPACE} wait --for=delete pod \
+			-l "app.kubernetes.io/name=${component}" --timeout=120s 2>/dev/null || true
+	done
+
+	info "Copying coverage data from the node"
+	helper_up
+	rm -rf "${OUTPUT_DIR}/data"
+	for component in ${COMPONENTS}; do
+		mkdir -p "${OUTPUT_DIR}/data/${component}"
+		kubectl -n ${NAMESPACE} exec ${HELPER_POD} -- \
+			tar cf - -C "/host-tmp/gocover/${component}" . 2>/dev/null |
+			tar xf - -C "${OUTPUT_DIR}/data/${component}" || true
+		count=$(find "${OUTPUT_DIR}/data/${component}" -name 'covcounters.*' | wc -l)
+		info "${component}: ${count} covcounters file(s)"
+	done
+	helper_down
+
+	find "${OUTPUT_DIR}/data" -name 'covmeta.*' | grep -q . ||
+		die "no coverage data found; was PAC deployed with '$0 deploy'?"
+	find "${OUTPUT_DIR}/data" -name 'covcounters.*' | grep -q . ||
+		die "covmeta found but no covcounters: processes did not exit gracefully (coverage not flushed)"
+
+	info "Scaling deployments back up"
+	for component in ${COMPONENTS}; do
+		kubectl -n ${NAMESPACE} scale deployment "pipelines-as-code-${component}" --replicas=1
+	done
+	info "Done. Generate a report with: $0 report"
+}
+
+report() {
+	local dirs
+	dirs=$(find "${OUTPUT_DIR}/data" -mindepth 1 -maxdepth 1 -type d 2>/dev/null |
+		while read -r d; do ls "${d}"/covmeta.* >/dev/null 2>&1 && echo "${d}"; done | paste -sd,)
+	[[ -n ${dirs} ]] || die "no coverage data in ${OUTPUT_DIR}/data; run '$0 collect' first"
+
+	info "Converting to text profile"
+	go tool covdata textfmt -i="${dirs}" -o "${OUTPUT_DIR}/e2e-coverage.txt"
+
+	info "Coverage by package (e2e only):"
+	go tool covdata percent -i="${dirs}" | grep -v '0.0%' || true
+
+	go tool cover -html="${OUTPUT_DIR}/e2e-coverage.txt" -o "${OUTPUT_DIR}/e2e-coverage.html"
+	info "E2E report: ${OUTPUT_DIR}/e2e-coverage.html"
+
+	# Merge with unit coverage when unit tests also wrote binary coverage:
+	#   mkdir -p tmp/e2e-coverage/unit && \
+	#     go test -cover ./pkg/... -args -test.gocoverdir=$PWD/tmp/e2e-coverage/unit
+	if ls "${OUTPUT_DIR}/unit"/covmeta.* >/dev/null 2>&1; then
+		info "Merging with unit-test coverage"
+		go tool covdata textfmt -i="${dirs},${OUTPUT_DIR}/unit" -o "${OUTPUT_DIR}/combined-coverage.txt"
+		go tool cover -html="${OUTPUT_DIR}/combined-coverage.txt" -o "${OUTPUT_DIR}/combined-coverage.html"
+		go tool cover -func="${OUTPUT_DIR}/combined-coverage.txt" | tail -1
+		info "Combined report: ${OUTPUT_DIR}/combined-coverage.html"
+	else
+		info "No unit binary coverage found in ${OUTPUT_DIR}/unit — see comment in this script to generate it"
+	fi
+}
+
+clean() {
+	helper_up
+	helper_exec "rm -rf /host-tmp/gocover"
+	helper_down
+	rm -rf "${OUTPUT_DIR}"
+	info "Cleaned"
+}
+
+case ${1:-""} in
+deploy | collect | report | clean) "$1" ;;
+*)
+	sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'
+	exit 1
+	;;
+esac


### PR DESCRIPTION
## Changes

Codecov currently only receives unit-test coverage (`unit-tests` flag), so the reported number under-represents everything exercised by the E2E suite (webhook handling, matching, reconciling, full workflows). Ref [SRVKP-13050](https://issues.redhat.com/browse/SRVKP-13050).

This collects Go binary coverage from the PAC components running on the E2E kind cluster and uploads it to Codecov, where it is merged server-side with the unit coverage for the same commit SHA:

- **`hack/dev/e2e-coverage.sh`**: deploy/collect/report/clean tooling. `deploy` rebuilds the controller/watcher/webhook with `GOFLAGS=-cover` via ko and patches the deployments with a `GOCOVERDIR` hostPath mount; `collect` scales them down (SIGTERM → graceful exit → counters flushed), extracts the data through a helper pod, and scales back up; `report` converts to a text profile + HTML. Works against any cluster reachable via kubeconfig (registry and node arch auto-detected), so it is usable both locally and in CI.
- **Makefile**: `make e2e-coverage-deploy` and `make e2e-coverage` (optionally `E2E_TEST=TestName`) for local use.
- **`.github/workflows/e2e.yaml`**: each matrix job instruments PAC after cluster install, then after the log-gathering steps collects coverage and uploads it to Codecov via OIDC (`use_oidc: true`, flag `e2e`, `fail_ci_if_error: false`). The text profile is also kept as a `coverage-e2e-<provider>` artifact. `override_commit` uses the actually tested SHA so PR uploads merge with the unit-coverage upload.
- **`.codecov.yaml`**: `e2e` flag with `carryforward: true` since the E2E workflow is path-filtered and does not run on every PR.

Coverage collection hard-fails if no counters were flushed, so silent regressions (e.g. a component no longer exiting gracefully) are visible.

Depends on #2877 — without the controller graceful shutdown fix its coverage is never flushed.

## Submitter Checklist

- [x] 📝 Ensure your commit message is clear and informative.
- [x] ♽ Run `make test lint` before submitting a PR.
