### PR TITLE
fix: update golangci to golangci-2.13 and fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -127,7 +127,8 @@ formatters:
     - goimports
   settings:
     gofumpt:
-      extra-rules: true
+      extra:
+        group-params: true
   exclusions:
     generated: lax
     paths:

--- a/.tekton/go.yaml
+++ b/.tekton/go.yaml
@@ -91,7 +91,7 @@ spec:
 
             - name: lint
               displayName: "Go Lint"
-              image: docker.io/golangci/golangci-lint:v2.12.2
+              image: docker.io/golangci/golangci-lint:v2.13.2
               workingDir: $(workspaces.source.path)
               env:
                 - name: GOCACHE

--- a/.vale.ini
+++ b/.vale.ini
@@ -16,7 +16,8 @@ IgnoredScopes = code, tt, img, url, a, body.id
 # SkippedScopes specifies block-level HTML tags to ignore. Ignore any content in these scopes.
 # Default: ignore `script`, `style`, `pre`, and `figure`.
 # For AsciiDoc: by default, listingblock, and literalblock.
-SkippedScopes = script, style, pre, figure, code, tt, blockquote, listingblock, literalblock
+# Keep inline code scopes (`code`, `tt`) in `IgnoredScopes`; only block-level scopes belong here.
+SkippedScopes = script, style, pre, figure, blockquote, listingblock, literalblock
 
 [*]
 BasedOnStyles = Vale, RedHat, PaaC

--- a/pkg/customparams/standard.go
+++ b/pkg/customparams/standard.go
@@ -41,25 +41,27 @@ func (p *CustomParams) makeStandardParamsFromEvent(ctx context.Context) (map[str
 		gitTag = strings.TrimPrefix(p.event.BaseBranch, "refs/tags/")
 	}
 
-	return map[string]string{
-			"revision":            p.event.SHA,
-			"repo_url":            repoURL,
-			"repo_owner":          strings.ToLower(p.event.Organization),
-			"repo_name":           strings.ToLower(p.event.Repository),
-			"target_branch":       formatting.SanitizeBranch(p.event.BaseBranch),
-			"source_branch":       formatting.SanitizeBranch(p.event.HeadBranch),
-			"git_tag":             gitTag,
-			"source_url":          p.event.HeadURL,
-			"sender":              strings.ToLower(p.event.Sender),
-			"target_namespace":    p.repo.GetNamespace(),
-			"event_type":          opscomments.EventTypeBackwardCompat(p.eventEmitter, p.repo, p.event.EventType),
-			"trigger_comment":     triggerCommentAsSingleLine,
-			"pull_request_labels": pullRequestLabels,
-		}, map[string]any{
-			"all":      changedFiles.All,
-			"added":    changedFiles.Added,
-			"deleted":  changedFiles.Deleted,
-			"modified": changedFiles.Modified,
-			"renamed":  changedFiles.Renamed,
-		}
+	standardParams := map[string]string{
+		"revision":            p.event.SHA,
+		"repo_url":            repoURL,
+		"repo_owner":          strings.ToLower(p.event.Organization),
+		"repo_name":           strings.ToLower(p.event.Repository),
+		"target_branch":       formatting.SanitizeBranch(p.event.BaseBranch),
+		"source_branch":       formatting.SanitizeBranch(p.event.HeadBranch),
+		"git_tag":             gitTag,
+		"source_url":          p.event.HeadURL,
+		"sender":              strings.ToLower(p.event.Sender),
+		"target_namespace":    p.repo.GetNamespace(),
+		"event_type":          opscomments.EventTypeBackwardCompat(p.eventEmitter, p.repo, p.event.EventType),
+		"trigger_comment":     triggerCommentAsSingleLine,
+		"pull_request_labels": pullRequestLabels,
+	}
+	changedFilesParams := map[string]any{
+		"all":      changedFiles.All,
+		"added":    changedFiles.Added,
+		"deleted":  changedFiles.Deleted,
+		"modified": changedFiles.Modified,
+		"renamed":  changedFiles.Renamed,
+	}
+	return standardParams, changedFilesParams
 }

--- a/pkg/informer/transform/transform_benchmark_test.go
+++ b/pkg/informer/transform/transform_benchmark_test.go
@@ -35,7 +35,7 @@ func createRealisticRepository(name string) *pacv1alpha1.Repository {
 					APIVersion: "pipelinesascode.tekton.dev/v1alpha1",
 					Time:       &now,
 					FieldsType: "FieldsV1",
-					FieldsV1:   &metav1.FieldsV1{Raw: fieldsV1Data1},
+					FieldsV1:   metav1.NewFieldsV1(string(fieldsV1Data1)),
 				},
 			},
 			Annotations: map[string]string{
@@ -271,7 +271,7 @@ func createRealisticPipelineRun(name string) *tektonv1.PipelineRun {
 					APIVersion: "tekton.dev/v1",
 					Time:       &now,
 					FieldsType: "FieldsV1",
-					FieldsV1:   &metav1.FieldsV1{Raw: fieldsV1Data1},
+					FieldsV1:   metav1.NewFieldsV1(string(fieldsV1Data1)),
 				},
 				{
 					Manager:    "tekton-pipelines-controller",
@@ -279,7 +279,7 @@ func createRealisticPipelineRun(name string) *tektonv1.PipelineRun {
 					APIVersion: "tekton.dev/v1",
 					Time:       &now,
 					FieldsType: "FieldsV1",
-					FieldsV1:   &metav1.FieldsV1{Raw: fieldsV1Data2},
+					FieldsV1:   metav1.NewFieldsV1(string(fieldsV1Data2)),
 				},
 			},
 		},

--- a/pkg/pipelineascode/match_test.go
+++ b/pkg/pipelineascode/match_test.go
@@ -143,18 +143,21 @@ func TestChangePipelineRun(t *testing.T) {
 	}
 
 	tests := []struct {
-		name          string
-		prs           []*tektonv1.PipelineRun
-		expectedError string
+		name           string
+		prs            []*tektonv1.PipelineRun
+		expectedErrors []string
 	}{
 		{
 			name: "test with params",
 			prs:  prs,
 		},
 		{
-			name:          "test with json error",
-			prs:           jsonErrorPRs,
-			expectedError: "failed to marshal PipelineRun json-error-pr: json: error calling MarshalJSON for type v1.ParamValue: impossible ParamValues.Type: \"\"",
+			name: "test with json error",
+			prs:  jsonErrorPRs,
+			expectedErrors: []string{
+				"failed to marshal PipelineRun json-error-pr",
+				"impossible ParamValues.Type: \"\"",
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -164,10 +167,13 @@ func TestChangePipelineRun(t *testing.T) {
 			p := &PacRun{event: event}
 			ctx, _ := rtesting.SetupFakeContext(t)
 			err := p.changePipelineRun(ctx, repo, tt.prs)
-			if tt.expectedError != "" {
-				assert.Error(t, err, tt.expectedError)
+			if len(tt.expectedErrors) != 0 {
+				for _, expectedError := range tt.expectedErrors {
+					assert.ErrorContains(t, err, expectedError)
+				}
 				return
 			}
+			assert.NilError(t, err)
 			assert.Assert(t, strings.HasPrefix(tt.prs[0].GetName(), "pac-gitauth"), tt.prs[0].GetName(), "has no pac-gitauth prefix")
 			assert.Assert(t, tt.prs[0].GetAnnotations()[apipac.GitAuthSecret] != "")
 			assert.Assert(t, tt.prs[0].GetNamespace() == "testrepo", "namespace should be testrepo: %v", tt.prs[0].GetNamespace())

--- a/pkg/provider/gitlab/parse_payload_test.go
+++ b/pkg/provider/gitlab/parse_payload_test.go
@@ -104,7 +104,7 @@ func TestParsePayload(t *testing.T) {
 				event:   gitlab.EventTypePipeline,
 				payload: sample.MREventAsJSON("open", ""),
 			},
-			wantErrMsg: "json: cannot unmarshal object into Go struct field PipelineEventObjectAttributes.object_attributes.source of type string",
+			wantErrMsg: "object_attributes.source of type string",
 		},
 		{
 			name: "merge event",


### PR DESCRIPTION
## 📝 Description of the Change

Updates GolangCI-Lint to v2.13.2 and aligns the repository with its revised
configuration and static-analysis requirements.

This migrates the gofumpt configuration, replaces deprecated Kubernetes API
usage, resolves newly reported lint findings, and makes tests resilient to
Go-version differences in JSON error formatting. No runtime or user-facing
behavior changes are intended.

## 🔗 Linked GitHub Issue

None.

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

Validated locally with `make test` and `make lint`.

## 🤖 AI Assistance

AI assistance can be used for various tasks, such as code generation,
documentation, or testing.

Please indicate whether you have used AI assistance
for this PR and provide details if applicable.

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

AI assistance was used to diagnose and update two version-sensitive test
assertions and to draft this description. The changes were validated with the
full unit-test and lint suites.

> [!IMPORTANT]
>
> **Slop will be simply rejected**, if you are using AI assistance you need to make sure you
> understand the code generated and that it meets the project's standards. you
> need at least know how to run the code and deploy it (if needed). See
> [startpaac](https://github.com/openshift-pipelines/startpaac) to make it easy
> to deploy and test your code changes.
>
> If the **majority of the code** in this PR was generated by an AI, please add a `Co-authored-by` trailer to your commit message.
> For example:
>
> Co-authored-by: Claude <noreply@anthropic.com>

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.com/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♻ I have run `make test` and `make lint` locally to check for and fix any issues.
- [x] 📖 Documentation is not required because there are no user-facing changes.
- [x] 🧪 Existing unit tests cover these changes and the full suite passes.
- [x] 🎁 End-to-end tests are not required for these tooling and test-compatibility changes.
- [x] 🔎 No CI test flakiness is being bypassed.
- [x] The provider checklist is not applicable because this PR does not add a provider feature.
