### PR TITLE
test(pipelineascode): assert on queued check-run status for pending PipelineRuns

### DIFF
--- a/pkg/pipelineascode/pipelineascode_test.go
+++ b/pkg/pipelineascode/pipelineascode_test.go
@@ -51,7 +51,7 @@ func replyString(mux *http.ServeMux, url, body string) {
 	})
 }
 
-func testSetupCommonGhReplies(t *testing.T, mux *http.ServeMux, runevent info.Event, finalStatus, finalStatusText string, noReplyOrgPublicMembers bool) {
+func testSetupCommonGhReplies(t *testing.T, mux *http.ServeMux, runevent info.Event, finalStatus, finalStatusText, queuedStatusText string, noReplyOrgPublicMembers bool) {
 	t.Helper()
 	// Take a directory and generate replies as Github for it
 	replyString(mux,
@@ -87,12 +87,22 @@ func testSetupCommonGhReplies(t *testing.T, mux *http.ServeMux, runevent info.Ev
 			created := github.CreateCheckRunOptions{}
 			err := json.Unmarshal(body, &created)
 			assert.NilError(t, err)
-			// We created multiple status but the last one should be completed.
-			// TODO: we could maybe refine this test
-			if created.GetStatus() == "completed" {
+			// We create multiple statuses over the life of a testcase (e.g. queued,
+			// in_progress, completed), but "completed" is the only one guaranteed to
+			// be sent for every testcase, so it's asserted unconditionally. PipelineRuns
+			// left pending by an external controller never reach "completed" here, so
+			// testcases that expect that outcome opt into checking the "queued" status
+			// text instead via queuedStatusText.
+			switch created.GetStatus() {
+			case "completed":
 				assert.Equal(t, created.GetConclusion(), finalStatus, "we got the status `%s` but we should have get the status `%s`", created.GetConclusion(), finalStatus)
 				assert.Assert(t, strings.Contains(created.GetOutput().GetText(), finalStatusText),
 					"GetStatus/CheckRun %s != %s", created.GetOutput().GetText(), finalStatusText)
+			case queuedStatus:
+				if queuedStatusText != "" {
+					assert.Assert(t, strings.Contains(created.GetOutput().GetText(), queuedStatusText),
+						"GetStatus/CheckRun queued text %q does not contain %q", created.GetOutput().GetText(), queuedStatusText)
+				}
 			}
 		})
 }
@@ -122,6 +132,7 @@ func TestRun(t *testing.T) {
 		wantErr                      string
 		finalStatus                  string
 		finalStatusText              string
+		queuedStatusText             string
 		repositories                 []*v1alpha1.Repository
 		skipReplyingOrgPublicMembers bool
 		expectedNumberofCleanups     int
@@ -496,7 +507,8 @@ func TestRun(t *testing.T) {
 				PullRequestNumber: 666,
 				InstallationID:    1234,
 			},
-			tektondir: "testdata/pending_pipelinerun",
+			tektondir:        "testdata/pending_pipelinerun",
+			queuedStatusText: "has been queued",
 		},
 		{
 			name: "pull request/pipelinerun created in pending state without installationID (state changed by other controller)",
@@ -517,7 +529,8 @@ func TestRun(t *testing.T) {
 				TriggerTarget:     "pull_request",
 				PullRequestNumber: 666,
 			},
-			tektondir: "testdata/pending_pipelinerun",
+			tektondir:        "testdata/pending_pipelinerun",
+			queuedStatusText: "has been queued",
 		},
 	}
 	for _, tt := range tests {
@@ -579,7 +592,7 @@ func TestRun(t *testing.T) {
 				},
 			}
 
-			testSetupCommonGhReplies(t, mux, tt.runevent, tt.finalStatus, tt.finalStatusText, tt.skipReplyingOrgPublicMembers)
+			testSetupCommonGhReplies(t, mux, tt.runevent, tt.finalStatus, tt.finalStatusText, tt.queuedStatusText, tt.skipReplyingOrgPublicMembers)
 			if tt.tektondir != "" {
 				ghtesthelper.SetupGitTree(t, mux, tt.tektondir, &tt.runevent, false)
 			}

--- a/pkg/pipelineascode/pipelineascode_test.go
+++ b/pkg/pipelineascode/pipelineascode_test.go
@@ -51,7 +51,10 @@ func replyString(mux *http.ServeMux, url, body string) {
 	})
 }
 
-func testSetupCommonGhReplies(t *testing.T, mux *http.ServeMux, runevent info.Event, finalStatus, finalStatusText, queuedStatusText string, noReplyOrgPublicMembers bool) {
+// testSetupCommonGhReplies wires up the common GitHub API replies for a testcase and
+// returns a function reporting whether a "queued" check-run status was received, so
+// callers expecting one (via queuedStatusText) can assert it was actually sent.
+func testSetupCommonGhReplies(t *testing.T, mux *http.ServeMux, runevent info.Event, finalStatus, finalStatusText, queuedStatusText string, noReplyOrgPublicMembers bool) func() bool {
 	t.Helper()
 	// Take a directory and generate replies as Github for it
 	replyString(mux,
@@ -81,30 +84,31 @@ func testSetupCommonGhReplies(t *testing.T, mux *http.ServeMux, runevent info.Ev
 		fmt.Sprintf("/repos/%s/%s/check-runs", runevent.Organization, runevent.Repository),
 		`{"id": 26}`)
 
+	var queuedStatusReceived bool
 	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/check-runs/26", runevent.Organization, runevent.Repository),
 		func(_ http.ResponseWriter, r *http.Request) {
 			body, _ := io.ReadAll(r.Body)
 			created := github.CreateCheckRunOptions{}
 			err := json.Unmarshal(body, &created)
 			assert.NilError(t, err)
-			// We create multiple statuses over the life of a testcase (e.g. queued,
-			// in_progress, completed), but "completed" is the only one guaranteed to
-			// be sent for every testcase, so it's asserted unconditionally. PipelineRuns
-			// left pending by an external controller never reach "completed" here, so
-			// testcases that expect that outcome opt into checking the "queued" status
-			// text instead via queuedStatusText.
-			switch created.GetStatus() {
-			case CompletedStatus:
+			// "completed" is asserted unconditionally; "queued" is opt-in via queuedStatusText,
+			// since PipelineRuns left pending by another controller never reach "completed" here.
+			status := created.GetStatus()
+			if status == CompletedStatus {
 				assert.Equal(t, created.GetConclusion(), finalStatus, "we got the status `%s` but we should have get the status `%s`", created.GetConclusion(), finalStatus)
 				assert.Assert(t, strings.Contains(created.GetOutput().GetText(), finalStatusText),
 					"GetStatus/CheckRun %s != %s", created.GetOutput().GetText(), finalStatusText)
-			case queuedStatus:
+			}
+			if status == queuedStatus {
+				queuedStatusReceived = true
 				if queuedStatusText != "" {
 					assert.Assert(t, strings.Contains(created.GetOutput().GetText(), queuedStatusText),
 						"GetStatus/CheckRun queued text %q does not contain %q", created.GetOutput().GetText(), queuedStatusText)
 				}
 			}
 		})
+
+	return func() bool { return queuedStatusReceived }
 }
 
 func TestRun(t *testing.T) {
@@ -592,7 +596,7 @@ func TestRun(t *testing.T) {
 				},
 			}
 
-			testSetupCommonGhReplies(t, mux, tt.runevent, tt.finalStatus, tt.finalStatusText, tt.queuedStatusText, tt.skipReplyingOrgPublicMembers)
+			queuedStatusReceived := testSetupCommonGhReplies(t, mux, tt.runevent, tt.finalStatus, tt.finalStatusText, tt.queuedStatusText, tt.skipReplyingOrgPublicMembers)
 			if tt.tektondir != "" {
 				ghtesthelper.SetupGitTree(t, mux, tt.tektondir, &tt.runevent, false)
 			}
@@ -697,6 +701,10 @@ func TestRun(t *testing.T) {
 			}
 
 			assert.NilError(t, err)
+
+			if tt.queuedStatusText != "" {
+				assert.Assert(t, queuedStatusReceived(), "expected a queued check-run status update but none was received")
+			}
 
 			if tt.expectedLogSnippet != "" {
 				logmsg := log.FilterMessageSnippet(tt.expectedLogSnippet).TakeAll()

--- a/pkg/pipelineascode/pipelineascode_test.go
+++ b/pkg/pipelineascode/pipelineascode_test.go
@@ -94,7 +94,7 @@ func testSetupCommonGhReplies(t *testing.T, mux *http.ServeMux, runevent info.Ev
 			// testcases that expect that outcome opt into checking the "queued" status
 			// text instead via queuedStatusText.
 			switch created.GetStatus() {
-			case "completed":
+			case CompletedStatus:
 				assert.Equal(t, created.GetConclusion(), finalStatus, "we got the status `%s` but we should have get the status `%s`", created.GetConclusion(), finalStatus)
 				assert.Assert(t, strings.Contains(created.GetOutput().GetText(), finalStatusText),
 					"GetStatus/CheckRun %s != %s", created.GetOutput().GetText(), finalStatusText)

--- a/pkg/pipelineascode/pipelineascode_test.go
+++ b/pkg/pipelineascode/pipelineascode_test.go
@@ -51,7 +51,7 @@ func replyString(mux *http.ServeMux, url, body string) {
 	})
 }
 
-func testSetupCommonGhReplies(t *testing.T, mux *http.ServeMux, runevent info.Event, finalStatus, finalStatusText string, noReplyOrgPublicMembers bool) {
+func testSetupCommonGhReplies(t *testing.T, mux *http.ServeMux, runevent info.Event, finalStatus, finalStatusText, queuedStatusText string, noReplyOrgPublicMembers bool) {
 	t.Helper()
 	// Take a directory and generate replies as Github for it
 	replyString(mux,
@@ -87,12 +87,22 @@ func testSetupCommonGhReplies(t *testing.T, mux *http.ServeMux, runevent info.Ev
 			created := github.CreateCheckRunOptions{}
 			err := json.Unmarshal(body, &created)
 			assert.NilError(t, err)
-			// We created multiple status but the last one should be completed.
-			// TODO: we could maybe refine this test
-			if created.GetStatus() == "completed" {
+			// We create multiple statuses over the life of a testcase (e.g. queued,
+			// in_progress, completed), but "completed" is the only one guaranteed to
+			// be sent for every testcase, so it's asserted unconditionally. PipelineRuns
+			// left pending by an external controller never reach "completed" here, so
+			// testcases that expect that outcome opt into checking the "queued" status
+			// text instead via queuedStatusText.
+			switch created.GetStatus() {
+			case CompletedStatus:
 				assert.Equal(t, created.GetConclusion(), finalStatus, "we got the status `%s` but we should have get the status `%s`", created.GetConclusion(), finalStatus)
 				assert.Assert(t, strings.Contains(created.GetOutput().GetText(), finalStatusText),
 					"GetStatus/CheckRun %s != %s", created.GetOutput().GetText(), finalStatusText)
+			case queuedStatus:
+				if queuedStatusText != "" {
+					assert.Assert(t, strings.Contains(created.GetOutput().GetText(), queuedStatusText),
+						"GetStatus/CheckRun queued text %q does not contain %q", created.GetOutput().GetText(), queuedStatusText)
+				}
 			}
 		})
 }
@@ -122,6 +132,7 @@ func TestRun(t *testing.T) {
 		wantErr                      string
 		finalStatus                  string
 		finalStatusText              string
+		queuedStatusText             string
 		repositories                 []*v1alpha1.Repository
 		skipReplyingOrgPublicMembers bool
 		expectedNumberofCleanups     int
@@ -496,7 +507,8 @@ func TestRun(t *testing.T) {
 				PullRequestNumber: 666,
 				InstallationID:    1234,
 			},
-			tektondir: "testdata/pending_pipelinerun",
+			tektondir:        "testdata/pending_pipelinerun",
+			queuedStatusText: "has been queued",
 		},
 		{
 			name: "pull request/pipelinerun created in pending state without installationID (state changed by other controller)",
@@ -517,7 +529,8 @@ func TestRun(t *testing.T) {
 				TriggerTarget:     "pull_request",
 				PullRequestNumber: 666,
 			},
-			tektondir: "testdata/pending_pipelinerun",
+			tektondir:        "testdata/pending_pipelinerun",
+			queuedStatusText: "has been queued",
 		},
 	}
 	for _, tt := range tests {
@@ -579,7 +592,7 @@ func TestRun(t *testing.T) {
 				},
 			}
 
-			testSetupCommonGhReplies(t, mux, tt.runevent, tt.finalStatus, tt.finalStatusText, tt.skipReplyingOrgPublicMembers)
+			testSetupCommonGhReplies(t, mux, tt.runevent, tt.finalStatus, tt.finalStatusText, tt.queuedStatusText, tt.skipReplyingOrgPublicMembers)
 			if tt.tektondir != "" {
 				ghtesthelper.SetupGitTree(t, mux, tt.tektondir, &tt.runevent, false)
 			}


### PR DESCRIPTION
## 📝 Description of the Change

The check-run mock helper in `pkg/pipelineascode/pipelineascode_test.go` only asserted on a check-run write when its status was `"completed"`, silently ignoring every other status. Two testcases exercise a PipelineRun left in the `Pending` spec state, which never reaches `"completed"` in this code path — it only ever emits a `"queued"` check-run. Because those two testcases also left `finalStatus`/`finalStatusText` unset, they passed without validating anything at all.

This adds an opt-in `queuedStatusText` field so those two testcases now assert the `"queued"` check-run text contains `"has been queued"`. The assertion is opt-in (only applied when the field is non-empty) so it doesn't affect any other testcase, including an unrelated access-denied flow that also uses the `"queued"` status with different text.

**This is a narrow fix, not a full resolution of #1957.** As pointed out in review, the linked issue also asks for: (1) asserting on the `"in_progress"` status, not just `"completed"`/`"queued"`, and (2) splitting the monolithic table-driven test into focused, individual tests. Neither of those is done here — this PR only closes the specific vacuous-assertion gap for the two pending-state testcases. #1957 should stay open to track the remaining `in_progress` coverage and the structural refactor.

## 🔗 Linked GitHub Issue

Relates to #1957 (does not close it — see scope note above; remaining work should stay tracked there)

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

AI assistance can be used for various tasks, such as code generation,
documentation, or testing.

Please indicate whether you have used AI assistance
for this PR and provide details if applicable.

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

> [!IMPORTANT]
>
> **Slop will be simply rejected**, if you are using AI assistance you need to make sure you
> understand the code generated and that it meets the project's standards. you
> need at least know how to run the code and deploy it (if needed). See
> [startpaac](https://github.com/openshift-pipelines/startpaac) to make it easy
> to deploy and test your code changes.
>
> If the **majority of the code** in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Claude <noreply@anthropic.com>

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [ ] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
      <!-- Ran go build ./..., go test ./pkg/pipelineascode/..., go vet ./pkg/pipelineascode/..., gofmt on the changed file; golangci-lint/gofumpt were not available in this environment so the full `make lint`/`make fumpt` were not run. -->
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center

---
AI assistance: this change was drafted with Claude Code.
