### PR TITLE
refactor: export ControllerConfigMap and reuse in bootstrap

### DIFF
--- a/pkg/cmd/tknpac/bootstrap/kubestuff.go
+++ b/pkg/cmd/tknpac/bootstrap/kubestuff.go
@@ -6,8 +6,8 @@ import (
 	"slices"
 
 	"github.com/google/go-github/v90/github"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/hostpolicy"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
-	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/vcshost"
 	corev1 "k8s.io/api/core/v1"
@@ -49,10 +49,7 @@ func createPacSecret(ctx context.Context, run *params.Run, opts *bootstrapOpts, 
 // immediately: the hostname comes from the user running the bootstrap, not from
 // a webhook payload.
 func trustProviderHostname(ctx context.Context, run *params.Run, opts *bootstrapOpts) error {
-	configMapName := info.DefaultPipelinesAscodeConfigmapName
-	if run.Info.Controller != nil && run.Info.Controller.Configmap != "" {
-		configMapName = run.Info.Controller.Configmap
-	}
+	configMapName := hostpolicy.ControllerConfigMap(run)
 
 	host, err := vcshost.Parse(opts.GithubAPIURL)
 	if err != nil {

--- a/pkg/hostpolicy/hostpolicy.go
+++ b/pkg/hostpolicy/hostpolicy.go
@@ -68,7 +68,7 @@ func Trusted(ctx context.Context, run *params.Run, rawHost string) (string, erro
 	}
 
 	namespace := info.GetNS(ctx)
-	configMapName := controllerConfigMap(run)
+	configMapName := ControllerConfigMap(run)
 	policy, err := readPolicy(ctx, run.Clients.Kube, namespace, configMapName)
 	if err != nil {
 		return "", err
@@ -94,7 +94,7 @@ func TrustOnFirstUse(ctx context.Context, run *params.Run, rawHost string) (stri
 	canonical := vcshost.Canonical(host)
 
 	namespace := info.GetNS(ctx)
-	configMapName := controllerConfigMap(run)
+	configMapName := ControllerConfigMap(run)
 	if run.Clients.Kube == nil {
 		return "", noKubeClientError(namespace, configMapName)
 	}
@@ -149,10 +149,10 @@ func TrustOnFirstUse(ctx context.Context, run *params.Run, rawHost string) (stri
 	return canonical, nil
 }
 
-// controllerConfigMap returns the ConfigMap holding this controller policy. Each
+// ControllerConfigMap returns the ConfigMap holding this controller policy. Each
 // controller has its own, so a second controller can never widen the policy of
 // the first one.
-func controllerConfigMap(run *params.Run) string {
+func ControllerConfigMap(run *params.Run) string {
 	if run.Info.Controller != nil && run.Info.Controller.Configmap != "" {
 		return run.Info.Controller.Configmap
 	}

--- a/pkg/hostpolicy/hostpolicy_test.go
+++ b/pkg/hostpolicy/hostpolicy_test.go
@@ -385,6 +385,36 @@ func TestTrustedUsesControllerConfigMap(t *testing.T) {
 	assert.ErrorContains(t, err, "is not listed in")
 }
 
+func TestControllerConfigMap(t *testing.T) {
+	tests := []struct {
+		name       string
+		controller *info.ControllerInfo
+		want       string
+	}{
+		{
+			name:       "nil controller falls back to default",
+			controller: nil,
+			want:       info.DefaultPipelinesAscodeConfigmapName,
+		},
+		{
+			name:       "empty configmap field falls back to default",
+			controller: &info.ControllerInfo{Configmap: ""},
+			want:       info.DefaultPipelinesAscodeConfigmapName,
+		},
+		{
+			name:       "custom configmap is returned",
+			controller: &info.ControllerInfo{Configmap: "my-configmap"},
+			want:       "my-configmap",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			run := &params.Run{Info: info.Info{Controller: tt.controller}}
+			assert.Equal(t, ControllerConfigMap(run), tt.want)
+		})
+	}
+}
+
 // The error must tell the administrator exactly how to fix the situation.
 func TestNotTrustedErrorIsActionable(t *testing.T) {
 	err := NotTrustedError(testNamespace, testConfigMapName, "ghe.example.com", reasonUnconfigured)


### PR DESCRIPTION
## Description of the Change

Follow-up on @zakisk's [review comment](https://github.com/tektoncd/pipelines-as-code/pull/2871#pullrequestreview-4969228464) on PR #2871.

The `controllerConfigMap` helper in `pkg/hostpolicy` and the inline logic
in `pkg/cmd/tknpac/bootstrap/kubestuff.go` both resolve the controller
ConfigMap name with the same fallback. This PR exports the helper as
`ControllerConfigMap` so the bootstrap package can call it directly
instead of duplicating the logic.

## Linked GitHub Issue

Addresses review feedback from #2871.

## Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [x] Not Applicable

Existing tests in both `pkg/hostpolicy` and `pkg/cmd/tknpac/bootstrap`
continue to pass — no behavior change, just a rename and reuse.

## AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

## Submitter Checklist

- [x] My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits).
- [x] I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] I have run `make test` and `make lint` locally to check for and fix any issues.
- [x] I have added or updated documentation for any user-facing changes.
- [x] I have added sufficient unit tests for my code changes.
- [x] I have addressed any CI test flakiness or provided a clear reason to bypass it.