### PR TITLE
fix: exclude generated and non-library code from codecov coverage

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,26 +1,28 @@
 coverage:
-  # Commit status https://docs.codecov.io/docs/commit-status are used
-  # to block PR based on coverage threshold.
   status:
     project:
       default:
         target: auto
         threshold: 5%
     patch:
-      # Disable the coverage threshold of the patch, so that PRs are
-      # only failing because of overall project coverage threshold.
-      # See https://docs.codecov.io/docs/commit-status#disabling-a-status.
       default: false
 
 ignore:
+  # Auto-generated code.
   - "**/zz_generated*.go"
   - "**/*.pb.go"
-  - "hack"
+  - "**/fake/**"
+  # Auto-generated client/informer/lister code.
   - "pkg/generated"
+  # API type definitions.
   - "pkg/apis"
-  - "cmd/*"
+  # Entry-point binaries.
+  - "cmd"
+  # Test infrastructure.
   - "test"
   - "pkg/test"
   - "pkg/provider/**/test"
-  - "third_party"
+  - "hack"
+  - "config"
+  - "docs"
   - "vendor"

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -40,7 +40,12 @@ jobs:
           go-version-file: "go.mod"
 
       - name: Run unit tests with coverage
-        run: go test -coverprofile=coverage.txt -covermode=atomic ./pkg/...
+        run: |
+          PACKAGES=$(go list ./... | grep -vE '/cmd(/|$)|/vendor(/|$)|/hack(/|$)|/test(/|$)|/config(/|$)|/docs(/|$)|/pkg/generated(/|$)|/pkg/apis(/|$)|/pkg/test(/|$)|/pkg/provider/.*/test(/|$)|/fake(/|$)')
+          COVERPKG=$(echo $PACKAGES | tr ' ' ',')
+          go test -coverprofile=coverage_raw.txt -covermode=atomic -coverpkg="$COVERPKG" $PACKAGES
+          grep -vE 'zz_generated\.deepcopy\.go|\.pb\.go' coverage_raw.txt > coverage.txt
+          rm -f coverage_raw.txt
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
@@ -49,3 +54,4 @@ jobs:
           flags: unit-tests
           use_oidc: true
           fail_ci_if_error: true
+          disable_search: true


### PR DESCRIPTION
Codecov reports low coverage because it includes auto-generated client code, vendored deps, CLI entry points, and test infrastructure in the denominator. Filter these out so coverage reflects actual library code. Mirrors the approach proven in tektoncd/triggers#2101.

- Replace bare `go test ./pkg/...` with filtered package list + `-coverpkg`
- Strip zz_generated and .pb.go files from profile
- Add `disable_search: true` to codecov upload step
- Use bare directory names in .codecov.yaml

## 📝 Description of the Change

## 🔗 Linked GitHub Issue

Fixes #

<!-- This is optional, but if you have a Jira ticket related to this PR, please link it here. -->

## 🧪 Testing Strategy

- [ ] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

## 🤖 AI Assistance

AI assistance can be used for various tasks, such as code generation,
documentation, or testing.

Please indicate whether you have used AI assistance
for this PR and provide details if applicable.

- [ ] I have not used any AI assistance for this PR.
- [ ] I have used AI assistance for this PR.

> [!IMPORTANT]
>
> **Slop will be simply rejected**, if you are using AI assistance you need to make sure you
> understand the code generated and that it meets the project's standards. you
> need at least know how to run the code and deploy it (if needed). See
> [startpaac](https://github.com/openshift-pipelines/startpaac) to make it easy
> to deploy and test your code changes.
>
> If the **majority of the code** in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Claude <noreply@anthropic.com>

## ✅ Submitter Checklist

- [ ] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [ ] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [ ] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [ ] 📖 I have added or updated documentation for any user-facing changes.
- [ ] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center
