### PR TITLE
fix(gitlab): skip target_url when console dashboard is not configured

### DIFF
--- a/pkg/consoleui/custom.go
+++ b/pkg/consoleui/custom.go
@@ -29,14 +29,14 @@ func NewCustomConsole(pacInfo *info.PacOpts) *CustomConsole {
 
 func (o *CustomConsole) GetName() string {
 	if o.pacInfo.CustomConsoleName == "" {
-		return fmt.Sprintf("https://url.setting.%s.is.not.configured", settings.CustomConsoleNameKey)
+		return fmt.Sprintf("https://url.setting.%s.%s", settings.CustomConsoleNameKey, NotConfiguredURLSuffix)
 	}
 	return o.pacInfo.CustomConsoleName
 }
 
 func (o *CustomConsole) URL() string {
 	if o.pacInfo.CustomConsoleURL == "" {
-		return fmt.Sprintf("https://url.setting.%s.is.not.configured", settings.CustomConsoleURLKey)
+		return fmt.Sprintf("https://url.setting.%s.%s", settings.CustomConsoleURLKey, NotConfiguredURLSuffix)
 	}
 	return o.pacInfo.CustomConsoleURL
 }
@@ -78,7 +78,7 @@ func (o *CustomConsole) generateURL(urlTmpl string) string {
 
 func (o *CustomConsole) DetailURL(pr *tektonv1.PipelineRun) string {
 	if o.pacInfo.CustomConsolePRdetail == "" {
-		return fmt.Sprintf("https://detailurl.setting.%s.is.not.configured", settings.CustomConsolePRDetailKey)
+		return fmt.Sprintf("https://detailurl.setting.%s.%s", settings.CustomConsolePRDetailKey, NotConfiguredURLSuffix)
 	}
 	o.namespace = pr.GetNamespace()
 	o.pr = pr.GetName()
@@ -87,7 +87,7 @@ func (o *CustomConsole) DetailURL(pr *tektonv1.PipelineRun) string {
 
 func (o *CustomConsole) NamespaceURL(pr *tektonv1.PipelineRun) string {
 	if o.pacInfo.CustomConsoleNamespaceURL == "" {
-		return fmt.Sprintf("https://detailurl.setting.%s.is.not.configured", settings.CustomConsoleNamespaceURLKey)
+		return fmt.Sprintf("https://detailurl.setting.%s.%s", settings.CustomConsoleNamespaceURLKey, NotConfiguredURLSuffix)
 	}
 	o.namespace = pr.GetNamespace()
 	return o.generateURL(o.pacInfo.CustomConsoleNamespaceURL)
@@ -95,7 +95,7 @@ func (o *CustomConsole) NamespaceURL(pr *tektonv1.PipelineRun) string {
 
 func (o *CustomConsole) TaskLogURL(pr *tektonv1.PipelineRun, taskRunStatus *tektonv1.PipelineRunTaskRunStatus) string {
 	if o.pacInfo.CustomConsolePRTaskLog == "" {
-		return fmt.Sprintf("https://tasklogurl.setting.%s.is.not.configured", settings.CustomConsolePRTaskLogKey)
+		return fmt.Sprintf("https://tasklogurl.setting.%s.%s", settings.CustomConsolePRTaskLogKey, NotConfiguredURLSuffix)
 	}
 	firstFailedStep := ""
 	// search for the first failed steps in taskrunstatus

--- a/pkg/consoleui/interface.go
+++ b/pkg/consoleui/interface.go
@@ -8,7 +8,13 @@ import (
 	"k8s.io/client-go/dynamic"
 )
 
-const consoleIsnotConfiguredURL = "https://dashboard.is.not.configured"
+// NotConfiguredURLSuffix is the hostname suffix used by every placeholder
+// URL returned by this package when a console/dashboard has not been
+// configured (e.g. https://dashboard.is.not.configured). Providers can use
+// it to detect and skip sending these placeholders as real URLs.
+const NotConfiguredURLSuffix = "is.not.configured"
+
+const consoleIsnotConfiguredURL = "https://dashboard." + NotConfiguredURLSuffix
 
 type Interface interface {
 	DetailURL(pr *tektonv1.PipelineRun) string

--- a/pkg/consoleui/openshift.go
+++ b/pkg/consoleui/openshift.go
@@ -35,7 +35,7 @@ func (o *OpenshiftConsole) GetName() string {
 
 func (o *OpenshiftConsole) URL() string {
 	if o.host == "" {
-		return "https://openshift.url.is.not.configured"
+		return "https://openshift.url." + NotConfiguredURLSuffix
 	}
 	return "https://" + o.host
 }

--- a/pkg/consoleui/tektondashboard.go
+++ b/pkg/consoleui/tektondashboard.go
@@ -33,7 +33,7 @@ func (t *TektonDashboard) TaskLogURL(pr *tektonv1.PipelineRun, taskRunStatus *te
 func (t *TektonDashboard) URL() string {
 	// if BaseURL is not provided, return fake URL
 	if t.BaseURL == "" || t.BaseURL == "http://" || t.BaseURL == "https://" {
-		return "https://dashboard.url.is.not.configured"
+		return "https://dashboard.url." + NotConfiguredURLSuffix
 	}
 	return t.BaseURL
 }

--- a/pkg/provider/gitlab/gitlab.go
+++ b/pkg/provider/gitlab/gitlab.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/changedfiles"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/consoleui"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/events"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/opscomments"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
@@ -345,6 +346,22 @@ func (v *Provider) setClient(ctx context.Context, run *params.Run, runevent *inf
 	return nil
 }
 
+// isResolvableTargetURL reports whether detailsURL is a usable commit status
+// target_url. It excludes the pipelines-as-code placeholder URLs (e.g.
+// https://dashboard.is.not.configured) used when no console/dashboard has
+// been configured, since GitLab's URL blocker rejects hosts that don't
+// resolve and would otherwise fail the whole status update.
+func isResolvableTargetURL(detailsURL string) bool {
+	if detailsURL == "" {
+		return false
+	}
+	u, err := url.Parse(detailsURL)
+	if err != nil || u.Hostname() == "" {
+		return false
+	}
+	return !strings.HasSuffix(u.Hostname(), consoleui.NotConfiguredURLSuffix)
+}
+
 //nolint:misspell
 func (v *Provider) CreateStatus(ctx context.Context, event *info.Event, statusOpts providerstatus.StatusOpts,
 ) error {
@@ -399,9 +416,15 @@ func (v *Provider) CreateStatus(ctx context.Context, event *info.Event, statusOp
 	opt := &gitlab.SetCommitStatusOptions{
 		State:       state,
 		Name:        gitlab.Ptr(contextName),
-		TargetURL:   gitlab.Ptr(detailsURL),
 		Description: gitlab.Ptr(statusOpts.Title),
 		Context:     gitlab.Ptr(contextName),
+	}
+	// GitLab validates target_url and rejects hosts that don't resolve, which
+	// includes the "*.is.not.configured" placeholders pipelines-as-code falls
+	// back to when no console/dashboard URL has been configured. Only send it
+	// when it looks like a real URL, otherwise leave it unset.
+	if isResolvableTargetURL(detailsURL) {
+		opt.TargetURL = gitlab.Ptr(detailsURL)
 	}
 
 	// Reuse a previously discovered pipeline ID so that all commit statuses

--- a/pkg/provider/gitlab/gitlab_test.go
+++ b/pkg/provider/gitlab/gitlab_test.go
@@ -216,6 +216,69 @@ func TestCreateStatus(t *testing.T) {
 			},
 		},
 		{
+			name:       "placeholder details url is omitted from target_url",
+			wantClient: true,
+			wantErr:    false,
+			fields:     fields{targetProjectID: 700},
+			args: args{
+				statusOpts: providerstatus.StatusOpts{
+					Conclusion: "success",
+					DetailsURL: "https://dashboard.is.not.configured",
+				},
+				event: &info.Event{
+					TriggerTarget:   "pull_request",
+					SourceProjectID: 700,
+					TargetProjectID: 700,
+					SHA:             "notconfigured01",
+				},
+			},
+			setup: func(t *testing.T, mux *http.ServeMux) {
+				t.Helper()
+				mux.HandleFunc("/projects/700/statuses/notconfigured01", func(rw http.ResponseWriter, r *http.Request) {
+					var reqBody map[string]any
+					if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+						t.Fatalf("failed to decode request body: %v", err)
+					}
+					_, hasTargetURL := reqBody["target_url"]
+					assert.Assert(t, !hasTargetURL, "request should not have target_url for a placeholder details url")
+					rw.WriteHeader(http.StatusCreated)
+					fmt.Fprint(rw, `{"id": 1}`)
+				})
+			},
+		},
+		{
+			name:       "real details url is sent as target_url",
+			wantClient: true,
+			wantErr:    false,
+			fields:     fields{targetProjectID: 701},
+			args: args{
+				statusOpts: providerstatus.StatusOpts{
+					Conclusion: "success",
+					DetailsURL: "https://dashboard.example.com/run/1",
+				},
+				event: &info.Event{
+					TriggerTarget:   "pull_request",
+					SourceProjectID: 701,
+					TargetProjectID: 701,
+					SHA:             "realurl01",
+				},
+			},
+			setup: func(t *testing.T, mux *http.ServeMux) {
+				t.Helper()
+				mux.HandleFunc("/projects/701/statuses/realurl01", func(rw http.ResponseWriter, r *http.Request) {
+					var reqBody map[string]any
+					if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+						t.Fatalf("failed to decode request body: %v", err)
+					}
+					targetURL, hasTargetURL := reqBody["target_url"]
+					assert.Assert(t, hasTargetURL, "request should have target_url for a real details url")
+					assert.Equal(t, targetURL, "https://dashboard.example.com/run/1")
+					rw.WriteHeader(http.StatusCreated)
+					fmt.Fprint(rw, `{"id": 1}`)
+				})
+			},
+		},
+		{
 			name:       "pending conclusion for gitops command on pushed commit",
 			wantClient: true,
 			wantErr:    false,


### PR DESCRIPTION
## 📝 Description of the Change

When a PipelineRun fails to start on GitLab (e.g. an admission webhook
rejection) and no Tekton/OpenShift/custom dashboard has been configured,
pipelines-as-code falls back to a placeholder details URL such as
`https://dashboard.is.not.configured`. The GitLab provider's `CreateStatus`
always sent this placeholder as the commit status `target_url`. In the
original report (#2029), this caused GitLab to return a 400
`target_url: [is blocked: URI is invalid]` error, which failed the whole
`SetCommitStatus` call. For a push event (no merge request to comment on),
there is no other fallback, so the status update was silently lost and only
visible in the controller logs. We haven't been able to reliably reproduce
this against current gitlab.com, so the exact conditions that trigger it
aren't fully clear, but the placeholder never pointed to anything useful
either way.

This change adds an `isResolvableTargetURL` check in the GitLab provider so
`target_url` is only sent when the details URL is not one of the
`*.is.not.configured` placeholders used across the console UI fallbacks.
When it is a placeholder, `target_url` is simply omitted from the request
instead of being sent.

## 🔗 Linked GitHub Issue

Fixes #

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

AI assistance can be used for various tasks, such as code generation,
documentation, or testing.

Please indicate whether you have used AI assistance
for this PR and provide details if applicable.

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

> [!IMPORTANT]
>
> **Slop will be simply rejected**, if you are using AI assistance you need to make sure you
> understand the code generated and that it meets the project's standards. you
> need at least know how to run the code and deploy it (if needed). See
> [startpaac](https://github.com/openshift-pipelines/startpaac) to make it easy
> to deploy and test your code changes.
>
> If the **majority of the code** in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Claude <noreply@anthropic.com>

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center

---
AI assistance: this change was drafted with Claude Code.

Fixes #2029
