### PR TITLE
feat(bitbucket): query commit statuses for /retest

### DIFF
--- a/pkg/matcher/annotation_matcher.go
+++ b/pkg/matcher/annotation_matcher.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
+	providerstatus "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/status"
 
 	"github.com/gobwas/glob"
 	"github.com/google/cel-go/common/types"
@@ -491,32 +492,63 @@ func filterSuccessfulTemplates(ctx context.Context, logger *zap.SugaredLogger, c
 		}
 	}
 
-	// Also check provider commit statuses (covers pruned PipelineRuns)
+	// Also check provider commit statuses (covers pruned PipelineRuns).
+	// Two matching strategies are used:
+	// - parseOriginalPRName: strips the "AppName / " prefix to recover the
+	//   template name. Works for all providers and for Bitbucket Cloud when
+	//   the combined key fits within the 40-char limit.
+	// - GetBBCloudStatusKey fallback: computes the status key each template
+	//   would have produced and matches against the raw status keys. Handles
+	//   Bitbucket Cloud where the key is truncated (no prefix or hash suffix)
+	//   and parseOriginalPRName returns "".
 	commitStatuses, err := vcx.GetCommitStatuses(ctx, event)
 	if err != nil {
 		logger.Warnf("failed to get commit statuses from provider for SHA %s: %v", event.SHA, err)
-	} else if len(commitStatuses) > 0 {
-		appName := cs.Info.GetPacOpts().ApplicationName
-		for _, cs := range commitStatuses {
-			originalName := parseOriginalPRName(cs.Name, appName)
-			if originalName != "" && isSuccessStatus(cs.Status) {
-				successfulTemplates[originalName] = &tektonv1.PipelineRun{} // placeholder
-			}
+	}
+
+	var pacOpts info.PacOpts
+	if cs.Info.Pac != nil {
+		pacOpts = cs.Info.GetPacOpts()
+	}
+	successfulStatusKeys := map[string]struct{}{}
+	for _, cs := range commitStatuses {
+		if !isSuccessStatus(cs.Status) {
+			continue
+		}
+		successfulStatusKeys[cs.Name] = struct{}{}
+		if originalName := parseOriginalPRName(cs.Name, pacOpts.ApplicationName); originalName != "" {
+			successfulTemplates[originalName] = &tektonv1.PipelineRun{} // placeholder
 		}
 	}
 
-	// Filter out templates that have successful runs
 	var filteredPRs []Match
 
 	for _, match := range matchedPRs {
 		templateName := getName(match.PipelineRun)
 
 		if successfulPR, hasSuccessfulRun := successfulTemplates[templateName]; hasSuccessfulRun {
-			logger.Infof("skipping template '%s' for sha %s as it already has a successful pipelinerun '%s'",
-				templateName, event.SHA, successfulPR.Name)
-		} else {
-			filteredPRs = append(filteredPRs, match)
+			logger.Infof(
+				"skipping template '%s' for sha %s as it already has a successful pipelinerun '%s'",
+				templateName, event.SHA, successfulPR.Name,
+			)
+			continue
 		}
+
+		if vcx.GetConfig().Name == "bitbucket-cloud" && len(successfulStatusKeys) > 0 {
+			bbKey := provider.GetBBCloudStatusKey(
+				providerstatus.StatusOpts{OriginalPipelineRunName: templateName},
+				&pacOpts,
+			)
+			if _, ok := successfulStatusKeys[bbKey]; ok {
+				logger.Infof(
+					"skipping template '%s' for sha %s as it already has a successful commit status (key: %s)",
+					templateName, event.SHA, bbKey,
+				)
+				continue
+			}
+		}
+
+		filteredPRs = append(filteredPRs, match)
 	}
 
 	// Return the filtered list (which may be empty if all templates were skipped)

--- a/pkg/matcher/annotation_matcher.go
+++ b/pkg/matcher/annotation_matcher.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
+	providerstatus "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/status"
 
 	"github.com/gobwas/glob"
 	"github.com/google/cel-go/common/types"
@@ -491,32 +492,67 @@ func filterSuccessfulTemplates(ctx context.Context, logger *zap.SugaredLogger, c
 		}
 	}
 
-	// Also check provider commit statuses (covers pruned PipelineRuns)
+	// Also check provider commit statuses (covers pruned PipelineRuns).
+	// Two matching strategies are used:
+	// - parseOriginalPRName: strips the "AppName / " prefix to recover the
+	//   template name. Works for all providers and for Bitbucket Cloud when
+	//   the combined key fits within the 40-char limit.
+	// - GetBBCloudStatusKey fallback: computes the status key each template
+	//   would have produced and matches against the raw status keys. Handles
+	//   Bitbucket Cloud where the key is truncated (no prefix or hash suffix)
+	//   and parseOriginalPRName returns "".
 	commitStatuses, err := vcx.GetCommitStatuses(ctx, event)
 	if err != nil {
 		logger.Warnf("failed to get commit statuses from provider for SHA %s: %v", event.SHA, err)
-	} else if len(commitStatuses) > 0 {
-		appName := cs.Info.GetPacOpts().ApplicationName
-		for _, cs := range commitStatuses {
-			originalName := parseOriginalPRName(cs.Name, appName)
-			if originalName != "" && isSuccessStatus(cs.Status) {
-				successfulTemplates[originalName] = &tektonv1.PipelineRun{} // placeholder
-			}
+	}
+
+	var pacOpts info.PacOpts
+	if cs.Info.Pac != nil {
+		pacOpts = cs.Info.GetPacOpts()
+	} else {
+		pacOpts = *info.NewPacOpts()
+	}
+	successfulStatusKeys := map[string]struct{}{}
+	for _, cs := range commitStatuses {
+		if !isSuccessStatus(cs.Status) {
+			continue
+		}
+		successfulStatusKeys[cs.Name] = struct{}{}
+		if originalName := parseOriginalPRName(cs.Name, pacOpts.ApplicationName); originalName != "" {
+			successfulTemplates[originalName] = &tektonv1.PipelineRun{} // placeholder
 		}
 	}
 
-	// Filter out templates that have successful runs
 	var filteredPRs []Match
+
+	isBBCloud := vcx.GetConfig().Name == "bitbucket-cloud"
 
 	for _, match := range matchedPRs {
 		templateName := getName(match.PipelineRun)
 
 		if successfulPR, hasSuccessfulRun := successfulTemplates[templateName]; hasSuccessfulRun {
-			logger.Infof("skipping template '%s' for sha %s as it already has a successful pipelinerun '%s'",
-				templateName, event.SHA, successfulPR.Name)
-		} else {
-			filteredPRs = append(filteredPRs, match)
+			logger.Infof(
+				"skipping template '%s' for sha %s as it already has a successful pipelinerun '%s'",
+				templateName, event.SHA, successfulPR.Name,
+			)
+			continue
 		}
+
+		if isBBCloud && len(successfulStatusKeys) > 0 {
+			bbKey := provider.GetBBCloudStatusKey(
+				providerstatus.StatusOpts{OriginalPipelineRunName: templateName},
+				&pacOpts,
+			)
+			if _, ok := successfulStatusKeys[bbKey]; ok {
+				logger.Infof(
+					"skipping template '%s' for sha %s as it already has a successful commit status (key: %s)",
+					templateName, event.SHA, bbKey,
+				)
+				continue
+			}
+		}
+
+		filteredPRs = append(filteredPRs, match)
 	}
 
 	// Return the filtered list (which may be empty if all templates were skipped)

--- a/pkg/matcher/annotation_matcher_test.go
+++ b/pkg/matcher/annotation_matcher_test.go
@@ -3365,6 +3365,7 @@ func TestFilterSuccessfulTemplatesFallbackToCommitStatuses(t *testing.T) {
 
 	tests := []struct {
 		name           string
+		providerName   string
 		commitStatuses []provider.CommitStatusInfo
 		matchedPRs     []Match
 		expectedNames  []string
@@ -3415,6 +3416,41 @@ func TestFilterSuccessfulTemplatesFallbackToCommitStatuses(t *testing.T) {
 			},
 			expectedNames: []string{"template-a", "template-b"},
 		},
+		{
+			name:         "BB Cloud truncated key matched via GetBBCloudStatusKey",
+			providerName: "bitbucket-cloud",
+			commitStatuses: []provider.CommitStatusInfo{
+				{Name: "this-is-a-long-pipelinerun-name-t-989318", Status: "successful"},
+				{Name: "Pipelines as Code CI / pipelinerun-exit-1", Status: "failed"},
+			},
+			matchedPRs: []Match{
+				createMatchedPR("this-is-a-long-pipelinerun-name-that-exceeds-forty-characters"),
+				createMatchedPR("pipelinerun-exit-1"),
+			},
+			expectedNames: []string{"pipelinerun-exit-1"},
+		},
+		{
+			name:         "BB Cloud key without prefix matched via GetBBCloudStatusKey",
+			providerName: "bitbucket-cloud",
+			commitStatuses: []provider.CommitStatusInfo{
+				{Name: "my-long-pipeline-run-name-abcdef", Status: "successful"},
+			},
+			matchedPRs: []Match{
+				createMatchedPR("my-long-pipeline-run-name-abcdef"),
+			},
+			expectedNames: []string{},
+		},
+		{
+			name:         "Non BB Cloud provider skips GetBBCloudStatusKey fallback",
+			providerName: "github",
+			commitStatuses: []provider.CommitStatusInfo{
+				{Name: "this-is-a-long-pipelinerun-name-t-989318", Status: "successful"},
+			},
+			matchedPRs: []Match{
+				createMatchedPR("this-is-a-long-pipelinerun-name-that-exceeds-forty-characters"),
+			},
+			expectedNames: []string{"this-is-a-long-pipelinerun-name-that-exceeds-forty-characters"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -3425,6 +3461,7 @@ func TestFilterSuccessfulTemplatesFallbackToCommitStatuses(t *testing.T) {
 			}
 			vcx := &testprovider.TestProviderImp{
 				CommitStatuses: tt.commitStatuses,
+				ProviderName:   tt.providerName,
 			}
 
 			filtered := filterSuccessfulTemplates(ctx, logger, cs, event, repo, vcx, tt.matchedPRs)

--- a/pkg/matcher/annotation_matcher_test.go
+++ b/pkg/matcher/annotation_matcher_test.go
@@ -3365,6 +3365,8 @@ func TestFilterSuccessfulTemplatesFallbackToCommitStatuses(t *testing.T) {
 
 	tests := []struct {
 		name           string
+		providerName   string
+		nilPac         bool
 		commitStatuses []provider.CommitStatusInfo
 		matchedPRs     []Match
 		expectedNames  []string
@@ -3415,6 +3417,54 @@ func TestFilterSuccessfulTemplatesFallbackToCommitStatuses(t *testing.T) {
 			},
 			expectedNames: []string{"template-a", "template-b"},
 		},
+		{
+			name:         "BB Cloud truncated key matched via GetBBCloudStatusKey",
+			providerName: "bitbucket-cloud",
+			commitStatuses: []provider.CommitStatusInfo{
+				{Name: "this-is-a-long-pipelinerun-name-t-989318", Status: "successful"},
+				{Name: "Pipelines as Code CI / pipelinerun-exit-1", Status: "failed"},
+			},
+			matchedPRs: []Match{
+				createMatchedPR("this-is-a-long-pipelinerun-name-that-exceeds-forty-characters"),
+				createMatchedPR("pipelinerun-exit-1"),
+			},
+			expectedNames: []string{"pipelinerun-exit-1"},
+		},
+		{
+			name:         "BB Cloud key without prefix matched via GetBBCloudStatusKey",
+			providerName: "bitbucket-cloud",
+			commitStatuses: []provider.CommitStatusInfo{
+				{Name: "my-long-pipeline-run-name-abcdef", Status: "successful"},
+			},
+			matchedPRs: []Match{
+				createMatchedPR("my-long-pipeline-run-name-abcdef"),
+			},
+			expectedNames: []string{},
+		},
+		{
+			name:         "Non BB Cloud provider skips GetBBCloudStatusKey fallback",
+			providerName: "github",
+			commitStatuses: []provider.CommitStatusInfo{
+				{Name: "this-is-a-long-pipelinerun-name-t-989318", Status: "successful"},
+				{Name: "Pipelines as Code CI / this-is-a-long-pipelinerun-name-that-exceeds-forty-characters", Status: "failed"},
+			},
+			matchedPRs: []Match{
+				createMatchedPR("this-is-a-long-pipelinerun-name-that-exceeds-forty-characters"),
+			},
+			expectedNames: []string{"this-is-a-long-pipelinerun-name-that-exceeds-forty-characters"},
+		},
+		{
+			name:   "Nil Pac uses default ApplicationName for status matching",
+			nilPac: true,
+			commitStatuses: []provider.CommitStatusInfo{
+				{Name: "Pipelines as Code CI / template-a", Status: "success"},
+			},
+			matchedPRs: []Match{
+				createMatchedPR("template-a"),
+				createMatchedPR("template-b"),
+			},
+			expectedNames: []string{"template-b"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -3425,9 +3475,21 @@ func TestFilterSuccessfulTemplatesFallbackToCommitStatuses(t *testing.T) {
 			}
 			vcx := &testprovider.TestProviderImp{
 				CommitStatuses: tt.commitStatuses,
+				ProviderName:   tt.providerName,
 			}
 
-			filtered := filterSuccessfulTemplates(ctx, logger, cs, event, repo, vcx, tt.matchedPRs)
+			testCS := cs
+			if tt.nilPac {
+				testCS = &params.Run{
+					Clients: clients.Clients{
+						Log:    logger,
+						Tekton: stdata.Pipeline,
+						Kube:   stdata.Kube,
+					},
+				}
+			}
+
+			filtered := filterSuccessfulTemplates(ctx, logger, testCS, event, repo, vcx, tt.matchedPRs)
 
 			assert.Equal(t, len(tt.expectedNames), len(filtered),
 				"Expected %d templates but got %d", len(tt.expectedNames), len(filtered))

--- a/pkg/provider/bitbucketcloud/bitbucket.go
+++ b/pkg/provider/bitbucketcloud/bitbucket.go
@@ -162,8 +162,44 @@ func (v *Provider) CreateStatus(_ context.Context, event *info.Event, statusopts
 	return nil
 }
 
-func (v *Provider) GetCommitStatuses(_ context.Context, _ *info.Event) ([]provider.CommitStatusInfo, error) {
-	return nil, nil
+func (v *Provider) GetCommitStatuses(_ context.Context, event *info.Event) ([]provider.CommitStatusInfo, error) {
+	if v.bbClient == nil {
+		return nil, fmt.Errorf("no token has been set, cannot get commit statuses")
+	}
+
+	response, err := v.Client().Repositories.Commits.GetCommitStatuses(&bitbucket.CommitsOptions{
+		Owner:    event.Organization,
+		RepoSlug: event.Repository,
+		Revision: event.SHA,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	statuses := &types.Statuses{}
+	err = mapstructure.Decode(response, statuses)
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		result []provider.CommitStatusInfo
+		seen   = map[string]struct{}{}
+	)
+	for _, s := range statuses.Values {
+		st := strings.ToLower(s.State)
+		key := fmt.Sprintf("%s\x00%s", s.Key, st)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, provider.CommitStatusInfo{
+			Name:   s.Key,
+			Status: st,
+		})
+	}
+
+	return result, nil
 }
 
 func (v *Provider) GetTektonDir(_ context.Context, event *info.Event, path, provenance string) (string, error) {

--- a/pkg/provider/bitbucketcloud/bitbucket.go
+++ b/pkg/provider/bitbucketcloud/bitbucket.go
@@ -180,8 +180,35 @@ func (v *Provider) CreateStatus(_ context.Context, event *info.Event, statusopts
 	return nil
 }
 
-func (v *Provider) GetCommitStatuses(_ context.Context, _ *info.Event) ([]provider.CommitStatusInfo, error) {
-	return nil, nil
+func (v *Provider) GetCommitStatuses(_ context.Context, event *info.Event) ([]provider.CommitStatusInfo, error) {
+	if v.bbClient == nil {
+		return nil, fmt.Errorf("no token has been set, cannot get commit statuses")
+	}
+
+	response, err := v.Client().Repositories.Commits.GetCommitStatuses(&bitbucket.CommitsOptions{
+		Owner:    event.Organization,
+		RepoSlug: event.Repository,
+		Revision: event.SHA,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	statuses := &types.Statuses{}
+	err = mapstructure.Decode(response, statuses)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []provider.CommitStatusInfo
+	for _, s := range statuses.Values {
+		result = append(result, provider.CommitStatusInfo{
+			Name:   s.Key,
+			Status: strings.ToLower(s.State),
+		})
+	}
+
+	return result, nil
 }
 
 func (v *Provider) GetTektonDir(_ context.Context, event *info.Event, path, provenance string) (string, error) {

--- a/pkg/provider/bitbucketcloud/bitbucket_test.go
+++ b/pkg/provider/bitbucketcloud/bitbucket_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	bbcloudtest "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketcloud/test"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketcloud/types"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/status"
@@ -391,6 +392,101 @@ func TestCreateStatus(t *testing.T) {
 
 			err := v.CreateStatus(ctx, event, tt.status)
 			assert.NilError(t, err)
+		})
+	}
+}
+
+func TestGetCommitStatuses(t *testing.T) {
+	tests := []struct {
+		name         string
+		noClient     bool
+		statuses     []types.Status
+		wantErr      bool
+		wantStatuses []provider.CommitStatusInfo
+	}{
+		{
+			name:     "nil client returns error",
+			noClient: true,
+			wantErr:  true,
+		},
+		{
+			name: "statuses with mixed states",
+			statuses: []types.Status{
+				{Key: "Pipelines as Code CI / lint", State: "SUCCESSFUL"},
+				{Key: "Pipelines as Code CI / test", State: "FAILED"},
+				{Key: "Pipelines as Code CI / build", State: "INPROGRESS"},
+			},
+			wantStatuses: []provider.CommitStatusInfo{
+				{Name: "Pipelines as Code CI / lint", Status: "successful"},
+				{Name: "Pipelines as Code CI / test", Status: "failed"},
+				{Name: "Pipelines as Code CI / build", Status: "inprogress"},
+			},
+		},
+		{
+			name: "deduplication removes duplicate key and status pairs",
+			statuses: []types.Status{
+				{Key: "Pipelines as Code CI / lint", State: "SUCCESSFUL"},
+				{Key: "Pipelines as Code CI / lint", State: "SUCCESSFUL"},
+			},
+			wantStatuses: []provider.CommitStatusInfo{
+				{Name: "Pipelines as Code CI / lint", Status: "successful"},
+			},
+		},
+		{
+			name:         "empty statuses",
+			statuses:     []types.Status{},
+			wantStatuses: nil,
+		},
+		{
+			name: "raw key without prefix returned as-is",
+			statuses: []types.Status{
+				{Key: "my-very-long-pipeline-run-name", State: "SUCCESSFUL"},
+			},
+			wantStatuses: []provider.CommitStatusInfo{
+				{Name: "my-very-long-pipeline-run-name", Status: "successful"},
+			},
+		},
+		{
+			name: "truncated key with hash returned as-is",
+			statuses: []types.Status{
+				{Key: "ccccccccccccccccccccccccccccccccc-5de6bf", State: "SUCCESSFUL"},
+			},
+			wantStatuses: []provider.CommitStatusInfo{
+				{Name: "ccccccccccccccccccccccccccccccccc-5de6bf", Status: "successful"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+
+			if tt.noClient {
+				v := &Provider{}
+				_, err := v.GetCommitStatuses(ctx, bbcloudtest.MakeEvent(nil))
+				assert.Assert(t, err != nil)
+				return
+			}
+
+			bbclient, mux, tearDown := bbcloudtest.SetupBBCloudClient(t)
+			defer tearDown()
+
+			event := bbcloudtest.MakeEvent(nil)
+			bbcloudtest.MuxListCommitStatuses(t, mux, event, tt.statuses)
+
+			v := &Provider{bbClient: bbclient}
+
+			got, err := v.GetCommitStatuses(ctx, event)
+			if tt.wantErr {
+				assert.Assert(t, err != nil)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, len(got), len(tt.wantStatuses))
+			for i, want := range tt.wantStatuses {
+				assert.Equal(t, got[i].Name, want.Name)
+				assert.Equal(t, got[i].Status, want.Status)
+			}
 		})
 	}
 }

--- a/pkg/provider/bitbucketcloud/bitbucket_test.go
+++ b/pkg/provider/bitbucketcloud/bitbucket_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider"
 	bbcloudtest "github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketcloud/test"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketcloud/types"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/status"
@@ -534,6 +535,92 @@ func TestValidate(t *testing.T) {
 					}
 				}
 				assert.Assert(t, matched, "We didn't get the expected log message: %s", tt.wantLog)
+			}
+		})
+	}
+}
+
+func TestGetCommitStatuses(t *testing.T) {
+	tests := []struct {
+		name         string
+		noClient     bool
+		statuses     []types.Status
+		wantErr      bool
+		wantStatuses []provider.CommitStatusInfo
+	}{
+		{
+			name:     "nil client returns error",
+			noClient: true,
+			wantErr:  true,
+		},
+		{
+			name: "statuses with mixed states",
+			statuses: []types.Status{
+				{Key: "Pipelines as Code CI / lint", State: "SUCCESSFUL"},
+				{Key: "Pipelines as Code CI / test", State: "FAILED"},
+				{Key: "Pipelines as Code CI / build", State: "INPROGRESS"},
+			},
+			wantStatuses: []provider.CommitStatusInfo{
+				{Name: "Pipelines as Code CI / lint", Status: "successful"},
+				{Name: "Pipelines as Code CI / test", Status: "failed"},
+				{Name: "Pipelines as Code CI / build", Status: "inprogress"},
+			},
+		},
+		{
+			name:         "empty statuses",
+			statuses:     []types.Status{},
+			wantStatuses: nil,
+		},
+		{
+			name: "raw key without prefix returned as-is",
+			statuses: []types.Status{
+				{Key: "my-very-long-pipeline-run-name", State: "SUCCESSFUL"},
+			},
+			wantStatuses: []provider.CommitStatusInfo{
+				{Name: "my-very-long-pipeline-run-name", Status: "successful"},
+			},
+		},
+		{
+			name: "truncated key with hash returned as-is",
+			statuses: []types.Status{
+				{Key: "ccccccccccccccccccccccccccccccccc-5de6bf", State: "SUCCESSFUL"},
+			},
+			wantStatuses: []provider.CommitStatusInfo{
+				{Name: "ccccccccccccccccccccccccccccccccc-5de6bf", Status: "successful"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+
+			v := &Provider{}
+
+			if tt.noClient {
+				_, err := v.GetCommitStatuses(ctx, bbcloudtest.MakeEvent(nil))
+				assert.Assert(t, err != nil)
+				return
+			}
+
+			bbclient, mux, tearDown := bbcloudtest.SetupBBCloudClient(t)
+			defer tearDown()
+
+			event := bbcloudtest.MakeEvent(nil)
+			bbcloudtest.MuxListCommitStatuses(t, mux, event, tt.statuses)
+
+			v.bbClient = bbclient
+
+			got, err := v.GetCommitStatuses(ctx, event)
+			if tt.wantErr {
+				assert.Assert(t, err != nil)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, len(tt.wantStatuses), len(got))
+			for i, want := range tt.wantStatuses {
+				assert.Equal(t, want.Name, got[i].Name)
+				assert.Equal(t, want.Status, got[i].Status)
 			}
 		})
 	}

--- a/pkg/provider/bitbucketcloud/test/bbcloudtest.go
+++ b/pkg/provider/bitbucketcloud/test/bbcloudtest.go
@@ -226,6 +226,17 @@ func MuxCreateComment(t *testing.T, mux *http.ServeMux, event *info.Event, expec
 	})
 }
 
+func MuxListCommitStatuses(t *testing.T, mux *http.ServeMux, event *info.Event, statuses []types.Status) {
+	t.Helper()
+	path := fmt.Sprintf("/repositories/%s/%s/commit/%s/statuses", event.Organization, event.Repository, event.SHA)
+	mux.HandleFunc(path, func(rw http.ResponseWriter, _ *http.Request) {
+		resp := &types.Statuses{Values: statuses}
+		b, err := json.Marshal(resp)
+		assert.NilError(t, err)
+		fmt.Fprint(rw, string(b))
+	})
+}
+
 func MuxDirContent(t *testing.T, mux *http.ServeMux, event *info.Event, testdir, provenance string) {
 	t.Helper()
 	files, err := os.ReadDir(testdir)

--- a/pkg/provider/bitbucketcloud/test/bbcloudtest.go
+++ b/pkg/provider/bitbucketcloud/test/bbcloudtest.go
@@ -229,6 +229,17 @@ func MuxCreateComment(t *testing.T, mux *http.ServeMux, event *info.Event, expec
 	})
 }
 
+func MuxListCommitStatuses(t *testing.T, mux *http.ServeMux, event *info.Event, statuses []types.Status) {
+	t.Helper()
+	path := fmt.Sprintf("/repositories/%s/%s/commit/%s/statuses", event.Organization, event.Repository, event.SHA)
+	mux.HandleFunc(path, func(rw http.ResponseWriter, _ *http.Request) {
+		resp := &types.Statuses{Values: statuses}
+		b, err := json.Marshal(resp)
+		assert.NilError(t, err)
+		fmt.Fprint(rw, string(b))
+	})
+}
+
 func MuxDirContent(t *testing.T, mux *http.ServeMux, event *info.Event, testdir, provenance string) {
 	t.Helper()
 	files, err := os.ReadDir(testdir)

--- a/pkg/provider/bitbucketcloud/types/types.go
+++ b/pkg/provider/bitbucketcloud/types/types.go
@@ -125,6 +125,10 @@ type Comments struct {
 	Values []Comment
 }
 
+type Statuses struct {
+	Values []Status
+}
+
 type Status struct {
 	Key         string     `json:"key"`
 	Type        string     `json:"type"`

--- a/pkg/provider/github/github_test.go
+++ b/pkg/provider/github/github_test.go
@@ -3001,10 +3001,10 @@ func TestGetCommitStatuses(t *testing.T) {
 				return
 			}
 			assert.NilError(t, err)
-			assert.Equal(t, len(got), len(tt.wantStatuses))
+			assert.Equal(t, len(tt.wantStatuses), len(got))
 			for i, want := range tt.wantStatuses {
-				assert.Equal(t, got[i].Name, want.Name)
-				assert.Equal(t, got[i].Status, want.Status)
+				assert.Equal(t, want.Name, got[i].Name)
+				assert.Equal(t, want.Status, got[i].Status)
 			}
 		})
 	}

--- a/pkg/test/provider/testwebvcs.go
+++ b/pkg/test/provider/testwebvcs.go
@@ -35,6 +35,7 @@ type TestProviderImp struct {
 	CommitInfoErrorMsg     string
 	pacInfo                *info.PacOpts
 	CommitStatuses         []provider.CommitStatusInfo
+	ProviderName           string
 }
 
 func (v *TestProviderImp) SetPacInfo(pacInfo *info.PacOpts) {
@@ -72,7 +73,7 @@ func (v *TestProviderImp) ParsePayload(_ context.Context, _ *params.Run, _ *http
 }
 
 func (v *TestProviderImp) GetConfig() *info.ProviderConfig {
-	return &info.ProviderConfig{}
+	return &info.ProviderConfig{Name: v.ProviderName}
 }
 
 func (v *TestProviderImp) GetCommitInfo(_ context.Context, event *info.Event) error {

--- a/test/bitbucket_cloud_retest_pruned_test.go
+++ b/test/bitbucket_cloud_retest_pruned_test.go
@@ -1,0 +1,167 @@
+//go:build e2e
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/ktrysmt/go-bitbucket"
+	"github.com/mitchellh/mapstructure"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketcloud"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketcloud/types"
+	tbb "github.com/openshift-pipelines/pipelines-as-code/test/pkg/bitbucketcloud"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
+	twait "github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
+	"github.com/tektoncd/pipeline/pkg/names"
+	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestBitbucketCloudRetestAfterPipelineRunPruning verifies that /retest only
+// re-runs failed pipelines when PipelineRun objects have been pruned from the
+// cluster. This relies on GetCommitStatuses returning Bitbucket Cloud commit
+// statuses so that the annotation matcher can detect previously successful runs.
+func TestBitbucketCloudRetestAfterPipelineRunPruning(t *testing.T) {
+	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
+	ctx := context.Background()
+
+	runcnx, opts, bprovider, err := tbb.Setup(ctx)
+	if err != nil {
+		t.Skip(err.Error())
+		return
+	}
+	bcrepo := tbb.CreateCRD(ctx, t, bprovider, runcnx, opts, targetNS)
+	targetRefName := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test")
+	title := "TestRetestPruned - " + targetRefName
+
+	entries, err := payload.GetEntries(
+		map[string]string{
+			".tekton/always-good-pipelinerun-long-name.yaml": "testdata/always-good-pipelinerun-long-name.yaml",
+			".tekton/pipelinerun-exit-1.yaml":                "testdata/failures/pipelinerun-exit-1.yaml",
+		},
+		targetNS, options.MainBranch, triggertype.PullRequest.String(), map[string]string{},
+	)
+	assert.NilError(t, err)
+
+	pr, repobranch := tbb.MakePR(t, bprovider, runcnx, bcrepo, opts, title, targetRefName, entries)
+	defer tbb.TearDown(ctx, t, runcnx, bprovider, opts, pr.ID, targetRefName, targetNS, false)
+
+	hash, ok := repobranch.Target["hash"].(string)
+	assert.Assert(t, ok)
+
+	labelSelector := fmt.Sprintf("%s=%s", keys.SHA, formatting.CleanValueKubernetes(hash))
+
+	runcnx.Clients.Log.Infof("Waiting for 2 PipelineRuns to finish")
+	_, err = twait.UntilPipelineRunsFinished(ctx, runcnx.Clients, twait.Opts{
+		Namespace:       targetNS,
+		MinNumberStatus: 2,
+		PollTimeout:     twait.DefaultTimeout,
+		TargetSHA:       []string{hash},
+	})
+	assert.NilError(t, err)
+
+	pruns, err := runcnx.Clients.Tekton.TektonV1().PipelineRuns(targetNS).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, len(pruns.Items), 2, "expected 2 initial PipelineRuns")
+
+	initialPRNames := map[string]bool{}
+	for _, prun := range pruns.Items {
+		initialPRNames[prun.Name] = true
+	}
+
+	// Verify Bitbucket Cloud commit statuses before pruning
+	successCount, failureCount := countBBCloudTerminalStatuses(t, bprovider, opts, hash)
+	assert.Equal(t, successCount, 1, "expected exactly 1 successful pipeline status")
+	assert.Equal(t, failureCount, 1, "expected exactly 1 failed pipeline status")
+
+	runcnx.Clients.Log.Infof("Deleting all PipelineRuns to simulate pruning")
+	err = runcnx.Clients.Tekton.TektonV1().PipelineRuns(targetNS).DeleteCollection(ctx,
+		metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: labelSelector})
+	assert.NilError(t, err)
+
+	runcnx.Clients.Log.Infof("Waiting for PipelineRuns to be deleted")
+	pollErr := kubeinteraction.PollImmediateWithContext(ctx, twait.DefaultTimeout, func() (bool, error) {
+		pruns, err = runcnx.Clients.Tekton.TektonV1().PipelineRuns(targetNS).List(ctx, metav1.ListOptions{
+			LabelSelector: labelSelector,
+		})
+		if err != nil {
+			return false, err
+		}
+		return len(pruns.Items) == 0, nil
+	})
+	if pollErr != nil {
+		runcnx.Clients.Log.Infof("Warning: PipelineRuns not fully deleted after polling: %v (proceeding anyway)", pollErr)
+	}
+
+	runcnx.Clients.Log.Infof("Posting /retest comment on PR %d", pr.ID)
+	_, err = bprovider.Client().Repositories.PullRequests.AddComment(
+		&bitbucket.PullRequestCommentOptions{
+			Owner:         opts.Organization,
+			RepoSlug:      opts.Repo,
+			PullRequestID: fmt.Sprintf("%d", pr.ID),
+			Content:       "/retest",
+		},
+	)
+	assert.NilError(t, err)
+
+	runcnx.Clients.Log.Infof("Waiting for retest PipelineRun to finish")
+	_, err = twait.UntilPipelineRunsFinished(ctx, runcnx.Clients, twait.Opts{
+		Namespace:       targetNS,
+		MinNumberStatus: 1,
+		PollTimeout:     twait.DefaultTimeout,
+		TargetSHA:       []string{hash},
+	})
+	assert.NilError(t, err)
+
+	prunsAfterRetest, err := runcnx.Clients.Tekton.TektonV1().PipelineRuns(targetNS).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	assert.NilError(t, err)
+
+	newCount := 0
+	for _, prun := range prunsAfterRetest.Items {
+		if !initialPRNames[prun.Name] {
+			newCount++
+		}
+	}
+	assert.Equal(t, newCount, 1,
+		"expected only 1 new PipelineRun after /retest (only the failed pipeline should re-run), but got %d", newCount)
+}
+
+func countBBCloudTerminalStatuses(t *testing.T, bprovider bitbucketcloud.Provider, opts options.E2E, sha string) (successCount, failureCount int) {
+	t.Helper()
+	resp, err := bprovider.Client().Repositories.Commits.GetCommitStatuses(&bitbucket.CommitsOptions{
+		Owner:    opts.Organization,
+		RepoSlug: opts.Repo,
+		Revision: sha,
+	})
+	assert.NilError(t, err)
+
+	statusList := &types.Statuses{}
+	err = mapstructure.Decode(resp, statusList)
+	assert.NilError(t, err)
+
+	seen := map[string]struct{}{}
+	for _, s := range statusList.Values {
+		if _, ok := seen[s.Key]; ok {
+			continue
+		}
+		seen[s.Key] = struct{}{}
+		switch s.State {
+		case string(types.StateSuccessful):
+			successCount++
+		case string(types.StateFailed), string(types.StateStopped):
+			failureCount++
+		}
+	}
+	return successCount, failureCount
+}

--- a/test/bitbucket_cloud_retest_pruned_test.go
+++ b/test/bitbucket_cloud_retest_pruned_test.go
@@ -1,0 +1,142 @@
+//go:build e2e
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/ktrysmt/go-bitbucket"
+	"github.com/mitchellh/mapstructure"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketcloud"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/bitbucketcloud/types"
+	tbb "github.com/openshift-pipelines/pipelines-as-code/test/pkg/bitbucketcloud"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
+	twait "github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
+	"github.com/tektoncd/pipeline/pkg/names"
+	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestBitbucketCloudRetestAfterPipelineRunPruning verifies that /retest only
+// re-runs failed pipelines when PipelineRun objects have been pruned from the
+// cluster. This relies on GetCommitStatuses returning Bitbucket Cloud commit
+// statuses so that the annotation matcher can detect previously successful runs.
+func TestBitbucketCloudRetestAfterPipelineRunPruning(t *testing.T) {
+	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
+	ctx := context.Background()
+
+	runcnx, opts, bprovider, err := tbb.Setup(ctx)
+	if err != nil {
+		t.Skip(err.Error())
+		return
+	}
+	bcrepo := tbb.CreateCRD(ctx, t, bprovider, runcnx, opts, targetNS)
+	targetRefName := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-test")
+	title := "TestRetestPruned - " + targetRefName
+
+	entries, err := payload.GetEntries(
+		map[string]string{
+			".tekton/always-good-pipelinerun-long-name.yaml": "testdata/always-good-pipelinerun-long-name.yaml",
+			".tekton/pipelinerun-exit-1.yaml":                "testdata/failures/pipelinerun-exit-1.yaml",
+		},
+		targetNS, options.MainBranch, triggertype.PullRequest.String(), map[string]string{},
+	)
+	assert.NilError(t, err)
+
+	pr, repobranch := tbb.MakePR(t, bprovider, runcnx, bcrepo, opts, title, targetRefName, entries)
+	defer tbb.TearDown(ctx, t, runcnx, bprovider, opts, pr.ID, targetRefName, targetNS, false)
+
+	hash, ok := repobranch.Target["hash"].(string)
+	assert.Assert(t, ok)
+
+	labelSelector := fmt.Sprintf("%s=%s", keys.SHA, formatting.CleanValueKubernetes(hash))
+
+	runcnx.Clients.Log.Infof("Waiting for 2 PipelineRuns to finish")
+	_, err = twait.UntilPipelineRunsFinished(ctx, runcnx.Clients, twait.Opts{
+		Namespace:       targetNS,
+		MinNumberStatus: 2,
+		PollTimeout:     twait.DefaultTimeout,
+		TargetSHA:       []string{hash},
+	})
+	assert.NilError(t, err)
+
+	// Verify Bitbucket Cloud commit statuses before pruning
+	successCount, failureCount := countBBCloudTerminalStatuses(t, bprovider, opts, hash)
+	assert.Equal(t, successCount, 1, "expected exactly 1 successful pipeline status")
+	assert.Equal(t, failureCount, 1, "expected exactly 1 failed pipeline status")
+
+	runcnx.Clients.Log.Infof("Deleting all PipelineRuns to simulate pruning")
+	err = runcnx.Clients.Tekton.TektonV1().PipelineRuns(targetNS).DeleteCollection(ctx,
+		metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: labelSelector})
+	assert.NilError(t, err)
+
+	runcnx.Clients.Log.Infof("Waiting for PipelineRuns to be deleted")
+	pollErr := kubeinteraction.PollImmediateWithContext(ctx, twait.DefaultTimeout, func() (bool, error) {
+		remaining, listErr := runcnx.Clients.Tekton.TektonV1().PipelineRuns(targetNS).List(ctx, metav1.ListOptions{
+			LabelSelector: labelSelector,
+		})
+		if listErr != nil {
+			return false, listErr
+		}
+		return len(remaining.Items) == 0, nil
+	})
+	assert.NilError(t, pollErr, "PipelineRuns not fully deleted after polling")
+
+	runcnx.Clients.Log.Infof("Posting /retest comment on PR %d", pr.ID)
+	_, err = bprovider.Client().Repositories.PullRequests.AddComment(
+		&bitbucket.PullRequestCommentOptions{
+			Owner:         opts.Organization,
+			RepoSlug:      opts.Repo,
+			PullRequestID: fmt.Sprintf("%d", pr.ID),
+			Content:       "/retest",
+		},
+	)
+	assert.NilError(t, err)
+
+	runcnx.Clients.Log.Infof("Waiting for retest PipelineRun to finish")
+	_, err = twait.UntilPipelineRunsFinished(ctx, runcnx.Clients, twait.Opts{
+		Namespace:       targetNS,
+		MinNumberStatus: 1,
+		PollTimeout:     twait.DefaultTimeout,
+		TargetSHA:       []string{hash},
+	})
+	assert.NilError(t, err)
+
+	prunsAfterRetest, err := runcnx.Clients.Tekton.TektonV1().PipelineRuns(targetNS).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, len(prunsAfterRetest.Items), 1,
+		"expected exactly 1 new PipelineRun after /retest, but got %d", len(prunsAfterRetest.Items))
+}
+
+func countBBCloudTerminalStatuses(t *testing.T, bprovider bitbucketcloud.Provider, opts options.E2E, sha string) (successCount, failureCount int) {
+	t.Helper()
+	resp, err := bprovider.Client().Repositories.Commits.GetCommitStatuses(&bitbucket.CommitsOptions{
+		Owner:    opts.Organization,
+		RepoSlug: opts.Repo,
+		Revision: sha,
+	})
+	assert.NilError(t, err)
+
+	statusList := &types.Statuses{}
+	err = mapstructure.Decode(resp, statusList)
+	assert.NilError(t, err)
+
+	for _, s := range statusList.Values {
+		switch s.State {
+		case string(types.StateSuccessful):
+			successCount++
+		case string(types.StateFailed), string(types.StateStopped):
+			failureCount++
+		}
+	}
+	return successCount, failureCount
+}

--- a/test/testdata/always-good-pipelinerun-long-name.yaml
+++ b/test/testdata/always-good-pipelinerun-long-name.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: this-is-a-long-pipelinerun-name-that-exceeds-forty-characters
+  annotations:
+    pipelinesascode.tekton.dev/target-namespace: "\\ .TargetNamespace //"
+    pipelinesascode.tekton.dev/on-target-branch: "[\\ .TargetBranch //]"
+    pipelinesascode.tekton.dev/on-event: "[\\ .TargetEvent //]"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: task
+        displayName: "The Task name is Task"
+        taskSpec:
+          steps:
+            - name: task
+              image: registry.access.redhat.com/ubi10/ubi-micro
+              command: ["/bin/echo", "HELLOMOTO"]


### PR DESCRIPTION
## 📝 Description of the Change
Implement GetCommitStatuses for Bitbucket Cloud so /retest skips pipelines that already succeeded, even when PipelineRun objects have been pruned. The provider returns raw status keys; the annotation matcher uses GetBBCloudStatusKey to reverse-match truncated keys against template names.

## 🔗 Linked GitHub Issue
Partially fixes #2580

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [x] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

AI assistance can be used for various tasks, such as code generation,
documentation, or testing.

Please indicate whether you have used AI assistance
for this PR and provide details if applicable.

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

> [!IMPORTANT]
>
> **Slop will be simply rejected**, if you are using AI assistance you need to make sure you
> understand the code generated and that it meets the project's standards. you
> need at least know how to run the code and deploy it (if needed). See
> [startpaac](https://github.com/openshift-pipelines/startpaac) to make it easy
> to deploy and test your code changes.
>
> If the **majority of the code** in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Claude <noreply@anthropic.com>

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [x] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
