### PR TITLE
fix(watcher): gate /debug/queue behind an env var

### DIFF
--- a/cmd/pipelines-as-code-watcher/main.go
+++ b/cmd/pipelines-as-code-watcher/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -17,6 +18,23 @@ import (
 )
 
 const globalProbesPort = "8080"
+
+// queueDebugEnabled reports whether PAC_ENABLE_QUEUE_DEBUG asks for the
+// /debug/queue endpoint. It defaults to disabled and fails closed: an unset or
+// unparseable value never enables it, and an invalid value is logged so a typo
+// in the deployment does not silently do nothing.
+func queueDebugEnabled() bool {
+	val, ok := os.LookupEnv("PAC_ENABLE_QUEUE_DEBUG")
+	if !ok {
+		return false
+	}
+	enabled, err := strconv.ParseBool(val)
+	if err != nil {
+		log.Printf("PAC_ENABLE_QUEUE_DEBUG=%q is not a valid boolean, leaving /debug/queue disabled: %v", val, err)
+		return false
+	}
+	return enabled
+}
 
 func main() {
 	probesPort := globalProbesPort
@@ -33,7 +51,14 @@ func main() {
 
 	// Read-only view of the concurrency queues, so a test or an operator can
 	// tell whether the queue still agrees with the cluster.
-	mux.HandleFunc("/debug/queue", queue.DebugHandler())
+	//
+	// This is unauthenticated and reachable from any pod that can route to
+	// this one, including untrusted PipelineRun workloads, so it stays off
+	// unless explicitly enabled. An absent route beats one that answers 403,
+	// since it does not confirm the feature exists to probe further.
+	if queueDebugEnabled() {
+		mux.HandleFunc("/debug/queue", queue.DebugHandler())
+	}
 
 	c := make(chan struct{})
 	go func() {

--- a/cmd/pipelines-as-code-watcher/main_test.go
+++ b/cmd/pipelines-as-code-watcher/main_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestQueueDebugEnabled(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		set  bool
+		want bool
+	}{
+		{name: "unset defaults to disabled", set: false, want: false},
+		{name: "empty string is not a valid bool, fails closed", env: "", set: true, want: false},
+		{name: "true enables it", env: "true", set: true, want: true},
+		{name: "1 enables it", env: "1", set: true, want: true},
+		{name: "false disables it", env: "false", set: true, want: false},
+		{name: "0 disables it", env: "0", set: true, want: false},
+		{name: "garbage fails closed", env: "yolo", set: true, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.set {
+				t.Setenv("PAC_ENABLE_QUEUE_DEBUG", tt.env)
+			} else {
+				value, exists := os.LookupEnv("PAC_ENABLE_QUEUE_DEBUG")
+				assert.NilError(t, os.Unsetenv("PAC_ENABLE_QUEUE_DEBUG"))
+				t.Cleanup(func() {
+					if exists {
+						assert.NilError(t, os.Setenv("PAC_ENABLE_QUEUE_DEBUG", value))
+						return
+					}
+					assert.NilError(t, os.Unsetenv("PAC_ENABLE_QUEUE_DEBUG"))
+				})
+			}
+			assert.Equal(t, queueDebugEnabled(), tt.want)
+		})
+	}
+}

--- a/docs/content/docs/advanced/concurrency.md
+++ b/docs/content/docs/advanced/concurrency.md
@@ -46,15 +46,34 @@ queue looks stuck — nothing starting, or more running than the configured
 `concurrency_limit` — the fastest way to find out why is to ask the watcher
 directly instead of guessing from PipelineRun status.
 
-The watcher serves a read-only, JSON snapshot of its in-memory queues on
+The watcher can serve a read-only, JSON snapshot of its in-memory queues on
 `/debug/queue`, on the same port it already uses for its health probe.
 
-{{< callout type="info" >}}
-This exposes only the limit and the PipelineRun names PAC currently considers
-running or pending for each repository — nothing that is not already visible by
-listing PipelineRuns. It is meant for troubleshooting, not for regular
-monitoring.
+{{< callout type="warning" >}}
+This endpoint is disabled by default and must be explicitly enabled. It is
+unauthenticated: anything that can reach the watcher pod on its probe port
+(any workload in the cluster with network access to it, not just cluster
+API clients) can read the namespace, Repository name, and pending/running
+PipelineRun names for every repository the watcher knows about. Only turn it
+on for troubleshooting, and turn it back off afterward.
 {{< /callout >}}
+
+### Enabling it
+
+Set `PAC_ENABLE_QUEUE_DEBUG=true` on the `pac-watcher` container in the
+`pipelines-as-code-watcher` Deployment, then restart the pod:
+
+```shell
+kubectl -n pipelines-as-code set env deployment/pipelines-as-code-watcher \
+  -c pac-watcher PAC_ENABLE_QUEUE_DEBUG=true
+```
+
+Unset it (or set it to `false`) to disable the endpoint again:
+
+```shell
+kubectl -n pipelines-as-code set env deployment/pipelines-as-code-watcher \
+  -c pac-watcher PAC_ENABLE_QUEUE_DEBUG-
+```
 
 ### Querying it
 

--- a/test/gitea_concurrency_test.go
+++ b/test/gitea_concurrency_test.go
@@ -571,7 +571,10 @@ func TestGiteaConcurrencyTransientAPIFailureDoesNotWedgeQueue(t *testing.T) {
 	runcnx, opts, giteacnx, err := tgitea.Setup(ctx)
 	assert.NilError(t, err)
 
-	// Restarts the watcher, so it has to happen before there is anything queued.
+	// Restarts the watcher, so it has to happen before there is anything
+	// queued: enabling it later, after the scenario, would reset the
+	// in-memory queue state this test relies on AssertQueueDrained to check.
+	tkubestuff.EnsureQueueDebugEnabled(ctx, t, runcnx)
 
 	yamlFiles := map[string]string{}
 	for i := 0; i < numPipelines; i++ {

--- a/test/pkg/kubestuff/watcher.go
+++ b/test/pkg/kubestuff/watcher.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -23,7 +24,10 @@ const (
 	watcherDeployment = "pipelines-as-code-watcher"
 	watcherContainer  = "pac-watcher"
 	watcherProbesPort = "probes"
+	queueDebugEnvVar  = "PAC_ENABLE_QUEUE_DEBUG"
 )
+
+var enableQueueDebugOnce sync.Once
 
 // WatcherHealth is a snapshot of how many times the watcher has restarted.
 type WatcherHealth struct {
@@ -97,6 +101,13 @@ func BounceWatcher(ctx context.Context, t *testing.T, runcnx *params.Run) {
 // The endpoint answers 503 while the reconciler holds the queue lock, since it
 // gives up rather than block the thing it is reporting on. That is expected
 // under load, so retry for a bit before calling it a failure.
+//
+// Callers that intend to inspect queue state after running a scenario (for
+// example to detect a stranded reservation) must call
+// EnsureQueueDebugEnabled themselves *before* the scenario runs. Enabling it
+// here, lazily, would restart the watcher right when its in-memory state is
+// being examined, silently resetting whatever the scenario was trying to
+// prove leaked or did not leak.
 func QueueSnapshot(ctx context.Context, t *testing.T, runcnx *params.Run) map[string]queue.RepoQueue {
 	t.Helper()
 	pods := watcherPods(ctx, t, runcnx)
@@ -164,6 +175,90 @@ func keysOf(snapshot map[string]queue.RepoQueue) []string {
 		out = append(out, key)
 	}
 	return out
+}
+
+// EnsureQueueDebugEnabled turns on the watcher's /debug/queue endpoint if it
+// is not already on. The endpoint is disabled by default (it is
+// unauthenticated cluster-wide metadata), so E2E has to opt in explicitly the
+// same way an operator would, rather than relying on a special install.
+//
+// This restarts the watcher, so callers must invoke it before a scenario
+// queues or runs anything they intend to inspect afterward with
+// QueueSnapshot or AssertQueueDrained. Enabling it lazily, after the fact,
+// would reset the very in-memory state the scenario is trying to prove
+// leaked or did not leak.
+func EnsureQueueDebugEnabled(ctx context.Context, t *testing.T, runcnx *params.Run) {
+	t.Helper()
+	enableQueueDebugOnce.Do(func() {
+		dep, err := runcnx.Clients.Kube.AppsV1().Deployments(watcherNamespace).Get(ctx, watcherDeployment, metav1.GetOptions{})
+		assert.NilError(t, err)
+
+		foundContainer := false
+		for i := range dep.Spec.Template.Spec.Containers {
+			c := &dep.Spec.Template.Spec.Containers[i]
+			if c.Name != watcherContainer {
+				continue
+			}
+			foundContainer = true
+			foundEnv := false
+			for j := range c.Env {
+				if c.Env[j].Name == queueDebugEnvVar {
+					if v, parseErr := strconv.ParseBool(c.Env[j].Value); parseErr == nil && v {
+						return // already enabled, nothing to do
+					}
+					// Replacing the full entry also clears ValueFrom, which
+					// cannot be set alongside a non-empty Value.
+					c.Env[j] = corev1.EnvVar{Name: queueDebugEnvVar, Value: "true"}
+					foundEnv = true
+					break
+				}
+			}
+			if !foundEnv {
+				c.Env = append(c.Env, corev1.EnvVar{Name: queueDebugEnvVar, Value: "true"})
+			}
+			break
+		}
+		if !foundContainer {
+			t.Fatalf("watcher deployment has no %q container", watcherContainer)
+		}
+		updatedDep, err := runcnx.Clients.Kube.AppsV1().Deployments(watcherNamespace).Update(ctx, dep, metav1.UpdateOptions{})
+		assert.NilError(t, err)
+		runcnx.Clients.Log.Infof("enabled %s on the watcher deployment for this test run", queueDebugEnvVar)
+		// Use the generation the server assigned to this update, not the one
+		// on the pre-update object: that one is already <= the deployment
+		// controller's current ObservedGeneration, so waiting on it would
+		// return immediately instead of waiting for the new pods to roll out.
+		waitForWatcherRollout(ctx, t, runcnx, updatedDep.Generation)
+	})
+}
+
+// waitForWatcherRollout waits until the deployment controller has observed the
+// update and the rollout has fully completed: every desired replica is
+// updated, available, and ready, and none of the old pod template's replicas
+// remain. Checking UpdatedReplicas/ReadyReplicas alone is not enough on a
+// single-replica rollout: the new pod can count toward UpdatedReplicas before
+// it is ready while the old pod still counts toward ReadyReplicas, letting a
+// caller proceed while the old, pre-change watcher is still serving traffic.
+func waitForWatcherRollout(ctx context.Context, t *testing.T, runcnx *params.Run, targetGeneration int64) {
+	t.Helper()
+	for range 60 {
+		dep, err := runcnx.Clients.Kube.AppsV1().Deployments(watcherNamespace).Get(ctx, watcherDeployment, metav1.GetOptions{})
+		assert.NilError(t, err)
+		want := int32(1)
+		if dep.Spec.Replicas != nil {
+			want = *dep.Spec.Replicas
+		}
+		if dep.Status.ObservedGeneration >= targetGeneration &&
+			dep.Status.UpdatedReplicas == want &&
+			dep.Status.Replicas == want &&
+			dep.Status.AvailableReplicas == want &&
+			dep.Status.ReadyReplicas == want {
+			runcnx.Clients.Log.Infof("watcher rollout settled with %s enabled", queueDebugEnvVar)
+			return
+		}
+		time.Sleep(2 * time.Second)
+	}
+	t.Fatalf("watcher did not roll out the %s change within 2 minutes", queueDebugEnvVar)
 }
 
 func waitForWatcherReplicas(ctx context.Context, t *testing.T, runcnx *params.Run, want int32) {


### PR DESCRIPTION
## 📝 Description of the Change

The watcher has a debug page (`/debug/queue`) that shows what it
currently thinks is running or waiting for every repository it manages.
It was always turned on, with no login or token required, and reachable
by anything that can reach the watcher pod over the network — not just
someone with Kubernetes access. That page shows namespace names,
repository names, and PipelineRun names across every team using the
cluster, which is more than a random pod should be able to see.

This change turns that page off by default. An admin who wants it for
troubleshooting can turn it on with an environment variable, and it
stays off if that variable is missing or set to something that isn't a
clear yes/no. Docs and the end-to-end test helper were updated to match:
the test helper now turns the page on itself before reading it, the way
an admin would.

## 🔗 Linked GitHub Issue

Fixes #2947

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [x] Manual testing
- [ ] Not Applicable

Added a test covering: the variable unset, empty, `true`, `1`, `false`,
`0`, and garbage input, checking the page only turns on for a clear
"yes". Also ran `go build`/`go test` on the watcher binary and the
end-to-end helper package to confirm nothing else broke.

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

This PR was written with AI assistance (Claude Sonnet 5),
following a post-merge review of PR #2890. The exposure was confirmed by
hand (checked the deployment config and confirmed there is no
NetworkPolicy restricting pod-to-pod traffic), and the fix and test were
verified to build and pass before submitting.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [x] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [ ] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [ ] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center

