### PR TITLE
fix(queue): make concurrency limits reliable

### DIFF
--- a/cmd/pipelines-as-code-watcher/main.go
+++ b/cmd/pipelines-as-code-watcher/main.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/queue"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/reconciler"
 	"k8s.io/client-go/rest"
 	"knative.dev/pkg/injection"
@@ -29,6 +30,10 @@ func main() {
 		w.WriteHeader(http.StatusOK)
 		_, _ = fmt.Fprint(w, "ok")
 	})
+
+	// Read-only view of the concurrency queues, so a test or an operator can
+	// tell whether the queue still agrees with the cluster.
+	mux.HandleFunc("/debug/queue", queue.DebugHandler())
 
 	c := make(chan struct{})
 	go func() {

--- a/docs/content/docs/advanced/concurrency.md
+++ b/docs/content/docs/advanced/concurrency.md
@@ -37,3 +37,64 @@ graph TD
     K --> |No| N
 
 ```
+
+## Inspecting the queue at runtime
+
+Every concurrency bug is the same shape: what the watcher believes is running
+drifts away from what is really running in the cluster. When a repository's
+queue looks stuck — nothing starting, or more running than the configured
+`concurrency_limit` — the fastest way to find out why is to ask the watcher
+directly instead of guessing from PipelineRun status.
+
+The watcher serves a read-only, JSON snapshot of its in-memory queues on
+`/debug/queue`, on the same port it already uses for its health probe.
+
+{{< callout type="info" >}}
+This exposes only the limit and the PipelineRun names PAC currently considers
+running or pending for each repository — nothing that is not already visible by
+listing PipelineRuns. It is meant for troubleshooting, not for regular
+monitoring.
+{{< /callout >}}
+
+### Querying it
+
+The endpoint is not exposed by the watcher Service (which only serves
+metrics), so reach it through the pod itself. The API server's pod proxy does
+not resolve named container ports, so use the numeric port (`8080` by
+default, or whatever `PAC_WATCHER_PORT` is set to):
+
+```shell
+POD=$(kubectl -n pipelines-as-code get pods -l app.kubernetes.io/name=watcher -o jsonpath='{.items[0].metadata.name}')
+
+# through the API server's pod proxy (what "kubectl proxy" exposes too)
+kubectl get --raw "/api/v1/namespaces/pipelines-as-code/pods/http:${POD}:8080/proxy/debug/queue" | jq .
+
+# or port-forward straight to the pod
+kubectl -n pipelines-as-code port-forward "pod/${POD}" 8080:8080 &
+curl -s localhost:8080/debug/queue | jq .
+```
+
+The response is a map keyed by `namespace/repository`:
+
+```json
+{
+  "my-namespace/my-repo": {
+    "limit": 1,
+    "running": ["my-namespace/pr-run-2"],
+    "pending": ["my-namespace/pr-run-3", "my-namespace/pr-run-4"]
+  }
+}
+```
+
+A few things to look for:
+
+- `len(running)` should never exceed `limit`.
+- A repository key that never disappears after all of its PipelineRuns have
+  finished means a queue slot was leaked, and the next run for that
+  repository will never start until the watcher restarts.
+- `pending` staying non-empty while `running` is empty for longer than
+  expected means the queue has stalled.
+
+The endpoint answers `503` while the watcher is busy reconciling, because it
+gives up on the queue lock rather than block the work it is reporting on. That
+is normal under load — just ask again.

--- a/pkg/queue/common.go
+++ b/pkg/queue/common.go
@@ -5,15 +5,12 @@ import (
 )
 
 type Semaphore interface {
-	acquire(string) bool
 	acquireLatest() string
-	tryAcquire(string) (bool, string)
 	release(string) bool
 	resize(int) bool
 	addToQueue(string, time.Time) bool
 	addToPendingQueue(string, time.Time) bool
 	removeFromQueue(string)
-	getName() string
 	getLimit() int
 	getCurrentRunning() []string
 	getCurrentPending() []string

--- a/pkg/queue/debug.go
+++ b/pkg/queue/debug.go
@@ -1,0 +1,82 @@
+package queue
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+	"sync"
+)
+
+// RepoQueue is what the manager currently believes about one repository.
+type RepoQueue struct {
+	Limit   int      `json:"limit"`
+	Running []string `json:"running"`
+	Pending []string `json:"pending"`
+}
+
+// Snapshot returns the state of every queue, keyed by "namespace/repository".
+// The bool is false when the manager is busy, in which case there is no
+// snapshot to report.
+//
+// Every concurrency bug so far has been the in-memory queue drifting away from
+// what is really in the cluster. Reading the queue directly turns "nothing is
+// running and I do not know why" into a named PipelineRun.
+//
+// This takes the same lock the reconciler needs to admit and release runs, so
+// it only ever tries. A diagnostic that can stall the thing it is diagnosing is
+// worse than one that occasionally says "ask again".
+func (qm *Manager) Snapshot() (map[string]RepoQueue, bool) {
+	if !qm.lock.TryLock() {
+		return nil, false
+	}
+	defer qm.lock.Unlock()
+
+	out := make(map[string]RepoQueue, len(qm.queueMap))
+	for key, sema := range qm.queueMap {
+		running := sema.getCurrentRunning()
+		pending := sema.getCurrentPending()
+		sort.Strings(running)
+		sort.Strings(pending)
+		out[key] = RepoQueue{Limit: sema.getLimit(), Running: running, Pending: pending}
+	}
+	return out, true
+}
+
+var (
+	debugLock    sync.RWMutex
+	debugManager *Manager
+)
+
+// RegisterForDebug makes a Manager reachable from DebugHandler. The Manager is
+// built long after the watcher's HTTP server is set up, so the handler has to
+// find it later rather than be handed it up front.
+func RegisterForDebug(qm *Manager) {
+	debugLock.Lock()
+	defer debugLock.Unlock()
+	debugManager = qm
+}
+
+// DebugHandler serves a read-only view of the queues as JSON. It mutates
+// nothing and exposes only PipelineRun names, which the caller can already list
+// from the cluster.
+func DebugHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		debugLock.RLock()
+		qm := debugManager
+		debugLock.RUnlock()
+
+		if qm == nil {
+			http.Error(w, "queue manager is not ready yet", http.StatusServiceUnavailable)
+			return
+		}
+		snapshot, ok := qm.Snapshot()
+		if !ok {
+			http.Error(w, "queue manager is busy, try again", http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(snapshot); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}
+}

--- a/pkg/queue/debug_test.go
+++ b/pkg/queue/debug_test.go
@@ -1,0 +1,104 @@
+package queue
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"go.uber.org/zap"
+	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestDebugHandler(t *testing.T) {
+	limit := 2
+	repo := &v1alpha1.Repository{
+		ObjectMeta: metav1.ObjectMeta{Name: "repo", Namespace: "ns"},
+		Spec:       v1alpha1.RepositorySpec{ConcurrencyLimit: &limit},
+	}
+
+	tests := []struct {
+		name     string
+		register func() *Manager
+		wantCode int
+		want     map[string]RepoQueue
+	}{
+		{
+			name:     "no manager registered yet",
+			register: func() *Manager { return nil },
+			wantCode: http.StatusServiceUnavailable,
+		},
+		{
+			name:     "empty manager",
+			register: func() *Manager { return NewManager(zap.NewNop().Sugar()) },
+			wantCode: http.StatusOK,
+			want:     map[string]RepoQueue{},
+		},
+		{
+			name: "one running and one pending",
+			register: func() *Manager {
+				qm := NewManager(zap.NewNop().Sugar())
+				sema, err := qm.getSemaphore(repo)
+				assert.NilError(t, err)
+				sema.addToQueue("ns/pr-1", metav1.Now().Time)
+				sema.addToQueue("ns/pr-2", metav1.Now().Time)
+				sema.addToQueue("ns/pr-3", metav1.Now().Time)
+				sema.acquireLatest()
+				sema.acquireLatest()
+				return qm
+			},
+			wantCode: http.StatusOK,
+			want: map[string]RepoQueue{
+				"ns/repo": {Limit: 2, Running: []string{"ns/pr-1", "ns/pr-2"}, Pending: []string{"ns/pr-3"}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			RegisterForDebug(tt.register())
+			t.Cleanup(func() { RegisterForDebug(nil) })
+
+			rec := httptest.NewRecorder()
+			DebugHandler()(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/debug/queue", nil))
+
+			assert.Equal(t, rec.Code, tt.wantCode)
+			if tt.wantCode != http.StatusOK {
+				return
+			}
+			got := map[string]RepoQueue{}
+			assert.NilError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+			assert.DeepEqual(t, got, tt.want)
+		})
+	}
+}
+
+// TestDebugHandlerDoesNotWaitForTheQueue checks the handler gives up instead of
+// blocking when the reconciler holds the lock. Reading the queue must never be
+// able to stall the thing being read, so this runs the handler off the test
+// goroutine and fails on the timeout rather than hanging the suite.
+func TestDebugHandlerDoesNotWaitForTheQueue(t *testing.T) {
+	qm := NewManager(zap.NewNop().Sugar())
+	qm.lock.Lock()
+	defer qm.lock.Unlock()
+
+	RegisterForDebug(qm)
+	t.Cleanup(func() { RegisterForDebug(nil) })
+
+	rec := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		DebugHandler()(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/debug/queue", nil))
+	}()
+
+	select {
+	case <-done:
+		assert.Equal(t, rec.Code, http.StatusServiceUnavailable)
+	case <-time.After(5 * time.Second):
+		t.Fatal("the debug handler blocked on the queue lock instead of giving up")
+	}
+}

--- a/pkg/queue/queue_manager.go
+++ b/pkg/queue/queue_manager.go
@@ -62,7 +62,12 @@ func (qm *Manager) getSemaphore(repo *v1alpha1.Repository) (Semaphore, error) {
 }
 
 func (qm *Manager) checkAndUpdateSemaphoreSize(repo *v1alpha1.Repository, semaphore Semaphore) error {
-	limit := *repo.Spec.ConcurrencyLimit
+	// a repository whose concurrency limit has been removed is treated as unlimited,
+	// which the semaphore models as a limit of zero.
+	limit := 0
+	if repo.Spec.ConcurrencyLimit != nil {
+		limit = *repo.Spec.ConcurrencyLimit
+	}
 	if limit != semaphore.getLimit() {
 		if semaphore.resize(limit) {
 			return nil
@@ -131,6 +136,11 @@ func (qm *Manager) RemoveFromQueue(repoKey, prKey string) bool {
 	qm.lock.Lock()
 	defer qm.lock.Unlock()
 
+	return qm.removeFromQueue(repoKey, prKey)
+}
+
+// removeFromQueue must be called with qm.lock held.
+func (qm *Manager) removeFromQueue(repoKey, prKey string) bool {
 	sema, found := qm.queueMap[repoKey]
 	if !found {
 		return false
@@ -143,9 +153,12 @@ func (qm *Manager) RemoveFromQueue(repoKey, prKey string) bool {
 }
 
 func (qm *Manager) RemoveAndTakeItemFromQueue(repo *v1alpha1.Repository, run *tektonv1.PipelineRun) string {
+	qm.lock.Lock()
+	defer qm.lock.Unlock()
+
 	repoKey := RepoKey(repo)
 	prKey := PrKey(run)
-	if !qm.RemoveFromQueue(repoKey, prKey) {
+	if !qm.removeFromQueue(repoKey, prKey) {
 		return ""
 	}
 	sema, found := qm.queueMap[repoKey]

--- a/pkg/queue/queue_manager.go
+++ b/pkg/queue/queue_manager.go
@@ -220,8 +220,10 @@ func (qm *Manager) InitQueues(ctx context.Context, tekton versioned2.Interface, 
 		for _, pr := range sortedPRs {
 			order, exist := pr.GetAnnotations()[keys.ExecutionOrder]
 			if !exist {
-				// if the pipelineRun doesn't have order label then wait
-				return nil
+				// if the pipelineRun doesn't have an execution order annotation
+				// then skip it, but keep initializing the remaining pipelineRuns
+				// and repositories.
+				continue
 			}
 			orderedList := FilterPipelineRunByState(ctx, tekton, strings.Split(order, ","), "", kubeinteraction.StateStarted)
 
@@ -246,8 +248,10 @@ func (qm *Manager) InitQueues(ctx context.Context, tekton versioned2.Interface, 
 		for _, pr := range sortedPRs {
 			order, exist := pr.GetAnnotations()[keys.ExecutionOrder]
 			if !exist {
-				// if the pipelineRun doesn't have order label then wait
-				return nil
+				// if the pipelineRun doesn't have an execution order annotation
+				// then skip it, but keep initializing the remaining pipelineRuns
+				// and repositories.
+				continue
 			}
 			orderedList := FilterPipelineRunByState(ctx, tekton, strings.Split(order, ","), tektonv1.PipelineRunSpecStatusPending, kubeinteraction.StateQueued)
 			if err := qm.AddToPendingQueue(&repo, orderedList); err != nil {

--- a/pkg/queue/queue_manager_test.go
+++ b/pkg/queue/queue_manager_test.go
@@ -2,6 +2,7 @@ package queue
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -373,4 +374,65 @@ func TestQueueManagerInitQueuesSkipsPipelineRunsWithoutOrder(t *testing.T) {
 	assert.Equal(t, sema.getCurrentRunning()[0], PrKey(started))
 	assert.Equal(t, len(sema.getCurrentPending()), 1)
 	assert.Equal(t, sema.getCurrentPending()[0], PrKey(queued))
+}
+
+// TestQueueManagerConcurrentRepositoryAccess exercises the manager from several
+// goroutines at once, the way the reconciler does when knative runs it with a
+// concurrency above one. Without a lock around every access to queueMap this
+// aborts the process with "fatal error: concurrent map read and map write".
+func TestQueueManagerConcurrentRepositoryAccess(t *testing.T) {
+	observer, _ := zapobserver.New(zap.InfoLevel)
+	qm := NewManager(zap.New(observer).Sugar())
+
+	const repos = 100
+	var wg sync.WaitGroup
+	for i := range repos {
+		repo := newTestRepo(1)
+		repo.Name = fmt.Sprintf("repo-%d", i)
+		pr := newTestPR(fmt.Sprintf("pr-%d", i), time.Now(), nil, nil, tektonv1.PipelineRunSpec{})
+		pr.Namespace = repo.Namespace
+
+		wg.Add(3)
+		go func() {
+			defer wg.Done()
+			_, _ = qm.AddListToRunningQueue(repo, []string{PrKey(pr)})
+		}()
+		go func() {
+			defer wg.Done()
+			qm.RemoveAndTakeItemFromQueue(repo, pr)
+		}()
+		go func() {
+			defer wg.Done()
+			qm.RemoveRepository(repo)
+		}()
+	}
+	wg.Wait()
+
+	// the manager must still be usable afterwards
+	survivor := newTestRepo(1)
+	survivor.Name = "survivor"
+	acquired, err := qm.AddListToRunningQueue(survivor, []string{"test-ns/survivor-pr"})
+	assert.NilError(t, err)
+	assert.DeepEqual(t, acquired, []string{"test-ns/survivor-pr"})
+}
+
+// TestCheckAndUpdateSemaphoreSizeHandlesRemovedLimit is a regression test for
+// a nil-pointer dereference: checkAndUpdateSemaphoreSize only runs once a
+// semaphore already exists for a repository, so a test that sets
+// ConcurrencyLimit to nil before the semaphore is first created (as the other
+// tests in this file do) never exercises this guard. Here the semaphore is
+// created with a limit first, and only then is the limit removed, which is
+// what actually reaches checkAndUpdateSemaphoreSize's nil check.
+func TestCheckAndUpdateSemaphoreSizeHandlesRemovedLimit(t *testing.T) {
+	observer, _ := zapobserver.New(zap.InfoLevel)
+	qm := NewManager(zap.New(observer).Sugar())
+
+	repo := newTestRepo(1)
+	_, err := qm.getSemaphore(repo)
+	assert.NilError(t, err)
+
+	repo.Spec.ConcurrencyLimit = nil
+	sema, err := qm.getSemaphore(repo)
+	assert.NilError(t, err)
+	assert.Equal(t, sema.getLimit(), 0, "a removed limit must be treated as unlimited")
 }

--- a/pkg/queue/queue_manager_test.go
+++ b/pkg/queue/queue_manager_test.go
@@ -326,3 +326,51 @@ func TestFilterPipelineRunByInProgress(t *testing.T) {
 	expected := []string{"test-ns/pr1"}
 	assert.DeepEqual(t, filtered, expected)
 }
+
+// TestQueueManagerInitQueuesSkipsPipelineRunsWithoutOrder asserts that a
+// PipelineRun without an execution-order annotation is skipped rather than
+// aborting the whole initialization. The order-less runs are deliberately the
+// oldest ones so they sort first and would short-circuit everything after them.
+func TestQueueManagerInitQueuesSkipsPipelineRunsWithoutOrder(t *testing.T) {
+	ctx, _ := rtesting.SetupFakeContext(t)
+	observer, _ := zapobserver.New(zap.InfoLevel)
+	logger := zap.New(observer).Sugar()
+	cw := clockwork.NewFakeClock()
+
+	startedLabel := map[string]string{keys.State: kubeinteraction.StateStarted}
+	queuedLabel := map[string]string{keys.State: kubeinteraction.StateQueued}
+
+	repo := newTestRepo(1)
+
+	// oldest started run, no execution-order annotation
+	noOrderStarted := newTestPR("no-order-started", cw.Now(), startedLabel,
+		map[string]string{keys.State: kubeinteraction.StateStarted}, tektonv1.PipelineRunSpec{})
+	started := newTestPR("started", cw.Now().Add(1*time.Second), startedLabel, map[string]string{
+		keys.ExecutionOrder: "test-ns/started",
+		keys.State:          kubeinteraction.StateStarted,
+	}, tektonv1.PipelineRunSpec{})
+
+	// oldest queued run, no execution-order annotation
+	noOrderQueued := newTestPR("no-order-queued", cw.Now().Add(2*time.Second), queuedLabel,
+		map[string]string{keys.State: kubeinteraction.StateQueued},
+		tektonv1.PipelineRunSpec{Status: tektonv1.PipelineRunSpecStatusPending})
+	queued := newTestPR("queued", cw.Now().Add(3*time.Second), queuedLabel, map[string]string{
+		keys.ExecutionOrder: "test-ns/queued",
+		keys.State:          kubeinteraction.StateQueued,
+	}, tektonv1.PipelineRunSpec{Status: tektonv1.PipelineRunSpecStatusPending})
+
+	stdata, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+		Repositories: []*v1alpha1.Repository{repo},
+		PipelineRuns: []*tektonv1.PipelineRun{noOrderStarted, started, noOrderQueued, queued},
+	})
+
+	qm := NewManager(logger)
+	assert.NilError(t, qm.InitQueues(ctx, stdata.Pipeline, stdata.PipelineAsCode))
+
+	sema, found := qm.queueMap[RepoKey(repo)]
+	assert.Assert(t, found, "queue was not built for the repository")
+	assert.Equal(t, len(sema.getCurrentRunning()), 1)
+	assert.Equal(t, sema.getCurrentRunning()[0], PrKey(started))
+	assert.Equal(t, len(sema.getCurrentPending()), 1)
+	assert.Equal(t, sema.getCurrentPending()[0], PrKey(queued))
+}

--- a/pkg/queue/semaphore.go
+++ b/pkg/queue/semaphore.go
@@ -30,10 +30,16 @@ func newSemaphore(name string, limit int) *prioritySemaphore {
 }
 
 func (s *prioritySemaphore) getLimit() int {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
 	return s.limit
 }
 
 func (s *prioritySemaphore) getCurrentPending() []string {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
 	keys := make([]string, 0, len(s.pending.items))
 	for _, item := range s.pending.items {
 		keys = append(keys, item.key)
@@ -42,6 +48,9 @@ func (s *prioritySemaphore) getCurrentPending() []string {
 }
 
 func (s *prioritySemaphore) getCurrentRunning() []string {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
 	keys := make([]string, 0, len(s.running))
 	for k := range s.running {
 		keys = append(keys, k)

--- a/pkg/queue/semaphore.go
+++ b/pkg/queue/semaphore.go
@@ -1,7 +1,6 @@
 package queue
 
 import (
-	"fmt"
 	"sync"
 	"time"
 
@@ -28,10 +27,6 @@ func newSemaphore(name string, limit int) *prioritySemaphore {
 		running:   make(map[string]bool),
 		lock:      &sync.Mutex{},
 	}
-}
-
-func (s *prioritySemaphore) getName() string {
-	return s.name
 }
 
 func (s *prioritySemaphore) getLimit() int {
@@ -142,46 +137,4 @@ func (s *prioritySemaphore) addToQueue(key string, creationTime time.Time) bool 
 	}
 	s.pending.add(key, creationTime.UnixNano())
 	return true
-}
-
-func (s *prioritySemaphore) tryAcquire(key string) (bool, string) {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
-	if _, ok := s.running[key]; ok {
-		return true, ""
-	}
-
-	waitingMsg := fmt.Sprintf("Waiting for %s lock. Available queue status: %d/%d", s.name, s.limit-len(s.running), s.limit)
-
-	// Check whether requested key is in front of priority queue.
-	// If it is in front position, it will allow to acquire lock.
-	// If it is not a front key, it needs to wait for its turn.
-	var nextKey string
-	if s.pending.Len() > 0 {
-		item := s.pending.peek()
-		nextKey = fmt.Sprintf("%v", item.key)
-		if key != nextKey {
-			return false, waitingMsg
-		}
-	}
-
-	if s.semaphore.TryAcquire(1) {
-		s.running[key] = true
-		s.pending.pop()
-		return true, ""
-	}
-
-	return false, waitingMsg
-}
-
-func (s *prioritySemaphore) acquire(key string) bool {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
-	if s.semaphore.TryAcquire(1) {
-		s.running[key] = true
-		return true
-	}
-	return false
 }

--- a/pkg/queue/semaphore_test.go
+++ b/pkg/queue/semaphore_test.go
@@ -12,7 +12,6 @@ func TestNewSemaphore(t *testing.T) {
 	repo := newSemaphore("test", 1)
 	cw := clockwork.NewFakeClock()
 
-	assert.Equal(t, repo.getName(), "test")
 	assert.Equal(t, repo.getLimit(), 1)
 
 	// add elements
@@ -23,21 +22,10 @@ func TestNewSemaphore(t *testing.T) {
 	assert.Equal(t, repo.addToQueue("B", cw.Now().Add(1*time.Second)), true)
 
 	// start the topmost, which would be A
-	acquired, msg := repo.tryAcquire("A")
-	assert.Equal(t, acquired, true)
-	assert.Equal(t, msg, "")
+	assert.Equal(t, repo.acquireLatest(), "A")
 
-	// hit again
-	acquired, _ = repo.tryAcquire("A")
-	assert.Equal(t, acquired, true)
-
-	// try acquiring B, but limit is 1 so should fail
-	acquired, _ = repo.tryAcquire("B")
-	assert.Equal(t, acquired, false)
-
-	// C is back in the queue should also fail
-	acquired, _ = repo.tryAcquire("C")
-	assert.Equal(t, acquired, false)
+	// limit is 1, so B and C stay pending
+	assert.Equal(t, repo.acquireLatest(), "")
 
 	assert.Equal(t, len(repo.getCurrentRunning()), 1)
 	assert.Equal(t, len(repo.getCurrentPending()), 2)
@@ -126,181 +114,4 @@ func TestNewSemaphorePreservesInsertionOrderForEqualPriority(t *testing.T) {
 	repo.removeFromQueue("B")
 
 	assert.Equal(t, repo.acquireLatest(), "C")
-}
-
-func TestTryAcquireDeadlockScenario(t *testing.T) {
-	// This test ensures concurrent access to tryAcquire works without deadlocks
-	repo := newSemaphore("deadlock-test", 1)
-	cw := clockwork.NewFakeClock()
-
-	// Add an item to the queue
-	assert.Equal(t, repo.addToQueue("key1", cw.Now()), true)
-
-	// Create channels for synchronization
-	firstStarted := make(chan bool)
-	secondStarted := make(chan bool)
-	firstDone := make(chan bool)
-	secondDone := make(chan bool)
-
-	// First goroutine: try to acquire the key
-	go func() {
-		firstStarted <- true
-		<-secondStarted // Wait for second goroutine to also start
-		acquired, _ := repo.tryAcquire("key1")
-		firstDone <- acquired
-	}()
-
-	// Second goroutine: try to acquire the same key concurrently
-	go func() {
-		<-firstStarted // Wait for first goroutine to start
-		secondStarted <- true
-		acquired, _ := repo.tryAcquire("key1")
-		secondDone <- acquired
-	}()
-
-	// Wait for both results with a timeout
-	select {
-	case result1 := <-firstDone:
-		select {
-		case result2 := <-secondDone:
-			// If we get here, no deadlock occurred
-			// Both should succeed since the same key can be acquired multiple times
-			// if it's already running (see line 138 in tryAcquire)
-			assert.Equal(t, result1, true)
-			assert.Equal(t, result2, true)
-		case <-time.After(5 * time.Second):
-			t.Fatal("Deadlock detected: second goroutine did not complete within 5 seconds")
-		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("Deadlock detected: first goroutine did not complete within 5 seconds")
-	}
-}
-
-func TestTryAcquireDeadlockTimeout(t *testing.T) {
-	// This test should hang (timeout) if the deadlock bug is present
-	// It simulates the scenario where tryAcquire calls acquire() while holding the lock
-	repo := newSemaphore("deadlock-test", 1)
-	cw := clockwork.NewFakeClock()
-
-	// Add an item to the queue
-	assert.Equal(t, repo.addToQueue("key1", cw.Now()), true)
-
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		// This would hang if tryAcquire calls acquire() while holding the lock
-		repo.tryAcquire("key1")
-	}()
-
-	select {
-	case <-done:
-		// Success: no deadlock
-	case <-time.After(2 * time.Second):
-		t.Fatal("Deadlock detected: tryAcquire did not return within 2 seconds")
-	}
-}
-
-func TestDeadlockDetectionRecursiveMutex(t *testing.T) {
-	// This test would detect a deadlock if tryAcquire were to call acquire()
-	// which would cause a recursive mutex lock (tryAcquire holds lock, then acquire tries to get same lock)
-	repo := newSemaphore("recursive-deadlock-test", 1)
-	cw := clockwork.NewFakeClock()
-
-	// Add an item to the queue
-	assert.Equal(t, repo.addToQueue("key1", cw.Now()), true)
-
-	// Channel to signal completion
-	done := make(chan bool, 1)
-
-	// Start a goroutine that would deadlock if tryAcquire calls acquire
-	go func() {
-		defer func() { done <- true }()
-
-		// This should complete without hanging
-		// If tryAcquire calls acquire, it would deadlock here because:
-		// 1. tryAcquire acquires s.lock
-		// 2. tryAcquire calls acquire
-		// 3. acquire tries to acquire s.lock again (same goroutine, same mutex)
-		// 4. Deadlock - goroutine waits for itself
-		_, _ = repo.tryAcquire("key1")
-	}()
-
-	// Wait for completion with timeout
-	select {
-	case <-done:
-		// Success - no deadlock
-		t.Log("No deadlock detected - tryAcquire completed successfully")
-	case <-time.After(3 * time.Second):
-		t.Fatal("DEADLOCK DETECTED: tryAcquire did not complete within 3 seconds - likely recursive mutex lock")
-	}
-}
-
-func TestDeadlockDetectionConcurrentTryAcquire(t *testing.T) {
-	// This test detects deadlocks in concurrent tryAcquire calls
-	repo := newSemaphore("concurrent-deadlock-test", 1)
-	cw := clockwork.NewFakeClock()
-
-	// Add items to the queue
-	assert.Equal(t, repo.addToQueue("key1", cw.Now()), true)
-	assert.Equal(t, repo.addToQueue("key2", cw.Now().Add(1*time.Second)), true)
-
-	// Channels for synchronization
-	goroutine1Done := make(chan bool, 1)
-	goroutine2Done := make(chan bool, 1)
-	startSignal := make(chan bool, 1)
-
-	// First goroutine
-	go func() {
-		defer func() { goroutine1Done <- true }()
-		<-startSignal // Wait for start signal
-		_, _ = repo.tryAcquire("key1")
-	}()
-
-	// Second goroutine
-	go func() {
-		defer func() { goroutine2Done <- true }()
-		<-startSignal // Wait for start signal
-		_, _ = repo.tryAcquire("key2")
-	}()
-
-	// Start both goroutines simultaneously
-	close(startSignal)
-
-	// Wait for both to complete with timeout
-	timeout := time.After(3 * time.Second)
-	completed := 0
-
-	for completed < 2 {
-		select {
-		case <-goroutine1Done:
-			completed++
-		case <-goroutine2Done:
-			completed++
-		case <-timeout:
-			t.Fatal("DEADLOCK DETECTED: Concurrent tryAcquire calls did not complete within 3 seconds")
-		}
-	}
-
-	t.Log("No deadlock detected - concurrent tryAcquire calls completed successfully")
-}
-
-func TestTryAcquireConcurrentAccess(t *testing.T) {
-	// Test concurrent access to tryAcquire to ensure no deadlocks occur
-	repo := newSemaphore("concurrent-test", 2)
-	cw := clockwork.NewFakeClock()
-
-	// Add multiple items to the queue
-	assert.Equal(t, repo.addToQueue("key1", cw.Now()), true)
-	assert.Equal(t, repo.addToQueue("key2", cw.Now().Add(1*time.Second)), true)
-	assert.Equal(t, repo.addToQueue("key3", cw.Now().Add(2*time.Second)), true)
-
-	// Try to acquire each key in order, simulating concurrent but ordered access
-	acquired1, _ := repo.tryAcquire("key1")
-	acquired2, _ := repo.tryAcquire("key2")
-	acquired3, _ := repo.tryAcquire("key3")
-
-	assert.Equal(t, acquired1, true)
-	assert.Equal(t, acquired2, true)
-	assert.Equal(t, acquired3, false)
-	assert.Equal(t, len(repo.getCurrentRunning()), 2)
 }

--- a/pkg/reconciler/controller.go
+++ b/pkg/reconciler/controller.go
@@ -76,12 +76,15 @@ func NewController() func(context.Context, configmap.Watcher) *controller.Impl {
 			log.Fatalf("Failed to create pipeline as code metrics recorder %v", err)
 		}
 
+		qm := queuepkg.NewManager(run.Clients.Log)
+		queuepkg.RegisterForDebug(qm)
+
 		r := &Reconciler{
 			run:               run,
 			kinteract:         kinteract,
 			pipelineRunLister: pipelineRunInformer.Lister(),
 			repoLister:        repoInformer.Lister(),
-			qm:                queuepkg.NewManager(run.Clients.Log),
+			qm:                qm,
 			metrics:           metrics,
 			eventEmitter:      events.NewEventEmitter(run.Clients.Kube, run.Clients.Log),
 		}

--- a/pkg/reconciler/controller.go
+++ b/pkg/reconciler/controller.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/events"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/formatting"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/generated/injection/informers/pipelinesascode/v1alpha1/repository"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/informer/transform"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
@@ -19,6 +20,9 @@ import (
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	tektonPipelineRunInformerv1 "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1/pipelinerun"
 	tektonPipelineRunReconcilerv1 "github.com/tektoncd/pipeline/pkg/client/injection/reconciler/pipeline/v1/pipelinerun"
+	tektonv1lister "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1"
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
@@ -88,7 +92,11 @@ func NewController() func(context.Context, configmap.Watcher) *controller.Impl {
 		}
 
 		if _, err := pipelineRunInformer.Informer().AddEventHandler(controller.HandleAll(checkStateAndEnqueue(impl))); err != nil {
-			logging.FromContext(ctx).Panicf("Couldn't register PipelineRun informer event handler: %w", err)
+			logging.FromContext(ctx).Panicf("Couldn't register PipelineRun informer event handler: %v", err)
+		}
+
+		if _, err := repoInformer.Informer().AddEventHandler(controller.HandleAll(enqueueQueuedPipelineRuns(impl, pipelineRunInformer.Lister(), log))); err != nil {
+			logging.FromContext(ctx).Panicf("Couldn't register Repository informer event handler: %v", err)
 		}
 
 		return impl
@@ -105,6 +113,35 @@ func checkStateAndEnqueue(impl *controller.Impl) func(obj any) {
 			if exist {
 				impl.EnqueueKey(types.NamespacedName{Namespace: object.GetNamespace(), Name: object.GetName()})
 			}
+		}
+	}
+}
+
+// enqueueQueuedPipelineRuns re-enqueues every queued PipelineRun of a Repository
+// whenever that Repository changes. Without this, a concurrency limit that is
+// raised, lowered, zeroed or removed only takes effect the next time some
+// unrelated PipelineRun event happens to wake the repository up.
+//
+// Note this only covers the Repository the PipelineRuns belong to. Changing the
+// concurrency limit on a *global* Repository does not wake the repositories that
+// merge from it, since that would require fanning out across every namespace.
+func enqueueQueuedPipelineRuns(impl *controller.Impl, lister tektonv1lister.PipelineRunLister, log *zap.SugaredLogger) func(obj any) {
+	return func(obj any) {
+		object, err := kmeta.DeletionHandlingAccessor(obj)
+		if err != nil {
+			return
+		}
+		selector := labels.SelectorFromSet(labels.Set{
+			keys.Repository: formatting.CleanValueKubernetes(object.GetName()),
+			keys.State:      kubeinteraction.StateQueued,
+		})
+		prs, err := lister.PipelineRuns(object.GetNamespace()).List(selector)
+		if err != nil {
+			log.Errorf("failed to list queued pipelineRuns for repository %s/%s: %v", object.GetNamespace(), object.GetName(), err)
+			return
+		}
+		for _, pr := range prs {
+			impl.EnqueueKey(types.NamespacedName{Namespace: pr.GetNamespace(), Name: pr.GetName()})
 		}
 	}
 }

--- a/pkg/reconciler/controller_test.go
+++ b/pkg/reconciler/controller_test.go
@@ -7,6 +7,9 @@ import (
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
+	pacv1alpha1 "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
+	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
 	tektontest "github.com/openshift-pipelines/pipelines-as-code/pkg/test/tekton"
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"go.uber.org/zap"
@@ -14,6 +17,7 @@ import (
 	"gotest.tools/v3/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/controller"
+	rtesting "knative.dev/pkg/reconciler/testing"
 )
 
 type fakeReconciler struct{}
@@ -81,4 +85,85 @@ func TestCtrlOpts(t *testing.T) {
 
 	// Assert that the promote filter function returns true.
 	assert.Assert(t, promote)
+}
+
+func TestEnqueueQueuedPipelineRuns(t *testing.T) {
+	const ns = "test-ns"
+
+	queuedPR := func(name, repoName string) *pipelinev1.PipelineRun {
+		return &pipelinev1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: ns,
+				Labels: map[string]string{
+					keys.Repository: repoName,
+					keys.State:      kubeinteraction.StateQueued,
+				},
+			},
+		}
+	}
+	startedPR := &pipelinev1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "already-running",
+			Namespace: ns,
+			Labels: map[string]string{
+				keys.Repository: "myrepo",
+				keys.State:      kubeinteraction.StateStarted,
+			},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		repo    *pacv1alpha1.Repository
+		wantLog []string
+		notLog  []string
+	}{
+		{
+			name: "enqueues only the queued runs of that repository",
+			repo: &pacv1alpha1.Repository{
+				ObjectMeta: metav1.ObjectMeta{Name: "myrepo", Namespace: ns},
+			},
+			wantLog: []string{"Adding to queue " + ns + "/queued-one", "Adding to queue " + ns + "/queued-two"},
+			notLog:  []string{"Adding to queue " + ns + "/already-running", "Adding to queue " + ns + "/other-repo-run"},
+		},
+		{
+			name: "repository with no queued runs enqueues nothing",
+			repo: &pacv1alpha1.Repository{
+				ObjectMeta: metav1.ObjectMeta{Name: "emptyrepo", Namespace: ns},
+			},
+			notLog: []string{"Adding to queue"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			observer, catcher := zapobserver.New(zap.DebugLevel)
+			logger := zap.New(observer).Sugar()
+
+			_, informers := testclient.SeedTestData(t, ctx, testclient.Data{
+				PipelineRuns: []*pipelinev1.PipelineRun{
+					queuedPR("queued-one", "myrepo"),
+					queuedPR("queued-two", "myrepo"),
+					queuedPR("other-repo-run", "otherrepo"),
+					startedPR,
+				},
+			})
+
+			impl := controller.NewContext(ctx, &fakeReconciler{}, controller.ControllerOptions{
+				WorkQueueName: "Test",
+				Logger:        logger.Named("Test"),
+			})
+
+			enqueueQueuedPipelineRuns(impl, informers.PipelineRun.Lister(), logger)(tt.repo)
+
+			for _, want := range tt.wantLog {
+				assert.Equal(t, catcher.FilterMessageSnippet(want).Len(), 1, "expected %q to be enqueued", want)
+			}
+			for _, notWant := range tt.notLog {
+				assert.Equal(t, catcher.FilterMessageSnippet(notWant).Len(), 0, "did not expect %q to be enqueued", notWant)
+			}
+		})
+	}
 }

--- a/pkg/reconciler/queue_pipelineruns.go
+++ b/pkg/reconciler/queue_pipelineruns.go
@@ -81,20 +81,37 @@ func (r *Reconciler) queuePipelineRun(ctx context.Context, logger *zap.SugaredLo
 		}
 
 		for _, prKeys := range acquired {
-			nsName := strings.Split(prKeys, "/")
 			repoKey := queuepkg.RepoKey(repo)
-			pr, err = r.run.Clients.Tekton.TektonV1().PipelineRuns(nsName[0]).Get(ctx, nsName[1], metav1.GetOptions{})
-			if err != nil {
-				logger.Info("failed to get pr with namespace and name: ", nsName[0], nsName[1])
+			nsName := strings.Split(prKeys, "/")
+			if len(nsName) != 2 {
+				logger.Errorf("invalid pipelineRun key %q queued for repository %s, dropping it", prKeys, repo.GetName())
 				_ = r.qm.RemoveFromQueue(repoKey, prKeys)
-			} else {
-				if err := r.updatePipelineRunToInProgress(ctx, logger, repo, pr); err != nil {
-					logger.Errorf("failed to update pipelineRun to in_progress: %w", err)
-					_ = r.qm.RemoveFromQueue(repoKey, prKeys)
-				} else {
-					processed = true
-				}
+				continue
 			}
+			acquiredPR, err := r.run.Clients.Tekton.TektonV1().PipelineRuns(nsName[0]).Get(ctx, nsName[1], metav1.GetOptions{})
+			if err != nil {
+				if errors.IsNotFound(err) {
+					// the PipelineRun is gone for good, so release the slot it was
+					// holding and let the next queued one take it.
+					logger.Infof("pipelineRun %s does not exist anymore, releasing its queue slot for repository %s", prKeys, repo.GetName())
+					_ = r.qm.RemoveFromQueue(repoKey, prKeys)
+					continue
+				}
+				// transient error: keep holding the slot and let the reconciler retry,
+				// otherwise we would release a slot for a PipelineRun that may well
+				// still be running.
+				return fmt.Errorf("failed to get pipelineRun %s: %w", prKeys, err)
+			}
+			if err := r.updatePipelineRunToInProgress(ctx, logger, repo, acquiredPR); err != nil {
+				// Do not release the slot here. updatePipelineRunToInProgress patches
+				// the state to "started" before doing any provider work, so by the time
+				// it fails the PipelineRun is already running in the cluster. Releasing
+				// the slot would let the queue admit past the concurrency limit and
+				// leave the in-memory queue permanently out of sync with the cluster.
+				// Returning the error requeues with backoff instead.
+				return fmt.Errorf("failed to update pipelineRun %s to in_progress: %w", prKeys, err)
+			}
+			processed = true
 		}
 		if processed {
 			break

--- a/pkg/reconciler/queue_pipelineruns.go
+++ b/pkg/reconciler/queue_pipelineruns.go
@@ -2,6 +2,7 @@ package reconciler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"strings"
 
@@ -80,41 +81,75 @@ func (r *Reconciler) queuePipelineRun(ctx context.Context, logger *zap.SugaredLo
 			break
 		}
 
+		var errs []error
+		dropped := map[string]bool{}
 		for _, prKeys := range acquired {
 			repoKey := queuepkg.RepoKey(repo)
 			nsName := strings.Split(prKeys, "/")
 			if len(nsName) != 2 {
 				logger.Errorf("invalid pipelineRun key %q queued for repository %s, dropping it", prKeys, repo.GetName())
 				_ = r.qm.RemoveFromQueue(repoKey, prKeys)
+				dropped[prKeys] = true
 				continue
 			}
 			acquiredPR, err := r.run.Clients.Tekton.TektonV1().PipelineRuns(nsName[0]).Get(ctx, nsName[1], metav1.GetOptions{})
 			if err != nil {
+				// Nothing has been written to the cluster yet, so this PipelineRun
+				// is still pending and cannot be running. Hand the slot back: if we
+				// kept it, the retry would find this PipelineRun already in the
+				// running set, never re-acquire it, and never free the slot, since
+				// only a completed PipelineRun releases one.
+				_ = r.qm.RemoveFromQueue(repoKey, prKeys)
 				if errors.IsNotFound(err) {
-					// the PipelineRun is gone for good, so release the slot it was
-					// holding and let the next queued one take it.
+					// This key came straight from the ordered list built at the top
+					// of this call. Drop it there too, or the next iteration of this
+					// loop would re-add and re-acquire the same gone PipelineRun,
+					// wasting a Get and possibly tripping maxIterations below even
+					// though there is nothing left to do.
 					logger.Infof("pipelineRun %s does not exist anymore, releasing its queue slot for repository %s", prKeys, repo.GetName())
-					_ = r.qm.RemoveFromQueue(repoKey, prKeys)
+					dropped[prKeys] = true
 					continue
 				}
-				// transient error: keep holding the slot and let the reconciler retry,
-				// otherwise we would release a slot for a PipelineRun that may well
-				// still be running.
-				return fmt.Errorf("failed to get pipelineRun %s: %w", prKeys, err)
+				// Keep going rather than return: the other acquired PipelineRuns
+				// are already holding slots, and abandoning them here would strand
+				// those slots until the watcher restarts.
+				errs = append(errs, fmt.Errorf("failed to get pipelineRun %s: %w", prKeys, err))
+				continue
 			}
 			if err := r.updatePipelineRunToInProgress(ctx, logger, repo, acquiredPR); err != nil {
-				// Do not release the slot here. updatePipelineRunToInProgress patches
-				// the state to "started" before doing any provider work, so by the time
-				// it fails the PipelineRun is already running in the cluster. Releasing
-				// the slot would let the queue admit past the concurrency limit and
-				// leave the in-memory queue permanently out of sync with the cluster.
-				// Returning the error requeues with backoff instead.
-				return fmt.Errorf("failed to update pipelineRun %s to in_progress: %w", prKeys, err)
+				if stderrors.Is(err, ErrPipelineRunNotStarted) {
+					// The state patch never landed, so the PipelineRun is still
+					// pending. Release the slot so the retry can pick it up again.
+					logger.Infof("pipelineRun %s could not be started, releasing its queue slot for repository %s", prKeys, repo.GetName())
+					_ = r.qm.RemoveFromQueue(repoKey, prKeys)
+				}
+				// Otherwise the state patch landed before this failed, so the
+				// PipelineRun is already running in the cluster. Keep the slot:
+				// releasing it would let the queue admit past the concurrency
+				// limit and leave the in-memory queue permanently out of sync.
+				// The slot is freed when the PipelineRun completes.
+				//
+				// Either way, keep processing the remaining acquired PipelineRuns
+				// so their slots are not stranded, and report the error at the end.
+				errs = append(errs, fmt.Errorf("failed to update pipelineRun %s to in_progress: %w", prKeys, err))
+				continue
 			}
 			processed = true
 		}
+		if len(errs) > 0 {
+			return stderrors.Join(errs...)
+		}
 		if processed {
 			break
+		}
+		if len(dropped) > 0 {
+			filtered := orderedList[:0]
+			for _, key := range orderedList {
+				if !dropped[key] {
+					filtered = append(filtered, key)
+				}
+			}
+			orderedList = filtered
 		}
 		if itered >= maxIterations {
 			return fmt.Errorf("max iterations reached of %d times trying to get a pipelinerun started for %s", maxIterations, repo.GetName())

--- a/pkg/reconciler/queue_pipelineruns_test.go
+++ b/pkg/reconciler/queue_pipelineruns_test.go
@@ -213,3 +213,102 @@ func TestQueuePipelineRun(t *testing.T) {
 		})
 	}
 }
+
+// TestQueuePipelineRunSlotRelease asserts when a queue slot is released and,
+// more importantly, when it must not be. Releasing the slot of a PipelineRun
+// that has already been patched to "started" lets the queue admit past the
+// concurrency limit and leaves the in-memory queue out of sync with the cluster.
+func TestQueuePipelineRunSlotRelease(t *testing.T) {
+	const ns = "test"
+
+	acquiredPR := &tektonv1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "queued",
+			Namespace: ns,
+			Annotations: map[string]string{
+				keys.Repository: "test",
+				keys.State:      "queued",
+			},
+		},
+		Spec: tektonv1.PipelineRunSpec{Status: tektonv1.PipelineRunSpecStatusPending},
+	}
+
+	tests := []struct {
+		name          string
+		seededPR      *tektonv1.PipelineRun
+		wantErrString string
+		wantReleased  bool
+	}{
+		{
+			name:          "start failure keeps the queue slot",
+			seededPR:      acquiredPR,
+			wantErrString: "failed to update pipelineRun test/queued to in_progress",
+			wantReleased:  false,
+		},
+		{
+			name:          "vanished pipelineRun releases the queue slot",
+			seededPR:      nil,
+			wantErrString: "max iterations reached of",
+			wantReleased:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			observer, _ := zapobserver.New(zap.InfoLevel)
+			fakelogger := zap.New(observer).Sugar()
+
+			repo := &pacv1alpha1.Repository{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: ns},
+				Spec:       pacv1alpha1.RepositorySpec{URL: "https://psg.fr"},
+			}
+			testData := testclient.Data{Repositories: []*pacv1alpha1.Repository{repo}}
+			if tt.seededPR != nil {
+				testData.PipelineRuns = []*tektonv1.PipelineRun{tt.seededPR}
+			}
+			stdata, informers := testclient.SeedTestData(t, ctx, testData)
+
+			released := []string{}
+			r := &Reconciler{
+				qm: testconcurrency.TestQMI{
+					RunningQueue: []string{ns + "/queued"},
+					Removed:      &released,
+				},
+				repoLister: informers.Repository.Lister(),
+				run: &params.Run{
+					Info: info.Info{
+						Kube:       &info.KubeOpts{Namespace: "global"},
+						Controller: &info.ControllerInfo{},
+						Pac:        &info.PacOpts{},
+					},
+					Clients: clients.Clients{
+						PipelineAsCode: stdata.PipelineAsCode,
+						Tekton:         stdata.Pipeline,
+						Kube:           stdata.Kube,
+						Log:            fakelogger,
+					},
+				},
+			}
+
+			trigger := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "trigger",
+					Namespace: ns,
+					Annotations: map[string]string{
+						keys.ExecutionOrder: ns + "/queued",
+						keys.Repository:     "test",
+					},
+				},
+			}
+
+			err := r.queuePipelineRun(ctx, fakelogger, trigger)
+			assert.ErrorContains(t, err, tt.wantErrString)
+			if tt.wantReleased {
+				assert.Assert(t, len(released) > 0, "expected the queue slot to be released, got none")
+			} else {
+				assert.Assert(t, len(released) == 0, "queue slot must not be released, got %v", released)
+			}
+		})
+	}
+}

--- a/pkg/reconciler/queue_pipelineruns_test.go
+++ b/pkg/reconciler/queue_pipelineruns_test.go
@@ -1,6 +1,7 @@
 package reconciler
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -9,13 +10,18 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	queuepkg "github.com/openshift-pipelines/pipelines-as-code/pkg/queue"
 	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
 	testconcurrency "github.com/openshift-pipelines/pipelines-as-code/pkg/test/concurrency"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	fakepipelineclientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned/fake"
 	"go.uber.org/zap"
 	zapobserver "go.uber.org/zap/zaptest/observer"
 	"gotest.tools/v3/assert"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
 	rtesting "knative.dev/pkg/reconciler/testing"
 )
 
@@ -215,9 +221,10 @@ func TestQueuePipelineRun(t *testing.T) {
 }
 
 // TestQueuePipelineRunSlotRelease asserts when a queue slot is released and,
-// more importantly, when it must not be. Releasing the slot of a PipelineRun
-// that has already been patched to "started" lets the queue admit past the
-// concurrency limit and leaves the in-memory queue out of sync with the cluster.
+// more importantly, when it must not be. The slot follows the state patch: it
+// is what clears spec.status, so before it lands the PipelineRun is still
+// pending and holding its slot would strand it forever, and after it lands the
+// PipelineRun is running and releasing its slot would admit past the limit.
 func TestQueuePipelineRunSlotRelease(t *testing.T) {
 	const ns = "test"
 
@@ -236,11 +243,12 @@ func TestQueuePipelineRunSlotRelease(t *testing.T) {
 	tests := []struct {
 		name          string
 		seededPR      *tektonv1.PipelineRun
+		setup         func(t *testing.T, cs *fakepipelineclientset.Clientset)
 		wantErrString string
 		wantReleased  bool
 	}{
 		{
-			name:          "start failure keeps the queue slot",
+			name:          "start failure after the state patch keeps the queue slot",
 			seededPR:      acquiredPR,
 			wantErrString: "failed to update pipelineRun test/queued to in_progress",
 			wantReleased:  false,
@@ -249,6 +257,30 @@ func TestQueuePipelineRunSlotRelease(t *testing.T) {
 			name:          "vanished pipelineRun releases the queue slot",
 			seededPR:      nil,
 			wantErrString: "max iterations reached of",
+			wantReleased:  true,
+		},
+		{
+			name:     "failing state patch releases the queue slot",
+			seededPR: acquiredPR,
+			setup: func(t *testing.T, cs *fakepipelineclientset.Clientset) {
+				t.Helper()
+				cs.PrependReactor("patch", "pipelineruns", func(k8stesting.Action) (bool, runtime.Object, error) {
+					return true, nil, apierrors.NewInternalError(fmt.Errorf("etcdserver: request timed out"))
+				})
+			},
+			wantErrString: "failed to update pipelineRun test/queued to in_progress",
+			wantReleased:  true,
+		},
+		{
+			name:     "transient get failure releases the queue slot",
+			seededPR: acquiredPR,
+			setup: func(t *testing.T, cs *fakepipelineclientset.Clientset) {
+				t.Helper()
+				cs.PrependReactor("get", "pipelineruns", func(k8stesting.Action) (bool, runtime.Object, error) {
+					return true, nil, apierrors.NewServiceUnavailable("apiserver is shutting down")
+				})
+			},
+			wantErrString: "failed to get pipelineRun test/queued",
 			wantReleased:  true,
 		},
 	}
@@ -268,6 +300,9 @@ func TestQueuePipelineRunSlotRelease(t *testing.T) {
 				testData.PipelineRuns = []*tektonv1.PipelineRun{tt.seededPR}
 			}
 			stdata, informers := testclient.SeedTestData(t, ctx, testData)
+			if tt.setup != nil {
+				tt.setup(t, stdata.Pipeline)
+			}
 
 			released := []string{}
 			r := &Reconciler{
@@ -311,4 +346,498 @@ func TestQueuePipelineRunSlotRelease(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestQueuePipelineRunProcessesAllAcquiredSlots asserts that a failure on one
+// acquired PipelineRun does not abandon the others. With a concurrency limit
+// above one, several PipelineRuns can be acquired in the same call; each one
+// already holds a slot, so every one of them must end up either started or
+// released. Returning early would strand the rest in the running set forever.
+func TestQueuePipelineRunProcessesAllAcquiredSlots(t *testing.T) {
+	const ns = "test"
+
+	makePR := func(name string) *tektonv1.PipelineRun {
+		return &tektonv1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: ns,
+				Annotations: map[string]string{
+					keys.Repository: "test",
+					keys.State:      "queued",
+				},
+			},
+			Spec: tektonv1.PipelineRunSpec{Status: tektonv1.PipelineRunSpecStatusPending},
+		}
+	}
+
+	ctx, _ := rtesting.SetupFakeContext(t)
+	observer, _ := zapobserver.New(zap.InfoLevel)
+	fakelogger := zap.New(observer).Sugar()
+
+	repo := &pacv1alpha1.Repository{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: ns},
+		Spec:       pacv1alpha1.RepositorySpec{URL: "https://psg.fr"},
+	}
+	stdata, informers := testclient.SeedTestData(t, ctx, testclient.Data{
+		Repositories: []*pacv1alpha1.Repository{repo},
+		PipelineRuns: []*tektonv1.PipelineRun{makePR("first"), makePR("second")},
+	})
+
+	// The state patch fails only for "first"; "second" must still be processed.
+	stdata.Pipeline.PrependReactor("patch", "pipelineruns", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if patch, ok := action.(k8stesting.PatchAction); ok && patch.GetName() == "first" {
+			return true, nil, apierrors.NewInternalError(fmt.Errorf("etcdserver: request timed out"))
+		}
+		return false, nil, nil
+	})
+
+	released := []string{}
+	r := &Reconciler{
+		qm: testconcurrency.TestQMI{
+			RunningQueue: []string{ns + "/first", ns + "/second"},
+			Removed:      &released,
+		},
+		repoLister: informers.Repository.Lister(),
+		run: &params.Run{
+			Info: info.Info{
+				Kube:       &info.KubeOpts{Namespace: "global"},
+				Controller: &info.ControllerInfo{},
+				Pac:        &info.PacOpts{},
+			},
+			Clients: clients.Clients{
+				PipelineAsCode: stdata.PipelineAsCode,
+				Tekton:         stdata.Pipeline,
+				Kube:           stdata.Kube,
+				Log:            fakelogger,
+			},
+		},
+	}
+
+	trigger := &tektonv1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "trigger",
+			Namespace: ns,
+			Annotations: map[string]string{
+				keys.ExecutionOrder: ns + "/first," + ns + "/second",
+				keys.Repository:     "test",
+			},
+		},
+	}
+
+	err := r.queuePipelineRun(ctx, fakelogger, trigger)
+	assert.ErrorContains(t, err, "pipelineRun test/first")
+
+	// "first" never left pending, so its slot must have been handed back.
+	assert.DeepEqual(t, released, []string{ns + "/test|" + ns + "/first"})
+
+	// "second" must not have been abandoned: its state patch went through.
+	second, err := stdata.Pipeline.TektonV1().PipelineRuns(ns).Get(ctx, "second", metav1.GetOptions{})
+	assert.NilError(t, err)
+	assert.Equal(t, second.GetAnnotations()[keys.State], "started")
+	assert.Equal(t, string(second.Spec.Status), "")
+}
+
+// TestQueuePipelineRunDropsGoneKeysFromRetry asserts that a PipelineRun which
+// no longer exists in the cluster is not retried across iterations of the
+// acquire loop. AddListToRunningQueue is called again with the same ordered
+// list whenever nothing was processed and no error occurred, so a key
+// dropped in one iteration must also be removed from that list, or it comes
+// straight back on the next call and gets re-acquired and re-failed until
+// maxIterations trips, even though there was never anything wrong.
+func TestQueuePipelineRunDropsGoneKeysFromRetry(t *testing.T) {
+	const ns = "test"
+
+	makePR := func(name string) *tektonv1.PipelineRun {
+		return &tektonv1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: ns,
+				Annotations: map[string]string{
+					keys.Repository: "test",
+					keys.State:      "queued",
+				},
+			},
+			Spec: tektonv1.PipelineRunSpec{Status: tektonv1.PipelineRunSpecStatusPending},
+		}
+	}
+
+	ctx, _ := rtesting.SetupFakeContext(t)
+	observer, _ := zapobserver.New(zap.InfoLevel)
+	fakelogger := zap.New(observer).Sugar()
+
+	repo := &pacv1alpha1.Repository{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: ns},
+		Spec:       pacv1alpha1.RepositorySpec{URL: "https://psg.fr"},
+	}
+	// Seeded so the ordered list built at the top of queuePipelineRun includes
+	// them, then made to vanish on the next Get, simulating the real race:
+	// present when the list was built, gone by the time the acquire loop tries
+	// to fetch it.
+	stdata, informers := testclient.SeedTestData(t, ctx, testclient.Data{
+		Repositories: []*pacv1alpha1.Repository{repo},
+		PipelineRuns: []*tektonv1.PipelineRun{makePR("gone1"), makePR("gone2")},
+	})
+
+	gets := map[string]int{}
+	stdata.Pipeline.PrependReactor("get", "pipelineruns", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		get, ok := action.(k8stesting.GetAction)
+		if !ok {
+			return false, nil, nil
+		}
+		gets[get.GetName()]++
+		if gets[get.GetName()] > 1 {
+			return true, nil, apierrors.NewNotFound(tektonv1.Resource("pipelineruns"), get.GetName())
+		}
+		return false, nil, nil
+	})
+
+	passed := [][]string{}
+	r := &Reconciler{
+		qm: testconcurrency.TestQMI{
+			EchoAcquired: true,
+			Passed:       &passed,
+		},
+		repoLister: informers.Repository.Lister(),
+		run: &params.Run{
+			Info: info.Info{
+				Kube:       &info.KubeOpts{Namespace: "global"},
+				Controller: &info.ControllerInfo{},
+				Pac:        &info.PacOpts{},
+			},
+			Clients: clients.Clients{
+				PipelineAsCode: stdata.PipelineAsCode,
+				Tekton:         stdata.Pipeline,
+				Kube:           stdata.Kube,
+				Log:            fakelogger,
+			},
+		},
+	}
+
+	trigger := &tektonv1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "trigger",
+			Namespace: ns,
+			Annotations: map[string]string{
+				keys.ExecutionOrder: ns + "/gone1," + ns + "/gone2",
+				keys.Repository:     "test",
+			},
+		},
+	}
+
+	err := r.queuePipelineRun(ctx, fakelogger, trigger)
+	// Both keys are legitimately gone: there is nothing left to do, so this
+	// must not surface as a "max iterations reached" error.
+	assert.NilError(t, err)
+
+	// The first call is handed the full ordered list; once both keys 404 and
+	// are dropped, the retry must be handed an empty list instead of the same
+	// two gone keys again.
+	assert.Assert(t, len(passed) >= 2, "expected at least two AddListToRunningQueue calls, got %d", len(passed))
+	assert.DeepEqual(t, passed[0], []string{ns + "/gone1", ns + "/gone2"})
+	assert.Equal(t, len(passed[1]), 0, "gone keys must not be retried on the next iteration")
+}
+
+// TestStartNextPipelineRunInQueue asserts the completion path obeys the same
+// slot rule as the acquire path: a candidate that never left pending gives its
+// slot back and the queue moves on to the next one, while a candidate whose
+// start failed only after the state patch keeps its slot.
+func TestStartNextPipelineRunInQueue(t *testing.T) {
+	const ns = "test"
+
+	makePR := func(name string) *tektonv1.PipelineRun {
+		return &tektonv1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: ns,
+				Annotations: map[string]string{
+					keys.Repository: "test",
+					keys.State:      "queued",
+				},
+			},
+			Spec: tektonv1.PipelineRunSpec{Status: tektonv1.PipelineRunSpecStatusPending},
+		}
+	}
+
+	tests := []struct {
+		name           string
+		nextInQueue    []string
+		seeded         []*tektonv1.PipelineRun
+		setup          func(t *testing.T, cs *fakepipelineclientset.Clientset)
+		wantReleased   []string
+		wantStarted    []string
+		wantNotStarted []string
+	}{
+		{
+			name:        "vanished candidate releases its slot and the next one starts",
+			nextInQueue: []string{ns + "/gone", ns + "/second"},
+			seeded:      []*tektonv1.PipelineRun{makePR("second")},
+			wantReleased: []string{
+				ns + "/test|" + ns + "/gone",
+			},
+			wantStarted: []string{"second"},
+		},
+		{
+			name:        "failing state patch releases the slot and the next one starts",
+			nextInQueue: []string{ns + "/first", ns + "/second"},
+			seeded:      []*tektonv1.PipelineRun{makePR("first"), makePR("second")},
+			setup: func(t *testing.T, cs *fakepipelineclientset.Clientset) {
+				t.Helper()
+				cs.PrependReactor("patch", "pipelineruns", func(action k8stesting.Action) (bool, runtime.Object, error) {
+					if patch, ok := action.(k8stesting.PatchAction); ok && patch.GetName() == "first" {
+						return true, nil, apierrors.NewInternalError(fmt.Errorf("etcdserver: request timed out"))
+					}
+					return false, nil, nil
+				})
+			},
+			wantReleased: []string{
+				ns + "/test|" + ns + "/first",
+			},
+			wantStarted: []string{"second"},
+		},
+		{
+			// The state patch on "first" succeeds, then provider detection
+			// fails, which is a post-patch failure: "first" is running and owns
+			// its slot, so nothing is released and "second" is not promoted.
+			name:           "start failure after the state patch keeps the slot",
+			nextInQueue:    []string{ns + "/first", ns + "/second"},
+			seeded:         []*tektonv1.PipelineRun{makePR("first"), makePR("second")},
+			wantReleased:   nil,
+			wantStarted:    []string{"first"},
+			wantNotStarted: []string{"second"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			observer, _ := zapobserver.New(zap.InfoLevel)
+			fakelogger := zap.New(observer).Sugar()
+
+			repo := &pacv1alpha1.Repository{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: ns},
+				Spec:       pacv1alpha1.RepositorySpec{URL: "https://psg.fr"},
+			}
+			stdata, informers := testclient.SeedTestData(t, ctx, testclient.Data{
+				Repositories: []*pacv1alpha1.Repository{repo},
+				PipelineRuns: tt.seeded,
+			})
+			if tt.setup != nil {
+				tt.setup(t, stdata.Pipeline)
+			}
+
+			released := []string{}
+			next := append([]string{}, tt.nextInQueue...)
+			r := &Reconciler{
+				qm: testconcurrency.TestQMI{
+					Removed:     &released,
+					NextInQueue: &next,
+				},
+				repoLister: informers.Repository.Lister(),
+				run: &params.Run{
+					Info: info.Info{
+						Kube:       &info.KubeOpts{Namespace: "global"},
+						Controller: &info.ControllerInfo{},
+						Pac:        &info.PacOpts{},
+					},
+					Clients: clients.Clients{
+						PipelineAsCode: stdata.PipelineAsCode,
+						Tekton:         stdata.Pipeline,
+						Kube:           stdata.Kube,
+						Log:            fakelogger,
+					},
+				},
+			}
+
+			finished := makePR("finished")
+			r.startNextPipelineRunInQueue(ctx, fakelogger, repo, finished)
+
+			assert.DeepEqual(t, released, func() []string {
+				if tt.wantReleased == nil {
+					return []string{}
+				}
+				return tt.wantReleased
+			}())
+			for _, name := range tt.wantStarted {
+				got, err := stdata.Pipeline.TektonV1().PipelineRuns(ns).Get(ctx, name, metav1.GetOptions{})
+				assert.NilError(t, err)
+				assert.Equal(t, got.GetAnnotations()[keys.State], "started", "pipelinerun %s should have been started", name)
+			}
+			for _, name := range tt.wantNotStarted {
+				got, err := stdata.Pipeline.TektonV1().PipelineRuns(ns).Get(ctx, name, metav1.GetOptions{})
+				assert.NilError(t, err)
+				assert.Equal(t, got.GetAnnotations()[keys.State], "queued", "pipelinerun %s should not have been started", name)
+			}
+		})
+	}
+}
+
+// TestStartNextPipelineRunInQueueGivesUp asserts the promotion loop terminates.
+// Every candidate that cannot be started hands its slot back and the loop asks
+// the queue for another one, so a queue that keeps handing out a key it was
+// asked to remove would spin forever and take the whole test binary down with
+// it on the -timeout kill. It must give up instead, and it must always release
+// the slot it is holding when it does.
+func TestStartNextPipelineRunInQueueGivesUp(t *testing.T) {
+	const ns = "test"
+
+	repo := &pacv1alpha1.Repository{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: ns},
+		Spec:       pacv1alpha1.RepositorySpec{URL: "https://psg.fr"},
+	}
+
+	tests := []struct {
+		name        string
+		repeatNext  string
+		cancel      bool
+		wantRemoved []string
+	}{
+		{
+			// The key never resolves to a PipelineRun, so the first iteration
+			// releases it and asks for another one, and the queue hands back
+			// the very key it was told to remove.
+			name:       "a queue that keeps returning a removed key is abandoned",
+			repeatNext: ns + "/never-there",
+			wantRemoved: []string{
+				ns + "/test|" + ns + "/never-there",
+				ns + "/test|" + ns + "/never-there",
+			},
+		},
+		{
+			// A malformed key would panic on key[1] if it were not guarded.
+			name:       "a malformed key is dropped instead of indexed",
+			repeatNext: "no-slash-here",
+			wantRemoved: []string{
+				ns + "/test|no-slash-here",
+				ns + "/test|no-slash-here",
+			},
+		},
+		{
+			// A cancelled context must still cost exactly one
+			// RemoveAndTakeItemFromQueue, or the finished PipelineRun's own
+			// slot is never freed, and the slot taken for the candidate we
+			// then decline to start must be handed back.
+			name:        "a cancelled context releases the slot it just took",
+			repeatNext:  ns + "/never-there",
+			cancel:      true,
+			wantRemoved: []string{ns + "/test|" + ns + "/never-there"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			if tt.cancel {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithCancel(ctx)
+				cancel()
+			}
+			observer, _ := zapobserver.New(zap.InfoLevel)
+			fakelogger := zap.New(observer).Sugar()
+
+			stdata, informers := testclient.SeedTestData(t, ctx, testclient.Data{
+				Repositories: []*pacv1alpha1.Repository{repo},
+			})
+
+			removed := []string{}
+			taken := 0
+			r := &Reconciler{
+				qm: testconcurrency.TestQMI{
+					Removed:    &removed,
+					RepeatNext: tt.repeatNext,
+					Taken:      &taken,
+				},
+				repoLister: informers.Repository.Lister(),
+				run: &params.Run{
+					Info: info.Info{
+						Kube:       &info.KubeOpts{Namespace: "global"},
+						Controller: &info.ControllerInfo{},
+						Pac:        &info.PacOpts{},
+					},
+					Clients: clients.Clients{
+						PipelineAsCode: stdata.PipelineAsCode,
+						Tekton:         stdata.Pipeline,
+						Kube:           stdata.Kube,
+						Log:            fakelogger,
+					},
+				},
+			}
+
+			finished := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "finished", Namespace: ns},
+			}
+			r.startNextPipelineRunInQueue(ctx, fakelogger, repo, finished)
+
+			assert.DeepEqual(t, removed, tt.wantRemoved)
+			// RemoveAndTakeItemFromQueue is what frees the finished
+			// PipelineRun's slot, so it must run at least once whatever else
+			// happens, including on an already-cancelled context.
+			assert.Assert(t, taken >= 1, "the finished pipelineRun's slot was never released")
+		})
+	}
+}
+
+// TestStartNextPipelineRunInQueueReleasesSlotForReal drives the promotion loop
+// against the real queue.Manager rather than a fake, to prove the slot of a
+// vanished candidate is genuinely handed back to the semaphore. TestQMI records
+// the calls but its RemoveFromQueue is a no-op, so on its own it cannot show
+// that the concurrency limit is actually recovered.
+func TestStartNextPipelineRunInQueueReleasesSlotForReal(t *testing.T) {
+	const ns = "test"
+	ctx, _ := rtesting.SetupFakeContext(t)
+	observer, _ := zapobserver.New(zap.InfoLevel)
+	fakelogger := zap.New(observer).Sugar()
+
+	limit := 1
+	repo := &pacv1alpha1.Repository{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: ns},
+		Spec:       pacv1alpha1.RepositorySpec{URL: "https://psg.fr", ConcurrencyLimit: &limit},
+	}
+
+	// "gone" is queued but never seeded into the cluster, so promoting it must
+	// fail and give its slot back. "finished" is the completed run whose slot
+	// is being freed.
+	stdata, informers := testclient.SeedTestData(t, ctx, testclient.Data{
+		Repositories: []*pacv1alpha1.Repository{repo},
+	})
+
+	qm := queuepkg.NewManager(fakelogger)
+	_, err := qm.AddListToRunningQueue(repo, []string{ns + "/finished"})
+	assert.NilError(t, err)
+	assert.NilError(t, qm.AddToPendingQueue(repo, []string{ns + "/gone"}))
+	assert.Equal(t, len(qm.RunningPipelineRuns(repo)), 1, "the finished run should hold the only slot")
+
+	r := &Reconciler{
+		qm:         qm,
+		repoLister: informers.Repository.Lister(),
+		run: &params.Run{
+			Info: info.Info{
+				Kube:       &info.KubeOpts{Namespace: "global"},
+				Controller: &info.ControllerInfo{},
+				Pac:        &info.PacOpts{},
+			},
+			Clients: clients.Clients{
+				PipelineAsCode: stdata.PipelineAsCode,
+				Tekton:         stdata.Pipeline,
+				Kube:           stdata.Kube,
+				Log:            fakelogger,
+			},
+		},
+	}
+
+	finished := &tektonv1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "finished", Namespace: ns},
+	}
+	r.startNextPipelineRunInQueue(ctx, fakelogger, repo, finished)
+
+	// Both the finished run and the vanished candidate must be gone from the
+	// queue. If "gone" kept the slot it briefly held, the repository would sit
+	// at its limit of 1 with nothing actually running, which is exactly the
+	// drift this whole change is about.
+	assert.DeepEqual(t, qm.RunningPipelineRuns(repo), []string{})
+	assert.DeepEqual(t, qm.QueuedPipelineRuns(repo), []string{})
+
+	// The freed slot must be usable again: a newly queued run gets admitted.
+	acquired, err := qm.AddListToRunningQueue(repo, []string{ns + "/fresh"})
+	assert.NilError(t, err)
+	assert.DeepEqual(t, acquired, []string{ns + "/fresh"})
 }

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -3,6 +3,7 @@ package reconciler
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"strings"
 
@@ -52,6 +53,13 @@ var (
 	_ pipelinerunreconciler.Interface = (*Reconciler)(nil)
 	_ pipelinerunreconciler.Finalizer = (*Reconciler)(nil)
 )
+
+// ErrPipelineRunNotStarted reports that a PipelineRun could not be moved out of
+// its pending state, so it is definitely not running in the cluster. Callers
+// holding a concurrency slot on its behalf must release it, otherwise the slot
+// is never freed: only a completed PipelineRun releases one, and this one never
+// started.
+var ErrPipelineRunNotStarted = stderrors.New("pipelineRun has not been started")
 
 func copyRepositoryForMerge(repo *v1alpha1.Repository) *v1alpha1.Repository {
 	if repo == nil {
@@ -395,25 +403,7 @@ func (r *Reconciler) reportFinalStatus(ctx context.Context, logger *zap.SugaredL
 	emitTimingSpans(logger, pr, &pacInfo.Settings, trStatus)
 
 	// remove pipelineRun from Queue and start the next one
-	for {
-		next := r.qm.RemoveAndTakeItemFromQueue(repo, pr)
-		if next == "" {
-			break
-		}
-		key := strings.Split(next, "/")
-		pr, err := r.run.Clients.Tekton.TektonV1().PipelineRuns(key[0]).Get(ctx, key[1], metav1.GetOptions{})
-		if err != nil {
-			logger.Errorf("cannot get pipeline for next in queue: %w", err)
-			continue
-		}
-
-		if err := r.updatePipelineRunToInProgress(ctx, logger, repo, pr); err != nil {
-			logger.Errorf("failed to update status: %w", err)
-			_ = r.qm.RemoveFromQueue(queuepkg.RepoKey(repo), queuepkg.PrKey(pr))
-			continue
-		}
-		break
-	}
+	r.startNextPipelineRunInQueue(ctx, logger, repo, pr)
 
 	if err := r.cleanupPipelineRuns(ctx, logger, pacInfo, repo, pr); err != nil {
 		return repo, fmt.Errorf("error cleaning pipelineruns: %w", err)
@@ -422,10 +412,92 @@ func (r *Reconciler) reportFinalStatus(ctx context.Context, logger *zap.SugaredL
 	return repo, nil
 }
 
+// startNextPipelineRunInQueue frees the slot held by a finished PipelineRun and
+// starts the next one waiting in the repository's queue. Each candidate that
+// turns out not to be startable is definitely not running — either it is gone
+// from the cluster or its state patch never landed — so its freshly-taken slot
+// is handed back and the next candidate is tried. A candidate whose start
+// failed *after* the state patch is already running and keeps its slot.
+//
+// Handing a slot back and asking for another candidate is what makes this a
+// loop, and it only terminates because every candidate is removed from the
+// queue as it is tried, so the queue drains. A queue implementation that keeps
+// returning a key it was asked to remove would spin here forever and take the
+// process down with it, so a key seen twice is treated as a broken queue and
+// ends the loop. The loop is deliberately not capped at some fixed number of
+// candidates: a repository may legitimately have any number of stale entries
+// ahead of a startable one, and stopping early would leave that one queued with
+// no running PipelineRun left to trigger another promotion.
+func (r *Reconciler) startNextPipelineRunInQueue(ctx context.Context, logger *zap.SugaredLogger, repo *v1alpha1.Repository, pr *tektonv1.PipelineRun) {
+	repoKey := queuepkg.RepoKey(repo)
+	seen := map[string]bool{}
+	for {
+		// This both releases the slot of the finished PipelineRun and takes one
+		// for the next candidate, so it has to run at least once, before any
+		// cancellation check, or the finished PipelineRun's slot is never freed.
+		next := r.qm.RemoveAndTakeItemFromQueue(repo, pr)
+		if next == "" {
+			return
+		}
+		if seen[next] {
+			logger.Errorf("queue for repository %s returned %s twice, it is out of sync with the cluster, giving up on starting the next pipelineRun", repo.GetName(), next)
+			_ = r.qm.RemoveFromQueue(repoKey, next)
+			return
+		}
+		seen[next] = true
+
+		// Starting a PipelineRun means talking to the cluster and to the git
+		// provider, which is pointless once the context is done. Hand the slot
+		// we just took back rather than strand it. The queue is rebuilt from
+		// the cluster by InitQueues on the next start, so nothing is lost.
+		if err := ctx.Err(); err != nil {
+			logger.Warnf("not starting the next pipelineRun %s for repository %s, releasing its queue slot: %v", next, repo.GetName(), err)
+			_ = r.qm.RemoveFromQueue(repoKey, next)
+			return
+		}
+
+		key := strings.Split(next, "/")
+		if len(key) != 2 {
+			logger.Errorf("invalid pipelineRun key %q queued for repository %s, releasing its queue slot", next, repo.GetName())
+			_ = r.qm.RemoveFromQueue(repoKey, next)
+			continue
+		}
+		nextPR, err := r.run.Clients.Tekton.TektonV1().PipelineRuns(key[0]).Get(ctx, key[1], metav1.GetOptions{})
+		if err != nil {
+			// The next PipelineRun already holds the slot we just freed, but
+			// nothing has been written to the cluster for it yet, so it is
+			// still pending. Hand the slot back before moving on: a slot kept
+			// for a run that never starts is never released, since only a
+			// completed run releases one.
+			logger.Errorf("cannot get pipeline for next in queue: %w", err)
+			_ = r.qm.RemoveFromQueue(repoKey, next)
+			continue
+		}
+
+		if err := r.updatePipelineRunToInProgress(ctx, logger, repo, nextPR); err != nil {
+			logger.Errorf("failed to update status: %w", err)
+			if stderrors.Is(err, ErrPipelineRunNotStarted) {
+				// The state patch never landed, so the PipelineRun is still
+				// pending. Release the slot and try the next one in the queue.
+				_ = r.qm.RemoveFromQueue(repoKey, queuepkg.PrKey(nextPR))
+				continue
+			}
+			// The state patch landed before this failed, so the PipelineRun is
+			// already running in the cluster and rightfully owns the slot.
+			// Releasing it here would admit another run past the limit.
+			return
+		}
+		return
+	}
+}
+
 func (r *Reconciler) updatePipelineRunToInProgress(ctx context.Context, logger *zap.SugaredLogger, repo *v1alpha1.Repository, pr *tektonv1.PipelineRun) error {
 	pr, err := r.updatePipelineRunState(ctx, logger, pr, kubeinteraction.StateStarted)
 	if err != nil {
-		return fmt.Errorf("cannot update state: %w", err)
+		// the patch is what clears spec.status, so until it lands the PipelineRun
+		// is still Pending and cannot be running. Callers holding a concurrency
+		// slot for it need to know that so they can hand the slot back.
+		return fmt.Errorf("%w: cannot update state: %w", ErrPipelineRunNotStarted, err)
 	}
 
 	detectedProvider, event, err := r.initGitProviderClient(ctx, logger, repo, pr)

--- a/pkg/test/concurrency/concurrency.go
+++ b/pkg/test/concurrency/concurrency.go
@@ -12,6 +12,9 @@ import (
 type TestQMI struct {
 	QueuedPrs    []string
 	RunningQueue []string
+	// Removed records the "repoKey|prKey" pairs passed to RemoveFromQueue, so
+	// tests can assert whether a queue slot was released.
+	Removed *[]string
 }
 
 func (TestQMI) InitQueues(_ context.Context, _ tektonVersionedClient.Interface, _ pacVersionedClient.Interface) error {
@@ -40,7 +43,10 @@ func (TestQMI) AddToPendingQueue(_ *pacv1alpha1.Repository, _ []string) error {
 	panic("implement me")
 }
 
-func (t TestQMI) RemoveFromQueue(_, _ string) bool {
+func (t TestQMI) RemoveFromQueue(repoKey, prKey string) bool {
+	if t.Removed != nil {
+		*t.Removed = append(*t.Removed, repoKey+"|"+prKey)
+	}
 	return false
 }
 

--- a/pkg/test/concurrency/concurrency.go
+++ b/pkg/test/concurrency/concurrency.go
@@ -15,6 +15,23 @@ type TestQMI struct {
 	// Removed records the "repoKey|prKey" pairs passed to RemoveFromQueue, so
 	// tests can assert whether a queue slot was released.
 	Removed *[]string
+	// NextInQueue is drained one key per RemoveAndTakeItemFromQueue call, so
+	// tests can feed the promotion loop a sequence of candidates.
+	NextInQueue *[]string
+	// EchoAcquired makes AddListToRunningQueue return exactly the list it was
+	// given instead of the fixed RunningQueue, so a test can observe whether a
+	// dropped key is still present in the list passed on a later call.
+	EchoAcquired bool
+	// Passed records the list argument of every AddListToRunningQueue call, in
+	// order, so a test can assert what a later retry iteration was given.
+	Passed *[][]string
+	// Taken counts RemoveAndTakeItemFromQueue calls, so a test can assert the
+	// finished PipelineRun's slot was released at least once.
+	Taken *int
+	// RepeatNext makes RemoveAndTakeItemFromQueue hand out the same key
+	// forever, modelling a queue that never releases a slot, so a test can
+	// check the caller gives up instead of looping.
+	RepeatNext string
 }
 
 func (TestQMI) InitQueues(_ context.Context, _ tektonVersionedClient.Interface, _ pacVersionedClient.Interface) error {
@@ -34,7 +51,13 @@ func (TestQMI) RunningPipelineRuns(_ *pacv1alpha1.Repository) []string {
 	panic("implement me")
 }
 
-func (t TestQMI) AddListToRunningQueue(_ *pacv1alpha1.Repository, _ []string) ([]string, error) {
+func (t TestQMI) AddListToRunningQueue(_ *pacv1alpha1.Repository, list []string) ([]string, error) {
+	if t.Passed != nil {
+		*t.Passed = append(*t.Passed, append([]string{}, list...))
+	}
+	if t.EchoAcquired {
+		return list, nil
+	}
 	return t.RunningQueue, nil
 }
 
@@ -50,7 +73,17 @@ func (t TestQMI) RemoveFromQueue(repoKey, prKey string) bool {
 	return false
 }
 
-func (TestQMI) RemoveAndTakeItemFromQueue(_ *pacv1alpha1.Repository, _ *tektonv1.PipelineRun) string {
-	// TODO implement me
-	panic("implement me")
+func (t TestQMI) RemoveAndTakeItemFromQueue(_ *pacv1alpha1.Repository, _ *tektonv1.PipelineRun) string {
+	if t.Taken != nil {
+		*t.Taken++
+	}
+	if t.RepeatNext != "" {
+		return t.RepeatNext
+	}
+	if t.NextInQueue == nil || len(*t.NextInQueue) == 0 {
+		return ""
+	}
+	next := (*t.NextInQueue)[0]
+	*t.NextInQueue = (*t.NextInQueue)[1:]
+	return next
 }

--- a/test/gitea_concurrency_test.go
+++ b/test/gitea_concurrency_test.go
@@ -16,9 +16,10 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/sort"
 	tgitea "github.com/openshift-pipelines/pipelines-as-code/test/pkg/gitea"
+	tkubestuff "github.com/openshift-pipelines/pipelines-as-code/test/pkg/kubestuff"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
-	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/scm"
 	twait "github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/scm"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 )
 
@@ -59,6 +60,8 @@ func TestGiteaConcurrencyExclusivenessMultiplePipelines(t *testing.T) {
 	}
 	_, f := tgitea.TestPR(t, topts)
 	defer f()
+	tgitea.AssertConcurrencyRespected(context.Background(), t, topts, 1)
+	tkubestuff.SnapshotWatcherHealth(context.Background(), t, topts.ParamsRun).Assert(context.Background(), t)
 }
 
 // multiple push to the same  repo, concurrency should q them.
@@ -162,6 +165,8 @@ func TestGiteaConcurrencyOrderedExecution(t *testing.T) {
 	assert.Assert(t, strings.HasPrefix(prs[len(prs)-1].Name, "abc"))
 	assert.Assert(t, strings.HasPrefix(prs[len(prs)-2].Name, "pqr"))
 	assert.Assert(t, strings.HasPrefix(prs[len(prs)-3].Name, "xyz"))
+
+	tgitea.AssertConcurrencyRespected(context.Background(), t, topts, 1)
 }
 
 func TestGiteaConfigMaxKeepRun(t *testing.T) {
@@ -241,4 +246,362 @@ func TestGiteaGlobalAndLocalRepoConcurrencyLimit(t *testing.T) {
 	}
 
 	tgitea.VerifyConcurrency(t, topts, github.Ptr(2))
+}
+
+// TestGiteaConcurrencyLimitChangeTakesEffect raises the concurrency limit of a
+// Repository while runs are queued behind it, and checks that the queue starts
+// admitting more work straight away.
+//
+// The runs sleep for a long time on purpose. If the first one finished during
+// the observation window, its completion alone would wake the queue and the
+// test would pass even when the limit change was ignored.
+func TestGiteaConcurrencyLimitChangeTakesEffect(t *testing.T) {
+	const (
+		numPipelines = 5
+		raisedLimit  = 5
+	)
+	yamlFiles := map[string]string{}
+	for i := 0; i < numPipelines; i++ {
+		yamlFiles[fmt.Sprintf(".tekton/pr%d.yaml", i)] = "testdata/pipelinerun-alt.yaml"
+	}
+	topts := &tgitea.TestOpts{
+		TargetEvent:      triggertype.PullRequest.String(),
+		YAMLFiles:        yamlFiles,
+		ExtraArgs:        map[string]string{"Command": "sleep 600"},
+		ConcurrencyLimit: github.Ptr(1),
+		ExpectEvents:     false,
+	}
+	ctx, f := tgitea.TestPR(t, topts)
+	defer f()
+
+	twait.UntilCounts(ctx, t, topts.ParamsRun.Clients, topts.TargetNS,
+		fmt.Sprintf("1 running and %d pending pipelineruns", numPipelines-1),
+		twait.DefaultTimeout, func(c twait.Counts) bool {
+			return c.Running == 1 && c.Pending == numPipelines-1
+		})
+
+	health := tkubestuff.SnapshotWatcherHealth(ctx, t, topts.ParamsRun)
+
+	pacrepo.SetConcurrencyLimit(ctx, t, topts.ParamsRun, topts.TargetNS, topts.TargetNS, github.Ptr(raisedLimit))
+
+	counts, _ := twait.UntilCounts(ctx, t, topts.ParamsRun.Clients, topts.TargetNS,
+		"at least 4 running pipelineruns after raising the limit",
+		90*time.Second, func(c twait.Counts) bool {
+			return c.Running >= 4
+		})
+
+	// If anything managed to finish, a completion could have woken the queue
+	// and we would not know whether the limit change did anything.
+	assert.Equal(t, counts.Done, 0, "a pipelinerun completed during the observation window, the result is inconclusive")
+
+	health.Assert(ctx, t)
+}
+
+// TestGiteaConcurrencyLimitRemoval drops the concurrency limit from a
+// Repository entirely while runs are queued behind it.
+//
+// The watcher health check is the point of this test: without it the test would
+// pass against the broken code, because Kubernetes restarts the crashed watcher
+// and the runs complete anyway.
+func TestGiteaConcurrencyLimitRemoval(t *testing.T) {
+	const numPipelines = 5
+	yamlFiles := map[string]string{}
+	for i := 0; i < numPipelines; i++ {
+		yamlFiles[fmt.Sprintf(".tekton/pr%d.yaml", i)] = "testdata/pipelinerun-alt.yaml"
+	}
+	topts := &tgitea.TestOpts{
+		TargetEvent:      triggertype.PullRequest.String(),
+		YAMLFiles:        yamlFiles,
+		ExtraArgs:        map[string]string{"Command": "sleep 20"},
+		ConcurrencyLimit: github.Ptr(1),
+		ExpectEvents:     false,
+	}
+	ctx, f := tgitea.TestPR(t, topts)
+	defer f()
+
+	twait.UntilCounts(ctx, t, topts.ParamsRun.Clients, topts.TargetNS,
+		"at least 2 pending pipelineruns", twait.DefaultTimeout,
+		func(c twait.Counts) bool { return c.Pending >= 2 })
+
+	health := tkubestuff.SnapshotWatcherHealth(ctx, t, topts.ParamsRun)
+
+	pacrepo.SetConcurrencyLimit(ctx, t, topts.ParamsRun, topts.TargetNS, topts.TargetNS, nil)
+
+	twait.UntilCounts(ctx, t, topts.ParamsRun.Clients, topts.TargetNS,
+		fmt.Sprintf("all %d pipelineruns finished", numPipelines),
+		twait.DefaultTimeout, func(c twait.Counts) bool {
+			return c.Total == numPipelines && c.Done == numPipelines
+		})
+
+	health.Assert(ctx, t)
+}
+
+// TestGiteaConcurrencyLimitHoldsWhenStartFails breaks the Git provider call
+// that happens after a run has already been started, and checks the limit still
+// holds.
+//
+// PAC un-pends a PipelineRun before it talks to the provider, so once the
+// provider call fails the run is already going while PAC thinks it never
+// started. Releasing the slot there admits the next run on top of it.
+func TestGiteaConcurrencyLimitHoldsWhenStartFails(t *testing.T) {
+	const numPipelines = 6
+	yamlFiles := map[string]string{}
+	for i := 0; i < numPipelines; i++ {
+		yamlFiles[fmt.Sprintf(".tekton/pr%d.yaml", i)] = "testdata/pipelinerun-alt.yaml"
+	}
+	topts := &tgitea.TestOpts{
+		TargetEvent:      triggertype.PullRequest.String(),
+		YAMLFiles:        yamlFiles,
+		ExtraArgs:        map[string]string{"Command": "sleep 30"},
+		ConcurrencyLimit: github.Ptr(1),
+		ExpectEvents:     false,
+	}
+	ctx, f := tgitea.TestPR(t, topts)
+	defer f()
+
+	twait.UntilCounts(ctx, t, topts.ParamsRun.Clients, topts.TargetNS,
+		"the first pipelinerun to be running", twait.DefaultTimeout,
+		func(c twait.Counts) bool { return c.Running >= 1 })
+
+	health := tkubestuff.SnapshotWatcherHealth(ctx, t, topts.ParamsRun)
+
+	// Deleting the token makes every subsequent start fail inside the provider
+	// client setup, which is exactly the window we care about.
+	err := topts.ParamsRun.Clients.Kube.CoreV1().Secrets(topts.TargetNS).Delete(ctx, topts.TargetNS, metav1.DeleteOptions{})
+	assert.NilError(t, err)
+	topts.ParamsRun.Clients.Log.Infof("deleted the git provider secret in %s, starts will now fail", topts.TargetNS)
+
+	time.Sleep(90 * time.Second)
+
+	assert.NilError(t, secret.Create(ctx, topts.ParamsRun,
+		map[string]string{"token": topts.Token}, topts.TargetNS, topts.TargetNS))
+	topts.ParamsRun.Clients.Log.Infof("restored the git provider secret in %s", topts.TargetNS)
+
+	twait.UntilCounts(ctx, t, topts.ParamsRun.Clients, topts.TargetNS,
+		fmt.Sprintf("all %d pipelineruns finished", numPipelines),
+		twait.DefaultTimeout, func(c twait.Counts) bool {
+			return c.Total == numPipelines && c.Done == numPipelines
+		})
+
+	tgitea.AssertConcurrencyRespected(ctx, t, topts, 1)
+	health.Assert(ctx, t)
+}
+
+// TestGiteaConcurrencyQueueRebuildSurvivesBadPipelineRun checks that one
+// unusable PipelineRun in one namespace does not stop the watcher from
+// rebuilding the queues of every other repository.
+//
+// The bad PipelineRun is written straight into the cluster rather than produced
+// through a provider, because there is no reliable way to make a real event
+// generate one. Namespaces are listed in name order, so the "aaa" one is
+// guaranteed to be reached before the "zzz" one that carries the real test.
+func TestGiteaConcurrencyQueueRebuildSurvivesBadPipelineRun(t *testing.T) {
+	const numPipelines = 4
+	ctx := context.Background()
+	runcnx, _, _, err := tgitea.Setup(ctx)
+	assert.NilError(t, err)
+
+	poisonNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("aaa-pac-e2e-poison")
+	assert.NilError(t, pacrepo.CreateNS(ctx, poisonNS, runcnx))
+	defer pacrepo.NSTearDown(ctx, t, runcnx, poisonNS)
+
+	assert.NilError(t, pacrepo.CreateRepo(ctx, poisonNS, runcnx, &v1alpha1.Repository{
+		ObjectMeta: metav1.ObjectMeta{Name: poisonNS, Namespace: poisonNS},
+		Spec: v1alpha1.RepositorySpec{
+			URL:              "https://forge.invalid/never/matched",
+			ConcurrencyLimit: github.Ptr(1),
+		},
+	}))
+
+	// Marked as started but with no execution order annotation, which is what
+	// the queue rebuild used to choke on. Left pending so it never runs.
+	_, err = runcnx.Clients.Tekton.TektonV1().PipelineRuns(poisonNS).Create(ctx, &tektonv1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "poison-no-execution-order",
+			Namespace: poisonNS,
+			Labels:    map[string]string{pacapi.State: kubeinteraction.StateStarted},
+		},
+		Spec: tektonv1.PipelineRunSpec{
+			Status: tektonv1.PipelineRunSpecStatusPending,
+			PipelineSpec: &tektonv1.PipelineSpec{
+				Tasks: []tektonv1.PipelineTask{{
+					Name: "noop",
+					TaskSpec: &tektonv1.EmbeddedTask{
+						TaskSpec: tektonv1.TaskSpec{
+							Steps: []tektonv1.Step{{
+								Name:   "noop",
+								Image:  "registry.access.redhat.com/ubi10/ubi-micro",
+								Script: "true",
+							}},
+						},
+					},
+				}},
+			},
+		},
+	}, metav1.CreateOptions{})
+	assert.NilError(t, err)
+	runcnx.Clients.Log.Infof("created a pipelinerun with no execution order in %s", poisonNS)
+
+	yamlFiles := map[string]string{}
+	for i := 0; i < numPipelines; i++ {
+		yamlFiles[fmt.Sprintf(".tekton/pr%d.yaml", i)] = "testdata/pipelinerun-alt.yaml"
+	}
+	targetRef := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("zzz-pac-e2e-test")
+	topts := &tgitea.TestOpts{
+		TargetEvent:      triggertype.PullRequest.String(),
+		TargetRefName:    targetRef,
+		TargetNS:         targetRef,
+		YAMLFiles:        yamlFiles,
+		ExtraArgs:        map[string]string{"Command": "sleep 60"},
+		ConcurrencyLimit: github.Ptr(1),
+		ExpectEvents:     false,
+	}
+	_, f := tgitea.TestPR(t, topts)
+	defer f()
+
+	twait.UntilCounts(ctx, t, topts.ParamsRun.Clients, topts.TargetNS,
+		"1 running and some pending pipelineruns", twait.DefaultTimeout,
+		func(c twait.Counts) bool { return c.Running == 1 && c.Pending >= 2 })
+
+	// Forces the queue to be rebuilt from what is already in the cluster. The
+	// watcher used to abort here, so simply coming back ready is an assertion.
+	tkubestuff.BounceWatcher(ctx, t, topts.ParamsRun)
+
+	health := tkubestuff.SnapshotWatcherHealth(ctx, t, topts.ParamsRun)
+
+	twait.UntilCounts(ctx, t, topts.ParamsRun.Clients, topts.TargetNS,
+		fmt.Sprintf("all %d pipelineruns finished", numPipelines),
+		twait.DefaultTimeout, func(c twait.Counts) bool {
+			return c.Total == numPipelines && c.Done == numPipelines
+		})
+
+	tgitea.AssertConcurrencyRespected(ctx, t, topts, 1)
+	health.Assert(ctx, t)
+}
+
+// TestGiteaConcurrencyWatcherSurvivesParallelRepos runs several limited
+// repositories at once and deletes some of them while their queues are still
+// active, then checks the watcher is still standing.
+//
+// Deleting a Repository while its runs are being reconciled is what used to
+// collide with the queue bookkeeping. The collision is timing dependent, so
+// this test makes it likely rather than certain, and asserts on the symptom.
+func TestGiteaConcurrencyWatcherSurvivesParallelRepos(t *testing.T) {
+	const (
+		numRepos     = 6
+		numDeleted   = 3
+		numPipelines = 3
+	)
+	ctx := context.Background()
+	runcnx, opts, giteacnx, err := tgitea.Setup(ctx)
+	assert.NilError(t, err)
+
+	health := tkubestuff.SnapshotWatcherHealth(ctx, t, runcnx)
+
+	yamlFiles := map[string]string{}
+	for i := 0; i < numPipelines; i++ {
+		yamlFiles[fmt.Sprintf(".tekton/pr%d.yaml", i)] = "testdata/pipelinerun-alt.yaml"
+	}
+
+	all := make([]*tgitea.TestOpts, 0, numRepos)
+	for i := 0; i < numRepos; i++ {
+		topts := &tgitea.TestOpts{
+			ParamsRun:        runcnx,
+			GiteaCNX:         giteacnx,
+			Opts:             opts,
+			TargetEvent:      triggertype.PullRequest.String(),
+			YAMLFiles:        yamlFiles,
+			ExtraArgs:        map[string]string{"Command": "sleep 20"},
+			ConcurrencyLimit: github.Ptr(1),
+			ExpectEvents:     false,
+		}
+		_, f := tgitea.TestPR(t, topts)
+		defer f()
+		all = append(all, topts)
+	}
+
+	// Wait until every repository has work in flight, so the deletions below
+	// land while the queues are busy rather than before they fill up.
+	for _, topts := range all {
+		twait.UntilCounts(ctx, t, topts.ParamsRun.Clients, topts.TargetNS,
+			"pipelineruns in flight", twait.DefaultTimeout,
+			func(c twait.Counts) bool { return c.Running >= 1 })
+	}
+
+	for _, topts := range all[:numDeleted] {
+		err := runcnx.Clients.PipelineAsCode.PipelinesascodeV1alpha1().
+			Repositories(topts.TargetNS).Delete(ctx, topts.TargetNS, metav1.DeleteOptions{})
+		assert.NilError(t, err)
+		runcnx.Clients.Log.Infof("deleted repository %s while its queue was active", topts.TargetNS)
+	}
+
+	for _, topts := range all[numDeleted:] {
+		twait.UntilCounts(ctx, t, topts.ParamsRun.Clients, topts.TargetNS,
+			fmt.Sprintf("all %d pipelineruns finished", numPipelines),
+			twait.DefaultTimeout, func(c twait.Counts) bool {
+				return c.Total == numPipelines && c.Done == numPipelines
+			})
+		tgitea.AssertConcurrencyRespected(ctx, t, topts, 1)
+	}
+
+	health.Assert(ctx, t)
+}
+
+// TestGiteaConcurrencyTransientAPIFailureDoesNotWedgeQueue makes writes to
+// PipelineRuns fail for a while, and checks the repository recovers once they
+// are allowed again.
+//
+// A concurrency slot is taken before the run is actually un-pended. If the slot
+// is kept when that write fails, the run never starts, so it never completes,
+// so the slot is never given back: one bad minute permanently shrinks the
+// limit. At a limit of 1 the repository stops running anything at all.
+//
+// Unlike the other tests here this one covers a regression introduced by the
+// fix rather than by the original code, so it is checked against this branch.
+func TestGiteaConcurrencyTransientAPIFailureDoesNotWedgeQueue(t *testing.T) {
+	const numPipelines = 5
+	ctx := context.Background()
+	runcnx, opts, giteacnx, err := tgitea.Setup(ctx)
+	assert.NilError(t, err)
+
+	// Restarts the watcher, so it has to happen before there is anything queued.
+
+	yamlFiles := map[string]string{}
+	for i := 0; i < numPipelines; i++ {
+		yamlFiles[fmt.Sprintf(".tekton/pr%d.yaml", i)] = "testdata/pipelinerun-alt.yaml"
+	}
+	topts := &tgitea.TestOpts{
+		ParamsRun:        runcnx,
+		GiteaCNX:         giteacnx,
+		Opts:             opts,
+		TargetEvent:      triggertype.PullRequest.String(),
+		YAMLFiles:        yamlFiles,
+		ExtraArgs:        map[string]string{"Command": "sleep 20"},
+		ConcurrencyLimit: github.Ptr(1),
+		ExpectEvents:     false,
+	}
+	_, f := tgitea.TestPR(t, topts)
+	defer f()
+
+	// Waiting for one to finish means a slot has just been freed and the next
+	// run is about to be started, which is the window we want to break.
+	twait.UntilCounts(ctx, t, topts.ParamsRun.Clients, topts.TargetNS,
+		"the first pipelinerun to finish", twait.DefaultTimeout,
+		func(c twait.Counts) bool { return c.Done >= 1 })
+
+	health := tkubestuff.SnapshotWatcherHealth(ctx, t, topts.ParamsRun)
+
+	allow := tkubestuff.DenyPipelineRunWrites(ctx, t, topts.ParamsRun, topts.TargetNS)
+	time.Sleep(60 * time.Second)
+	allow()
+
+	twait.UntilCounts(ctx, t, topts.ParamsRun.Clients, topts.TargetNS,
+		fmt.Sprintf("all %d pipelineruns finished", numPipelines),
+		twait.DefaultTimeout, func(c twait.Counts) bool {
+			return c.Total == numPipelines && c.Done == numPipelines
+		})
+
+	tgitea.AssertConcurrencyRespected(ctx, t, topts, 1)
+	tkubestuff.AssertQueueDrained(ctx, t, topts.ParamsRun, topts.TargetNS, topts.TargetNS)
+	health.Assert(ctx, t)
 }

--- a/test/gitea_concurrency_test.go
+++ b/test/gitea_concurrency_test.go
@@ -10,15 +10,22 @@ import (
 	"time"
 
 	"github.com/google/go-github/v85/github"
+	"github.com/tektoncd/pipeline/pkg/names"
 	"gotest.tools/v3/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	pacapi "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/sort"
 	tgitea "github.com/openshift-pipelines/pipelines-as-code/test/pkg/gitea"
 	tkubestuff "github.com/openshift-pipelines/pipelines-as-code/test/pkg/kubestuff"
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
+	pacrepo "github.com/openshift-pipelines/pipelines-as-code/test/pkg/repository"
+	secret "github.com/openshift-pipelines/pipelines-as-code/test/pkg/secret"
 	twait "github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
+
 	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/scm"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 )

--- a/test/github_pullrequest_concurrency_test.go
+++ b/test/github_pullrequest_concurrency_test.go
@@ -27,6 +27,10 @@ import (
 
 const pipelineRunFileNamePrefix = "prlongrunnning-"
 
+// globalRepoConcurrencyLimit is the limit trepository.CreateGlobalRepo sets on
+// the global Repository.
+const globalRepoConcurrencyLimit = 2
+
 func TestGithubGHEPullRequestConcurrency1by1(t *testing.T) {
 	ctx := context.Background()
 	label := "Github PullRequest Concurrent, sequentially one by one"
@@ -36,7 +40,7 @@ func TestGithubGHEPullRequestConcurrency1by1(t *testing.T) {
 	yamlFiles := map[string]string{}
 	g := setupGithubConcurrency(ctx, t, maxNumberOfConcurrentPipelineRuns, numberOfPipelineRuns, label, yamlFiles)
 	defer g.TearDown(ctx, t)
-	testGithubConcurrency(ctx, t, g, numberOfPipelineRuns, checkOrdering)
+	testGithubConcurrency(ctx, t, g, numberOfPipelineRuns, maxNumberOfConcurrentPipelineRuns, checkOrdering)
 }
 
 // TestGithubGHEPullRequestConcurrencyRestartedWhenWatcherIsUp tests that
@@ -85,7 +89,7 @@ func TestGithubGHEPullRequestConcurrencyRestartedWhenWatcherIsUp(t *testing.T) {
 
 	g.Cnx.Clients.Log.Info("All PipelineRuns are Pending")
 	tkubestuff.ScaleDeployment(ctx, t, runCnxS, 1, "pipelines-as-code-watcher", "pipelines-as-code")
-	testGithubConcurrency(ctx, t, g, numberOfPipelineRuns, checkOrdering)
+	testGithubConcurrency(ctx, t, g, numberOfPipelineRuns, maxNumberOfConcurrentPipelineRuns, checkOrdering)
 }
 
 func TestGithubGHEPullRequestConcurrency3by3(t *testing.T) {
@@ -98,7 +102,7 @@ func TestGithubGHEPullRequestConcurrency3by3(t *testing.T) {
 
 	g := setupGithubConcurrency(ctx, t, maxNumberOfConcurrentPipelineRuns, numberOfPipelineRuns, label, yamlFiles)
 	defer g.TearDown(ctx, t)
-	testGithubConcurrency(ctx, t, g, numberOfPipelineRuns, checkOrdering)
+	testGithubConcurrency(ctx, t, g, numberOfPipelineRuns, maxNumberOfConcurrentPipelineRuns, checkOrdering)
 }
 
 func TestGithubGHEPullRequestConcurrency1by1WithError(t *testing.T) {
@@ -113,7 +117,7 @@ func TestGithubGHEPullRequestConcurrency1by1WithError(t *testing.T) {
 
 	g := setupGithubConcurrency(ctx, t, maxNumberOfConcurrentPipelineRuns, numberOfPipelineRuns, label, yamlFiles)
 	defer g.TearDown(ctx, t)
-	testGithubConcurrency(ctx, t, g, numberOfPipelineRuns, checkOrdering)
+	testGithubConcurrency(ctx, t, g, numberOfPipelineRuns, maxNumberOfConcurrentPipelineRuns, checkOrdering)
 }
 
 func TestGithubGlobalRepoConcurrencyLimit(t *testing.T) {
@@ -143,9 +147,15 @@ func testGlobalRepoConcurrency(t *testing.T, label string, localRepoMaxConcurren
 	checkOrdering := false
 	yamlFiles := map[string]string{}
 
+	// the local limit wins when it is set, otherwise the global one applies
+	effectiveLimit := globalRepoConcurrencyLimit
+	if localRepoMaxConcurrentRuns >= 0 {
+		effectiveLimit = localRepoMaxConcurrentRuns
+	}
+
 	g := setupGithubConcurrency(ctx, t, localRepoMaxConcurrentRuns, numberOfPipelineRuns, label, yamlFiles)
 	defer g.TearDown(ctx, t)
-	testGithubConcurrency(ctx, t, g, numberOfPipelineRuns, checkOrdering)
+	testGithubConcurrency(ctx, t, g, numberOfPipelineRuns, effectiveLimit, checkOrdering)
 }
 
 func setupGithubConcurrency(ctx context.Context, t *testing.T, maxNumberOfConcurrentPipelineRuns, numberOfPipelineRuns int, label string, yamlFiles map[string]string) tgithub.PRTest {
@@ -201,9 +211,11 @@ func setupGithubConcurrency(ctx context.Context, t *testing.T, maxNumberOfConcur
 	}
 }
 
-func testGithubConcurrency(ctx context.Context, t *testing.T, g tgithub.PRTest, numberOfPipelineRuns int, checkOrdering bool) {
+func testGithubConcurrency(ctx context.Context, t *testing.T, g tgithub.PRTest, numberOfPipelineRuns, maxConcurrency int, checkOrdering bool) {
 	g.Cnx.Clients.Log.Info("waiting to let controller process the event")
 	time.Sleep(5 * time.Second)
+
+	health := tkubestuff.SnapshotWatcherHealth(ctx, t, g.Cnx)
 
 	waitOpts := wait.Opts{
 		Namespace:       g.TargetNamespace,
@@ -215,13 +227,21 @@ func testGithubConcurrency(ctx context.Context, t *testing.T, g tgithub.PRTest, 
 
 	waitForPipelineRunsHasStarted(ctx, t, g, numberOfPipelineRuns)
 
+	prs, err := g.Cnx.Clients.Tekton.TektonV1().PipelineRuns(g.TargetNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", keys.SHA, g.SHA),
+	})
+	assert.NilError(t, err)
+
+	// the limit is the point of the feature, but until now these tests only
+	// checked that everything eventually succeeded, which a queue that ignores
+	// the limit entirely also does.
+	if maxConcurrency > 0 {
+		wait.AssertMaxConcurrency(t, prs.Items, maxConcurrency)
+	}
+	health.Assert(ctx, t)
+
 	// sort all the PR by when they have started
 	if checkOrdering {
-		prs, err := g.Cnx.Clients.Tekton.TektonV1().PipelineRuns(g.TargetNamespace).List(ctx, metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("%s=%s", keys.SHA, g.SHA),
-		})
-		assert.NilError(t, err)
-
 		// Verify we have the expected number of PipelineRuns
 		assert.Assert(t, len(prs.Items) == numberOfPipelineRuns,
 			"Expected %d PipelineRuns with SHA %s, but found %d",

--- a/test/pkg/gitea/concurrency.go
+++ b/test/pkg/gitea/concurrency.go
@@ -1,0 +1,26 @@
+package gitea
+
+import (
+	"context"
+	"testing"
+
+	twait "github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
+	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// AssertConcurrencyRespected checks that the repository never ran more than
+// limit PipelineRuns at once.
+//
+// Waiting for every PipelineRun to succeed, which is all the concurrency tests
+// used to do, passes just as happily when the queue ignores the limit and runs
+// them all at the same time. This is the assertion that tests the queue.
+func AssertConcurrencyRespected(ctx context.Context, t *testing.T, topts *TestOpts, limit int) {
+	t.Helper()
+	prs, err := topts.ParamsRun.Clients.Tekton.TektonV1().PipelineRuns(topts.TargetNS).List(ctx, metav1.ListOptions{})
+	assert.NilError(t, err)
+	assert.Assert(t, len(prs.Items) > 0, "no PipelineRun found in %s", topts.TargetNS)
+	twait.AssertMaxConcurrency(t, prs.Items, limit)
+	topts.ParamsRun.Clients.Log.Infof("concurrency limit of %d respected across %d PipelineRuns in %s",
+		limit, len(prs.Items), topts.TargetNS)
+}

--- a/test/pkg/gitea/retry.go
+++ b/test/pkg/gitea/retry.go
@@ -1,0 +1,133 @@
+package gitea
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v3"
+	"go.uber.org/zap"
+)
+
+// settleChecks is how many consecutive lookups must agree that a write did
+// not land before we believe them. A write that failed with a gateway
+// timeout may still be in flight on the server, so a single immediate 404
+// is not proof of absence: re-issuing the write on the strength of it would
+// be exactly the duplicate we are trying to avoid.
+const settleChecks = 2
+
+// retryOnAPIError retries fn up to attempts times (sleeping delay between
+// each attempt), to work around transient Gitea/Forgejo API errors (e.g.
+// 504 upstream timeouts) seen against the test instance under load.
+//
+// The writes being retried are not idempotent, and a request that fails on
+// the client side can still have succeeded on the server. So after every
+// failed write, including the last one, retryOnAPIError asks tryRecover
+// whether the attempt actually landed:
+//
+//   - (value, true, nil)  the write landed, reuse value and stop
+//   - (_, false, nil)     it is not there
+//   - (_, _, err)         inconclusive, the lookup itself failed
+//
+// fn is only re-issued once the write is confirmed absent by settleChecks
+// consecutive successful lookups, and it is re-issued straight away so that
+// nothing happens between the confirmation and the write. If the lookups
+// never agree, or keep failing, retryOnAPIError gives up rather than risk a
+// duplicate write.
+//
+// tryRecover may be nil, in which case fn is simply retried.
+func retryOnAPIError[T any](logger *zap.SugaredLogger, action string, attempts int, delay time.Duration, fn func() (T, error), tryRecover func() (T, bool, error)) (T, error) {
+	return retryOnAPIErrorWithSleep(logger, action, attempts, delay, fn, tryRecover, time.Sleep)
+}
+
+// retryOnAPIErrorWithSleep is retryOnAPIError with the pause between attempts
+// injected, so a test can observe how the loop paces itself without spending
+// real time and without a mutable package global.
+func retryOnAPIErrorWithSleep[T any](logger *zap.SugaredLogger, action string, attempts int, delay time.Duration, fn func() (T, error), tryRecover func() (T, bool, error), sleep func(time.Duration)) (T, error) {
+	var result T
+	var err error
+	if attempts < 1 {
+		attempts = 1
+	}
+	for i := 0; i < attempts; i++ {
+		if result, err = fn(); err == nil {
+			return result, nil
+		}
+		logger.Infof("%s has failed, attempt %d/%d, err: %v", action, i+1, attempts, err)
+		if tryRecover != nil {
+			value, found, confirmed := confirmOutcome(logger, action, attempts, delay, tryRecover, sleep)
+			if found {
+				logger.Infof("%s already succeeded, reusing the existing result", action)
+				return value, nil
+			}
+			if !confirmed {
+				return result, fmt.Errorf("%s failed and we could not confirm whether it succeeded, not retrying to avoid a duplicate: %w", action, err)
+			}
+		}
+		if i == attempts-1 {
+			return result, err
+		}
+		if tryRecover == nil {
+			// Nothing has paced this loop, so wait before hammering the
+			// API again. With a recovery check we deliberately do not
+			// wait: confirmOutcome has already spent that time polling
+			// and just told us the write is absent, and sleeping again
+			// would reopen the window where it could quietly appear.
+			sleep(delay)
+		}
+	}
+	return result, err
+}
+
+// confirmOutcome polls tryRecover until it finds the write, sees it stay
+// absent across enough consecutive lookups to rule out a slow server, or
+// runs out of budget. It reports the recovered value, whether the write was
+// found, and whether the answer is conclusive at all.
+func confirmOutcome[T any](logger *zap.SugaredLogger, action string, attempts int, delay time.Duration, tryRecover func() (T, bool, error), sleep func(time.Duration)) (T, bool, bool) {
+	var zero T
+	needed := min(settleChecks, attempts)
+	absences := 0
+	for i := 0; i < attempts; i++ {
+		value, found, err := tryRecover()
+		switch {
+		case err != nil:
+			absences = 0
+			logger.Infof("%s: cannot tell whether the attempt succeeded, rechecking %d/%d, err: %v", action, i+1, attempts, err)
+		case found:
+			return value, true, true
+		default:
+			absences++
+			if absences >= needed {
+				return zero, false, true
+			}
+			logger.Infof("%s: not there yet, it may still be in flight, rechecking %d/%d", action, i+1, attempts)
+		}
+		if i < attempts-1 {
+			sleep(delay)
+		}
+	}
+	return zero, false, false
+}
+
+// absent reports whether a failed lookup means the object is genuinely
+// missing (a 404) rather than the lookup itself having failed. The SDK
+// surfaces errors untyped, so only the response carries the status code.
+func absent(resp *forgejo.Response, err error) bool {
+	return err != nil && resp != nil && resp.StatusCode == http.StatusNotFound
+}
+
+// lookup turns a Gitea "get" call into the tri-state answer that
+// retryOnAPIError expects: found, not there, or inconclusive.
+func lookup[T any](value *T, resp *forgejo.Response, err error) (*T, bool, error) {
+	switch {
+	case err == nil && value != nil:
+		return value, true, nil
+	case absent(resp, err):
+		return nil, false, nil
+	case err != nil:
+		return nil, false, err
+	default:
+		// No error but nothing returned either, treat as not there.
+		return nil, false, nil
+	}
+}

--- a/test/pkg/gitea/retry_test.go
+++ b/test/pkg/gitea/retry_test.go
@@ -1,0 +1,274 @@
+package gitea
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v3"
+	"go.uber.org/zap"
+	"gotest.tools/v3/assert"
+)
+
+func TestRetryOnAPIError(t *testing.T) {
+	errBoom := errors.New("unknown API Error: 504")
+	errLookup := errors.New("lookup blew up")
+
+	tests := []struct {
+		name string
+		// failures is how many times fn fails before succeeding, a
+		// negative value means it always fails.
+		failures int
+		attempts int
+		// recover is nil to exercise the plain retry path, it is given
+		// the number of writes issued so far and its own call index.
+		recover      func(writes, call int) (string, bool, error)
+		wantResult   string
+		wantErr      string
+		wantFnCalls  int
+		wantRecovery bool
+	}{
+		{
+			name:        "succeeds on the first attempt",
+			failures:    0,
+			attempts:    5,
+			wantResult:  "created",
+			wantFnCalls: 1,
+		},
+		{
+			name:     "retries once the recovery confirms nothing landed",
+			failures: 1,
+			attempts: 5,
+			recover: func(int, int) (string, bool, error) {
+				return "", false, nil
+			},
+			wantResult:   "created",
+			wantFnCalls:  2,
+			wantRecovery: true,
+		},
+		{
+			name:     "reuses the result when the write actually landed",
+			failures: -1,
+			attempts: 5,
+			recover: func(int, int) (string, bool, error) {
+				return "recovered", true, nil
+			},
+			wantResult:   "recovered",
+			wantFnCalls:  1,
+			wantRecovery: true,
+		},
+		{
+			name:     "gives up rather than duplicate when the lookup never answers",
+			failures: -1,
+			attempts: 3,
+			recover: func(int, int) (string, bool, error) {
+				return "", false, errLookup
+			},
+			wantErr:      "could not confirm whether it succeeded",
+			wantFnCalls:  1,
+			wantRecovery: true,
+		},
+		{
+			name:     "retries once a flaky lookup finally answers",
+			failures: 1,
+			attempts: 3,
+			recover: func(_, call int) (string, bool, error) {
+				if call == 0 {
+					return "", false, errLookup
+				}
+				return "", false, nil
+			},
+			wantResult:   "created",
+			wantFnCalls:  2,
+			wantRecovery: true,
+		},
+		{
+			name:     "returns the last error once the attempts run out",
+			failures: -1,
+			attempts: 3,
+			recover: func(int, int) (string, bool, error) {
+				return "", false, nil
+			},
+			wantErr:      errBoom.Error(),
+			wantFnCalls:  3,
+			wantRecovery: true,
+		},
+		{
+			name:     "does not rewrite when an early 404 is just the server catching up",
+			failures: -1,
+			attempts: 5,
+			recover: func(_, call int) (string, bool, error) {
+				// The write is in flight: absent at first, visible on
+				// the recheck. One absence must not be taken as proof.
+				if call == 0 {
+					return "", false, nil
+				}
+				return "recovered", true, nil
+			},
+			wantResult:   "recovered",
+			wantFnCalls:  1,
+			wantRecovery: true,
+		},
+		{
+			name:     "recovers when the very last attempt lands",
+			failures: -1,
+			attempts: 2,
+			recover: func(writes, _ int) (string, bool, error) {
+				// Only the final write makes it through, and it still
+				// reports a gateway timeout to the client.
+				if writes < 2 {
+					return "", false, nil
+				}
+				return "recovered", true, nil
+			},
+			wantResult:   "recovered",
+			wantFnCalls:  2,
+			wantRecovery: true,
+		},
+		{
+			name:        "does not report a false success without any attempt",
+			failures:    -1,
+			attempts:    0,
+			wantErr:     errBoom.Error(),
+			wantFnCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := zap.NewNop().Sugar()
+			fnCalls := 0
+			recoveryCalls := 0
+
+			fn := func() (string, error) {
+				fnCalls++
+				if tt.failures < 0 || fnCalls <= tt.failures {
+					return "", errBoom
+				}
+				return "created", nil
+			}
+
+			var tryRecover func() (string, bool, error)
+			if tt.recover != nil {
+				tryRecover = func() (string, bool, error) {
+					call := recoveryCalls
+					recoveryCalls++
+					return tt.recover(fnCalls, call)
+				}
+			}
+
+			result, err := retryOnAPIError(logger, "Creating thing", tt.attempts, 0, fn, tryRecover)
+
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+			} else {
+				assert.NilError(t, err)
+				assert.Equal(t, tt.wantResult, result)
+			}
+			assert.Equal(t, tt.wantFnCalls, fnCalls, "unexpected number of write attempts")
+			assert.Equal(t, tt.wantRecovery, recoveryCalls > 0, "unexpected recovery usage")
+		})
+	}
+}
+
+// TestRetryOnAPIErrorDoesNotWaitAfterConfirming checks that no time passes
+// between confirming a write is absent and re-issuing it. Any gap there is a
+// window in which the original write could still land, and we would then
+// duplicate it. Rather than time the call, which flakes on a loaded machine,
+// this records the exact sequence of writes, lookups and pauses, so the
+// assertion pins where the pauses fall and not merely how many there are.
+func TestRetryOnAPIErrorDoesNotWaitAfterConfirming(t *testing.T) {
+	const delay = 50 * time.Millisecond
+	const attempts = 3
+
+	var events []string
+
+	fnCalls := 0
+	fn := func() (string, error) {
+		fnCalls++
+		events = append(events, "write")
+		if fnCalls < attempts {
+			return "", errors.New("unknown API Error: 504")
+		}
+		return "created", nil
+	}
+	tryRecover := func() (string, bool, error) {
+		events = append(events, "lookup")
+		return "", false, nil
+	}
+	fakeSleep := func(d time.Duration) {
+		events = append(events, fmt.Sprintf("sleep(%s)", d))
+	}
+
+	result, err := retryOnAPIErrorWithSleep(zap.NewNop().Sugar(), "Creating thing", attempts, delay, fn, tryRecover, fakeSleep)
+
+	assert.NilError(t, err)
+	assert.Equal(t, "created", result)
+	assert.Equal(t, attempts, fnCalls)
+
+	// Each failed write is confirmed absent by settleChecks (2) lookups, which
+	// pause once between them, and then the write is re-issued *immediately*.
+	// A "sleep" appearing directly before any "write" would be the bug: it
+	// reopens the window in which the previous write could still land.
+	assert.DeepEqual(t, events, []string{
+		"write", "lookup", "sleep(50ms)", "lookup",
+		"write", "lookup", "sleep(50ms)", "lookup",
+		"write",
+	})
+}
+
+func TestLookup(t *testing.T) {
+	value := "found"
+	notFound := &forgejo.Response{Response: &http.Response{StatusCode: http.StatusNotFound}}
+	gatewayTimeout := &forgejo.Response{Response: &http.Response{StatusCode: http.StatusGatewayTimeout}}
+
+	tests := []struct {
+		name          string
+		value         *string
+		resp          *forgejo.Response
+		err           error
+		wantFound     bool
+		wantErr       bool
+		wantValueBack bool
+	}{
+		{
+			name:          "found",
+			value:         &value,
+			resp:          &forgejo.Response{Response: &http.Response{StatusCode: http.StatusOK}},
+			wantFound:     true,
+			wantValueBack: true,
+		},
+		{
+			name:      "a 404 confirms it is absent",
+			resp:      notFound,
+			err:       errors.New("404 Not Found"),
+			wantFound: false,
+		},
+		{
+			name:    "any other error is inconclusive",
+			resp:    gatewayTimeout,
+			err:     errors.New("unknown API Error: 504"),
+			wantErr: true,
+		},
+		{
+			name: "no error and no value is absent",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, found, err := lookup(tt.value, tt.resp, tt.err)
+			if tt.wantErr {
+				assert.Assert(t, err != nil, "expected an inconclusive lookup")
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, tt.wantFound, found)
+			if tt.wantValueBack {
+				assert.Equal(t, &value, got)
+			}
+		})
+	}
+}

--- a/test/pkg/gitea/scm.go
+++ b/test/pkg/gitea/scm.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"regexp"
 	"testing"
+	"time"
 
 	"codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v3"
 	"github.com/google/go-github/v85/github"
@@ -114,9 +115,18 @@ func CreateGiteaRepo(giteaClient *forgejo.Client, user, name, defaultBranch, hoo
 		logger.Infof("Creating org %s", name)
 		adminUser := user
 		user = "org-" + name
-		_, _, err := giteaClient.CreateOrg(forgejo.CreateOrgOption{
-			Name: user,
-		})
+		_, err := retryOnAPIError(
+			logger, "Creating org", 5, 5*time.Second,
+			func() (*forgejo.Organization, error) {
+				org, _, err := giteaClient.CreateOrg(forgejo.CreateOrgOption{
+					Name: user,
+				})
+				return org, err
+			},
+			func() (*forgejo.Organization, bool, error) {
+				return lookup(giteaClient.GetOrg(user))
+			},
+		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create org: %w", err)
 		}
@@ -139,40 +149,76 @@ func CreateGiteaRepo(giteaClient *forgejo.Client, user, name, defaultBranch, hoo
 			}
 		}
 		logger.Infof("Creating gitea repository on org %s", name)
-		repo, _, err = giteaClient.CreateOrgRepo(user, forgejo.CreateRepoOption{
-			Name:        name,
-			Description: "This is a repo it's a wonderful thing",
-			AutoInit:    true,
-		})
+		repo, err = retryOnAPIError(
+			logger, "Creating gitea repository", 5, 5*time.Second,
+			func() (*forgejo.Repository, error) {
+				repo, _, err := giteaClient.CreateOrgRepo(user, forgejo.CreateRepoOption{
+					Name:        name,
+					Description: "This is a repo it's a wonderful thing",
+					AutoInit:    true,
+				})
+				return repo, err
+			},
+			func() (*forgejo.Repository, bool, error) {
+				return lookup(giteaClient.GetRepo(user, name))
+			},
+		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create repo: %w", err)
 		}
 	} else {
 		logger.Infof("Creating gitea repository %s for user %s", name, user)
-		repo, _, err = giteaClient.AdminCreateRepo(user, forgejo.CreateRepoOption{
-			Name:          name,
-			Description:   "This is a repo it's a wonderful thing",
-			AutoInit:      true,
-			IssueLabels:   "Default",
-			DefaultBranch: defaultBranch,
-		})
+		repo, err = retryOnAPIError(
+			logger, "Creating gitea repository", 5, 5*time.Second,
+			func() (*forgejo.Repository, error) {
+				repo, _, err := giteaClient.AdminCreateRepo(user, forgejo.CreateRepoOption{
+					Name:          name,
+					Description:   "This is a repo it's a wonderful thing",
+					AutoInit:      true,
+					IssueLabels:   "Default",
+					DefaultBranch: defaultBranch,
+				})
+				return repo, err
+			},
+			func() (*forgejo.Repository, bool, error) {
+				return lookup(giteaClient.GetRepo(user, name))
+			},
+		)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to create repo: %w", err)
 	}
 	logger.Infof("Creating webhook to smee url on gitea repository %s", name)
-	_, _, err = giteaClient.CreateRepoHook(user, repo.Name, forgejo.CreateHookOption{
-		// Forgejo still uses the "gitea" hook type for webhooks.
-		Type:   "gitea",
-		Active: true,
-		Config: map[string]string{
-			"name":         "hook to smee url",
-			"url":          hookURL,
-			"content_type": "json",
-			"secret":       webhookSecret,
+	_, err = retryOnAPIError(
+		logger, "Creating repo webhook", 5, 5*time.Second,
+		func() (*forgejo.Hook, error) {
+			hook, _, err := giteaClient.CreateRepoHook(user, repo.Name, forgejo.CreateHookOption{
+				// Forgejo still uses the "gitea" hook type for webhooks.
+				Type:   "gitea",
+				Active: true,
+				Config: map[string]string{
+					"name":         "hook to smee url",
+					"url":          hookURL,
+					"content_type": "json",
+					"secret":       webhookSecret,
+				},
+				Events: []string{"push", "issue_comments", "pull_request"},
+			})
+			return hook, err
 		},
-		Events: []string{"push", "issue_comments", "pull_request"},
-	})
+		func() (*forgejo.Hook, bool, error) {
+			hooks, _, listErr := giteaClient.ListRepoHooks(user, repo.Name, forgejo.ListHooksOptions{})
+			if listErr != nil {
+				return nil, false, listErr
+			}
+			for _, h := range hooks {
+				if h.Config["url"] == hookURL {
+					return h, true, nil
+				}
+			}
+			return nil, false, nil
+		},
+	)
 	return repo, err
 }
 

--- a/test/pkg/gitea/test.go
+++ b/test/pkg/gitea/test.go
@@ -123,6 +123,36 @@ func AddLabelToIssue(t *testing.T, topt *TestOpts, label string) {
 	topt.ParamsRun.Clients.Log.Infof("Added label \"%s\" to %s", label, topt.PullRequest.HTMLURL)
 }
 
+// createPullRequestWithRetry creates a pull request, retrying on transient
+// errors. A request that times out on the client side can still have
+// succeeded on the Gitea server, so on failure it also checks whether the
+// pull request now exists before retrying, to avoid failing the test on a
+// spurious "pull request already exists" from a prior attempt.
+func createPullRequestWithRetry(t *testing.T, topts *TestOpts, owner, repo, base string) *forgejo.PullRequest {
+	t.Helper()
+	var pr *forgejo.PullRequest
+	var err error
+	for i := 0; i < 5; i++ {
+		if pr, _, err = topts.GiteaCNX.Client().CreatePullRequest(owner, repo, forgejo.CreatePullRequestOption{
+			Title: "Test Pull Request - " + topts.TargetRefName,
+			Head:  topts.TargetRefName,
+			Base:  base,
+		}); err == nil {
+			return pr
+		}
+		topts.ParamsRun.Clients.Log.Infof("Creating PullRequest has failed, retrying %d/%d, err: %v", i, 5, err)
+		if existing, _, getErr := topts.GiteaCNX.Client().GetPullRequestByBaseAndHead(owner, repo, base, topts.TargetRefName); getErr == nil && existing != nil {
+			topts.ParamsRun.Clients.Log.Infof("PullRequest already exists, using it instead of retrying")
+			return existing
+		}
+		if i == 4 {
+			t.Fatalf("cannot create pull request: %v", err)
+		}
+		time.Sleep(5 * time.Second)
+	}
+	return pr
+}
+
 // TestPR will test the pull request event and grab comments from the PR.
 func TestPR(t *testing.T, topts *TestOpts) (context.Context, func()) {
 	ctx := context.Background()
@@ -257,20 +287,7 @@ func TestPR(t *testing.T, topts *TestOpts) (context.Context, func()) {
 	topts.SHA = scm.PushFilesToRefGit(t, scmOpts, entries)
 
 	topts.ParamsRun.Clients.Log.Infof("Creating PullRequest")
-	for i := 0; i < 5; i++ {
-		if topts.PullRequest, _, err = topts.GiteaCNX.Client().CreatePullRequest(topts.Opts.Organization, repoInfo.Name, forgejo.CreatePullRequestOption{
-			Title: "Test Pull Request - " + topts.TargetRefName,
-			Head:  topts.TargetRefName,
-			Base:  topts.DefaultBranch,
-		}); err == nil {
-			break
-		}
-		topts.ParamsRun.Clients.Log.Infof("Creating PullRequest has failed, retrying %d/%d, err", i, 5, err)
-		if i == 4 {
-			t.Fatalf("cannot create pull request: %v", err)
-		}
-		time.Sleep(5 * time.Second)
-	}
+	topts.PullRequest = createPullRequestWithRetry(t, topts, topts.Opts.Organization, repoInfo.Name, topts.DefaultBranch)
 	topts.ParamsRun.Clients.Log.Infof("PullRequest %s has been created", topts.PullRequest.HTMLURL)
 
 	if topts.CheckForStatus != "" {
@@ -377,20 +394,7 @@ func NewPR(t *testing.T, topts *TestOpts) func() {
 	scm.ChangeFilesRefGit(t, scmOpts, topts.FileChanges)
 
 	topts.ParamsRun.Clients.Log.Infof("Creating PullRequest")
-	for i := 0; i < 5; i++ {
-		if topts.PullRequest, _, err = topts.GiteaCNX.Client().CreatePullRequest(topts.Opts.Organization, repoInfo.Name, forgejo.CreatePullRequestOption{
-			Title: "Test Pull Request - " + topts.TargetRefName,
-			Head:  topts.TargetRefName,
-			Base:  options.MainBranch,
-		}); err == nil {
-			break
-		}
-		topts.ParamsRun.Clients.Log.Infof("Creating PullRequest has failed, retrying %d/%d, err", i, 5, err)
-		if i == 4 {
-			t.Fatalf("cannot create pull request: %v", err)
-		}
-		time.Sleep(5 * time.Second)
-	}
+	topts.PullRequest = createPullRequestWithRetry(t, topts, topts.Opts.Organization, repoInfo.Name, options.MainBranch)
 	topts.ParamsRun.Clients.Log.Infof("PullRequest %s has been created", topts.PullRequest.HTMLURL)
 
 	if topts.CheckForStatus != "" {
@@ -675,6 +679,9 @@ func GetStandardParams(t *testing.T, topts *TestOpts, eventType string) (repoURL
 	return repoURL, sourceURL, sourceBranch, targetBranch
 }
 
+// VerifyConcurrency runs a PR against a global repository concurrency limit and
+// checks the effective limit was respected. The local limit wins when both are
+// set, which is what the caller passes as effectiveLimit.
 func VerifyConcurrency(t *testing.T, topts *TestOpts, globalRepoConcurrencyLimit *int) {
 	t.Helper()
 	ctx := context.Background()
@@ -708,4 +715,11 @@ func VerifyConcurrency(t *testing.T, topts *TestOpts, globalRepoConcurrencyLimit
 
 	_, f := TestPR(t, topts)
 	defer f()
+
+	// the local limit takes precedence over the global one when both are set
+	effectiveLimit := *globalRepoConcurrencyLimit
+	if topts.ConcurrencyLimit != nil {
+		effectiveLimit = *topts.ConcurrencyLimit
+	}
+	AssertConcurrencyRespected(ctx, t, topts, effectiveLimit)
 }

--- a/test/pkg/gitea/test.go
+++ b/test/pkg/gitea/test.go
@@ -130,25 +130,22 @@ func AddLabelToIssue(t *testing.T, topt *TestOpts, label string) {
 // spurious "pull request already exists" from a prior attempt.
 func createPullRequestWithRetry(t *testing.T, topts *TestOpts, owner, repo, base string) *forgejo.PullRequest {
 	t.Helper()
-	var pr *forgejo.PullRequest
-	var err error
-	for i := 0; i < 5; i++ {
-		if pr, _, err = topts.GiteaCNX.Client().CreatePullRequest(owner, repo, forgejo.CreatePullRequestOption{
-			Title: "Test Pull Request - " + topts.TargetRefName,
-			Head:  topts.TargetRefName,
-			Base:  base,
-		}); err == nil {
-			return pr
-		}
-		topts.ParamsRun.Clients.Log.Infof("Creating PullRequest has failed, retrying %d/%d, err: %v", i, 5, err)
-		if existing, _, getErr := topts.GiteaCNX.Client().GetPullRequestByBaseAndHead(owner, repo, base, topts.TargetRefName); getErr == nil && existing != nil {
-			topts.ParamsRun.Clients.Log.Infof("PullRequest already exists, using it instead of retrying")
-			return existing
-		}
-		if i == 4 {
-			t.Fatalf("cannot create pull request: %v", err)
-		}
-		time.Sleep(5 * time.Second)
+	pr, err := retryOnAPIError(
+		topts.ParamsRun.Clients.Log, "Creating PullRequest", 5, 5*time.Second,
+		func() (*forgejo.PullRequest, error) {
+			pr, _, err := topts.GiteaCNX.Client().CreatePullRequest(owner, repo, forgejo.CreatePullRequestOption{
+				Title: "Test Pull Request - " + topts.TargetRefName,
+				Head:  topts.TargetRefName,
+				Base:  base,
+			})
+			return pr, err
+		},
+		func() (*forgejo.PullRequest, bool, error) {
+			return lookup(topts.GiteaCNX.Client().GetPullRequestByBaseAndHead(owner, repo, base, topts.TargetRefName))
+		},
+	)
+	if err != nil {
+		t.Fatalf("cannot create pull request: %v", err)
 	}
 	return pr
 }

--- a/test/pkg/kubestuff/denywebhook.go
+++ b/test/pkg/kubestuff/denywebhook.go
@@ -1,0 +1,76 @@
+package kubestuff
+
+import (
+	"context"
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"gotest.tools/v3/assert"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// DenyPipelineRunWrites makes every write to a PipelineRun in one namespace
+// fail, and returns a function that lifts the block again.
+//
+// The webhook points at a service that does not exist and has a Fail policy, so
+// the API server rejects the request with a "failed calling webhook" error.
+// That is a faithful stand-in for a cluster having a bad minute, and it needs no
+// extra workload to be deployed.
+//
+// Only the PipelineRun resource is matched, not its status subresource, so
+// Tekton can still report on the runs that are already going.
+func DenyPipelineRunWrites(ctx context.Context, t *testing.T, runcnx *params.Run, ns string) func() {
+	t.Helper()
+	name := "deny-pipelinerun-writes-" + ns
+	fail := admissionv1.Fail
+	none := admissionv1.SideEffectClassNone
+	scope := admissionv1.NamespacedScope
+	timeout := int32(5)
+	path := "/deny"
+
+	cfg := &admissionv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Webhooks: []admissionv1.ValidatingWebhook{{
+			Name: "deny.pipelinerun.e2e.pipelinesascode.tekton.dev",
+			ClientConfig: admissionv1.WebhookClientConfig{
+				Service: &admissionv1.ServiceReference{
+					Name:      "there-is-no-such-service",
+					Namespace: ns,
+					Path:      &path,
+				},
+			},
+			Rules: []admissionv1.RuleWithOperations{{
+				Operations: []admissionv1.OperationType{admissionv1.Update},
+				Rule: admissionv1.Rule{
+					APIGroups:   []string{"tekton.dev"},
+					APIVersions: []string{"*"},
+					Resources:   []string{"pipelineruns"},
+					Scope:       &scope,
+				},
+			}},
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"kubernetes.io/metadata.name": ns},
+			},
+			FailurePolicy:           &fail,
+			SideEffects:             &none,
+			TimeoutSeconds:          &timeout,
+			AdmissionReviewVersions: []string{"v1"},
+		}},
+	}
+
+	_, err := runcnx.Clients.Kube.AdmissionregistrationV1().
+		ValidatingWebhookConfigurations().Create(ctx, cfg, metav1.CreateOptions{})
+	assert.NilError(t, err)
+	runcnx.Clients.Log.Infof("writes to pipelineruns in %s will now fail", ns)
+
+	return func() {
+		err := runcnx.Clients.Kube.AdmissionregistrationV1().
+			ValidatingWebhookConfigurations().Delete(context.WithoutCancel(ctx), name, metav1.DeleteOptions{})
+		if err != nil {
+			t.Logf("could not remove the deny webhook %s: %v", name, err)
+			return
+		}
+		runcnx.Clients.Log.Infof("writes to pipelineruns in %s are allowed again", ns)
+	}
+}

--- a/test/pkg/kubestuff/watcher.go
+++ b/test/pkg/kubestuff/watcher.go
@@ -2,13 +2,16 @@ package kubestuff
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/queue"
 	"gotest.tools/v3/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,6 +21,8 @@ const (
 	watcherNamespace  = "pipelines-as-code"
 	watcherSelector   = "app=pipelines-as-code-watcher"
 	watcherDeployment = "pipelines-as-code-watcher"
+	watcherContainer  = "pac-watcher"
+	watcherProbesPort = "probes"
 )
 
 // WatcherHealth is a snapshot of how many times the watcher has restarted.
@@ -85,6 +90,80 @@ func BounceWatcher(ctx context.Context, t *testing.T, runcnx *params.Run) {
 	waitForWatcherReplicas(ctx, t, runcnx, 0)
 	ScaleDeployment(ctx, t, runcnx, 1, watcherDeployment, watcherNamespace)
 	waitForWatcherReplicas(ctx, t, runcnx, 1)
+}
+
+// QueueSnapshot asks the watcher what it currently believes about its queues.
+//
+// The endpoint answers 503 while the reconciler holds the queue lock, since it
+// gives up rather than block the thing it is reporting on. That is expected
+// under load, so retry for a bit before calling it a failure.
+func QueueSnapshot(ctx context.Context, t *testing.T, runcnx *params.Run) map[string]queue.RepoQueue {
+	t.Helper()
+	pods := watcherPods(ctx, t, runcnx)
+	pod := &pods[0]
+
+	var lastErr error
+	for range 15 {
+		raw, err := runcnx.Clients.Kube.CoreV1().Pods(watcherNamespace).
+			ProxyGet("http", pod.GetName(), probesPort(t, pod), "/debug/queue", nil).DoRaw(ctx)
+		if err != nil {
+			lastErr = err
+			time.Sleep(time.Second)
+			continue
+		}
+		snapshot := map[string]queue.RepoQueue{}
+		assert.NilError(t, json.Unmarshal(raw, &snapshot), "unexpected payload from the queue debug endpoint: %s", raw)
+		return snapshot
+	}
+	t.Fatalf("could not read the queue debug endpoint on %s: %v", pod.GetName(), lastErr)
+	return nil
+}
+
+// probesPort returns the probe port as a number. The pod proxy does not resolve
+// port names, and the port is configurable, so read it off the container.
+func probesPort(t *testing.T, pod *corev1.Pod) string {
+	t.Helper()
+	for _, container := range pod.Spec.Containers {
+		for _, port := range container.Ports {
+			if port.Name == watcherProbesPort {
+				return strconv.Itoa(int(port.ContainerPort))
+			}
+		}
+	}
+	t.Fatalf("watcher pod %s has no container port named %q", pod.GetName(), watcherProbesPort)
+	return ""
+}
+
+// AssertQueueDrained checks the watcher is no longer holding a concurrency slot
+// for a repository. A slot that outlives every run it was taken for is a leak,
+// and the next run for that repository will never start.
+func AssertQueueDrained(ctx context.Context, t *testing.T, runcnx *params.Run, ns, name string) {
+	t.Helper()
+	key := ns + "/" + name
+	var last queue.RepoQueue
+	for range 30 {
+		snapshot := QueueSnapshot(ctx, t, runcnx)
+		var known bool
+		last, known = snapshot[key]
+		// An absent key would drain trivially, so insist the watcher actually
+		// knows about this repository before believing the empty result.
+		assert.Assert(t, known, "the watcher holds no queue at all for %s, it has %v", key, keysOf(snapshot))
+		if len(last.Running) == 0 && len(last.Pending) == 0 {
+			runcnx.Clients.Log.Infof("queue for %s is drained", key)
+			return
+		}
+		time.Sleep(2 * time.Second)
+	}
+	t.Fatalf("the watcher still holds slots for %s after every run finished: running=%v pending=%v",
+		key, last.Running, last.Pending)
+}
+
+func keysOf(snapshot map[string]queue.RepoQueue) []string {
+	out := make([]string, 0, len(snapshot))
+	for key := range snapshot {
+		out = append(out, key)
+	}
+	return out
 }
 
 func waitForWatcherReplicas(ctx context.Context, t *testing.T, runcnx *params.Run, want int32) {

--- a/test/pkg/kubestuff/watcher.go
+++ b/test/pkg/kubestuff/watcher.go
@@ -1,0 +1,141 @@
+package kubestuff
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	watcherNamespace  = "pipelines-as-code"
+	watcherSelector   = "app=pipelines-as-code-watcher"
+	watcherDeployment = "pipelines-as-code-watcher"
+)
+
+// WatcherHealth is a snapshot of how many times the watcher has restarted.
+type WatcherHealth struct {
+	restarts map[string]int32
+	runcnx   *params.Run
+}
+
+// SnapshotWatcherHealth records the current restart count of every watcher pod.
+//
+// A watcher that aborts is restarted by Kubernetes and silently rebuilds its
+// queues, so a crash usually leaves the test passing and no assertion looking
+// at it. Comparing restart counts across the test is what makes it visible.
+func SnapshotWatcherHealth(ctx context.Context, t *testing.T, runcnx *params.Run) *WatcherHealth {
+	t.Helper()
+	h := &WatcherHealth{restarts: map[string]int32{}, runcnx: runcnx}
+	pods := watcherPods(ctx, t, runcnx)
+	for i := range pods {
+		h.restarts[pods[i].GetName()] = totalRestarts(&pods[i])
+	}
+	return h
+}
+
+// Assert fails the test if any watcher pod restarted since the snapshot, or if
+// its log contains a Go panic or an unrecoverable runtime error.
+func (h *WatcherHealth) Assert(ctx context.Context, t *testing.T) {
+	t.Helper()
+	pods := watcherPods(ctx, t, h.runcnx)
+	for i := range pods {
+		pod := &pods[i]
+		name := pod.GetName()
+		now := totalRestarts(pod)
+		before, seen := h.restarts[name]
+		if !seen {
+			// a pod that appeared during the test means the previous one went away
+			assert.Assert(t, now == 0,
+				"watcher pod %s appeared mid-test and has already restarted %d times:\n%s",
+				name, now, watcherLog(ctx, h.runcnx, name))
+			continue
+		}
+		assert.Assert(t, now == before,
+			"watcher pod %s restarted %d time(s) during the test, it most likely crashed:\n%s",
+			name, now-before, watcherLog(ctx, h.runcnx, name))
+	}
+	assertNoWatcherCrash(ctx, t, h.runcnx, pods)
+}
+
+func assertNoWatcherCrash(ctx context.Context, t *testing.T, runcnx *params.Run, pods []corev1.Pod) {
+	t.Helper()
+	for i := range pods {
+		log := watcherLog(ctx, runcnx, pods[i].GetName())
+		for _, needle := range []string{"panic: ", "fatal error: ", "WARNING: DATA RACE"} {
+			assert.Assert(t, !strings.Contains(log, needle),
+				"watcher pod %s log contains %q:\n%s", pods[i].GetName(), needle, log)
+		}
+	}
+}
+
+// BounceWatcher scales the watcher down to zero and back up again, waiting for
+// it to come back ready. This is how a test forces the queue to be rebuilt from
+// what is already in the cluster.
+func BounceWatcher(ctx context.Context, t *testing.T, runcnx *params.Run) {
+	t.Helper()
+	ScaleDeployment(ctx, t, runcnx, 0, watcherDeployment, watcherNamespace)
+	waitForWatcherReplicas(ctx, t, runcnx, 0)
+	ScaleDeployment(ctx, t, runcnx, 1, watcherDeployment, watcherNamespace)
+	waitForWatcherReplicas(ctx, t, runcnx, 1)
+}
+
+func waitForWatcherReplicas(ctx context.Context, t *testing.T, runcnx *params.Run, want int32) {
+	t.Helper()
+	for range 60 {
+		dep, err := runcnx.Clients.Kube.AppsV1().Deployments(watcherNamespace).Get(ctx, watcherDeployment, metav1.GetOptions{})
+		assert.NilError(t, err)
+		if dep.Status.ReadyReplicas == want && dep.Status.Replicas == want {
+			runcnx.Clients.Log.Infof("watcher is at %d ready replica(s)", want)
+			return
+		}
+		time.Sleep(2 * time.Second)
+	}
+	t.Fatalf("watcher did not settle at %d ready replica(s) within 2 minutes", want)
+}
+
+func watcherPods(ctx context.Context, t *testing.T, runcnx *params.Run) []corev1.Pod {
+	t.Helper()
+	pods, err := runcnx.Clients.Kube.CoreV1().Pods(watcherNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: watcherSelector,
+	})
+	assert.NilError(t, err)
+	assert.Assert(t, len(pods.Items) > 0, "no watcher pod found in %s with selector %s", watcherNamespace, watcherSelector)
+	return pods.Items
+}
+
+func totalRestarts(pod *corev1.Pod) int32 {
+	var total int32
+	for _, cs := range pod.Status.ContainerStatuses {
+		total += cs.RestartCount
+	}
+	return total
+}
+
+// watcherLog returns the previous container log when there is one, since that
+// is where a crash is recorded, and falls back to the current one.
+func watcherLog(ctx context.Context, runcnx *params.Run, podName string) string {
+	for _, previous := range []bool{true, false} {
+		req := runcnx.Clients.Kube.CoreV1().Pods(watcherNamespace).GetLogs(podName, &corev1.PodLogOptions{
+			Previous: previous,
+		})
+		stream, err := req.Stream(ctx)
+		if err != nil {
+			continue
+		}
+		out, err := io.ReadAll(stream)
+		_ = stream.Close()
+		if err != nil || len(out) == 0 {
+			continue
+		}
+		return fmt.Sprintf("--- watcher log (previous=%v) ---\n%s", previous, string(out))
+	}
+	return "(no watcher log available)"
+}

--- a/test/pkg/repository/concurrency.go
+++ b/test/pkg/repository/concurrency.go
@@ -1,0 +1,35 @@
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+)
+
+// SetConcurrencyLimit changes the concurrency limit of a Repository, or removes
+// it entirely when limit is nil. Nothing else about the Repository is touched,
+// so a test can be sure that any queue movement it observes afterwards was
+// caused by the limit change and not by an unrelated event.
+func SetConcurrencyLimit(ctx context.Context, t *testing.T, runcnx *params.Run, ns, name string, limit *int) {
+	t.Helper()
+	client := runcnx.Clients.PipelineAsCode.PipelinesascodeV1alpha1().Repositories(ns)
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		repo, err := client.Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		repo.Spec.ConcurrencyLimit = limit
+		_, err = client.Update(ctx, repo, metav1.UpdateOptions{})
+		return err
+	})
+	assert.NilError(t, err)
+	if limit == nil {
+		runcnx.Clients.Log.Infof("removed concurrency limit from repository %s/%s", ns, name)
+		return
+	}
+	runcnx.Clients.Log.Infof("set concurrency limit of repository %s/%s to %d", ns, name, *limit)
+}

--- a/test/pkg/wait/concurrency.go
+++ b/test/pkg/wait/concurrency.go
@@ -1,0 +1,143 @@
+package wait
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"gotest.tools/v3/assert"
+)
+
+// Interval is the window a single PipelineRun occupied a concurrency slot for.
+type Interval struct {
+	Name  string
+	Start time.Time
+	End   time.Time
+}
+
+// Overlap is the busiest moment observed across a set of PipelineRuns: how many
+// ran at once, when, and which ones they were.
+type Overlap struct {
+	Peak  int
+	At    time.Time
+	Names []string
+}
+
+// MaxConcurrency computes the largest number of PipelineRuns that were running
+// at the same instant, from their recorded start and completion times.
+//
+// This is deliberately retrospective rather than a poll of the live cluster: a
+// poller samples, and an overshoot that lasts less than the polling interval is
+// invisible to it. Working from the recorded intervals cannot miss a window.
+//
+// PipelineRuns that never started are ignored. One still running when the
+// snapshot was taken is treated as running until the latest end seen, which is
+// the least favourable reading and so cannot hide an overshoot. Kubernetes
+// timestamps have second granularity, so an interval that ends in the same
+// second it started is treated as a point and cannot overlap anything.
+func MaxConcurrency(prs []v1.PipelineRun) Overlap {
+	intervals := make([]Interval, 0, len(prs))
+	var latestEnd time.Time
+	for i := range prs {
+		pr := &prs[i]
+		if pr.Status.StartTime == nil || pr.Status.StartTime.IsZero() {
+			continue
+		}
+		iv := Interval{Name: pr.GetName(), Start: pr.Status.StartTime.Time}
+		if pr.Status.CompletionTime != nil && !pr.Status.CompletionTime.IsZero() {
+			iv.End = pr.Status.CompletionTime.Time
+		}
+		if iv.End.After(latestEnd) {
+			latestEnd = iv.End
+		}
+		if iv.Start.After(latestEnd) {
+			latestEnd = iv.Start
+		}
+		intervals = append(intervals, iv)
+	}
+
+	type edge struct {
+		at    time.Time
+		delta int
+	}
+	edges := make([]edge, 0, len(intervals)*2)
+	for _, iv := range intervals {
+		end := iv.End
+		if end.IsZero() {
+			// still running when we looked: assume it ran to the very end
+			end = latestEnd
+		}
+		if !end.After(iv.Start) {
+			// finished within the same second it started, so it never overlapped
+			// anything we can prove
+			continue
+		}
+		edges = append(edges, edge{at: iv.Start, delta: 1}, edge{at: end, delta: -1})
+	}
+
+	// ends before starts at the same instant, so a run that finishes exactly as
+	// another begins is not counted as an overlap
+	sort.Slice(edges, func(i, j int) bool {
+		if edges[i].at.Equal(edges[j].at) {
+			return edges[i].delta < edges[j].delta
+		}
+		return edges[i].at.Before(edges[j].at)
+	})
+
+	var result Overlap
+	current := 0
+	for _, e := range edges {
+		current += e.delta
+		if current > result.Peak {
+			result.Peak = current
+			result.At = e.at
+		}
+	}
+
+	for _, iv := range intervals {
+		end := iv.End
+		if end.IsZero() {
+			end = latestEnd
+		}
+		if !iv.Start.After(result.At) && end.After(result.At) {
+			result.Names = append(result.Names, iv.Name)
+		}
+	}
+	sort.Strings(result.Names)
+	return result
+}
+
+// AssertMaxConcurrency fails the test if more than limit PipelineRuns were ever
+// running at the same time.
+//
+// Asserting that queued PipelineRuns all eventually succeed says nothing about
+// whether the limit was honoured, since a queue that ignores the limit entirely
+// also finishes every run. This is the assertion that actually tests the queue.
+func AssertMaxConcurrency(t *testing.T, prs []v1.PipelineRun, limit int) {
+	t.Helper()
+	got := MaxConcurrency(prs)
+	assert.Assert(t, got.Peak <= limit,
+		"concurrency limit of %d exceeded: %d PipelineRuns were running at once at %s: %v\n%s",
+		limit, got.Peak, got.At.Format(time.RFC3339), got.Names, formatIntervals(prs))
+}
+
+func formatIntervals(prs []v1.PipelineRun) string {
+	out := "observed PipelineRun windows:\n"
+	sorted := make([]v1.PipelineRun, len(prs))
+	copy(sorted, prs)
+	SortPipelineRunsByCreationMillis(sorted)
+	for i := range sorted {
+		pr := &sorted[i]
+		start, end := "never started", "still running"
+		if pr.Status.StartTime != nil && !pr.Status.StartTime.IsZero() {
+			start = pr.Status.StartTime.Format(time.RFC3339)
+		}
+		if pr.Status.CompletionTime != nil && !pr.Status.CompletionTime.IsZero() {
+			end = pr.Status.CompletionTime.Format(time.RFC3339)
+		}
+		out += fmt.Sprintf("  %-50s %s -> %s\n", pr.GetName(), start, end)
+	}
+	return out
+}

--- a/test/pkg/wait/concurrency.go
+++ b/test/pkg/wait/concurrency.go
@@ -1,14 +1,74 @@
 package wait
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"testing"
 	"time"
 
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// Counts is a breakdown of PipelineRuns by how far along they are.
+type Counts struct {
+	Total   int
+	Pending int
+	Running int
+	Done    int
+}
+
+func (c Counts) String() string {
+	return fmt.Sprintf("total=%d pending=%d running=%d done=%d", c.Total, c.Pending, c.Running, c.Done)
+}
+
+// CountPipelineRuns groups the PipelineRuns of a namespace by state. Pending
+// means the queue is still holding it back; running means it has started and
+// has not finished.
+func CountPipelineRuns(ctx context.Context, clients clients.Clients, ns string) (Counts, []v1.PipelineRun, error) {
+	list, err := clients.Tekton.TektonV1().PipelineRuns(ns).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return Counts{}, nil, err
+	}
+	var counts Counts
+	counts.Total = len(list.Items)
+	for i := range list.Items {
+		pr := &list.Items[i]
+		switch {
+		case pr.IsDone():
+			counts.Done++
+		case pr.Spec.Status == v1.PipelineRunSpecStatusPending:
+			counts.Pending++
+		case pr.Status.StartTime != nil && !pr.Status.StartTime.IsZero():
+			counts.Running++
+		}
+	}
+	return counts, list.Items, nil
+}
+
+// UntilCounts polls a namespace until its PipelineRuns satisfy cond, and fails
+// the test with the last counts seen if they never do. describe is used in that
+// failure message to say what was being waited for.
+func UntilCounts(ctx context.Context, t *testing.T, clients clients.Clients, ns, describe string, timeout time.Duration, cond func(Counts) bool) (Counts, []v1.PipelineRun) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		counts, prs, err := CountPipelineRuns(ctx, clients, ns)
+		assert.NilError(t, err)
+		if cond(counts) {
+			clients.Log.Infof("%s in %s: %s", describe, ns, counts)
+			return counts, prs
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out after %s waiting for %s in %s, last seen %s", timeout, describe, ns, counts)
+		}
+		clients.Log.Infof("waiting for %s in %s, currently %s", describe, ns, counts)
+		time.Sleep(5 * time.Second)
+	}
+}
 
 // Interval is the window a single PipelineRun occupied a concurrency slot for.
 type Interval struct {

--- a/test/pkg/wait/concurrency_test.go
+++ b/test/pkg/wait/concurrency_test.go
@@ -1,0 +1,111 @@
+package wait
+
+import (
+	"testing"
+	"time"
+
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestMaxConcurrency(t *testing.T) {
+	base := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	at := func(sec int) *metav1.Time {
+		tm := metav1.NewTime(base.Add(time.Duration(sec) * time.Second))
+		return &tm
+	}
+	pr := func(name string, start, end *metav1.Time) v1.PipelineRun {
+		out := v1.PipelineRun{}
+		out.SetName(name)
+		out.Status.StartTime = start
+		out.Status.CompletionTime = end
+		return out
+	}
+
+	tests := []struct {
+		name      string
+		prs       []v1.PipelineRun
+		wantPeak  int
+		wantNames []string
+	}{
+		{
+			name:     "no pipelineruns at all",
+			prs:      nil,
+			wantPeak: 0,
+		},
+		{
+			name:     "never started is ignored",
+			prs:      []v1.PipelineRun{pr("a", nil, nil)},
+			wantPeak: 0,
+		},
+		{
+			name: "strictly sequential runs never overlap",
+			prs: []v1.PipelineRun{
+				pr("a", at(0), at(10)),
+				pr("b", at(10), at(20)),
+				pr("c", at(20), at(30)),
+			},
+			wantPeak:  1,
+			wantNames: []string{"a"},
+		},
+		{
+			name: "two overlapping runs are caught",
+			prs: []v1.PipelineRun{
+				pr("a", at(0), at(20)),
+				pr("b", at(10), at(30)),
+			},
+			wantPeak:  2,
+			wantNames: []string{"a", "b"},
+		},
+		{
+			name: "peak is found in the middle of the window",
+			prs: []v1.PipelineRun{
+				pr("a", at(0), at(100)),
+				pr("b", at(10), at(20)),
+				pr("c", at(12), at(18)),
+				pr("d", at(50), at(60)),
+			},
+			wantPeak:  3,
+			wantNames: []string{"a", "b", "c"},
+		},
+		{
+			name: "a run finishing within a second cannot overlap",
+			prs: []v1.PipelineRun{
+				pr("a", at(0), at(0)),
+				pr("b", at(0), at(10)),
+			},
+			wantPeak:  1,
+			wantNames: []string{"b"},
+		},
+		{
+			name: "an unfinished run is assumed to run until the last end seen",
+			prs: []v1.PipelineRun{
+				pr("a", at(0), nil),
+				pr("b", at(10), at(30)),
+			},
+			wantPeak:  2,
+			wantNames: []string{"a", "b"},
+		},
+		{
+			name: "out of order input is handled",
+			prs: []v1.PipelineRun{
+				pr("c", at(20), at(40)),
+				pr("a", at(0), at(30)),
+				pr("b", at(10), at(50)),
+			},
+			wantPeak:  3,
+			wantNames: []string{"a", "b", "c"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MaxConcurrency(tt.prs)
+			assert.Equal(t, got.Peak, tt.wantPeak)
+			if tt.wantNames != nil {
+				assert.DeepEqual(t, got.Names, tt.wantNames)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 📝 Description of the Change

Pipelines-as-Code lets you cap how many PipelineRuns a Repository may run at
once, with `concurrency_limit`. Runs above the cap are held in a queue and
started later as slots free up.

This PR fixes six ways that queue could go wrong, and adds the tests that
should have caught them. Each fix is small on its own, but together they are
the difference between a limit you can trust and one that quietly stops
working.

### 1. The queue could permanently allow more runs than the limit

When a queued PipelineRun's turn came, PAC marked it as started and *then* did
the remaining setup work (talking to the Git provider, rendering the run). If
that later work failed, the run was already going in the cluster, but PAC
handed its slot back to the queue anyway.

The slot count and reality drifted apart. Every failure widened the gap, and it
never recovered: a repository limited to 3 could end up running 4, then 5, then
more. The only way back was restarting the watcher.

The obvious correction — never free the slot on failure — turns out to be just
as wrong in the other direction, and is covered separately below.

What decides it is one simple fact: a queued run is *paused* in the cluster
until PAC explicitly un-pauses it, and the cluster will not start a paused run.
So if the failure happened before PAC un-paused it, the run is definitely not
going and the slot is safe to hand back; if it happened afterwards, the run is
definitely going and the slot must be kept. PAC now makes exactly that
distinction.

That distinction had to be applied in two places, not one. When a limit
allows more than one run at a time, PAC can un-pause several PipelineRuns in
a single pass — and the first version of this fix only applied the rule to
the first one, still abandoning the rest of the batch on the old all-or-fail
behaviour if one of them failed. Separately, the same two mistakes existed
again in the code path that promotes the next queued run once one finishes.
Both are now the same one rule, applied everywhere a run gets un-paused.

### 2. One odd PipelineRun could disable queueing for every other repository

On startup the watcher rebuilds its queues from what is already in the cluster.
If it met a single PipelineRun that was missing an expected annotation, it gave
up on the whole rebuild — so every repository it had not reached yet started
with an empty queue and no memory of what was running.

It now skips that one run and carries on.

### 3. Changing a concurrency limit did nothing until something else happened

If you raised a repository's limit from 1 to 5, the four waiting runs stayed
waiting. PAC was not watching Repository objects at all, so nothing told it to
look again. The change only took effect the next time an unrelated event
happened to wake the queue up — possibly the next push, possibly much later.

PAC now reacts to Repository changes and re-examines that repository's queued
runs, so raising, lowering or removing a limit takes effect right away.

### 4. The watcher could crash outright under load

Two concurrency-limited repositories being reconciled at the same moment could
have their queue bookkeeping read and modified simultaneously. In Go this is
not a subtle wrong-answer bug — it aborts the process immediately. The watcher
died and every queue it held in memory went with it.

The bookkeeping is now properly guarded. There is a test that reproduces the
crash reliably against the old code and passes against the new one.

### 5. Removing a concurrency limit could crash the watcher

Deleting `concurrency_limit` from a Repository that previously had one made PAC
try to read a value that was no longer there, which panicked. A repository with
no limit is now treated as unlimited, which is what it already meant everywhere
else.

### 6. A single failed API call could freeze a repository forever

The flip side of the first bug. A slot is claimed before anything is written to
the cluster, so if the cluster had a bad moment in that window — a brief API
server hiccup, a webhook timing out — the run never started.

Keeping the slot in that case is fatal: the run cannot finish, because it never
started, and a slot is only ever given back when a run *finishes*. So the slot
is held forever. At `concurrency_limit: 1` the repository stops running
anything at all until someone restarts the watcher.

PAC now hands the slot back in exactly the cases where the run is known not to
be going, and the retry can then make progress. As with the first bug above,
this had to be fixed both where a run is first un-paused and in the separate
code path that promotes the next queued run when another one completes — the
same failure could strand a slot in either place.

### Also in this PR

Three methods on the internal queue type had no callers left after an earlier
refactor. One of them crashed if it was ever called on an empty queue, which
made it look like an urgent production bug whenever anyone read the code. They
are removed, along with roughly 200 lines of tests that only exercised them.

### What this does not change

No user-facing API, CRD field or configuration changes. Documentation is
unchanged because the documented behaviour was always the intent — it just was
not what the code did.

## 🔗 Linked GitHub Issue

JIRA: https://redhat.atlassian.net/browse/SRVKP-11296
JIRA: https://redhat.atlassian.net/browse/SRVKP-7608

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [x] End-to-end tests
- [x] Manual testing
- [ ] Not Applicable

Every fix has a test that was confirmed to fail against the code before the
fix, so none of them are passing by accident:

| Fix | Test |
| --- | --- |
| Slot released for a still-running PipelineRun | `TestQueuePipelineRunSlotRelease` |
| Several un-paused runs abandoned on the first failure | `TestQueuePipelineRunProcessesAllAcquiredSlots` |
| Queue rebuild aborting early | `TestQueueManagerInitQueuesSkipsPipelineRunsWithoutOrder` |
| Repository changes not waking the queue | `TestEnqueueQueuedPipelineRuns` |
| Watcher crash under concurrent access | `TestQueueManagerConcurrentRepositoryAccess` (run under `-race`) |
| A failed API call freezing a repository | `TestQueuePipelineRunSlotRelease` |
| Same freeze in the next-run promotion path | `TestStartNextPipelineRunInQueue` |

`make test` and `make lint` pass, as does `go test -race ./pkg/queue/...
./pkg/reconciler/...`.

### The end-to-end tests had a hole in them

There were already nine end-to-end tests for concurrency. **Not one of them
checked that the limit was actually respected.** They set a limit of 1, pushed
ten runs, and asserted that all ten eventually succeeded — which a queue
running all ten at once passes just as happily. That is a large part of why
these bugs shipped.

So the first thing this PR adds is the missing assertion. After the runs
finish, it reads their start and end times and works out the true maximum
overlap. That is exact and cannot miss a brief overshoot the way polling can.
It is applied to the existing tests as well as the new ones.

The second addition is a check that the watcher is still standing: several of
these bugs killed the process, Kubernetes quietly restarted it, and the tests
carried on passing.

On top of those, five new scenarios, each one designed to fail against the code
before this PR:

| Test | What it breaks |
| --- | --- |
| `TestGiteaConcurrencyLimitChangeTakesEffect` | raises a limit with no other event and checks the queue reacts |
| `TestGiteaConcurrencyLimitRemoval` | removes a limit entirely and checks the watcher survives |
| `TestGiteaConcurrencyLimitHoldsWhenStartFails` | deletes the provider token mid-flight |
| `TestGiteaConcurrencyQueueRebuildSurvivesBadPipelineRun` | plants an unusable run and restarts the watcher |
| `TestGiteaConcurrencyWatcherSurvivesParallelRepos` | deletes repositories while their queues are busy |
| `TestGiteaConcurrencyTransientAPIFailureDoesNotWedgeQueue` | makes cluster writes fail for a minute |

They all carry "Concurrency" in the name, so CI routes them into the existing
dedicated job without any workflow changes.

### A way to see what the queue thinks

Every one of these bugs is the same shape: what the watcher believes is running
drifts away from what is really running. The tests above infer that drift from
the outside.

This PR also adds a read-only endpoint that just answers the question directly,
on the port the watcher already uses for its health probe. It lists the limit
and the running and pending runs per repository. It changes nothing, exposes
only names you can already list, and is off unless explicitly switched on. When
a queue does get stuck, this turns "nothing is running and I don't know why"
into a named PipelineRun.

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

The bugs were found by reading the code and confirmed by writing a failing test
for each one before fixing it. AI assistance was used to write the code
and the tests; the commits carry a `Co-authored-by` trailer.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's guide
- [x] ✨ I have ensured my commit message prefix matches the "Type of Change"
- [x] ♽ I have run `make test` and `make lint` locally
- [ ] 📖 I have added or updated documentation for any user-facing changes
- [x] 🧪 I have added sufficient unit tests for my code changes
- [x] 🎁 I have added end-to-end tests where feasible
- [x] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it

