### PR TITLE
Security: Fix Go stdlib CVEs - bump Go 1.26.5 to 1.26.6 (release-v0.49.x)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift-pipelines/pipelines-as-code
 
-go 1.26.5
+go 1.26.6
 
 require (
 	codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v3 v3.0.0


### PR DESCRIPTION
## Summary

This PR fixes **6 Go standard library CVEs** by upgrading Go from `1.26.5` to `1.26.6` in `go.mod`.

### CVE Details

| CVE / Go ID | Package | Fixed In |
|---|---|---|
| GO-2026-6218 | net/url | go1.26.6 |
| GO-2026-6091 | html/template | go1.26.6 |
| GO-2026-6090 | crypto/tls | go1.26.6 |
| GO-2026-6089 | net/http | go1.26.6 |
| GO-2026-5972 | encoding/asn1 | go1.26.6 |
| GO-2026-5026 | net/http | go1.26.6 |

### Fix Summary

Updated go 1.26.5 to go 1.26.6 in go.mod. Ran go mod tidy and go mod verify.

### Jira References

Resolves: SRVKP-12834

### Test Results

Status: All tests passed. Command: go test ./pkg/... — 30 packages, 0 failures.

### Breaking Changes

None. Patch version upgrade within 1.26.x — fully backward compatible.

### Risk Assessment

Low risk. Single line change in go.mod. All unit tests pass. Go 1.26 patch release.

---
Generated by CVE Fixer Workflow