### PR TITLE
Security: Fix 6 Go stdlib CVEs (Go 1.26.5 → 1.26.6) - release-v0.50.x

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift-pipelines/pipelines-as-code
 
-go 1.26.5
+go 1.26.6
 
 require (
 	codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v3 v3.0.0


### PR DESCRIPTION
## Summary

This PR fixes **6 Go standard library CVEs** by upgrading the Go version from `1.26.5` to `1.26.6` in `go.mod`.

### CVE Details

| CVE ID | Go Vuln ID | Package | Description |
|--------|-----------|---------|-------------|
| CVE-2026-56860 | GO-2026-6218 | net/url | Quadratic complexity in resolvePath |
| CVE-2026-56858 | GO-2026-6091 | html/template | Javascript regexp context tracking |
| CVE-2026-56862 | GO-2026-6090 | crypto/tls | Unbounded post-handshake message accumulation |
| CVE-2026-56853 | GO-2026-6089 | net/http | ReadHeaderTimeout bypass in HTTP/2 |
| CVE-2026-33818 | GO-2026-5972 | encoding/asn1 | Excessive recursion depth during decode |
| CVE-2026-39821 | GO-2026-5026 | net (via x/net/idna) | Punycode ASCII-only label rejection |

**All CVEs are fixed in Go 1.26.6.** Pre-fix scan detected 7 callable vulnerabilities; post-fix scan confirms 0 remaining callable stdlib CVEs.

### Fix Summary

- **go.mod**: Updated `go 1.26.5` → `go 1.26.6`
- **go mod tidy + go mod verify**: Both run successfully
- **go build ./...**: Succeeds with no errors
- **govulncheck post-fix**: 0 callable stdlib CVEs remaining

### Test Results

**Status**: ✅ Tests passed

**Tests run**: `go test ./pkg/resolve/... ./pkg/matcher/... ./pkg/params/...`
**Result**: All PASSED
**Build**: `go build ./...` succeeded

### Breaking Changes

None. This is a patch-level Go toolchain update (1.26.5 → 1.26.6) with no API changes.

### Verification Steps

- [x] Pre-fix govulncheck confirmed 6+ callable stdlib CVEs
- [x] go.mod updated from 1.26.5 to 1.26.6
- [x] go mod tidy run successfully
- [x] go mod verify: all modules verified
- [x] go build succeeded
- [x] Post-fix govulncheck: 0 callable stdlib CVEs

### Risk Assessment

**Risk: Low** — Patch-level Go toolchain update in the same minor line (1.26.x). No API changes, no dependency graph changes. Standard security patch.

---
🤖 Generated by CVE Fixer Workflow
<!-- cve-fixer-workflow -->