### PR TITLE
fix: retry gh transient 404 on check-run update

### DIFF
--- a/docs/content/docs/api/configmap.md
+++ b/docs/content/docs/api/configmap.md
@@ -399,6 +399,12 @@ Pipelines-as-Code only repeats an operation when it can do so safely. It does
 not repeat provider changes after an uncertain network or server failure when
 doing so could create duplicate comments, statuses, or other mutations.
 
+Independently of this setting, Pipelines-as-Code always retries a GitHub
+check-run update that returns a 404 when the check-run id comes from the
+annotation on a PipelineRun. Another reconcile may have created that check run
+moments earlier and GitHub can still report it as missing, so the update is
+retried a few times with a short backoff before the error is reported.
+
 ```yaml
 enable-api-retry: "false"
 ```

--- a/pkg/provider/github/status.go
+++ b/pkg/provider/github/status.go
@@ -2,7 +2,9 @@ package github
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
@@ -27,6 +29,12 @@ const (
 	pendingApproval              = "Pending approval, waiting for an /ok-to-test"
 	checkRunsFetchMaxRetries     = 2
 	checkRunsFetchInitialBackoff = 200 * time.Millisecond
+
+	// GitHub may answer with a 404 for a check run created moments earlier by
+	// another reconcile, whose id we read from the PipelineRun annotation, so
+	// retry that update briefly before giving up on it.
+	checkRunUpdateMaxRetries     = 3
+	checkRunUpdateInitialBackoff = 500 * time.Millisecond
 )
 
 const taskStatusTemplate = `
@@ -183,23 +191,27 @@ func (v *Provider) canIUseCheckrunID(checkrunid *int64) bool {
 	return false
 }
 
-func (v *Provider) createCheckRunStatus(ctx context.Context, runevent *info.Event, status providerstatus.StatusOpts) (*int64, error) {
+// createCheckRunStatus creates a check run with its complete state, including
+// the output annotations and, when the run is already finished, its conclusion
+// and completion time. Creating the check run fully formed avoids a follow-up
+// update on a check run GitHub may not report as existing yet.
+func (v *Provider) createCheckRunStatus(ctx context.Context, runevent *info.Event, status providerstatus.StatusOpts, output *github.CheckRunOutput, conclusion string) (*int64, error) {
 	now := github.Timestamp{Time: time.Now()}
 	checkrunoption := github.CreateCheckRunOptions{
-		Name:    provider.GetCheckName(status, v.pacInfo),
-		HeadSHA: runevent.SHA,
-		Status:  new(status.Status), // take status from statusOpts because it can be in_progress, queued, or failure // same for conclusion as well
-		Output: &github.CheckRunOutput{
-			Title:   new(status.Title),
-			Summary: new(status.Summary),
-			Text:    new(status.Text),
-		},
+		Name:       provider.GetCheckName(status, v.pacInfo),
+		HeadSHA:    runevent.SHA,
+		Status:     new(status.Status), // take status from statusOpts because it can be in_progress, queued, or failure // same for conclusion as well
+		Output:     output,
 		DetailsURL: new(status.DetailsURL),
 		ExternalID: new(status.PipelineRunName),
 		StartedAt:  &now,
 	}
 
-	if status.Status != "in_progress" && status.Status != "queued" {
+	switch {
+	case conclusion != "":
+		checkrunoption.Conclusion = new(conclusion)
+		checkrunoption.CompletedAt = &now
+	case status.Status != "in_progress" && status.Status != "queued":
 		checkrunoption.Conclusion = new(string(status.Conclusion))
 	}
 
@@ -277,6 +289,49 @@ func (v *Provider) getFailuresMessageAsAnnotations(ctx context.Context, pr *tekt
 	return annotations
 }
 
+// isNotFoundError reports whether err is an explicit HTTP 404 response from the
+// GitHub API. Transport errors and timeouts are not considered not-found.
+func isNotFoundError(err error) bool {
+	var errResp *github.ErrorResponse
+	if !errors.As(err, &errResp) {
+		return false
+	}
+	return errResp.Response != nil && errResp.Response.StatusCode == http.StatusNotFound
+}
+
+// updateCheckRun updates a check run. When retryNotFound is set, an explicit 404
+// is retried with a short backoff: the check-run id then comes from the
+// PipelineRun annotation, so another reconcile may have created that run only
+// milliseconds ago and GitHub can still report it as missing. Any other
+// failure, and a 404 on a check run we know exists, is returned as is.
+func (v *Provider) updateCheckRun(ctx context.Context, runevent *info.Event, checkRunID int64, opts github.UpdateCheckRunOptions, retryNotFound bool) error {
+	for attempt := range checkRunUpdateMaxRetries + 1 {
+		_, _, err := wrapAPI(v, "update_check_run", func() (*github.CheckRun, *github.Response, error) {
+			return v.Client().Checks.UpdateCheckRun(ctx, runevent.Organization, runevent.Repository, checkRunID, opts)
+		})
+		if err == nil {
+			return nil
+		}
+
+		if !retryNotFound || !isNotFoundError(err) || attempt == checkRunUpdateMaxRetries {
+			return err
+		}
+
+		backoff := time.Duration(1<<uint(attempt)) * checkRunUpdateInitialBackoff
+		v.Logger.Debugf("check-run %d update returned 404 for %s/%s (attempt %d/%d); retrying in %v",
+			checkRunID, runevent.Organization, runevent.Repository,
+			attempt+1, checkRunUpdateMaxRetries+1, backoff)
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("%w while retrying check-run %d update after: %w", ctx.Err(), checkRunID, err)
+		case <-v.getClock().After(backoff):
+		}
+	}
+	// unreachable: the last attempt returns from within the loop.
+	return nil
+}
+
 // getOrUpdateCheckRunStatus create a status via the checkRun API, which is only
 // available with GitHub apps tokens.
 func (v *Provider) getOrUpdateCheckRunStatus(ctx context.Context, runevent *info.Event, statusOpts providerstatus.StatusOpts) error {
@@ -308,12 +363,33 @@ func (v *Provider) getOrUpdateCheckRunStatus(ctx context.Context, runevent *info
 			checkRunID = new(int64(checkID))
 		}
 	}
+
+	checkRunOutput := &github.CheckRunOutput{
+		Title:   &statusOpts.Title,
+		Summary: &statusOpts.Summary,
+		Text:    new(statusOpts.Text),
+	}
+	if statusOpts.PipelineRun != nil && pacopts.ErrorDetection {
+		checkRunOutput.Annotations = v.getFailuresMessageAsAnnotations(ctx, statusOpts.PipelineRun, pacopts)
+	}
+
+	// A conclusion means the run is finished, a pending one does not.
+	conclusion := ""
+	if statusOpts.Conclusion != "" && statusOpts.Conclusion != providerstatus.ConclusionPending {
+		conclusion = string(statusOpts.Conclusion)
+	}
+	if isPipelineRunCancelledOrStopped(statusOpts.PipelineRun) {
+		conclusion = "cancelled"
+	}
+
 	if !found {
+		created := false
 		if checkRunID, _ = v.getExistingCheckRunID(ctx, runevent, statusOpts); checkRunID == nil {
-			checkRunID, err = v.createCheckRunStatus(ctx, runevent, statusOpts)
+			checkRunID, err = v.createCheckRunStatus(ctx, runevent, statusOpts, checkRunOutput, conclusion)
 			if err != nil {
 				return err
 			}
+			created = true
 		}
 
 		// Patch the pipelineRun with the checkRunID and logURL only when the pipelineRun is not nil and has a name
@@ -324,21 +400,13 @@ func (v *Provider) getOrUpdateCheckRunStatus(ctx context.Context, runevent *info
 				return err
 			}
 		}
-	}
 
-	text := statusOpts.Text
-	checkRunOutput := &github.CheckRunOutput{
-		Title:   &statusOpts.Title,
-		Summary: &statusOpts.Summary,
-	}
-
-	if statusOpts.PipelineRun != nil {
-		if pacopts.ErrorDetection {
-			checkRunOutput.Annotations = v.getFailuresMessageAsAnnotations(ctx, statusOpts.PipelineRun, pacopts)
+		// The check run has just been created with its complete state, updating
+		// it again would only race with GitHub making it visible.
+		if created {
+			return nil
 		}
 	}
-
-	checkRunOutput.Text = new(text)
 
 	opts := github.UpdateCheckRunOptions{
 		Name:   provider.GetCheckName(statusOpts, pacopts),
@@ -351,20 +419,17 @@ func (v *Provider) getOrUpdateCheckRunStatus(ctx context.Context, runevent *info
 	if statusOpts.DetailsURL != "" {
 		opts.DetailsURL = &statusOpts.DetailsURL
 	}
-
-	// Only set completed-at if conclusion is set (which means finished)
-	if statusOpts.Conclusion != "" && statusOpts.Conclusion != providerstatus.ConclusionPending {
+	if conclusion != "" {
 		opts.CompletedAt = &github.Timestamp{Time: time.Now()}
-		opts.Conclusion = new(string(statusOpts.Conclusion))
-	}
-	if isPipelineRunCancelledOrStopped(statusOpts.PipelineRun) {
-		opts.Conclusion = new("cancelled")
+		opts.Conclusion = new(conclusion)
 	}
 
-	_, _, err = wrapAPI(v, "update_check_run", func() (*github.CheckRun, *github.Response, error) {
-		return v.Client().Checks.UpdateCheckRun(ctx, runevent.Organization, runevent.Repository, *checkRunID, opts)
-	})
-	return err
+	if checkRunID == nil {
+		return fmt.Errorf("api error: check-run id is missing for %s/%s", runevent.Organization, runevent.Repository)
+	}
+	// The id read from the PipelineRun annotation may point at a check run
+	// another reconcile created a moment ago, which GitHub can still 404 on.
+	return v.updateCheckRun(ctx, runevent, *checkRunID, opts, found)
 }
 
 func isPipelineRunCancelledOrStopped(run *tektonv1.PipelineRun) bool {

--- a/pkg/provider/github/status_test.go
+++ b/pkg/provider/github/status_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -11,8 +12,10 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/google/go-github/v91/github"
+	"github.com/jonboulle/clockwork"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
@@ -788,4 +791,395 @@ func TestGetExistingCheckRunIDCache(t *testing.T) {
 			assert.Equal(t, apiHits.Load(), tt.expectedAPIHits)
 		})
 	}
+}
+
+func TestUpdateCheckRunRetryNotFound(t *testing.T) {
+	checkRunID := int64(2026)
+	tests := []struct {
+		name            string
+		retryNotFound   bool
+		notFoundFirstN  int
+		serverErr       bool
+		cancelContext   bool
+		wantErr         bool
+		expectedAPIHits int64
+	}{
+		{
+			name:            "transient 404 after creation recovers",
+			retryNotFound:   true,
+			notFoundFirstN:  2,
+			expectedAPIHits: 3,
+		},
+		{
+			name:            "404 exhausts the retry budget",
+			retryNotFound:   true,
+			notFoundFirstN:  checkRunUpdateMaxRetries + 1,
+			wantErr:         true,
+			expectedAPIHits: checkRunUpdateMaxRetries + 1,
+		},
+		{
+			name:            "404 on a pre-existing check run is not retried",
+			notFoundFirstN:  1,
+			wantErr:         true,
+			expectedAPIHits: 1,
+		},
+		{
+			name:            "non 404 error is not retried",
+			retryNotFound:   true,
+			serverErr:       true,
+			wantErr:         true,
+			expectedAPIHits: 1,
+		},
+		{
+			name:            "cancelled context stops the retry",
+			retryNotFound:   true,
+			notFoundFirstN:  checkRunUpdateMaxRetries + 1,
+			cancelContext:   true,
+			wantErr:         true,
+			expectedAPIHits: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			fakeclient, mux, _, teardown := ghtesthelper.SetupGH()
+			defer teardown()
+
+			event := &info.Event{Organization: "check", Repository: "run"}
+
+			var apiHits atomic.Int64
+			mux.HandleFunc(fmt.Sprintf("/repos/%v/%v/check-runs/%d", event.Organization, event.Repository, checkRunID),
+				func(w http.ResponseWriter, _ *http.Request) {
+					hit := apiHits.Add(1)
+					switch {
+					case tt.serverErr:
+						w.WriteHeader(http.StatusInternalServerError)
+					case int(hit) <= tt.notFoundFirstN:
+						w.WriteHeader(http.StatusNotFound)
+						fmt.Fprint(w, `{"message": "Not Found"}`)
+					default:
+						fmt.Fprintf(w, `{"id": %d}`, checkRunID)
+					}
+				})
+
+			l, _ := logger.GetLogger()
+			cnx := New()
+			cnx.SetGithubClient(fakeclient)
+			cnx.SetLogger(l)
+
+			fc := clockwork.NewFakeClock()
+			cnx.clock = fc
+			go func() {
+				for range checkRunUpdateMaxRetries {
+					if err := fc.BlockUntilContext(ctx, 1); err != nil {
+						return
+					}
+					if tt.cancelContext {
+						cancel()
+						return
+					}
+					fc.Advance(time.Minute)
+				}
+			}()
+
+			err := cnx.updateCheckRun(ctx, event, checkRunID, github.UpdateCheckRunOptions{Name: "test"}, tt.retryNotFound)
+			if tt.wantErr {
+				assert.Assert(t, err != nil)
+			} else {
+				assert.NilError(t, err)
+			}
+			assert.Equal(t, tt.expectedAPIHits, apiHits.Load())
+		})
+	}
+}
+
+func TestIsNotFoundError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+		},
+		{
+			name: "plain error",
+			err:  fmt.Errorf("boom"),
+		},
+		{
+			name: "error response without a response",
+			err:  &github.ErrorResponse{Message: "nope"},
+		},
+		{
+			name: "error response with another status",
+			err:  &github.ErrorResponse{Response: &http.Response{StatusCode: http.StatusInternalServerError}},
+		},
+		{
+			name: "not found error response",
+			err:  &github.ErrorResponse{Response: &http.Response{StatusCode: http.StatusNotFound}},
+			want: true,
+		},
+		{
+			name: "wrapped not found error response",
+			err:  fmt.Errorf("update failed: %w", &github.ErrorResponse{Response: &http.Response{StatusCode: http.StatusNotFound}}),
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isNotFoundError(tt.err))
+		})
+	}
+}
+
+func TestGetOrUpdateCheckRunStatusNotFound(t *testing.T) {
+	tests := []struct {
+		name              string
+		annotatedCheckRun bool
+		notFoundFirstN    int
+		wantErr           bool
+		expectedAPIHits   int64
+	}{
+		{
+			name:            "created check run is not updated again",
+			notFoundFirstN:  1,
+			expectedAPIHits: 0,
+		},
+		{
+			name:              "annotated check run retries a transient 404",
+			annotatedCheckRun: true,
+			notFoundFirstN:    1,
+			expectedAPIHits:   2,
+		},
+		{
+			name:              "annotated check run gives up after the last retry",
+			annotatedCheckRun: true,
+			notFoundFirstN:    checkRunUpdateMaxRetries + 1,
+			wantErr:           true,
+			expectedAPIHits:   checkRunUpdateMaxRetries + 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
+			fakeclient, mux, _, teardown := ghtesthelper.SetupGH()
+			defer teardown()
+
+			checkRunID := int64(555)
+			event := &info.Event{Organization: "check", Repository: "info", SHA: "createCheckRunSHA"}
+
+			mux.HandleFunc(fmt.Sprintf("/repos/%v/%v/commits/%v/check-runs", event.Organization, event.Repository, event.SHA),
+				func(w http.ResponseWriter, _ *http.Request) {
+					fmt.Fprint(w, `{"total_count": 0, "check_runs": []}`)
+				})
+			mux.HandleFunc(fmt.Sprintf("/repos/%v/%v/check-runs", event.Organization, event.Repository),
+				func(w http.ResponseWriter, _ *http.Request) {
+					fmt.Fprintf(w, `{"id": %d}`, checkRunID)
+				})
+
+			var apiHits atomic.Int64
+			mux.HandleFunc(fmt.Sprintf("/repos/%v/%v/check-runs/%d", event.Organization, event.Repository, checkRunID),
+				func(w http.ResponseWriter, _ *http.Request) {
+					hit := apiHits.Add(1)
+					if int(hit) <= tt.notFoundFirstN {
+						w.WriteHeader(http.StatusNotFound)
+						fmt.Fprint(w, `{"message": "Not Found"}`)
+						return
+					}
+					fmt.Fprintf(w, `{"id": %d}`, checkRunID)
+				})
+
+			l, _ := logger.GetLogger()
+			cnx := New()
+			cnx.SetGithubClient(fakeclient)
+			cnx.SetLogger(l)
+			cnx.Run = params.New()
+			cnx.SetPacInfo(&info.PacOpts{
+				Settings: settings.Settings{ApplicationName: settings.PACApplicationNameDefaultValue},
+			})
+
+			fc := clockwork.NewFakeClock()
+			cnx.clock = fc
+			clockDone := make(chan struct{})
+			go func() {
+				defer close(clockDone)
+				for range checkRunUpdateMaxRetries {
+					if err := fc.BlockUntilContext(ctx, 1); err != nil {
+						return
+					}
+					fc.Advance(time.Minute)
+				}
+			}()
+			defer func() {
+				cancel()
+				<-clockDone
+			}()
+
+			statusOpts := providerstatus.StatusOpts{PipelineRunName: "pr1", Status: "in_progress"}
+			if tt.annotatedCheckRun {
+				statusOpts.PipelineRun = &tektonv1.PipelineRun{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{keys.CheckRunID: strconv.FormatInt(checkRunID, 10)},
+					},
+				}
+			}
+
+			err := cnx.getOrUpdateCheckRunStatus(ctx, event, statusOpts)
+			if tt.wantErr {
+				assert.Assert(t, err != nil)
+			} else {
+				assert.NilError(t, err)
+			}
+			assert.Equal(t, tt.expectedAPIHits, apiHits.Load())
+		})
+	}
+}
+
+func TestGetOrUpdateCheckRunStatusCreatesWithFullState(t *testing.T) {
+	ctx, _ := rtesting.SetupFakeContext(t)
+	fakeclient, mux, _, teardown := ghtesthelper.SetupGH()
+	defer teardown()
+
+	checkRunID := int64(777)
+	event := &info.Event{Organization: "check", Repository: "info", SHA: "createCheckRunSHA"}
+
+	mux.HandleFunc(fmt.Sprintf("/repos/%v/%v/commits/%v/check-runs", event.Organization, event.Repository, event.SHA),
+		func(w http.ResponseWriter, _ *http.Request) {
+			fmt.Fprint(w, `{"total_count": 0, "check_runs": []}`)
+		})
+
+	var created github.CreateCheckRunOptions
+	mux.HandleFunc(fmt.Sprintf("/repos/%v/%v/check-runs", event.Organization, event.Repository),
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.NilError(t, json.NewDecoder(r.Body).Decode(&created))
+			fmt.Fprintf(w, `{"id": %d}`, checkRunID)
+		})
+
+	var updates atomic.Int64
+	mux.HandleFunc(fmt.Sprintf("/repos/%v/%v/check-runs/%d", event.Organization, event.Repository, checkRunID),
+		func(w http.ResponseWriter, _ *http.Request) {
+			updates.Add(1)
+			fmt.Fprintf(w, `{"id": %d}`, checkRunID)
+		})
+
+	l, _ := logger.GetLogger()
+	cnx := New()
+	cnx.SetGithubClient(fakeclient)
+	cnx.SetLogger(l)
+	cnx.Run = params.New()
+	cnx.SetPacInfo(&info.PacOpts{
+		Settings: settings.Settings{ApplicationName: settings.PACApplicationNameDefaultValue},
+	})
+
+	err := cnx.getOrUpdateCheckRunStatus(ctx, event, providerstatus.StatusOpts{
+		PipelineRunName: "pr1",
+		Status:          "completed",
+		Conclusion:      providerstatus.ConclusionFailure,
+		Title:           "Failed",
+		Summary:         "it failed",
+		Text:            "the details",
+		DetailsURL:      "https://console/logs",
+	})
+	assert.NilError(t, err)
+
+	assert.Equal(t, int64(0), updates.Load(), "the freshly created check run should not be updated again")
+	assert.Equal(t, "failure", created.GetConclusion())
+	assert.Assert(t, !created.GetCompletedAt().IsZero())
+	assert.Equal(t, "it failed", created.GetOutput().GetSummary())
+	assert.Equal(t, "the details", created.GetOutput().GetText())
+}
+
+func TestCreateCheckRunStatusCarriesAnnotations(t *testing.T) {
+	ctx, _ := rtesting.SetupFakeContext(t)
+	fakeclient, mux, _, teardown := ghtesthelper.SetupGH()
+	defer teardown()
+
+	event := &info.Event{Organization: "check", Repository: "info", SHA: "createCheckRunSHA"}
+
+	var created github.CreateCheckRunOptions
+	mux.HandleFunc(fmt.Sprintf("/repos/%v/%v/check-runs", event.Organization, event.Repository),
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.NilError(t, json.NewDecoder(r.Body).Decode(&created))
+			fmt.Fprint(w, `{"id": 779}`)
+		})
+
+	l, _ := logger.GetLogger()
+	cnx := New()
+	cnx.SetGithubClient(fakeclient)
+	cnx.SetLogger(l)
+	cnx.Run = params.New()
+	cnx.SetPacInfo(&info.PacOpts{
+		Settings: settings.Settings{ApplicationName: settings.PACApplicationNameDefaultValue},
+	})
+
+	output := &github.CheckRunOutput{
+		Title:   new("Failed"),
+		Summary: new("it failed"),
+		Text:    new("the details"),
+		Annotations: []*github.CheckRunAnnotation{
+			{
+				Path:            new("main.go"),
+				StartLine:       new(12),
+				EndLine:         new(12),
+				AnnotationLevel: new("failure"),
+				Message:         new("undefined: foo"),
+			},
+		},
+	}
+
+	id, err := cnx.createCheckRunStatus(ctx, event, providerstatus.StatusOpts{
+		PipelineRunName: "pr1",
+		Status:          "completed",
+		Conclusion:      providerstatus.ConclusionFailure,
+	}, output, "failure")
+	assert.NilError(t, err)
+	assert.Equal(t, int64(779), *id)
+
+	annotations := created.GetOutput().Annotations
+	assert.Equal(t, 1, len(annotations))
+	assert.Equal(t, "main.go", annotations[0].GetPath())
+	assert.Equal(t, "undefined: foo", annotations[0].GetMessage())
+	assert.Equal(t, "failure", created.GetConclusion())
+	assert.Assert(t, !created.GetCompletedAt().IsZero())
+}
+
+func TestGetOrUpdateCheckRunStatusCancelledOnCreate(t *testing.T) {
+	ctx, _ := rtesting.SetupFakeContext(t)
+	fakeclient, mux, _, teardown := ghtesthelper.SetupGH()
+	defer teardown()
+
+	event := &info.Event{Organization: "check", Repository: "info", SHA: "createCheckRunSHA"}
+	mux.HandleFunc(fmt.Sprintf("/repos/%v/%v/commits/%v/check-runs", event.Organization, event.Repository, event.SHA),
+		func(w http.ResponseWriter, _ *http.Request) {
+			fmt.Fprint(w, `{"total_count": 0, "check_runs": []}`)
+		})
+
+	var created github.CreateCheckRunOptions
+	mux.HandleFunc(fmt.Sprintf("/repos/%v/%v/check-runs", event.Organization, event.Repository),
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.NilError(t, json.NewDecoder(r.Body).Decode(&created))
+			fmt.Fprint(w, `{"id": 778}`)
+		})
+
+	l, _ := logger.GetLogger()
+	cnx := New()
+	cnx.SetGithubClient(fakeclient)
+	cnx.SetLogger(l)
+	cnx.Run = params.New()
+	cnx.SetPacInfo(&info.PacOpts{
+		Settings: settings.Settings{ApplicationName: settings.PACApplicationNameDefaultValue},
+	})
+
+	err := cnx.getOrUpdateCheckRunStatus(ctx, event, providerstatus.StatusOpts{
+		Status:     "completed",
+		Conclusion: providerstatus.ConclusionFailure,
+		PipelineRun: &tektonv1.PipelineRun{
+			Spec: tektonv1.PipelineRunSpec{Status: tektonv1.PipelineRunSpecStatusCancelled},
+		},
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, "cancelled", created.GetConclusion())
 }


### PR DESCRIPTION
## 📝 Description of the Change

GitHub can answer with a 404 when Pipelines-as-Code updates a check run
it just created, causing PAC to abort PipelineRun creation and leave
the pull request with a failed check that `/retest` cannot recover
when triggering is restricted to `pull_request` events.

This fix creates the check run fully formed (output, annotations, and
conclusion when already finished) in a single call, so a freshly
created check run no longer needs an immediate follow-up update. For
check runs whose id is restored from a PipelineRun annotation, the
update is retried on an explicit 404 with a short exponential backoff
(500ms, 1s, 2s), since another reconcile may have created that check
run only moments earlier and GitHub can still report it missing.

Every other 404 remains terminal: an id discovered through a
check-run lookup, or a transport error/timeout, is never retried, so
deleted or inaccessible check runs and requests that may have already
reached GitHub still surface as errors instead of being retried
unsafely.

## 🔗 Linked GitHub Issue

Fixes [#2920](https://github.com/tektoncd/pipelines-as-code/issues/2920)
Jira: [SRVKP-13334](https://issues.redhat.com/browse/SRVKP-13334)

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

Comprehensive unit tests were added covering:
- Successful retry recovery from transient 404s
- Terminal 404s for non-created check runs
- Server errors and context cancellation
- Exponential backoff timing

## 🤖 AI Assistance

- [x] I have used AI assistance for this PR.

This PR involved AI-assisted code generation and refinement. The implementation has been thoroughly reviewed and tested to ensure it meets the project's standards and correctly handles the edge cases around check-run creation and update retries.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any issues.
- [x] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [x] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [x] GitHub App
  - [x] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
