### PR TITLE
Security: Fix CVE-2026-33211 (tektoncd/pipeline path traversal)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.10.2
-	github.com/tektoncd/pipeline v1.15.0
+	github.com/tektoncd/pipeline v1.15.1
 	gitlab.com/gitlab-org/api/client-go v1.46.0
 	// otel is pinned via the replace block below, see the comment there.
 	go.opentelemetry.io/otel v1.45.0

--- a/go.sum
+++ b/go.sum
@@ -269,8 +269,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/tektoncd/pipeline v1.15.0 h1:ZGboFUaEdpYurZWqeGT5rn9e6qmomGL/gLSKhHp2vvQ=
-github.com/tektoncd/pipeline v1.15.0/go.mod h1:HghtkZ1D9b91o0YiXABDUd+c2C6R4kbk+PumnHqs3Bk=
+github.com/tektoncd/pipeline v1.15.1 h1:eCGlMonJr7OhiLaaykO/+qXZv15eijswriT7JrLW9aQ=
+github.com/tektoncd/pipeline v1.15.1/go.mod h1:t2/vjjHPODK3hvx1OFgWVyo9Va/gGE1gR3o/beAsXKg=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -388,7 +388,7 @@ github.com/spf13/cobra
 # github.com/spf13/pflag v1.0.10
 ## explicit; go 1.12
 github.com/spf13/pflag
-# github.com/tektoncd/pipeline v1.15.0
+# github.com/tektoncd/pipeline v1.15.1
 ## explicit; go 1.26.4
 github.com/tektoncd/pipeline/internal/artifactref
 github.com/tektoncd/pipeline/pkg/apis/config


### PR DESCRIPTION
## Summary

This PR fixes **CVE-2026-33211** by upgrading \`github.com/tektoncd/pipeline\` from v1.15.0 to v1.15.1.

### CVE Details
- **CVE ID**: CVE-2026-33211
- **GHSA**: GHSA-j5q5-j9gm-2w5c
- **Package**: github.com/tektoncd/pipeline
- **Severity**: CRITICAL
- **Impact**: Path traversal in Tekton Pipelines git resolver — allows reading arbitrary files from resolver pod
- **Vulnerable versions**: < v1.15.1
- **Fixed version**: v1.15.1
- **Jira Issues**: SRVKP-12834

### Fix Summary
- Updated \`github.com/tektoncd/pipeline\` from \`v1.15.0\` → \`v1.15.1\` (minimum safe patch in 1.15.x line)
- Ran \`go mod tidy\`, \`go mod verify\`, \`make vendor\`, \`go build ./...\` — all passed

### Test Results

**Status**: ⚠️ Unit tests running in CI

**Build verification**: ✅ \`go build ./...\` passed
**go mod verify**: ✅ all modules verified

### Breaking Changes
None — v1.15.1 is a patch release with security fix only.

### Verification Steps
- [x] CVE present at v1.15.0 (GHSA-j5q5-j9gm-2w5c)
- [x] v1.15.1 is minimum safe patch in same minor line
- [x] go mod tidy + go mod verify passed
- [x] make vendor completed successfully
- [x] Build passes with no errors

### Risk Assessment
**Low** — patch-only bump within 1.15.x; no API changes expected.

---

🤖 Generated by CVE Fixer Workflow
<!-- cve-fixer-workflow -->