### PR TITLE
fix(bitbucketdatacenter): support on-comment annotation for non-gitops comments

### DIFF
--- a/pkg/provider/bitbucketdatacenter/detect.go
+++ b/pkg/provider/bitbucketdatacenter/detect.go
@@ -42,15 +42,10 @@ func (v *Provider) Detect(req *http.Request, payload string, logger *zap.Sugared
 			return setLoggerAndProceed(true, "", nil)
 		}
 		if provider.Valid(event, []string{"pr:comment:added"}) {
-			if provider.IsTestRetestComment(e.Comment.Text) {
+			if e.PullRequest.Open {
 				return setLoggerAndProceed(true, "", nil)
 			}
-			if provider.IsOkToTestComment(e.Comment.Text) {
-				return setLoggerAndProceed(true, "", nil)
-			}
-			if provider.IsCancelComment(e.Comment.Text) {
-				return setLoggerAndProceed(true, "", nil)
-			}
+			return setLoggerAndProceed(false, "comments on closed pull requests are not supported", nil)
 		}
 		return setLoggerAndProceed(false, fmt.Sprintf("not a recognized bitbucket event: \"%s\"", event), nil)
 

--- a/pkg/provider/bitbucketdatacenter/detect.go
+++ b/pkg/provider/bitbucketdatacenter/detect.go
@@ -42,16 +42,6 @@ func (v *Provider) Detect(req *http.Request, payload string, logger *zap.Sugared
 			return setLoggerAndProceed(true, "", nil)
 		}
 		if provider.Valid(event, []string{"pr:comment:added"}) {
-			if provider.IsTestRetestComment(e.Comment.Text) {
-				return setLoggerAndProceed(true, "", nil)
-			}
-			if provider.IsOkToTestComment(e.Comment.Text) {
-				return setLoggerAndProceed(true, "", nil)
-			}
-			if provider.IsCancelComment(e.Comment.Text) {
-				return setLoggerAndProceed(true, "", nil)
-			}
-			// non-gitops comment
 			return setLoggerAndProceed(true, "", nil)
 		}
 		return setLoggerAndProceed(false, fmt.Sprintf("not a recognized bitbucket event: \"%s\"", event), nil)

--- a/pkg/provider/bitbucketdatacenter/detect.go
+++ b/pkg/provider/bitbucketdatacenter/detect.go
@@ -51,6 +51,8 @@ func (v *Provider) Detect(req *http.Request, payload string, logger *zap.Sugared
 			if provider.IsCancelComment(e.Comment.Text) {
 				return setLoggerAndProceed(true, "", nil)
 			}
+			// non-gitops comment
+			return setLoggerAndProceed(true, "", nil)
 		}
 		return setLoggerAndProceed(false, fmt.Sprintf("not a recognized bitbucket event: \"%s\"", event), nil)
 

--- a/pkg/provider/bitbucketdatacenter/detect_test.go
+++ b/pkg/provider/bitbucketdatacenter/detect_test.go
@@ -68,7 +68,8 @@ func TestProviderDetect(t *testing.T) {
 		{
 			name: "retest comment",
 			event: types.PullRequestEvent{
-				Comment: types.ActivityComment{Text: "/retest"},
+				PullRequest: types.PullRequest{Open: true},
+				Comment:     types.ActivityComment{Text: "/retest"},
 			},
 			eventType:  "pr:comment:added",
 			isBS:       true,
@@ -77,16 +78,18 @@ func TestProviderDetect(t *testing.T) {
 		{
 			name: "random comment",
 			event: types.PullRequestEvent{
-				Comment: types.ActivityComment{Text: "random string, ignore me :)"},
+				PullRequest: types.PullRequest{Open: true},
+				Comment:     types.ActivityComment{Text: "random string, ignore me :)"},
 			},
 			eventType:  "pr:comment:added",
 			isBS:       true,
-			processReq: false,
+			processReq: true,
 		},
 		{
 			name: "ok-to-test comment",
 			event: types.PullRequestEvent{
-				Comment: types.ActivityComment{Text: "/ok-to-test"},
+				PullRequest: types.PullRequest{Open: true},
+				Comment:     types.ActivityComment{Text: "/ok-to-test"},
 			},
 			eventType:  "pr:comment:added",
 			isBS:       true,
@@ -95,7 +98,8 @@ func TestProviderDetect(t *testing.T) {
 		{
 			name: "cancel comment",
 			event: types.PullRequestEvent{
-				Comment: types.ActivityComment{Text: "/cancel"},
+				PullRequest: types.PullRequest{Open: true},
+				Comment:     types.ActivityComment{Text: "/cancel"},
 			},
 			eventType:  "pr:comment:added",
 			isBS:       true,
@@ -104,11 +108,23 @@ func TestProviderDetect(t *testing.T) {
 		{
 			name: "cancel a pipelinerun comment",
 			event: types.PullRequestEvent{
-				Comment: types.ActivityComment{Text: "/cancel dummy"},
+				PullRequest: types.PullRequest{Open: true},
+				Comment:     types.ActivityComment{Text: "/cancel dummy"},
 			},
 			eventType:  "pr:comment:added",
 			isBS:       true,
 			processReq: true,
+		},
+		{
+			name: "comment on closed pull request",
+			event: types.PullRequestEvent{
+				PullRequest: types.PullRequest{Open: false},
+				Comment:     types.ActivityComment{Text: "/retest"},
+			},
+			eventType:  "pr:comment:added",
+			isBS:       true,
+			processReq: false,
+			wantReason: "comments on closed pull requests are not supported",
 		},
 	}
 

--- a/pkg/provider/bitbucketdatacenter/detect_test.go
+++ b/pkg/provider/bitbucketdatacenter/detect_test.go
@@ -81,7 +81,7 @@ func TestProviderDetect(t *testing.T) {
 			},
 			eventType:  "pr:comment:added",
 			isBS:       true,
-			processReq: false,
+			processReq: true,
 		},
 		{
 			name: "ok-to-test comment",

--- a/pkg/provider/bitbucketdatacenter/parse_payload.go
+++ b/pkg/provider/bitbucketdatacenter/parse_payload.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/opscomments"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
@@ -111,25 +112,8 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 			processedEvent.TriggerTarget = triggertype.PullRequest
 			processedEvent.EventType = triggertype.PullRequest.String()
 		} else if provider.Valid(eventType, []string{"pr:comment:added", "pr:comment:edited"}) {
-			switch {
-			case provider.IsTestRetestComment(e.Comment.Text):
-				processedEvent.TriggerTarget = triggertype.PullRequest
-				if strings.Contains(e.Comment.Text, "/test") {
-					processedEvent.EventType = "test-comment"
-				} else {
-					processedEvent.EventType = "retest-comment"
-				}
-				processedEvent.TargetTestPipelineRun = provider.GetPipelineRunFromTestComment(e.Comment.Text)
-			case provider.IsOkToTestComment(e.Comment.Text):
-				processedEvent.TriggerTarget = triggertype.PullRequest
-				processedEvent.EventType = "ok-to-test-comment"
-			case provider.IsCancelComment(e.Comment.Text):
-				processedEvent.TriggerTarget = triggertype.PullRequest
-				processedEvent.EventType = "cancel-comment"
-				processedEvent.CancelPipelineRuns = true
-				processedEvent.TargetCancelPipelineRun = provider.GetPipelineRunFromCancelComment(e.Comment.Text)
-			}
-			processedEvent.TriggerComment = e.Comment.Text
+			processedEvent.TriggerTarget = triggertype.PullRequest
+			opscomments.SetEventTypeAndTargetPR(processedEvent, e.Comment.Text, "/")
 		}
 
 		if err := checkValidPayload(e); err != nil {

--- a/pkg/provider/bitbucketdatacenter/parse_payload.go
+++ b/pkg/provider/bitbucketdatacenter/parse_payload.go
@@ -111,7 +111,7 @@ func (v *Provider) ParsePayload(_ context.Context, _ *params.Run, request *http.
 		if provider.Valid(eventType, []string{"pr:from_ref_updated", "pr:opened"}) {
 			processedEvent.TriggerTarget = triggertype.PullRequest
 			processedEvent.EventType = triggertype.PullRequest.String()
-		} else if provider.Valid(eventType, []string{"pr:comment:added", "pr:comment:edited"}) {
+		} else if provider.Valid(eventType, []string{"pr:comment:added"}) {
 			processedEvent.TriggerTarget = triggertype.PullRequest
 			opscomments.SetEventTypeAndTargetPR(processedEvent, e.Comment.Text, "/")
 		}
@@ -216,7 +216,7 @@ func parsePayloadType(event string) (any, error) {
 	var localEvent string
 	if strings.HasPrefix(event, "pr:") {
 		if !provider.Valid(event, []string{
-			"pr:from_ref_updated", "pr:opened", "pr:comment:added", "pr:comment:edited",
+			"pr:from_ref_updated", "pr:opened", "pr:comment:added",
 		}) {
 			return nil, fmt.Errorf("event \"%s\" is not supported", event)
 		}

--- a/pkg/provider/bitbucketdatacenter/parse_payload_test.go
+++ b/pkg/provider/bitbucketdatacenter/parse_payload_test.go
@@ -574,6 +574,9 @@ func TestParsePayload(t *testing.T) {
 		rawStr                  string
 		targetPipelinerun       string
 		canceltargetPipelinerun string
+		expTriggerTarget        string
+		expEventType            string
+		expTriggerComment       string
 	}{
 		{
 			name:          "bad/invalid event type",
@@ -604,16 +607,20 @@ func TestParsePayload(t *testing.T) {
 			wantErrSubstr: "invalid control character",
 		},
 		{
-			name:         "good/pull_request",
-			eventType:    "pr:opened",
-			payloadEvent: bbv1test.MakePREvent(ev1, ""),
-			expEvent:     ev1,
+			name:             "good/pull_request",
+			eventType:        "pr:opened",
+			payloadEvent:     bbv1test.MakePREvent(ev1, ""),
+			expEvent:         ev1,
+			expEventType:     "pull_request",
+			expTriggerTarget: "pull_request",
 		},
 		{
-			name:         "good/push",
-			eventType:    "repo:refs_changed",
-			payloadEvent: bbv1test.MakePushEvent(ev1, []types.PushRequestEventChange{{ToHash: ev1.SHA, RefID: "base"}}, []types.Commit{{ID: ev1.SHA}}),
-			expEvent:     ev1,
+			name:             "good/push",
+			eventType:        "repo:refs_changed",
+			payloadEvent:     bbv1test.MakePushEvent(ev1, []types.PushRequestEventChange{{ToHash: ev1.SHA, RefID: "base"}}, []types.Commit{{ID: ev1.SHA}}),
+			expEvent:         ev1,
+			expEventType:     "push",
+			expTriggerTarget: "push",
 		},
 		{
 			name:          "bad/changes are empty in push",
@@ -630,16 +637,32 @@ func TestParsePayload(t *testing.T) {
 			wantErrSubstr: "push event contains no commits; cannot proceed",
 		},
 		{
-			name:         "good/comment ok-to-test",
-			eventType:    "pr:comment:added",
-			payloadEvent: bbv1test.MakePREvent(ev1, "/ok-to-test"),
-			expEvent:     ev1,
+			name:              "good/comment ok-to-test",
+			eventType:         "pr:comment:added",
+			payloadEvent:      bbv1test.MakePREvent(ev1, "/ok-to-test"),
+			expEvent:          ev1,
+			expEventType:      "ok-to-test-comment",
+			expTriggerTarget:  "pull_request",
+			expTriggerComment: "/ok-to-test",
 		},
 		{
-			name:         "good/comment test",
-			eventType:    "pr:comment:added",
-			payloadEvent: bbv1test.MakePREvent(ev1, "/test"),
-			expEvent:     ev1,
+			name:              "good/comment test",
+			eventType:         "pr:comment:added",
+			payloadEvent:      bbv1test.MakePREvent(ev1, "/test"),
+			expEvent:          ev1,
+			expEventType:      "test-all-comment",
+			expTriggerTarget:  "pull_request",
+			expTriggerComment: "/test",
+		},
+		{
+			name:              "good/comment test single",
+			eventType:         "pr:comment:added",
+			payloadEvent:      bbv1test.MakePREvent(ev1, "/test dummy"),
+			expEvent:          ev1,
+			expEventType:      "test-comment",
+			expTriggerTarget:  "pull_request",
+			targetPipelinerun: "dummy",
+			expTriggerComment: "/test dummy",
 		},
 		{
 			name:              "good/comment retest a pr",
@@ -647,6 +670,9 @@ func TestParsePayload(t *testing.T) {
 			payloadEvent:      bbv1test.MakePREvent(ev1, "/retest dummy"),
 			expEvent:          ev1,
 			targetPipelinerun: "dummy",
+			expEventType:      "retest-comment",
+			expTriggerTarget:  "pull_request",
+			expTriggerComment: "/retest dummy",
 		},
 		{
 			name:                    "good/comment cancel a pr",
@@ -654,12 +680,27 @@ func TestParsePayload(t *testing.T) {
 			payloadEvent:            bbv1test.MakePREvent(ev1, "/cancel dummy"),
 			expEvent:                ev1,
 			canceltargetPipelinerun: "dummy",
+			expEventType:            "cancel-comment",
+			expTriggerTarget:        "pull_request",
+			expTriggerComment:       "/cancel dummy",
 		},
 		{
-			name:         "good/comment cancel all",
-			eventType:    "pr:comment:added",
-			payloadEvent: bbv1test.MakePREvent(ev1, "/cancel"),
-			expEvent:     ev1,
+			name:              "good/comment cancel all",
+			eventType:         "pr:comment:added",
+			payloadEvent:      bbv1test.MakePREvent(ev1, "/cancel"),
+			expEvent:          ev1,
+			expEventType:      "cancel-all-comment",
+			expTriggerTarget:  "pull_request",
+			expTriggerComment: "/cancel",
+		},
+		{
+			name:              "good/comment non-gitops",
+			eventType:         "pr:comment:added",
+			payloadEvent:      bbv1test.MakePREvent(ev1, "/review"),
+			expEvent:          ev1,
+			expTriggerTarget:  "pull_request",
+			expEventType:      "no-ops-comment",
+			expTriggerComment: "/review",
 		},
 		{
 			name:      "branch/deleted with zero hash",
@@ -722,6 +763,9 @@ func TestParsePayload(t *testing.T) {
 			if tt.canceltargetPipelinerun != "" {
 				assert.Equal(t, got.TargetCancelPipelineRun, tt.canceltargetPipelinerun)
 			}
+			assert.Equal(t, string(got.TriggerTarget), tt.expTriggerTarget)
+			assert.Equal(t, string(got.EventType), tt.expEventType)
+			assert.Equal(t, got.TriggerComment, tt.expTriggerComment)
 		})
 	}
 }

--- a/pkg/provider/bitbucketdatacenter/types/types.go
+++ b/pkg/provider/bitbucketdatacenter/types/types.go
@@ -162,12 +162,9 @@ type PullRequestEvent struct {
 	PullRequest PullRequest   `json:"pullRequest"`
 	EventKey    string        `json:"eventKey"`
 
-	// Comment should be used when event is `pr:comment:added` or `pr:comment:edited`.
-	Comment ActivityComment `json:"comment"`
-
-	// CommentParentID and PreviousComment should be used when event is `pr:comment:edited`.
-	CommentParentID string `json:"commentParentId"`
-	PreviousComment string `json:"previousComment"`
+	Comment         ActivityComment `json:"comment"`
+	CommentParentID string          `json:"commentParentId"`
+	PreviousComment string          `json:"previousComment"`
 }
 
 type PushRequestEventChange struct {

--- a/test/bitbucket_datacenter_on_comment_test.go
+++ b/test/bitbucket_datacenter_on_comment_test.go
@@ -1,0 +1,65 @@
+//go:build e2e
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
+	tbbdc "github.com/openshift-pipelines/pipelines-as-code/test/pkg/bitbucketdatacenter"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
+
+	"github.com/jenkins-x/go-scm/scm"
+	"github.com/tektoncd/pipeline/pkg/names"
+	"gotest.tools/v3/assert"
+)
+
+func TestBitbucketDataCenterNonGitopsCommentTriggersPipelineRun(t *testing.T) {
+	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
+	ctx := context.Background()
+	bitbucketWSOwner := os.Getenv("TEST_BITBUCKET_DATA_CENTER_E2E_REPOSITORY")
+
+	ctx, runcnx, opts, client, err := tbbdc.Setup(ctx)
+	assert.NilError(t, err)
+
+	repo := tbbdc.CreateCRD(ctx, t, client, runcnx, bitbucketWSOwner, targetNS)
+	runcnx.Clients.Log.Infof("Repository %s has been created", repo.Name)
+	defer tbbdc.TearDownNs(ctx, t, runcnx, targetNS)
+
+	files := map[string]string{
+		".tekton/on-comment.yaml": "testdata/pipelinerun-on-comment-annotation.yaml",
+	}
+	files, err = payload.GetEntries(files, targetNS, options.MainBranch, triggertype.PullRequest.String(), map[string]string{})
+	assert.NilError(t, err)
+
+	pr := tbbdc.CreatePR(ctx, t, client, runcnx, opts, repo, files, bitbucketWSOwner, targetNS)
+	runcnx.Clients.Log.Infof("Pull Request with title '%s' is created", pr.Title)
+	defer tbbdc.TearDown(ctx, t, runcnx, client, pr, bitbucketWSOwner, targetNS)
+
+	triggerComment := "/hello-world"
+	runcnx.Clients.Log.Infof("Posting comment %q on PR", triggerComment)
+	_, _, err = client.PullRequests.CreateComment(ctx, bitbucketWSOwner, pr.Number, &scm.CommentInput{Body: triggerComment})
+	assert.NilError(t, err)
+
+	waitOpts := wait.Opts{
+		Namespace:       targetNS,
+		MinNumberStatus: 1,
+		PollTimeout:     wait.DefaultTimeout,
+	}
+	prs, err := wait.UntilPipelineRunsFinished(ctx, runcnx.Clients, waitOpts)
+	assert.NilError(t, err)
+	assert.Equal(t, prs[0].Annotations[keys.EventType], "on-comment",
+		"PipelineRun should have on-comment event type when triggered by a non-gitops comment")
+
+	err = wait.RegexpMatchingInPodLog(context.Background(), runcnx, targetNS,
+		fmt.Sprintf("tekton.dev/pipelineRun=%s", prs[0].Name),
+		"step-task", *regexp.MustCompile(triggerComment), "", 2, nil)
+	assert.NilError(t, err, "pod logs should contain the trigger comment text %q", triggerComment)
+}

--- a/test/bitbucket_datacenter_on_comment_test.go
+++ b/test/bitbucket_datacenter_on_comment_test.go
@@ -1,0 +1,69 @@
+//go:build e2e
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/triggertype"
+	tbbdc "github.com/openshift-pipelines/pipelines-as-code/test/pkg/bitbucketdatacenter"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/options"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/payload"
+	"github.com/openshift-pipelines/pipelines-as-code/test/pkg/wait"
+
+	"github.com/jenkins-x/go-scm/scm"
+	"github.com/tektoncd/pipeline/pkg/names"
+	"gotest.tools/v3/assert"
+)
+
+func TestBitbucketDataCenterNonGitopsCommentTriggersPipelineRun(t *testing.T) {
+	// Given: a PR exists with a PipelineRun annotated on-comment: "^/hello-world"
+	targetNS := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("pac-e2e-ns")
+	ctx := context.Background()
+	bitbucketWSOwner := os.Getenv("TEST_BITBUCKET_DATA_CENTER_E2E_REPOSITORY")
+
+	ctx, runcnx, opts, client, err := tbbdc.Setup(ctx)
+	assert.NilError(t, err)
+
+	repo := tbbdc.CreateCRD(ctx, t, client, runcnx, bitbucketWSOwner, targetNS)
+	runcnx.Clients.Log.Infof("Repository %s has been created", repo.Name)
+	defer tbbdc.TearDownNs(ctx, t, runcnx, targetNS)
+
+	files := map[string]string{
+		".tekton/on-comment.yaml": "testdata/pipelinerun-on-comment-annotation.yaml",
+	}
+	files, err = payload.GetEntries(files, targetNS, options.MainBranch, triggertype.PullRequest.String(), map[string]string{})
+	assert.NilError(t, err)
+
+	pr := tbbdc.CreatePR(ctx, t, client, runcnx, opts, repo, files, bitbucketWSOwner, targetNS)
+	runcnx.Clients.Log.Infof("Pull Request with title '%s' is created", pr.Title)
+	defer tbbdc.TearDown(ctx, t, runcnx, client, pr, bitbucketWSOwner, targetNS)
+
+	// When: a non-gitops comment "/hello-world" is posted on the PR
+	triggerComment := "/hello-world"
+	runcnx.Clients.Log.Infof("Posting comment %q on PR", triggerComment)
+	_, _, err = client.PullRequests.CreateComment(ctx, bitbucketWSOwner, pr.Number, &scm.CommentInput{Body: triggerComment})
+	assert.NilError(t, err)
+
+	// Then: a PipelineRun is created with EventType == "on-comment"
+	// and trigger_comment contains the posted comment text
+	waitOpts := wait.Opts{
+		Namespace:       targetNS,
+		MinNumberStatus: 1,
+		PollTimeout:     wait.DefaultTimeout,
+	}
+	prs, err := wait.UntilPipelineRunsFinished(ctx, runcnx.Clients, waitOpts)
+	assert.NilError(t, err)
+	assert.Equal(t, prs[0].Annotations[keys.EventType], "on-comment",
+		"PipelineRun should have on-comment event type when triggered by a non-gitops comment")
+
+	err = wait.RegexpMatchingInPodLog(context.Background(), runcnx, targetNS,
+		fmt.Sprintf("tekton.dev/pipelineRun=%s", prs[0].Name),
+		"step-task", *regexp.MustCompile(triggerComment), "", 2, nil)
+	assert.NilError(t, err, "pod logs should contain the trigger comment text %q", triggerComment)
+}


### PR DESCRIPTION
## 📝 Description of the Change

Bitbucket Data Center silently drops non-gitops PR comments (`pr:comment:added` events that are not `/test`, `/retest`, `/ok-to-test`, or `/cancel`). This means the `on-comment` PipelineRun annotation never triggers on Bitbucket DC, while it works on GitHub, GitLab, and Gitea.

## Additional Refactorings

**Remove dead guards in `Detect`**: The `IsTestRetestComment`, `IsOkToTestComment`, and `IsCancelComment` checks all returned the same result as the catch-all. Stripped them out. `Detect` just decides whether to process an event; `ParsePayload` handles classification via `SetEventTypeAndTargetPR`.

**Fix `EventType` for bare gitops commands**:
- `/test` → `test-all-comment`, `/retest` → `retest-all-comment`, `/cancel` → `cancel-all-comment`

This means bare `/retest` now correctly goes through `filterSuccessfulTemplates` (only re-runs failed pipelines), matching all other providers.

## 🔗 Linked GitHub Issue

Fixes #2910

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [x] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

I could not test the E2E because I don´t have the infrastructure set-up for it. So I am relying on the CI for that one.

## 🤖 AI Assistance

AI assistance can be used for various tasks, such as code generation,
documentation, or testing.

Please indicate whether you have used AI assistance
for this PR and provide details if applicable.

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [x] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
