### PR TITLE
fix(reconciler): skip redundant spec.status patch on already-started PipelineRuns

### DIFF
--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -608,8 +608,13 @@ func (r *Reconciler) updatePipelineRunState(ctx context.Context, logger *zap.Sug
 		},
 	}
 
-	// if state is started then remove pipelineRun pending status
-	if state == kubeinteraction.StateStarted {
+	// if state is started and the pipelineRun is still pending then clear the
+	// pending status so Tekton can pick it up. If it already isn't pending
+	// (e.g. Tekton already started it before we got a chance to report it),
+	// skip this patch: the field is already cleared, and some Tekton versions'
+	// admission webhook rejects any spec update once a PipelineRun has started,
+	// even a no-op one.
+	if state == kubeinteraction.StateStarted && pr.Spec.Status == tektonv1.PipelineRunSpecStatusPending {
 		mergePatch["spec"] = map[string]any{
 			"status": "",
 		}

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -408,9 +408,10 @@ func TestUpdatePipelineRunState(t *testing.T) {
 	fakelogger := zap.New(observer).Sugar()
 
 	tests := []struct {
-		name        string
-		pipelineRun *tektonv1.PipelineRun
-		state       string
+		name          string
+		pipelineRun   *tektonv1.PipelineRun
+		state         string
+		wantSpecPatch bool
 	}{
 		{
 			name: "queued to started",
@@ -427,7 +428,8 @@ func TestUpdatePipelineRunState(t *testing.T) {
 				},
 				Status: tektonv1.PipelineRunStatus{},
 			},
-			state: kubeinteraction.StateStarted,
+			state:         kubeinteraction.StateStarted,
+			wantSpecPatch: true,
 		},
 		{
 			name: "started to completed",
@@ -444,6 +446,26 @@ func TestUpdatePipelineRunState(t *testing.T) {
 			},
 			state: kubeinteraction.StateCompleted,
 		},
+		{
+			name: "already running reported as started should not repatch spec",
+			pipelineRun: &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test",
+					Name:      "test",
+					Annotations: map[string]string{
+						keys.State: kubeinteraction.StateQueued,
+					},
+				},
+				// Tekton already cleared the pending status and started the
+				// PipelineRun before PAC got a chance to report it (see the
+				// "Running reason without SCMReportingPLRStarted" scenario in
+				// TestReconcileKindSCMReportingLogic).
+				Spec:   tektonv1.PipelineRunSpec{},
+				Status: tektonv1.PipelineRunStatus{},
+			},
+			state:         kubeinteraction.StateStarted,
+			wantSpecPatch: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -452,6 +474,15 @@ func TestUpdatePipelineRunState(t *testing.T) {
 				PipelineRuns: []*tektonv1.PipelineRun{tt.pipelineRun},
 			}
 			stdata, _ := testclient.SeedTestData(t, ctx, testData)
+
+			var gotPatch []byte
+			stdata.Pipeline.PrependReactor("patch", "pipelineruns", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				if patch, ok := action.(k8stesting.PatchAction); ok {
+					gotPatch = patch.GetPatch()
+				}
+				return false, nil, nil
+			})
+
 			r := &Reconciler{
 				run: &params.Run{
 					Clients: clients.Clients{
@@ -465,6 +496,11 @@ func TestUpdatePipelineRunState(t *testing.T) {
 
 			assert.Equal(t, updatedPR.Annotations[keys.State], tt.state)
 			assert.Equal(t, updatedPR.Spec.Status, tektonv1.PipelineRunSpecStatus(""))
+
+			var patchBody map[string]any
+			assert.NilError(t, json.Unmarshal(gotPatch, &patchBody))
+			_, hasSpec := patchBody["spec"]
+			assert.Equal(t, hasSpec, tt.wantSpecPatch, "unexpected spec field in patch %s", string(gotPatch))
 
 			// Test SCMReportingPLRStarted annotation for started state
 			if tt.state == kubeinteraction.StateStarted {


### PR DESCRIPTION
## 📝 Description of the Change

`updatePipelineRunState` unconditionally included a `spec.status: ""` merge
patch whenever it moved a PipelineRun to the "started" state, even when
`spec.status` was already not `Pending` (e.g. when Tekton's own controller
had already cleared pending and started running the PipelineRun before PAC
got a chance to report it — the exact scenario already exercised by
`TestReconcileKindSCMReportingLogic`'s "Running reason without
SCMReportingPLRStarted" case). That patch is now only sent when
`pr.Spec.Status` is actually still `Pending`, avoiding a redundant, no-op
spec update on an already-started PipelineRun.

As @chmouel pointed out, this is defensive cleanup rather than a confirmed
fix for #2093: the vendored Tekton version here (v1.15.0) already allows
`spec.status` changes on a running PipelineRun, so the no-op patch is
harmless against it. We have not reproduced the admission webhook rejection
from #2093 against the affected Tekton version, so skipping this unneeded
patch removes one plausible trigger without confirming it's the one behind
that issue.

## 🔗 Linked GitHub Issue

Related to #2093 (not confirmed fixed — see description above)

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

AI assistance can be used for various tasks, such as code generation,
documentation, or testing.

Please indicate whether you have used AI assistance
for this PR and provide details if applicable.

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

> [!IMPORTANT]
>
> **Slop will be simply rejected**, if you are using AI assistance you need to make sure you
> understand the code generated and that it meets the project's standards. you
> need at least know how to run the code and deploy it (if needed). See
> [startpaac](https://github.com/openshift-pipelines/startpaac) to make it easy
> to deploy and test your code changes.
>
> If the **majority of the code** in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Claude <noreply@anthropic.com>

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center

---
AI assistance: this change was drafted with Claude Code.

Related to #2093
