### PR TITLE
Security: Fix CVE-2026-33211 (github.com/tektoncd/pipeline path traversal)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.10.2
-	github.com/tektoncd/pipeline v1.14.0
+	github.com/tektoncd/pipeline v1.14.1
 	gitlab.com/gitlab-org/api/client-go v1.46.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0

--- a/go.sum
+++ b/go.sum
@@ -269,8 +269,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/tektoncd/pipeline v1.14.0 h1:1jxq2oJnQ3t1MNZ3QntJ9vVTMP3XyHOAmfg3SCVilVc=
-github.com/tektoncd/pipeline v1.14.0/go.mod h1:02XVcI1djpd6APKLX7JdnUddiVuwulCTWamQxlNF5CI=
+github.com/tektoncd/pipeline v1.14.1 h1:yVv/yNkJ5bghhy2IZ9ScJPvqr8H48vyvXiuhBEzLqzQ=
+github.com/tektoncd/pipeline v1.14.1/go.mod h1:02XVcI1djpd6APKLX7JdnUddiVuwulCTWamQxlNF5CI=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -385,7 +385,7 @@ github.com/spf13/cobra
 # github.com/spf13/pflag v1.0.10
 ## explicit; go 1.12
 github.com/spf13/pflag
-# github.com/tektoncd/pipeline v1.14.0
+# github.com/tektoncd/pipeline v1.14.1
 ## explicit; go 1.26.4
 github.com/tektoncd/pipeline/internal/artifactref
 github.com/tektoncd/pipeline/pkg/apis/config


### PR DESCRIPTION
## Summary

This PR fixes **CVE-2026-33211** by upgrading `github.com/tektoncd/pipeline` from `v1.14.0` to `v1.14.1`.

### CVE Details
- **CVE ID**: CVE-2026-33211
- **GHSA**: GHSA-j5q5-j9gm-2w5c
- **Package**: github.com/tektoncd/pipeline
- **Severity**: CRITICAL
- **Impact**: Path traversal in Tekton Pipelines git resolver allows reading arbitrary files from the resolver pod
- **Vulnerable versions**: v1.14.0 (and prior affected ranges)
- **Fixed version**: v1.14.1
- **Jira Issues**: SRVKP-12834

### Changes
- Upgraded `github.com/tektoncd/pipeline` from `v1.14.0` → `v1.14.1`
- Ran `go mod tidy` + `go mod vendor` to sync all dependency manifests
- Ran `go mod verify`: all modules verified ✅

### Also Confirmed Already Fixed
- **CVE-2026-33186** (gRPC-Go auth bypass): repo uses `google.golang.org/grpc v1.82.1` which is already > the required fix version `v1.79.3` ✅
- **CVE-2026-24051** (OTel PATH hijacking): repo uses `go.opentelemetry.io/otel v1.44.0` which is already > the fixed version `v1.40.0` ✅

### Test Results

**Status**: ✅ Unit tests passed

**Tests run**: `go test ./pkg/apis/... ./pkg/cel/... ./pkg/formatting/... ./pkg/secrets/...`
**Result**: PASSED — all packages OK
**Note**: Full test suite (including E2E/Gitea) runs in CI after PR creation

### Post-Fix Vulnerability Scan

Run `govulncheck` after upgrade:
- `GO-2026-4730` (CVE-2026-33022, controller panic via long resolver name) — shown as `Fixed in: N/A` in govulncheck DB (OSV DB not yet updated for v1.14.x fixes), upgrade still addresses the reported SRVKP-12834 issue
- `GO-2023-1901` — older advisory with `Fixed in: N/A`, unrelated to this CVE batch
- **CVE-2026-33211** (GO-2026-4761) — not in symbol call graph for this codebase (PAC does not invoke the git resolver directly)

### Breaking Changes
None. v1.14.1 is a patch release with no API changes per the release notes.

### Risk Assessment
| Factor | Assessment |
|--------|-----------|
| Change scope | Minimal — 3 files (go.mod, go.sum, vendor/modules.txt) |
| API compatibility | No breaking changes (patch release) |
| Risk level | **Low** |

### Verification Checklist
- [x] `go mod tidy` completed successfully
- [x] `go mod vendor` completed successfully
- [x] `go mod verify` passed — all modules verified
- [x] Unit tests passed
- [x] No duplicate open PRs found
- [ ] CI checks pass (runs post-merge)

---

Resolves: SRVKP-12834

🤖 Generated by CVE Fixer Workflow
<!-- cve-fixer-workflow -->