### PR TITLE
fix(queue): concurrency follow-ups from #2890 post-merge review

### DIFF
--- a/cmd/pipelines-as-code-watcher/main.go
+++ b/cmd/pipelines-as-code-watcher/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -18,13 +19,23 @@ import (
 
 const globalProbesPort = "8080"
 
-func main() {
-	probesPort := globalProbesPort
-	envProbePort := os.Getenv("PAC_WATCHER_PORT")
-	if envProbePort != "" {
-		probesPort = envProbePort
+// queueDebugEnabled reports whether PAC_ENABLE_QUEUE_DEBUG asks for the
+// /debug/queue endpoint. It fails closed: unset or unparseable never enables
+// it, and an invalid value is logged so a typo does not silently do nothing.
+func queueDebugEnabled() bool {
+	val, ok := os.LookupEnv("PAC_ENABLE_QUEUE_DEBUG")
+	if !ok {
+		return false
 	}
+	enabled, err := strconv.ParseBool(val)
+	if err != nil {
+		log.Printf("PAC_ENABLE_QUEUE_DEBUG=%q is not a valid boolean, leaving /debug/queue disabled: %v", val, err)
+		return false
+	}
+	return enabled
+}
 
+func newProbeMux() *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/live", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -33,8 +44,25 @@ func main() {
 
 	// Read-only view of the concurrency queues, so a test or an operator can
 	// tell whether the queue still agrees with the cluster.
-	mux.HandleFunc("/debug/queue", queue.DebugHandler())
+	//
+	// This is unauthenticated and reachable from any pod that can route to
+	// this one, including untrusted PipelineRun workloads, so it stays off
+	// unless explicitly enabled. An absent route beats one that answers 403,
+	// since it does not confirm the feature exists to probe further.
+	if queueDebugEnabled() {
+		mux.HandleFunc("/debug/queue", queue.DebugHandler())
+	}
+	return mux
+}
 
+func main() {
+	probesPort := globalProbesPort
+	envProbePort := os.Getenv("PAC_WATCHER_PORT")
+	if envProbePort != "" {
+		probesPort = envProbePort
+	}
+
+	mux := newProbeMux()
 	c := make(chan struct{})
 	go func() {
 		log.Println("started goroutine for watcher")

--- a/cmd/pipelines-as-code-watcher/main_test.go
+++ b/cmd/pipelines-as-code-watcher/main_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestQueueDebugEnabled(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		set  bool
+		want bool
+	}{
+		{name: "unset defaults to disabled", set: false, want: false},
+		{name: "empty string is not a valid bool, fails closed", env: "", set: true, want: false},
+		{name: "true enables it", env: "true", set: true, want: true},
+		{name: "1 enables it", env: "1", set: true, want: true},
+		{name: "false disables it", env: "false", set: true, want: false},
+		{name: "0 disables it", env: "0", set: true, want: false},
+		{name: "garbage fails closed", env: "yolo", set: true, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// t.Setenv in both branches so its cleanup restores whatever the
+			// caller had exported; the unset case then clears it, which keeps
+			// the default-off assertion independent of the parent environment.
+			t.Setenv("PAC_ENABLE_QUEUE_DEBUG", tt.env)
+			if !tt.set {
+				if err := os.Unsetenv("PAC_ENABLE_QUEUE_DEBUG"); err != nil {
+					t.Fatalf("cannot unset PAC_ENABLE_QUEUE_DEBUG: %v", err)
+				}
+			}
+			if got := queueDebugEnabled(); got != tt.want {
+				t.Errorf("queueDebugEnabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProbeMuxQueueDebugRoute(t *testing.T) {
+	tests := []struct {
+		name     string
+		env      string
+		set      bool
+		wantCode int
+	}{
+		{name: "unset does not register the route", set: false, wantCode: http.StatusNotFound},
+		{name: "invalid value does not register the route", env: "yolo", set: true, wantCode: http.StatusNotFound},
+		{name: "false does not register the route", env: "false", set: true, wantCode: http.StatusNotFound},
+		{name: "true registers the route", env: "true", set: true, wantCode: http.StatusServiceUnavailable},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("PAC_ENABLE_QUEUE_DEBUG", tt.env)
+			if !tt.set {
+				assert.NilError(t, os.Unsetenv("PAC_ENABLE_QUEUE_DEBUG"))
+			}
+
+			rec := httptest.NewRecorder()
+			newProbeMux().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/debug/queue", nil))
+
+			assert.Equal(t, rec.Code, tt.wantCode)
+		})
+	}
+}

--- a/docs/content/docs/advanced/concurrency.md
+++ b/docs/content/docs/advanced/concurrency.md
@@ -46,15 +46,34 @@ queue looks stuck — nothing starting, or more running than the configured
 `concurrency_limit` — the fastest way to find out why is to ask the watcher
 directly instead of guessing from PipelineRun status.
 
-The watcher serves a read-only, JSON snapshot of its in-memory queues on
+The watcher can serve a read-only, JSON snapshot of its in-memory queues on
 `/debug/queue`, on the same port it already uses for its health probe.
 
-{{< callout type="info" >}}
-This exposes only the limit and the PipelineRun names PAC currently considers
-running or pending for each repository — nothing that is not already visible by
-listing PipelineRuns. It is meant for troubleshooting, not for regular
-monitoring.
+{{< callout type="warning" >}}
+This endpoint is disabled by default and must be explicitly enabled. It is
+unauthenticated: anything that can reach the watcher pod on its probe port
+(any workload in the cluster with network access to it, not just cluster
+API clients) can read the namespace, Repository name, and pending/running
+PipelineRun names for every repository the watcher knows about. Only turn it
+on for troubleshooting, and turn it back off afterward.
 {{< /callout >}}
+
+### Enabling it
+
+Set `PAC_ENABLE_QUEUE_DEBUG=true` on the `pac-watcher` container in the
+`pipelines-as-code-watcher` Deployment, then restart the pod:
+
+```shell
+kubectl -n pipelines-as-code set env deployment/pipelines-as-code-watcher \
+  -c pac-watcher PAC_ENABLE_QUEUE_DEBUG=true
+```
+
+Unset it (or set it to `false`) to disable the endpoint again:
+
+```shell
+kubectl -n pipelines-as-code set env deployment/pipelines-as-code-watcher \
+  -c pac-watcher PAC_ENABLE_QUEUE_DEBUG-
+```
 
 ### Querying it
 

--- a/pkg/queue/admission.go
+++ b/pkg/queue/admission.go
@@ -1,0 +1,239 @@
+package queue
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type AdmissionMode int
+
+const (
+	AdmissionInitial AdmissionMode = iota
+	AdmissionResume
+	AdmissionPromotion
+)
+
+type StartOutcome int
+
+const (
+	StartRetry StartOutcome = iota
+	StartSucceeded
+	StartGone
+)
+
+// StartCandidate is a worker's private copy. Attempted retries retain their
+// reservation even when a read still says Pending: a lost write can commit later.
+type StartCandidate struct {
+	Key       string
+	UID       types.UID
+	Attempted bool
+	Outcome   StartOutcome
+	reserved  bool
+}
+
+type admissionState struct {
+	owner         string
+	promotion     bool
+	busy          bool
+	done          bool
+	releasedOwner bool
+	candidates    []StartCandidate
+}
+
+// Admission leases one owner's unfinished work to one worker. FinishAdmission
+// must be called even on cancellation; it atomically records every batch result.
+type Admission struct {
+	Candidates []StartCandidate
+	repoKey    string
+	state      *admissionState
+}
+
+func admissionOwner(pr *tektonv1.PipelineRun) string {
+	return PrKey(pr) + "/" + string(pr.UID)
+}
+
+// Finishing reports whether a PipelineRun has finished or been asked to stop.
+// Both graceful modes need their own check: they leave the run executing its
+// finally tasks, so IsDone and IsCancelled stay false throughout.
+func Finishing(pr *tektonv1.PipelineRun) bool {
+	return pr.DeletionTimestamp != nil ||
+		pr.IsDone() || pr.IsCancelled() ||
+		pr.IsGracefullyCancelled() || pr.IsGracefullyStopped()
+}
+
+func (qm *Manager) acquireUnowned(repoKey string, sema Semaphore) string {
+	if qm.claims[repoKey][sema.nextPending()] != nil {
+		return ""
+	}
+	return sema.acquireLatest()
+}
+
+func (qm *Manager) forgetCandidate(repoKey, key string) {
+	if state := qm.claims[repoKey][key]; state != nil {
+		state.candidates = slices.DeleteFunc(state.candidates, func(c StartCandidate) bool { return c.Key == key })
+		delete(qm.claims[repoKey], key)
+		if !state.promotion && !state.busy && !state.releasedOwner && len(state.candidates) == 0 {
+			delete(qm.admissions[repoKey], state.owner)
+		}
+	}
+}
+
+func (qm *Manager) ForgetAdmission(repoKey string, owner *tektonv1.PipelineRun) {
+	qm.lock.Lock()
+	defer qm.lock.Unlock()
+	key := admissionOwner(owner)
+	// Unfinished work must be resumed, not forgotten when its owner completes.
+	if state := qm.admissions[repoKey][key]; state != nil && !state.busy && len(state.candidates) == 0 {
+		delete(qm.admissions[repoKey], key)
+	}
+}
+
+func (qm *Manager) AcquireAdmission(repo *v1alpha1.Repository, owner *tektonv1.PipelineRun, list []string, mode AdmissionMode) (*Admission, error) {
+	qm.lock.Lock()
+	defer qm.lock.Unlock()
+	repoKey, ownerKey := RepoKey(repo), admissionOwner(owner)
+	state := qm.admissions[repoKey][ownerKey]
+	if mode == AdmissionResume && (state == nil || state.promotion) {
+		return nil, nil
+	}
+	if state != nil && state.busy {
+		return nil, fmt.Errorf("queue admission for %s is already being processed", ownerKey)
+	}
+	sema, err := qm.getSemaphore(repo)
+	if err != nil {
+		return nil, err
+	}
+	if state == nil {
+		if mode == AdmissionPromotion {
+			// An absent owner cannot hand off twice after a successful finalizer
+			// or terminal write. Unfinished handoffs have their own record below.
+			if !slices.Contains(sema.getCurrentRunning(), PrKey(owner)) && !slices.Contains(sema.getCurrentPending(), PrKey(owner)) {
+				return nil, nil
+			}
+			qm.removeFromQueue(repoKey, PrKey(owner))
+		}
+		state = &admissionState{owner: ownerKey, promotion: mode == AdmissionPromotion}
+		if qm.admissions[repoKey] == nil {
+			qm.admissions[repoKey] = make(map[string]*admissionState)
+			qm.claims[repoKey] = make(map[string]*admissionState)
+		}
+		qm.admissions[repoKey][ownerKey] = state
+	}
+	claims := qm.claims[repoKey]
+	if claims == nil {
+		return nil, fmt.Errorf("missing admission claims for repository %s", repoKey)
+	}
+	if state.promotion != (mode == AdmissionPromotion) {
+		return nil, fmt.Errorf("unfinished admission for %s must be resumed before promotion", ownerKey)
+	}
+	if mode == AdmissionResume && Finishing(owner) &&
+		(slices.Contains(sema.getCurrentRunning(), PrKey(owner)) || slices.Contains(sema.getCurrentPending(), PrKey(owner))) {
+		// A completed batch owner must not hold the capacity its retries need,
+		// particularly after the concurrency limit has been reduced.
+		state.releasedOwner = true
+		qm.removeFromQueue(repoKey, PrKey(owner))
+		if len(state.candidates) == 0 {
+			state.done = true
+		}
+	}
+	for _, key := range list {
+		sema.addToQueue(key, time.Now())
+	}
+	for i := range state.candidates {
+		candidate := &state.candidates[i]
+		if !candidate.reserved && sema.nextPending() == candidate.Key && sema.acquireLatest() != "" {
+			candidate.reserved = true
+		}
+	}
+	if len(state.candidates) == 0 && !state.done {
+		limit := sema.getLimit()
+		if state.promotion {
+			limit = 1
+		}
+		for limit == 0 || len(state.candidates) < limit {
+			if claims[sema.nextPending()] != nil {
+				if len(state.candidates) == 0 {
+					return nil, fmt.Errorf("next queue candidate is owned by another admission")
+				}
+				break
+			}
+			next := sema.acquireLatest()
+			if next == "" {
+				break
+			}
+			state.candidates = append(state.candidates, StartCandidate{Key: next, reserved: true})
+			claims[next] = state
+		}
+		if len(state.candidates) == 0 {
+			state.done = true
+		}
+	}
+	candidates := make([]StartCandidate, 0, len(state.candidates))
+	for _, candidate := range state.candidates {
+		if candidate.reserved {
+			candidates = append(candidates, candidate)
+		}
+	}
+	if len(state.candidates) != 0 && len(candidates) == 0 {
+		return nil, fmt.Errorf("waiting to resume queue candidates for %s", ownerKey)
+	}
+	state.busy = true
+	return &Admission{Candidates: candidates, repoKey: repoKey, state: state}, nil
+}
+
+func (qm *Manager) FinishAdmission(work *Admission) error {
+	qm.lock.Lock()
+	defer qm.lock.Unlock()
+	state := work.state
+	if qm.admissions[work.repoKey][state.owner] != state {
+		return nil // Repository removal or reconstruction invalidated this lease.
+	}
+	defer func() { state.busy = false }()
+	sema := qm.queueMap[work.repoKey]
+	if sema == nil {
+		return fmt.Errorf("missing queue while finishing admission in repository %s", work.repoKey)
+	}
+	var errs []error
+	for _, candidate := range work.Candidates {
+		if qm.claims[work.repoKey][candidate.Key] != state {
+			continue // Completion/deletion already removed this candidate.
+		}
+		switch candidate.Outcome {
+		case StartSucceeded:
+			qm.forgetCandidate(work.repoKey, candidate.Key)
+			state.done = true
+		case StartGone:
+			qm.forgetCandidate(work.repoKey, candidate.Key)
+			qm.removeFromQueue(work.repoKey, candidate.Key)
+		default:
+			if !candidate.Attempted {
+				if !sema.requeue(candidate.Key) {
+					errs = append(errs, fmt.Errorf("cannot restore queue candidate %s", candidate.Key))
+					continue
+				}
+				candidate.reserved = false
+			}
+			if i := slices.IndexFunc(state.candidates, func(c StartCandidate) bool { return c.Key == candidate.Key }); i >= 0 {
+				state.candidates[i] = candidate
+			}
+		}
+	}
+	if !state.promotion && len(state.candidates) == 0 {
+		if state.releasedOwner {
+			state.promotion = true
+			state.done = false
+		} else if state.done {
+			delete(qm.admissions[work.repoKey], state.owner)
+		}
+	}
+	if len(state.candidates) != 0 {
+		errs = append(errs, fmt.Errorf("unfinished queue admission for %s", state.owner))
+	}
+	return errors.Join(errs...)
+}

--- a/pkg/queue/admission_test.go
+++ b/pkg/queue/admission_test.go
@@ -1,0 +1,268 @@
+package queue
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"go.uber.org/zap"
+	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	rtesting "knative.dev/pkg/reconciler/testing"
+)
+
+func TestAdmissionOwnedRetries(t *testing.T) {
+	tests := []struct {
+		name      string
+		attempted bool
+	}{
+		{name: "unread candidate returns to its original queue position"},
+		{name: "uncertain start keeps the reservation", attempted: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			limit := 1
+			repo := &v1alpha1.Repository{ObjectMeta: metav1.ObjectMeta{Name: "repo", Namespace: "ns"}, Spec: v1alpha1.RepositorySpec{ConcurrencyLimit: &limit}}
+			owner := &tektonv1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Name: "finished", Namespace: "ns", UID: "owner"}}
+			qm := NewManager(zap.NewNop().Sugar())
+			_, err := qm.AddListToRunningQueue(repo, []string{PrKey(owner)})
+			assert.NilError(t, err)
+			assert.NilError(t, qm.AddToPendingQueue(repo, []string{"ns/first", "ns/second", "ns/third"}))
+			work, err := qm.AcquireAdmission(repo, owner, nil, AdmissionPromotion)
+			assert.NilError(t, err)
+			assert.Equal(t, work.Candidates[0].Key, "ns/first")
+			work.Candidates[0].Attempted = tt.attempted
+			work.Candidates[0].UID = "first-uid"
+			assert.ErrorContains(t, qm.FinishAdmission(work), "unfinished queue admission")
+			if tt.attempted {
+				assert.DeepEqual(t, qm.RunningPipelineRuns(repo), []string{"ns/first"})
+			} else {
+				assert.Equal(t, len(qm.RunningPipelineRuns(repo)), 0)
+				assert.Equal(t, qm.queueMap[RepoKey(repo)].nextPending(), "ns/first")
+			}
+			// Other reconciliations must neither steal a retry nor bypass its
+			// restored position, even though the semaphore can now be free.
+			other := &tektonv1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Name: "other", Namespace: "ns"}}
+			otherWork, otherErr := qm.AcquireAdmission(repo, other, nil, AdmissionInitial)
+			if tt.attempted {
+				assert.NilError(t, otherErr)
+				assert.Equal(t, len(otherWork.Candidates), 0)
+				assert.NilError(t, qm.FinishAdmission(otherWork))
+			} else {
+				assert.ErrorContains(t, otherErr, "owned by another")
+			}
+			work, err = qm.AcquireAdmission(repo, owner, nil, AdmissionPromotion)
+			assert.NilError(t, err)
+			assert.Equal(t, work.Candidates[0].Key, "ns/first")
+			assert.Equal(t, string(work.Candidates[0].UID), "first-uid")
+			work.Candidates[0].Outcome = StartSucceeded
+			assert.NilError(t, qm.FinishAdmission(work))
+			assert.Equal(t, len(qm.claims[RepoKey(repo)]), 0)
+			assert.Equal(t, qm.queueMap[RepoKey(repo)].nextPending(), "ns/second")
+		})
+	}
+}
+
+func TestAdmissionConcurrentClaims(t *testing.T) {
+	tests := []struct {
+		name string
+		mode AdmissionMode
+	}{
+		{name: "initial batch", mode: AdmissionInitial},
+		{name: "successor handoff", mode: AdmissionPromotion},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			limit := 2
+			repo := &v1alpha1.Repository{ObjectMeta: metav1.ObjectMeta{Name: "repo"}, Spec: v1alpha1.RepositorySpec{ConcurrencyLimit: &limit}}
+			owner := &tektonv1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Name: "owner"}}
+			qm := NewManager(zap.NewNop().Sugar())
+			_, err := qm.AddListToRunningQueue(repo, []string{PrKey(owner)})
+			assert.NilError(t, err)
+			assert.NilError(t, qm.AddToPendingQueue(repo, []string{"ns/first", "ns/second"}))
+			var wg sync.WaitGroup
+			results := make(chan *Admission, 16)
+			for range 16 {
+				wg.Go(func() {
+					work, err := qm.AcquireAdmission(repo, owner, nil, tt.mode)
+					if err == nil {
+						results <- work
+					}
+				})
+			}
+			wg.Wait()
+			close(results)
+			assert.Equal(t, len(results), 1)
+			work := <-results
+			assert.Equal(t, len(work.Candidates), 1)
+			work.Candidates[0].Attempted = true
+			assert.ErrorContains(t, qm.FinishAdmission(work), "unfinished queue admission")
+			retry, err := qm.AcquireAdmission(repo, owner, nil, tt.mode)
+			assert.NilError(t, err)
+			assert.Equal(t, retry.Candidates[0].Key, work.Candidates[0].Key)
+			retry.Candidates[0].Outcome = StartSucceeded
+			assert.NilError(t, qm.FinishAdmission(retry))
+		})
+	}
+}
+
+func TestAdmissionCleanup(t *testing.T) {
+	tests := []struct {
+		name    string
+		cleanup func(*testing.T, *Manager, *v1alpha1.Repository, *tektonv1.PipelineRun)
+	}{
+		{
+			name: "repository removed while worker holds lease",
+			cleanup: func(_ *testing.T, qm *Manager, repo *v1alpha1.Repository, _ *tektonv1.PipelineRun) {
+				qm.RemoveRepository(repo)
+			},
+		},
+		{
+			name: "queues reconstructed while old lease exists",
+			cleanup: func(t *testing.T, qm *Manager, _ *v1alpha1.Repository, _ *tektonv1.PipelineRun) {
+				t.Helper()
+				ctx, _ := rtesting.SetupFakeContext(t)
+				data, _ := testclient.SeedTestData(t, ctx, testclient.Data{})
+				assert.NilError(t, qm.InitQueues(ctx, data.Pipeline, data.PipelineAsCode))
+			},
+		},
+		{
+			name: "candidate completed or cancelled",
+			cleanup: func(_ *testing.T, qm *Manager, repo *v1alpha1.Repository, _ *tektonv1.PipelineRun) {
+				qm.RemoveFromQueue(RepoKey(repo), "ns/first")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			limit := 1
+			repo := &v1alpha1.Repository{ObjectMeta: metav1.ObjectMeta{Name: "repo"}, Spec: v1alpha1.RepositorySpec{ConcurrencyLimit: &limit}}
+			owner := &tektonv1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Name: "owner"}}
+			qm := NewManager(zap.NewNop().Sugar())
+			work, err := qm.AcquireAdmission(repo, owner, []string{"ns/first"}, AdmissionInitial)
+			assert.NilError(t, err)
+			work.Candidates[0].Attempted = true
+			tt.cleanup(t, qm, repo, owner)
+			assert.NilError(t, qm.FinishAdmission(work))
+			assert.Equal(t, len(qm.claims[RepoKey(repo)]), 0)
+			assert.Equal(t, len(qm.admissions[RepoKey(repo)]), 0)
+		})
+	}
+}
+
+func TestAdmissionResumesPartialBatchAfterResize(t *testing.T) {
+	tests := []struct {
+		name        string
+		ownerStatus tektonv1.PipelineRunSpecStatus
+	}{
+		{name: "only acquire the retries that fit"},
+		{name: "cancelled owner frees capacity for its batch", ownerStatus: tektonv1.PipelineRunSpecStatusCancelled},
+		{name: "gracefully cancelled owner frees capacity for its batch", ownerStatus: tektonv1.PipelineRunSpecStatusCancelledRunFinally},
+		{name: "gracefully stopped owner frees capacity for its batch", ownerStatus: tektonv1.PipelineRunSpecStatusStoppedRunFinally},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ownerDone := tt.ownerStatus != ""
+			limit := 3
+			repo := &v1alpha1.Repository{ObjectMeta: metav1.ObjectMeta{Name: "repo"}, Spec: v1alpha1.RepositorySpec{ConcurrencyLimit: &limit}}
+			owner := &tektonv1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Name: "owner", Namespace: "ns"}}
+			qm := NewManager(zap.NewNop().Sugar())
+			list := []string{"ns/first", "ns/second", "ns/third"}
+			if ownerDone {
+				list[0] = PrKey(owner)
+			}
+			work, err := qm.AcquireAdmission(repo, owner, list, AdmissionInitial)
+			assert.NilError(t, err)
+			if ownerDone {
+				work.Candidates[0].Outcome = StartSucceeded
+				owner.Spec.Status = tt.ownerStatus
+			}
+			assert.ErrorContains(t, qm.FinishAdmission(work), "unfinished queue admission")
+			limit = 1
+			work, err = qm.AcquireAdmission(repo, owner, nil, AdmissionResume)
+			assert.NilError(t, err)
+			assert.Equal(t, len(work.Candidates), 1, "a partial acquisition must be returned, not stranded")
+			assert.NilError(t, qm.AddToPendingQueue(repo, []string{"ns/later"}))
+			for {
+				key := work.Candidates[0].Key
+				work.Candidates[0].Outcome = StartSucceeded
+				err = qm.FinishAdmission(work)
+				qm.RemoveFromQueue(RepoKey(repo), key)
+				if err == nil {
+					break
+				}
+				assert.ErrorContains(t, err, "unfinished queue admission")
+				work, err = qm.AcquireAdmission(repo, owner, nil, AdmissionResume)
+				assert.NilError(t, err)
+				assert.Equal(t, len(work.Candidates), 1)
+			}
+			if ownerDone {
+				work, err = qm.AcquireAdmission(repo, owner, nil, AdmissionPromotion)
+				assert.NilError(t, err)
+				assert.Equal(t, work.Candidates[0].Key, "ns/later", "the early release must still finish its handoff")
+				work.Candidates[0].Outcome = StartSucceeded
+				assert.NilError(t, qm.FinishAdmission(work))
+				qm.ForgetAdmission(RepoKey(repo), owner)
+			}
+			assert.Equal(t, len(qm.claims[RepoKey(repo)]), 0)
+			assert.Equal(t, len(qm.admissions[RepoKey(repo)]), 0)
+		})
+	}
+}
+
+func TestAdmissionResumePreservesReservationsAfterResize(t *testing.T) {
+	tests := []struct {
+		name string
+		held int
+	}{
+		{name: "uncertain start fills the reduced limit", held: 1},
+		{name: "uncertain starts exceed the reduced limit", held: 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			limit := 3
+			repo := &v1alpha1.Repository{ObjectMeta: metav1.ObjectMeta{Name: "repo", Namespace: "ns"}, Spec: v1alpha1.RepositorySpec{ConcurrencyLimit: &limit}}
+			owner := &tektonv1.PipelineRun{ObjectMeta: metav1.ObjectMeta{Name: "owner", Namespace: "ns"}}
+			qm := NewManager(zap.NewNop().Sugar())
+			work, err := qm.AcquireAdmission(repo, owner, []string{"ns/first", "ns/second", "ns/third"}, AdmissionInitial)
+			assert.NilError(t, err)
+			for i := range tt.held {
+				work.Candidates[i].Attempted = true
+			}
+			assert.ErrorContains(t, qm.FinishAdmission(work), "unfinished queue admission")
+
+			limit = 1
+			work, err = qm.AcquireAdmission(repo, owner, nil, AdmissionResume)
+			assert.NilError(t, err)
+			assert.Equal(t, len(work.Candidates), tt.held)
+			assert.Equal(t, qm.queueMap[RepoKey(repo)].getLimit(), 1)
+			assert.Equal(t, len(qm.RunningPipelineRuns(repo)), tt.held)
+			assert.Equal(t, len(qm.QueuedPipelineRuns(repo)), 3-tt.held)
+			for i := range work.Candidates {
+				assert.Assert(t, work.Candidates[i].Attempted)
+				work.Candidates[i].Outcome = StartSucceeded
+			}
+			assert.ErrorContains(t, qm.FinishAdmission(work), "unfinished queue admission")
+			for i, candidate := range work.Candidates {
+				_, err := qm.AcquireAdmission(repo, owner, nil, AdmissionResume)
+				assert.ErrorContains(t, err, "waiting to resume")
+				qm.RemoveFromQueue(RepoKey(repo), candidate.Key)
+				assert.Equal(t, len(qm.RunningPipelineRuns(repo)), tt.held-i-1)
+			}
+			work, err = qm.AcquireAdmission(repo, owner, nil, AdmissionResume)
+			assert.NilError(t, err)
+			assert.Equal(t, len(work.Candidates), 1)
+			assert.Assert(t, !work.Candidates[0].Attempted)
+			work.Candidates[0].Outcome = StartGone
+			err = qm.FinishAdmission(work)
+			if tt.held == 1 {
+				assert.ErrorContains(t, err, "unfinished queue admission")
+			} else {
+				assert.NilError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/queue/common.go
+++ b/pkg/queue/common.go
@@ -6,6 +6,8 @@ import (
 
 type Semaphore interface {
 	acquireLatest() string
+	nextPending() string
+	requeue(string) bool
 	release(string) bool
 	resize(int) bool
 	addToQueue(string, time.Time) bool

--- a/pkg/queue/queue_manager.go
+++ b/pkg/queue/queue_manager.go
@@ -15,8 +15,10 @@ import (
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	versioned2 "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	"go.uber.org/zap"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"knative.dev/pkg/logging"
 )
 
 const (
@@ -24,16 +26,20 @@ const (
 )
 
 type Manager struct {
-	queueMap map[string]Semaphore
-	lock     *sync.Mutex
-	logger   *zap.SugaredLogger
+	queueMap   map[string]Semaphore
+	admissions map[string]map[string]*admissionState
+	claims     map[string]map[string]*admissionState
+	lock       *sync.Mutex
+	logger     *zap.SugaredLogger
 }
 
 func NewManager(logger *zap.SugaredLogger) *Manager {
 	return &Manager{
-		queueMap: make(map[string]Semaphore),
-		lock:     &sync.Mutex{},
-		logger:   logger,
+		queueMap:   make(map[string]Semaphore),
+		admissions: make(map[string]map[string]*admissionState),
+		claims:     make(map[string]map[string]*admissionState),
+		lock:       &sync.Mutex{},
+		logger:     logger,
 	}
 }
 
@@ -105,7 +111,7 @@ func (qm *Manager) AddListToRunningQueue(repo *v1alpha1.Repository, list []strin
 
 	acquiredList := []string{}
 	for i := 0; i < *repo.Spec.ConcurrencyLimit; i++ {
-		acquired := sema.acquireLatest()
+		acquired := qm.acquireUnowned(RepoKey(repo), sema)
 		if acquired != "" {
 			qm.logger.Infof("moved (%s) to running for repository (%s)", acquired, RepoKey(repo))
 			acquiredList = append(acquiredList, acquired)
@@ -146,6 +152,10 @@ func (qm *Manager) removeFromQueue(repoKey, prKey string) bool {
 		return false
 	}
 
+	if state := qm.claims[repoKey][prKey]; state != nil {
+		state.done = true
+	}
+	qm.forgetCandidate(repoKey, prKey)
 	sema.release(prKey)
 	sema.removeFromQueue(prKey)
 	qm.logger.Infof("removed (%s) for repository (%s)", prKey, repoKey)
@@ -166,7 +176,7 @@ func (qm *Manager) RemoveAndTakeItemFromQueue(repo *v1alpha1.Repository, run *te
 		return ""
 	}
 
-	if next := sema.acquireLatest(); next != "" {
+	if next := qm.acquireUnowned(repoKey, sema); next != "" {
 		qm.logger.Infof("moved (%s) to running for repository (%s)", next, repoKey)
 		return next
 	}
@@ -178,13 +188,24 @@ func (qm *Manager) RemoveAndTakeItemFromQueue(repo *v1alpha1.Repository, run *te
 // from the Tekton API and checks their annotations and status to determine if they should be included.
 //
 // Returns A list of PipelineRun names that are in a "queued" state and have a pending status.
-func FilterPipelineRunByState(ctx context.Context, tekton versioned2.Interface, orderList []string, wantedStatus, wantedState string) []string {
+func FilterPipelineRunByState(ctx context.Context, tekton versioned2.Interface, orderList []string, wantedStatus, wantedState string) ([]string, error) {
 	orderedList := []string{}
 	for _, prName := range orderList {
-		prKey := strings.Split(prName, "/")
-		pr, err := tekton.TektonV1().PipelineRuns(prKey[0]).Get(ctx, prKey[1], v1.GetOptions{})
-		if err != nil {
+		// The list comes straight from a user-editable annotation, so a
+		// malformed entry must be skipped, not indexed: a panic here takes
+		// down the whole watcher, and from InitQueues it does so on every
+		// restart.
+		namespace, name, ok := SplitPrKey(prName)
+		if !ok {
+			logging.FromContext(ctx).Warnf("ignoring malformed execution-order entry %q", prName)
 			continue
+		}
+		pr, err := tekton.TektonV1().PipelineRuns(namespace).Get(ctx, name, v1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return nil, fmt.Errorf("cannot read execution-order pipelineRun %s: %w", prName, err)
 		}
 
 		state, exist := pr.GetAnnotations()[keys.State]
@@ -196,15 +217,21 @@ func FilterPipelineRunByState(ctx context.Context, tekton versioned2.Interface, 
 			if wantedStatus != "" && pr.Spec.Status != tektonv1.PipelineRunSpecStatus(wantedStatus) {
 				continue
 			}
-			orderedList = append(orderedList, prName)
+			orderedList = append(orderedList, namespace+"/"+name)
 		}
 	}
-	return orderedList
+	return orderedList, nil
 }
 
 // InitQueues rebuild all the queues for all repository if concurrency is defined before
 // reconciler started reconciling them.
 func (qm *Manager) InitQueues(ctx context.Context, tekton versioned2.Interface, pac versioned.Interface) error {
+	// Reconstruction runs before workers start; no old ownership survives it.
+	qm.lock.Lock()
+	qm.queueMap = make(map[string]Semaphore)
+	qm.admissions = make(map[string]map[string]*admissionState)
+	qm.claims = make(map[string]map[string]*admissionState)
+	qm.lock.Unlock()
 	// fetch all repos
 	repos, err := pac.PipelinesascodeV1alpha1().Repositories("").List(ctx, v1.ListOptions{})
 	if err != nil {
@@ -238,7 +265,10 @@ func (qm *Manager) InitQueues(ctx context.Context, tekton versioned2.Interface, 
 				// and repositories.
 				continue
 			}
-			orderedList := FilterPipelineRunByState(ctx, tekton, strings.Split(order, ","), "", kubeinteraction.StateStarted)
+			orderedList, err := FilterPipelineRunByState(ctx, tekton, strings.Split(order, ","), "", kubeinteraction.StateStarted)
+			if err != nil {
+				return err
+			}
 
 			_, err = qm.AddListToRunningQueue(&repo, orderedList)
 			if err != nil {
@@ -266,7 +296,10 @@ func (qm *Manager) InitQueues(ctx context.Context, tekton versioned2.Interface, 
 				// and repositories.
 				continue
 			}
-			orderedList := FilterPipelineRunByState(ctx, tekton, strings.Split(order, ","), tektonv1.PipelineRunSpecStatusPending, kubeinteraction.StateQueued)
+			orderedList, err := FilterPipelineRunByState(ctx, tekton, strings.Split(order, ","), tektonv1.PipelineRunSpecStatusPending, kubeinteraction.StateQueued)
+			if err != nil {
+				return err
+			}
 			if err := qm.AddToPendingQueue(&repo, orderedList); err != nil {
 				qm.logger.Error("failed to init queue for repo: ", repo.GetName())
 			}
@@ -282,6 +315,8 @@ func (qm *Manager) RemoveRepository(repo *v1alpha1.Repository) {
 
 	repoKey := RepoKey(repo)
 	delete(qm.queueMap, repoKey)
+	delete(qm.admissions, repoKey)
+	delete(qm.claims, repoKey)
 }
 
 func (qm *Manager) QueuedPipelineRuns(repo *v1alpha1.Repository) []string {

--- a/pkg/queue/queue_manager_interface.go
+++ b/pkg/queue/queue_manager_interface.go
@@ -3,11 +3,13 @@ package queue
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/generated/clientset/versioned"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	tektonVersionedClient "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	"k8s.io/client-go/rest"
 )
 
 type ManagerInterface interface {
@@ -19,6 +21,9 @@ type ManagerInterface interface {
 	AddToPendingQueue(repo *v1alpha1.Repository, list []string) error
 	RemoveFromQueue(repoKey, prKey string) bool
 	RemoveAndTakeItemFromQueue(repo *v1alpha1.Repository, run *tektonv1.PipelineRun) string
+	AcquireAdmission(repo *v1alpha1.Repository, owner *tektonv1.PipelineRun, list []string, mode AdmissionMode) (*Admission, error)
+	FinishAdmission(work *Admission) error
+	ForgetAdmission(repoKey string, owner *tektonv1.PipelineRun)
 }
 
 func RepoKey(repo *v1alpha1.Repository) string {
@@ -27,4 +32,29 @@ func RepoKey(repo *v1alpha1.Repository) string {
 
 func PrKey(run *tektonv1.PipelineRun) string {
 	return fmt.Sprintf("%s/%s", run.Namespace, run.Name)
+}
+
+// SplitPrKey parses a "namespace/name" queue key, the inverse of PrKey.
+//
+// Keys can come straight from the user-editable execution-order annotation, so
+// a malformed entry must be rejected rather than indexed: callers use the
+// namespace and name to index a slice or make a Tekton client call, and a
+// panic here has in the past taken the whole watcher down on every restart.
+//
+// Both segments are checked against the client's own path-segment rules. A
+// segment the client refuses to encode (".", ".." or one containing "%") fails
+// locally, before any request, with a plain error that is not a NotFound, so
+// callers would treat it as retryable and InitQueues would abort startup on
+// every restart over a single bad annotation.
+func SplitPrKey(key string) (namespace, name string, ok bool) {
+	namespace, name, found := strings.Cut(strings.TrimSpace(key), "/")
+	namespace = strings.TrimSpace(namespace)
+	name = strings.TrimSpace(name)
+	if !found || namespace == "" || name == "" || strings.Contains(name, "/") {
+		return "", "", false
+	}
+	if len(rest.IsValidPathSegmentName(namespace)) != 0 || len(rest.IsValidPathSegmentName(name)) != 0 {
+		return "", "", false
+	}
+	return namespace, name, true
 }

--- a/pkg/queue/queue_manager_interface_test.go
+++ b/pkg/queue/queue_manager_interface_test.go
@@ -1,0 +1,44 @@
+package queue
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestSplitPrKey(t *testing.T) {
+	tests := []struct {
+		name          string
+		key           string
+		wantNamespace string
+		wantName      string
+		wantOK        bool
+	}{
+		{name: "valid key", key: "ns/name", wantNamespace: "ns", wantName: "name", wantOK: true},
+		{name: "trims surrounding and inner whitespace", key: "  ns / name  ", wantNamespace: "ns", wantName: "name", wantOK: true},
+		{name: "empty string", key: "", wantOK: false},
+		{name: "missing separator", key: "no-slash", wantOK: false},
+		{name: "empty namespace", key: "/name-only", wantOK: false},
+		{name: "empty name", key: "ns-only/", wantOK: false},
+		{name: "name contains a slash", key: "too/many/slashes", wantOK: false},
+		// A segment the client cannot encode as a path fails locally with an
+		// error that is not a NotFound, so it must be rejected here rather
+		// than treated as a retryable read.
+		{name: "name contains a percent", key: "ns/%", wantOK: false},
+		{name: "namespace contains a percent", key: "%/name", wantOK: false},
+		{name: "dot namespace", key: "./name", wantOK: false},
+		{name: "dotdot namespace", key: "../name", wantOK: false},
+		{name: "dot name", key: "ns/.", wantOK: false},
+		{name: "dotdot name", key: "ns/..", wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			namespace, name, ok := SplitPrKey(tt.key)
+			assert.Equal(t, ok, tt.wantOK)
+			if tt.wantOK {
+				assert.Equal(t, namespace, tt.wantNamespace)
+				assert.Equal(t, name, tt.wantName)
+			}
+		})
+	}
+}

--- a/pkg/queue/queue_manager_test.go
+++ b/pkg/queue/queue_manager_test.go
@@ -323,9 +323,52 @@ func TestFilterPipelineRunByInProgress(t *testing.T) {
 		orderList[i] = fmt.Sprintf("%s/%s", ns, pr.GetName())
 	}
 	stdata, _ := testclient.SeedTestData(t, ctx, tdata)
-	filtered := FilterPipelineRunByState(ctx, stdata.Pipeline, orderList, tektonv1.PipelineRunSpecStatusPending, kubeinteraction.StateQueued)
+	filtered, err := FilterPipelineRunByState(ctx, stdata.Pipeline, orderList, tektonv1.PipelineRunSpecStatusPending, kubeinteraction.StateQueued)
+	assert.NilError(t, err)
 	expected := []string{"test-ns/pr1"}
 	assert.DeepEqual(t, filtered, expected)
+}
+
+// TestFilterPipelineRunByStateSkipsMalformedKeys asserts that a malformed
+// entry in the execution-order annotation is skipped rather than panicking.
+// The annotation is user-editable, and this function runs inside InitQueues at
+// watcher startup, so a panic here is a persistent CrashLoopBackOff for the
+// whole cluster, not one dropped reconcile.
+func TestFilterPipelineRunByStateSkipsMalformedKeys(t *testing.T) {
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ns := "test-ns"
+
+	pipelineRuns := []*tektonv1.PipelineRun{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "valid",
+				Namespace: ns,
+				Annotations: map[string]string{
+					keys.State: kubeinteraction.StateQueued,
+				},
+			},
+			Spec: tektonv1.PipelineRunSpec{
+				Status: tektonv1.PipelineRunSpecStatusPending,
+			},
+		},
+	}
+	stdata, _ := testclient.SeedTestData(t, ctx, testclient.Data{
+		Namespaces:   []*corev1.Namespace{{ObjectMeta: metav1.ObjectMeta{Name: ns}}},
+		PipelineRuns: pipelineRuns,
+	})
+
+	orderList := []string{
+		"",                 // strings.Split("", ",") yields this
+		"no-slash",         // missing namespace separator
+		"/name-only",       // empty namespace
+		"ns-only/",         // empty name
+		"too/many/slashes", // name would contain a slash
+		"  " + ns + " / valid  ",
+		ns + "/valid",
+	}
+	filtered, err := FilterPipelineRunByState(ctx, stdata.Pipeline, orderList, tektonv1.PipelineRunSpecStatusPending, kubeinteraction.StateQueued)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, filtered, []string{ns + "/valid", ns + "/valid"})
 }
 
 // TestQueueManagerInitQueuesSkipsPipelineRunsWithoutOrder asserts that a

--- a/pkg/queue/semaphore.go
+++ b/pkg/queue/semaphore.go
@@ -1,6 +1,7 @@
 package queue
 
 import (
+	"container/heap"
 	"sync"
 	"time"
 
@@ -11,7 +12,7 @@ type prioritySemaphore struct {
 	name      string
 	limit     int
 	pending   *priorityQueue
-	running   map[string]bool
+	running   map[string]*item
 	semaphore *sema.Weighted
 	lock      *sync.Mutex
 }
@@ -24,7 +25,7 @@ func newSemaphore(name string, limit int) *prioritySemaphore {
 		limit:     limit,
 		pending:   &priorityQueue{itemByKey: make(map[string]*item)},
 		semaphore: sema.NewWeighted(int64(limit)),
-		running:   make(map[string]bool),
+		running:   make(map[string]*item),
 		lock:      &sync.Mutex{},
 	}
 }
@@ -108,12 +109,37 @@ func (s *prioritySemaphore) acquireLatest() string {
 
 	ready := s.pending.peek()
 
-	if s.semaphore.TryAcquire(1) {
-		_ = s.pending.pop()
-		s.running[ready.key] = true
+	if s.limit == 0 || s.semaphore.TryAcquire(1) {
+		s.running[ready.key] = s.pending.pop()
 		return ready.key
 	}
+
 	return ""
+}
+
+func (s *prioritySemaphore) nextPending() string {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if s.pending.Len() == 0 {
+		return ""
+	}
+	return s.pending.peek().key
+}
+
+// requeue restores the original priority and tie-breaker, not the retry time.
+func (s *prioritySemaphore) requeue(key string) bool {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	entry, ok := s.running[key]
+	if !ok {
+		return false
+	}
+	delete(s.running, key)
+	if s.limit > 0 && len(s.running) < s.limit {
+		s.semaphore.Release(1)
+	}
+	heap.Push(s.pending, entry)
+	return true
 }
 
 func (s *prioritySemaphore) release(key string) bool {

--- a/pkg/reconciler/event.go
+++ b/pkg/reconciler/event.go
@@ -2,6 +2,7 @@ package reconciler
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"strconv"
 
@@ -18,6 +19,13 @@ import (
 	"go.uber.org/zap"
 )
 
+// ErrProviderNotConfigured marks a detectProvider failure as permanent: the
+// PipelineRun's git-provider annotation is missing or names a provider PAC
+// does not know. Retrying detectProvider can never succeed in that case,
+// unlike e.g. a GitHub App client failing to initialize, which is worth a
+// retry.
+var ErrProviderNotConfigured = stderrors.New("provider not configured")
+
 // detectProvider detects the git provider for the given PipelineRun and
 // initializes the corresponding provider interface. It returns the provider
 // interface, event information, and an error if any occurs during detection or
@@ -28,7 +36,7 @@ import (
 func (r *Reconciler) detectProvider(ctx context.Context, logger *zap.SugaredLogger, pr *tektonv1.PipelineRun) (provider.Interface, *info.Event, error) {
 	gitProvider, ok := pr.GetAnnotations()[keys.GitProvider]
 	if !ok {
-		return nil, nil, fmt.Errorf("failed to detect git provider for pipleinerun %s : git-provider label not found", pr.GetName())
+		return nil, nil, fmt.Errorf("%w: git-provider annotation not found on pipelinerun %s", ErrProviderNotConfigured, pr.GetName())
 	}
 
 	event := buildEventFromPipelineRun(pr)
@@ -54,7 +62,7 @@ func (r *Reconciler) detectProvider(ctx context.Context, logger *zap.SugaredLogg
 	case "gitea", "forgejo":
 		provider = &gitea.Provider{}
 	default:
-		return nil, nil, fmt.Errorf("failed to detect provider for pipelinerun: %s : unknown provider", pr.GetName())
+		return nil, nil, fmt.Errorf("%w: unknown provider %q for pipelinerun %s", ErrProviderNotConfigured, gitProvider, pr.GetName())
 	}
 	provider.SetLogger(logger)
 	return provider, event, nil

--- a/pkg/reconciler/event_test.go
+++ b/pkg/reconciler/event_test.go
@@ -2,6 +2,7 @@ package reconciler
 
 import (
 	"context"
+	stderrors "errors"
 	"testing"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
@@ -109,12 +110,12 @@ func TestDetectProvider(t *testing.T) {
 		{
 			name:       "unknown provider",
 			annotation: "batman",
-			errStr:     "failed to detect provider for pipelinerun: test : unknown provider",
+			errStr:     `provider not configured: unknown provider "batman" for pipelinerun test`,
 		},
 		{
 			name:         "no label",
 			missTheLabel: true,
-			errStr:       "failed to detect git provider for pipleinerun test : git-provider label not found",
+			errStr:       "provider not configured: git-provider annotation not found on pipelinerun test",
 		},
 	}
 	for _, tt := range tests {
@@ -140,6 +141,8 @@ func TestDetectProvider(t *testing.T) {
 				return
 			}
 			assert.Error(t, err, tt.errStr)
+			assert.Assert(t, stderrors.Is(err, ErrProviderNotConfigured),
+				"a missing or unknown provider annotation must be classified as permanent")
 		})
 	}
 }

--- a/pkg/reconciler/finalizer.go
+++ b/pkg/reconciler/finalizer.go
@@ -3,13 +3,13 @@ package reconciler
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
 	"github.com/openshift-pipelines/pipelines-as-code/pkg/provider/status"
+	queuepkg "github.com/openshift-pipelines/pipelines-as-code/pkg/queue"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,7 +33,8 @@ func (r *Reconciler) finalizeKind(ctx context.Context, pr *tektonv1.PipelineRun)
 	// of a running PipelineRun would silently stop reporting.
 	ctx = info.StoreNS(ctx, system.Namespace())
 	state, exist := pr.GetAnnotations()[keys.State]
-	if !exist || state == kubeinteraction.StateCompleted {
+	if !exist || state == kubeinteraction.StateCompleted || state == kubeinteraction.StateFailed {
+		r.qm.ForgetAdmission(pr.Namespace+"/"+pr.Annotations[keys.Repository], pr)
 		return nil
 	}
 	controllerInfo, err := controllerInfoForPipelineRun(pr, r.run.Info.Controller)
@@ -72,20 +73,15 @@ func (r *Reconciler) finalizeKind(ctx context.Context, pr *tektonv1.PipelineRun)
 			}
 		}
 		logger = logger.With("namespace", repo.Namespace)
-		next := r.qm.RemoveAndTakeItemFromQueue(repo, pr)
-		if next != "" {
-			key := strings.Split(next, "/")
-			pr, err := r.run.Clients.Tekton.TektonV1().PipelineRuns(key[0]).Get(ctx, key[1], metav1.GetOptions{})
-			if err != nil {
-				return err
-			}
-			if err := r.
-				updatePipelineRunToInProgress(ctx, logger, repo, pr); err != nil {
-				logger.Errorf("failed to update status: %w", err)
-				return err
-			}
-			return nil
+		// This releases the slot the deleted PipelineRun held and promotes the
+		// next candidate, retrying past a malformed or already-gone queue key
+		// instead of leaving it stuck in the running set forever with no real
+		// PipelineRun ever completing to free it.
+		if err := r.startNextPipelineRunInQueue(ctx, logger, repo, pr); err != nil {
+			return err
 		}
+		r.qm.ForgetAdmission(queuepkg.RepoKey(repo), pr)
+		return nil
 	}
 	return nil
 }

--- a/pkg/reconciler/finalizer_test.go
+++ b/pkg/reconciler/finalizer_test.go
@@ -371,3 +371,149 @@ func TestReconcilerFinalizeKind(t *testing.T) {
 		})
 	}
 }
+
+// TestReconcilerFinalizeKindSkipsMalformedQueueKey is a regression test for a
+// panic on a malformed key taken off the queue: FinalizeKind splits and
+// indexes the "next" key returned by RemoveAndTakeItemFromQueue the same way
+// queue_pipelineruns.go and queue_manager.go do for execution-order entries,
+// so it needs the same guard against an entry that doesn't split into exactly
+// namespace/name. A malformed queue entry is not reachable through normal
+// annotation parsing today (see TestFilterPipelineRunByStateSkipsMalformedKeys),
+// but the guard here is deliberately defensive rather than relying on that
+// invariant holding everywhere a string is added to the queue.
+func TestReconcilerFinalizeKindSkipsMalformedQueueKey(t *testing.T) {
+	observer, logs := zapobserver.New(zap.InfoLevel)
+	fakelogger := zap.New(observer).Sugar()
+
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = logging.WithLogger(ctx, fakelogger)
+
+	stdata, informers := testclient.SeedTestData(t, ctx, testclient.Data{
+		Repositories: []*v1alpha1.Repository{finalizeTestRepo},
+	})
+
+	cs := &params.Run{
+		Clients: clients.Clients{
+			PipelineAsCode: stdata.PipelineAsCode,
+			Kube:           stdata.Kube,
+			Log:            fakelogger,
+		},
+		Info: info.Info{
+			Kube:       &info.KubeOpts{Namespace: "pac"},
+			Controller: &info.ControllerInfo{GlobalRepository: "pac"},
+			Pac:        info.NewPacOpts(),
+		},
+	}
+	cs.Clients.SetConsoleUI(consoleui.FallBackConsole{})
+	r := Reconciler{
+		repoLister: informers.Repository.Lister(),
+		qm:         queuepkg.NewManager(fakelogger),
+		run:        cs,
+		kinteract:  &testkubernetestint.KinterfaceTest{},
+	}
+
+	running := getTestPR("running", kubeinteraction.StateStarted)
+	_, err := r.qm.AddListToRunningQueue(finalizeTestRepo, []string{queuepkg.PrKey(running)})
+	assert.NilError(t, err)
+	// A malformed entry, as if something other than PrKey had added it to the
+	// queue: an extra "/" separator in the namespace/name key.
+	assert.NilError(t, r.qm.AddToPendingQueue(finalizeTestRepo, []string{"malformed/entry/with/extra-slash"}))
+
+	err = r.FinalizeKind(ctx, running)
+	assert.NilError(t, err, "a malformed queue entry must not panic or fail the finalizer")
+
+	found := false
+	for _, entry := range logs.All() {
+		if strings.Contains(entry.Message, "invalid pipelineRun key") {
+			found = true
+		}
+	}
+	assert.Assert(t, found, "expected a warning about the malformed queue entry, got: %v", logs.All())
+}
+
+// TestReconcilerFinalizeKindPromotesSuccessorPastMalformedKey is a regression
+// test for a slot leak: RemoveAndTakeItemFromQueue already moves the "next"
+// key into the running set before FinalizeKind gets a chance to validate it,
+// so simply discarding a malformed key without releasing that reservation
+// would strand it forever, since nothing ever completes to release a slot
+// that was never a real running PipelineRun. FinalizeKind must keep retrying
+// past the malformed entry and promote the next valid candidate instead of
+// leaving the running queue with a phantom occupant.
+func TestReconcilerFinalizeKindPromotesSuccessorPastMalformedKey(t *testing.T) {
+	observer, logs := zapobserver.New(zap.InfoLevel)
+	fakelogger := zap.New(observer).Sugar()
+
+	ctx, _ := rtesting.SetupFakeContext(t)
+	ctx = logging.WithLogger(ctx, fakelogger)
+
+	_, mux, mockServerURL, teardown := ghtesthelper.SetupGH()
+	defer teardown()
+	mux.HandleFunc("/repos/org/repo/statuses/123afc", func(rw http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(rw, `{"state":"pending"}`)
+	})
+
+	repo := finalizeTestRepo.DeepCopy()
+	repo.Spec.GitProvider.URL = mockServerURL
+
+	successor := getTestPR("successor", kubeinteraction.StateQueued)
+
+	stdata, informers := testclient.SeedTestData(t, ctx, testclient.Data{
+		Repositories: []*v1alpha1.Repository{repo},
+		PipelineRuns: []*tektonv1.PipelineRun{successor},
+		ConfigMap: []*corev1.ConfigMap{{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipelines-as-code", Namespace: system.Namespace()},
+			Data: map[string]string{
+				settings.TrustedProviderHostnamesKey: strings.TrimPrefix(mockServerURL, "http://"),
+			},
+		}},
+	})
+
+	cs := &params.Run{
+		Clients: clients.Clients{
+			PipelineAsCode: stdata.PipelineAsCode,
+			Kube:           stdata.Kube,
+			Tekton:         stdata.Pipeline,
+			Log:            fakelogger,
+		},
+		Info: info.Info{
+			Kube:       &info.KubeOpts{Namespace: "pac"},
+			Controller: &info.ControllerInfo{GlobalRepository: "pac"},
+			Pac:        info.NewPacOpts(),
+		},
+	}
+	cs.Clients.SetConsoleUI(consoleui.FallBackConsole{})
+	r := Reconciler{
+		repoLister: informers.Repository.Lister(),
+		qm:         queuepkg.NewManager(fakelogger),
+		run:        cs,
+		kinteract: &testkubernetestint.KinterfaceTest{
+			GetSecretResult: map[string]string{
+				"pac-git-basic-auth-owner-repo": "https://whateveryousayboss",
+			},
+		},
+	}
+
+	running := getTestPR("running", kubeinteraction.StateStarted)
+	_, err := r.qm.AddListToRunningQueue(repo, []string{queuepkg.PrKey(running)})
+	assert.NilError(t, err)
+	// The malformed entry is queued ahead of the valid successor so
+	// RemoveAndTakeItemFromQueue picks it first and FinalizeKind has to skip
+	// past it rather than stopping there.
+	assert.NilError(t, r.qm.AddToPendingQueue(repo, []string{"malformed-entry-with-no-slash"}))
+	assert.NilError(t, r.qm.AddToPendingQueue(repo, []string{queuepkg.PrKey(successor)}))
+
+	err = r.FinalizeKind(ctx, running)
+	assert.NilError(t, err, "a malformed queue entry must not panic or fail the finalizer")
+
+	found := false
+	for _, entry := range logs.All() {
+		if strings.Contains(entry.Message, "invalid pipelineRun key") {
+			found = true
+		}
+	}
+	assert.Assert(t, found, "expected a warning about the malformed queue entry, got: %v", logs.All())
+
+	runningKeys := r.qm.RunningPipelineRuns(repo)
+	assert.DeepEqual(t, runningKeys, []string{queuepkg.PrKey(successor)})
+	assert.Equal(t, len(r.qm.QueuedPipelineRuns(repo)), 0, "the successor must have been promoted, not left pending")
+}

--- a/pkg/reconciler/queue_pipelineruns.go
+++ b/pkg/reconciler/queue_pipelineruns.go
@@ -46,101 +46,73 @@ func (r *Reconciler) queuePipelineRun(ctx context.Context, logger *zap.SugaredLo
 		return fmt.Errorf("error getting PipelineRun: %w", err)
 	}
 
-	// merge local repo with global repo here in order to derive settings from global
-	// for further concurrency and other operations.
+	orderedList, err := queuepkg.FilterPipelineRunByState(ctx, r.run.Clients.Tekton, strings.Split(order, ","), tektonv1.PipelineRunSpecStatusPending, kubeinteraction.StateQueued)
+	if err != nil {
+		return err
+	}
+	return r.processQueueAdmission(ctx, logger, repo, pr, orderedList, queuepkg.AdmissionInitial)
+}
+
+func (r *Reconciler) processQueueAdmission(ctx context.Context, logger *zap.SugaredLogger, repo *pacAPIv1alpha1.Repository, owner *tektonv1.PipelineRun, orderedList []string, mode queuepkg.AdmissionMode) error {
+	// Resolve current limits for every admission, including resume, without
+	// changing the repository used to resolve inherited provider secrets.
+	queueRepo := repo
 	if globalRepo, err := r.repoLister.Repositories(r.run.Info.Kube.Namespace).Get(r.run.Info.Controller.GlobalRepository); err == nil && globalRepo != nil {
 		logger.Info("Merging global repository settings with local repository settings")
 		if merged := copyRepositoryForMerge(repo); merged != nil {
-			repo = merged
-			repo.Spec.Merge(globalRepo.Spec)
+			queueRepo = merged
+			queueRepo.Spec.Merge(globalRepo.Spec)
 		}
 	}
-
-	// if concurrency was set and later removed or changed to zero
-	// then remove pipelineRun from Queue and update pending state to running
-	if repo.Spec.ConcurrencyLimit != nil && *repo.Spec.ConcurrencyLimit == 0 {
-		_ = r.qm.RemoveAndTakeItemFromQueue(repo, pr)
-		if err := r.updatePipelineRunToInProgress(ctx, logger, repo, pr); err != nil {
-			return fmt.Errorf("failed to update PipelineRun to in_progress: %w", err)
-		}
-		return nil
-	}
-
-	var processed bool
-	var itered int
-	maxIterations := 5
-
-	orderedList := queuepkg.FilterPipelineRunByState(ctx, r.run.Clients.Tekton, strings.Split(order, ","), tektonv1.PipelineRunSpecStatusPending, kubeinteraction.StateQueued)
+	seen := map[string]bool{}
 	for {
-		acquired, err := r.qm.AddListToRunningQueue(repo, orderedList)
+		work, err := r.qm.AcquireAdmission(queueRepo, owner, orderedList, mode)
 		if err != nil {
-			return fmt.Errorf("failed to add to queue: %s: %w", pr.GetName(), err)
+			return fmt.Errorf("failed to acquire queue admission: %w", err)
 		}
-		if len(acquired) == 0 {
+		if work == nil {
+			return nil
+		}
+		if len(work.Candidates) == 0 {
 			logger.Infof("no new PipelineRun acquired for repo %s", repo.GetName())
-			break
+			return r.qm.FinishAdmission(work)
 		}
-
 		var errs []error
 		dropped := map[string]bool{}
-		for _, prKeys := range acquired {
-			repoKey := queuepkg.RepoKey(repo)
-			nsName := strings.Split(prKeys, "/")
-			if len(nsName) != 2 {
-				logger.Errorf("invalid pipelineRun key %q queued for repository %s, dropping it", prKeys, repo.GetName())
-				_ = r.qm.RemoveFromQueue(repoKey, prKeys)
-				dropped[prKeys] = true
+		started := false
+		for i := range work.Candidates {
+			candidate := &work.Candidates[i]
+			if seen[candidate.Key] {
+				errs = append(errs, fmt.Errorf("queue returned %s twice during admission", candidate.Key))
 				continue
 			}
-			acquiredPR, err := r.run.Clients.Tekton.TektonV1().PipelineRuns(nsName[0]).Get(ctx, nsName[1], metav1.GetOptions{})
+			seen[candidate.Key] = true
+			err := r.startQueueCandidate(ctx, logger, repo, candidate)
+			switch candidate.Outcome {
+			case queuepkg.StartRetry:
+			case queuepkg.StartGone:
+				dropped[candidate.Key] = true
+			case queuepkg.StartSucceeded:
+				started = true
+			}
 			if err != nil {
-				// Nothing has been written to the cluster yet, so this PipelineRun
-				// is still pending and cannot be running. Hand the slot back: if we
-				// kept it, the retry would find this PipelineRun already in the
-				// running set, never re-acquire it, and never free the slot, since
-				// only a completed PipelineRun releases one.
-				_ = r.qm.RemoveFromQueue(repoKey, prKeys)
-				if errors.IsNotFound(err) {
-					// This key came straight from the ordered list built at the top
-					// of this call. Drop it there too, or the next iteration of this
-					// loop would re-add and re-acquire the same gone PipelineRun,
-					// wasting a Get and possibly tripping maxIterations below even
-					// though there is nothing left to do.
-					logger.Infof("pipelineRun %s does not exist anymore, releasing its queue slot for repository %s", prKeys, repo.GetName())
-					dropped[prKeys] = true
-					continue
+				if mode == queuepkg.AdmissionPromotion && candidate.Outcome == queuepkg.StartSucceeded {
+					// Reporting is best effort after a confirmed start; it is
+					// not unfinished queue work.
+					logger.Errorf("started pipelineRun %s but could not report it: %v", candidate.Key, err)
+				} else {
+					errs = append(errs, err)
 				}
-				// Keep going rather than return: the other acquired PipelineRuns
-				// are already holding slots, and abandoning them here would strand
-				// those slots until the watcher restarts.
-				errs = append(errs, fmt.Errorf("failed to get pipelineRun %s: %w", prKeys, err))
-				continue
 			}
-			if err := r.updatePipelineRunToInProgress(ctx, logger, repo, acquiredPR); err != nil {
-				if stderrors.Is(err, ErrPipelineRunNotStarted) {
-					// The state patch never landed, so the PipelineRun is still
-					// pending. Release the slot so the retry can pick it up again.
-					logger.Infof("pipelineRun %s could not be started, releasing its queue slot for repository %s", prKeys, repo.GetName())
-					_ = r.qm.RemoveFromQueue(repoKey, prKeys)
-				}
-				// Otherwise the state patch landed before this failed, so the
-				// PipelineRun is already running in the cluster. Keep the slot:
-				// releasing it would let the queue admit past the concurrency
-				// limit and leave the in-memory queue permanently out of sync.
-				// The slot is freed when the PipelineRun completes.
-				//
-				// Either way, keep processing the remaining acquired PipelineRuns
-				// so their slots are not stranded, and report the error at the end.
-				errs = append(errs, fmt.Errorf("failed to update pipelineRun %s to in_progress: %w", prKeys, err))
-				continue
-			}
-			processed = true
 		}
-		if len(errs) > 0 {
-			return stderrors.Join(errs...)
+		// Account for the whole batch, including candidates after an error.
+		errs = append(errs, r.qm.FinishAdmission(work))
+		err = stderrors.Join(errs...)
+		if err != nil {
+			return err
 		}
-		if processed {
-			break
+		if started {
+			return nil
 		}
 		if len(dropped) > 0 {
 			filtered := orderedList[:0]
@@ -151,10 +123,45 @@ func (r *Reconciler) queuePipelineRun(ctx context.Context, logger *zap.SugaredLo
 			}
 			orderedList = filtered
 		}
-		if itered >= maxIterations {
-			return fmt.Errorf("max iterations reached of %d times trying to get a pipelinerun started for %s", maxIterations, repo.GetName())
+	}
+}
+
+func (r *Reconciler) startQueueCandidate(ctx context.Context, logger *zap.SugaredLogger, repo *pacAPIv1alpha1.Repository, candidate *queuepkg.StartCandidate) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	namespace, name, ok := queuepkg.SplitPrKey(candidate.Key)
+	if !ok {
+		logger.Errorf("invalid pipelineRun key %q queued for repository %s, dropping it", candidate.Key, repo.Name)
+		candidate.Outcome = queuepkg.StartGone
+		return nil
+	}
+	pr, err := r.run.Clients.Tekton.TektonV1().PipelineRuns(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			candidate.Outcome = queuepkg.StartGone
+			return nil
 		}
-		itered++
+		return fmt.Errorf("failed to get pipelineRun %s: %w", candidate.Key, err)
+	}
+	if candidate.Attempted && candidate.UID != pr.UID {
+		candidate.Outcome = queuepkg.StartGone
+		return nil
+	}
+	candidate.UID = pr.UID
+	candidate.Attempted = true
+	err = r.updatePipelineRunToInProgress(ctx, logger, repo, pr)
+	switch {
+	case stderrors.Is(err, errPipelineRunGone):
+		candidate.Outcome = queuepkg.StartGone
+		return nil
+	case stderrors.Is(err, ErrPipelineRunNotStarted):
+		// The attempt may still commit. Only this owner may resume its slot.
+	default:
+		candidate.Outcome = queuepkg.StartSucceeded
+	}
+	if err != nil {
+		return fmt.Errorf("failed to update pipelineRun %s to in_progress: %w", candidate.Key, err)
 	}
 	return nil
 }

--- a/pkg/reconciler/queue_pipelineruns_test.go
+++ b/pkg/reconciler/queue_pipelineruns_test.go
@@ -137,7 +137,7 @@ func TestQueuePipelineRun(t *testing.T) {
 			wantLog: "no new PipelineRun acquired for repo test",
 		},
 		{
-			name:         "failed to get PR from the Q after many iterations",
+			name:         "queue repeatedly returns a gone candidate",
 			runningQueue: []string{"test/test2"},
 			pipelineRun: &tektonv1.PipelineRun{
 				ObjectMeta: metav1.ObjectMeta{
@@ -159,7 +159,7 @@ func TestQueuePipelineRun(t *testing.T) {
 				},
 			},
 			wantLog:       "failed to get PR",
-			wantErrString: "max iterations reached of",
+			wantErrString: "twice during admission",
 		},
 	}
 	for _, tt := range tests {
@@ -221,10 +221,7 @@ func TestQueuePipelineRun(t *testing.T) {
 }
 
 // TestQueuePipelineRunSlotRelease asserts when a queue slot is released and,
-// more importantly, when it must not be. The slot follows the state patch: it
-// is what clears spec.status, so before it lands the PipelineRun is still
-// pending and holding its slot would strand it forever, and after it lands the
-// PipelineRun is running and releasing its slot would admit past the limit.
+// more importantly, when a failed start must retain its reservation.
 func TestQueuePipelineRunSlotRelease(t *testing.T) {
 	const ns = "test"
 
@@ -256,11 +253,11 @@ func TestQueuePipelineRunSlotRelease(t *testing.T) {
 		{
 			name:          "vanished pipelineRun releases the queue slot",
 			seededPR:      nil,
-			wantErrString: "max iterations reached of",
+			wantErrString: "twice during admission",
 			wantReleased:  true,
 		},
 		{
-			name:     "failing state patch releases the queue slot",
+			name:     "uncertain state patch retains the queue slot",
 			seededPR: acquiredPR,
 			setup: func(t *testing.T, cs *fakepipelineclientset.Clientset) {
 				t.Helper()
@@ -269,10 +266,10 @@ func TestQueuePipelineRunSlotRelease(t *testing.T) {
 				})
 			},
 			wantErrString: "failed to update pipelineRun test/queued to in_progress",
-			wantReleased:  true,
+			wantReleased:  false,
 		},
 		{
-			name:     "transient get failure releases the queue slot",
+			name:     "transient get failure is retried rather than dropped",
 			seededPR: acquiredPR,
 			setup: func(t *testing.T, cs *fakepipelineclientset.Clientset) {
 				t.Helper()
@@ -280,8 +277,8 @@ func TestQueuePipelineRunSlotRelease(t *testing.T) {
 					return true, nil, apierrors.NewServiceUnavailable("apiserver is shutting down")
 				})
 			},
-			wantErrString: "failed to get pipelineRun test/queued",
-			wantReleased:  true,
+			wantErrString: "cannot read execution-order pipelineRun test/queued",
+			wantReleased:  false,
 		},
 	}
 
@@ -307,8 +304,9 @@ func TestQueuePipelineRunSlotRelease(t *testing.T) {
 			released := []string{}
 			r := &Reconciler{
 				qm: testconcurrency.TestQMI{
-					RunningQueue: []string{ns + "/queued"},
-					Removed:      &released,
+					RunningQueue:     []string{ns + "/queued"},
+					Removed:          &released,
+					AdmissionRepoKey: queuepkg.RepoKey(repo),
 				},
 				repoLister: informers.Repository.Lister(),
 				run: &params.Run{
@@ -351,8 +349,7 @@ func TestQueuePipelineRunSlotRelease(t *testing.T) {
 // TestQueuePipelineRunProcessesAllAcquiredSlots asserts that a failure on one
 // acquired PipelineRun does not abandon the others. With a concurrency limit
 // above one, several PipelineRuns can be acquired in the same call; each one
-// already holds a slot, so every one of them must end up either started or
-// released. Returning early would strand the rest in the running set forever.
+// already holds a slot, so every one must be started or recorded for retry.
 func TestQueuePipelineRunProcessesAllAcquiredSlots(t *testing.T) {
 	const ns = "test"
 
@@ -394,8 +391,9 @@ func TestQueuePipelineRunProcessesAllAcquiredSlots(t *testing.T) {
 	released := []string{}
 	r := &Reconciler{
 		qm: testconcurrency.TestQMI{
-			RunningQueue: []string{ns + "/first", ns + "/second"},
-			Removed:      &released,
+			RunningQueue:     []string{ns + "/first", ns + "/second"},
+			Removed:          &released,
+			AdmissionRepoKey: queuepkg.RepoKey(repo),
 		},
 		repoLister: informers.Repository.Lister(),
 		run: &params.Run{
@@ -427,8 +425,8 @@ func TestQueuePipelineRunProcessesAllAcquiredSlots(t *testing.T) {
 	err := r.queuePipelineRun(ctx, fakelogger, trigger)
 	assert.ErrorContains(t, err, "pipelineRun test/first")
 
-	// "first" never left pending, so its slot must have been handed back.
-	assert.DeepEqual(t, released, []string{ns + "/test|" + ns + "/first"})
+	// A pending read cannot rule out a late commit of the failed start.
+	assert.Equal(t, len(released), 0)
 
 	// "second" must not have been abandoned: its state patch went through.
 	second, err := stdata.Pipeline.TektonV1().PipelineRuns(ns).Get(ctx, "second", metav1.GetOptions{})
@@ -538,9 +536,7 @@ func TestQueuePipelineRunDropsGoneKeysFromRetry(t *testing.T) {
 }
 
 // TestStartNextPipelineRunInQueue asserts the completion path obeys the same
-// slot rule as the acquire path: a candidate that never left pending gives its
-// slot back and the queue moves on to the next one, while a candidate whose
-// start failed only after the state patch keeps its slot.
+// reservation and retry rules as initial admission.
 func TestStartNextPipelineRunInQueue(t *testing.T) {
 	const ns = "test"
 
@@ -566,6 +562,7 @@ func TestStartNextPipelineRunInQueue(t *testing.T) {
 		wantReleased   []string
 		wantStarted    []string
 		wantNotStarted []string
+		wantErr        string
 	}{
 		{
 			name:        "vanished candidate releases its slot and the next one starts",
@@ -577,7 +574,7 @@ func TestStartNextPipelineRunInQueue(t *testing.T) {
 			wantStarted: []string{"second"},
 		},
 		{
-			name:        "failing state patch releases the slot and the next one starts",
+			name:        "uncertain state patch keeps the slot and returns an error",
 			nextInQueue: []string{ns + "/first", ns + "/second"},
 			seeded:      []*tektonv1.PipelineRun{makePR("first"), makePR("second")},
 			setup: func(t *testing.T, cs *fakepipelineclientset.Clientset) {
@@ -589,10 +586,8 @@ func TestStartNextPipelineRunInQueue(t *testing.T) {
 					return false, nil, nil
 				})
 			},
-			wantReleased: []string{
-				ns + "/test|" + ns + "/first",
-			},
-			wantStarted: []string{"second"},
+			wantNotStarted: []string{"first", "second"},
+			wantErr:        "start is not confirmed",
 		},
 		{
 			// The state patch on "first" succeeds, then provider detection
@@ -629,8 +624,9 @@ func TestStartNextPipelineRunInQueue(t *testing.T) {
 			next := append([]string{}, tt.nextInQueue...)
 			r := &Reconciler{
 				qm: testconcurrency.TestQMI{
-					Removed:     &released,
-					NextInQueue: &next,
+					Removed:          &released,
+					NextInQueue:      &next,
+					AdmissionRepoKey: queuepkg.RepoKey(repo),
 				},
 				repoLister: informers.Repository.Lister(),
 				run: &params.Run{
@@ -649,7 +645,12 @@ func TestStartNextPipelineRunInQueue(t *testing.T) {
 			}
 
 			finished := makePR("finished")
-			r.startNextPipelineRunInQueue(ctx, fakelogger, repo, finished)
+			err := r.startNextPipelineRunInQueue(ctx, fakelogger, repo, finished)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+			} else {
+				assert.NilError(t, err)
+			}
 
 			assert.DeepEqual(t, released, func() []string {
 				if tt.wantReleased == nil {
@@ -675,8 +676,7 @@ func TestStartNextPipelineRunInQueue(t *testing.T) {
 // Every candidate that cannot be started hands its slot back and the loop asks
 // the queue for another one, so a queue that keeps handing out a key it was
 // asked to remove would spin forever and take the whole test binary down with
-// it on the -timeout kill. It must give up instead, and it must always release
-// the slot it is holding when it does.
+// it on the -timeout kill. It must return an error without discarding recovery.
 func TestStartNextPipelineRunInQueueGivesUp(t *testing.T) {
 	const ns = "test"
 
@@ -699,7 +699,6 @@ func TestStartNextPipelineRunInQueueGivesUp(t *testing.T) {
 			repeatNext: ns + "/never-there",
 			wantRemoved: []string{
 				ns + "/test|" + ns + "/never-there",
-				ns + "/test|" + ns + "/never-there",
 			},
 		},
 		{
@@ -708,7 +707,6 @@ func TestStartNextPipelineRunInQueueGivesUp(t *testing.T) {
 			repeatNext: "no-slash-here",
 			wantRemoved: []string{
 				ns + "/test|no-slash-here",
-				ns + "/test|no-slash-here",
 			},
 		},
 		{
@@ -716,10 +714,10 @@ func TestStartNextPipelineRunInQueueGivesUp(t *testing.T) {
 			// RemoveAndTakeItemFromQueue, or the finished PipelineRun's own
 			// slot is never freed, and the slot taken for the candidate we
 			// then decline to start must be handed back.
-			name:        "a cancelled context releases the slot it just took",
+			name:        "a cancelled context preserves recovery",
 			repeatNext:  ns + "/never-there",
 			cancel:      true,
-			wantRemoved: []string{ns + "/test|" + ns + "/never-there"},
+			wantRemoved: []string{},
 		},
 	}
 
@@ -742,9 +740,10 @@ func TestStartNextPipelineRunInQueueGivesUp(t *testing.T) {
 			taken := 0
 			r := &Reconciler{
 				qm: testconcurrency.TestQMI{
-					Removed:    &removed,
-					RepeatNext: tt.repeatNext,
-					Taken:      &taken,
+					Removed:          &removed,
+					RepeatNext:       tt.repeatNext,
+					Taken:            &taken,
+					AdmissionRepoKey: queuepkg.RepoKey(repo),
 				},
 				repoLister: informers.Repository.Lister(),
 				run: &params.Run{
@@ -765,7 +764,12 @@ func TestStartNextPipelineRunInQueueGivesUp(t *testing.T) {
 			finished := &tektonv1.PipelineRun{
 				ObjectMeta: metav1.ObjectMeta{Name: "finished", Namespace: ns},
 			}
-			r.startNextPipelineRunInQueue(ctx, fakelogger, repo, finished)
+			err := r.startNextPipelineRunInQueue(ctx, fakelogger, repo, finished)
+			if tt.cancel {
+				assert.ErrorContains(t, err, ctx.Err().Error())
+			} else {
+				assert.ErrorContains(t, err, "twice during admission")
+			}
 
 			assert.DeepEqual(t, removed, tt.wantRemoved)
 			// RemoveAndTakeItemFromQueue is what frees the finished
@@ -827,7 +831,7 @@ func TestStartNextPipelineRunInQueueReleasesSlotForReal(t *testing.T) {
 	finished := &tektonv1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{Name: "finished", Namespace: ns},
 	}
-	r.startNextPipelineRunInQueue(ctx, fakelogger, repo, finished)
+	assert.NilError(t, r.startNextPipelineRunInQueue(ctx, fakelogger, repo, finished))
 
 	// Both the finished run and the vanished candidate must be gone from the
 	// queue. If "gone" kept the slot it briefly held, the repository would sit

--- a/pkg/reconciler/queue_recovery_test.go
+++ b/pkg/reconciler/queue_recovery_test.go
@@ -1,0 +1,636 @@
+package reconciler
+
+import (
+	"context"
+	"encoding/json"
+	stderrors "errors"
+	"fmt"
+	"io"
+	"strconv"
+	"testing"
+
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/keys"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/consoleui"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/events"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/kubeinteraction"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/clients"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/params/info"
+	prmetrics "github.com/openshift-pipelines/pipelines-as-code/pkg/pipelinerunmetrics"
+	queuepkg "github.com/openshift-pipelines/pipelines-as-code/pkg/queue"
+	testclient "github.com/openshift-pipelines/pipelines-as-code/pkg/test/clients"
+	testprovider "github.com/openshift-pipelines/pipelines-as-code/pkg/test/provider"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	fakepipeline "github.com/tektoncd/pipeline/pkg/client/clientset/versioned/fake"
+	"go.uber.org/zap"
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+	knativeapi "knative.dev/pkg/apis"
+	knativeduckv1 "knative.dev/pkg/apis/duck/v1"
+	rtesting "knative.dev/pkg/reconciler/testing"
+)
+
+type queueRecoveryFixture struct {
+	ctx         context.Context
+	r           *Reconciler
+	qm          *queuepkg.Manager
+	cs          *fakepipeline.Clientset
+	repo        *v1alpha1.Repository
+	owner       *tektonv1.PipelineRun
+	repoIndexer cache.Indexer
+}
+
+func newQueueRecoveryFixture(t *testing.T, limit int, initial bool) *queueRecoveryFixture {
+	t.Helper()
+	ctx, _ := rtesting.SetupFakeContext(t)
+	logger := zap.NewNop().Sugar()
+	repo := &v1alpha1.Repository{
+		ObjectMeta: metav1.ObjectMeta{Name: "repo", Namespace: "ns"},
+		Spec:       v1alpha1.RepositorySpec{ConcurrencyLimit: &limit},
+	}
+	prs := make([]*tektonv1.PipelineRun, 0, 4)
+	for _, name := range []string{"owner", "first", "second", "third"} {
+		prs = append(prs, &tektonv1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name, Namespace: "ns", UID: types.UID(name), ResourceVersion: "1",
+				Annotations: map[string]string{
+					keys.Repository: "repo", keys.State: kubeinteraction.StateQueued,
+					keys.ExecutionOrder: "ns/first,ns/second,ns/third", keys.SecretCreated: "true",
+				},
+			},
+			Spec: tektonv1.PipelineRunSpec{Status: tektonv1.PipelineRunSpecStatusPending},
+		})
+	}
+	owner := prs[0]
+	owner.Spec.Status = ""
+	owner.Annotations[keys.State] = kubeinteraction.StateStarted
+	owner.Status.Status = knativeduckv1.Status{Conditions: knativeduckv1.Conditions{{
+		Type: knativeapi.ConditionSucceeded, Status: corev1.ConditionTrue, Reason: string(tektonv1.PipelineRunReasonSuccessful),
+	}}}
+	if initial {
+		owner = prs[1]
+	}
+	seed, informers := testclient.SeedTestData(t, ctx, testclient.Data{
+		Repositories: []*v1alpha1.Repository{repo}, PipelineRuns: prs,
+	})
+	qm := queuepkg.NewManager(logger)
+	if !initial {
+		_, err := qm.AddListToRunningQueue(repo, []string{queuepkg.PrKey(owner)})
+		assert.NilError(t, err)
+		assert.NilError(t, qm.AddToPendingQueue(repo, []string{"ns/first", "ns/second", "ns/third"}))
+	}
+	recorder, err := prmetrics.NewRecorder()
+	assert.NilError(t, err)
+	run := &params.Run{
+		Clients: clients.Clients{Tekton: seed.Pipeline, Kube: seed.Kube, Log: logger},
+		Info: info.Info{
+			Pac: &info.PacOpts{}, Kube: &info.KubeOpts{Namespace: "global"},
+			Controller: &info.ControllerInfo{GlobalRepository: "global"},
+		},
+	}
+	run.Clients.SetConsoleUI(consoleui.FallBackConsole{})
+	r := &Reconciler{
+		qm: qm, run: run, repoLister: informers.Repository.Lister(),
+		kinteract: &kubeinteraction.Interaction{Run: run}, metrics: recorder,
+		eventEmitter: events.NewEventEmitter(seed.Kube, logger),
+	}
+	f := &queueRecoveryFixture{ctx: ctx, r: r, qm: qm, cs: seed.Pipeline, repo: repo, owner: owner, repoIndexer: informers.Repository.Informer().GetIndexer()}
+	// The fake tracker does not enforce optimistic concurrency or advance RVs.
+	seed.Pipeline.PrependReactor("patch", "pipelineruns", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return f.applyPatch(t, action)
+	})
+	return f
+}
+
+func (f *queueRecoveryFixture) get(t *testing.T, name string) *tektonv1.PipelineRun {
+	t.Helper()
+	pr, err := f.cs.TektonV1().PipelineRuns("ns").Get(f.ctx, name, metav1.GetOptions{})
+	assert.NilError(t, err)
+	return pr
+}
+
+func (f *queueRecoveryFixture) applyPatch(t *testing.T, action k8stesting.Action) (bool, runtime.Object, error) {
+	t.Helper()
+	patch, ok := action.(k8stesting.PatchAction)
+	assert.Assert(t, ok)
+	var body struct {
+		Metadata metav1.ObjectMeta `json:"metadata"`
+	}
+	assert.NilError(t, json.Unmarshal(patch.GetPatch(), &body))
+	resource := tektonv1.SchemeGroupVersion.WithResource("pipelineruns")
+	obj, err := f.cs.Tracker().Get(resource, "ns", patch.GetName())
+	if err != nil {
+		return true, nil, err
+	}
+	current, ok := obj.(*tektonv1.PipelineRun)
+	assert.Assert(t, ok)
+	if body.Metadata.Annotations[keys.State] == kubeinteraction.StateStarted {
+		assert.Assert(t, body.Metadata.UID != "")
+		assert.Assert(t, body.Metadata.ResourceVersion != "")
+		if current.UID != body.Metadata.UID || current.ResourceVersion != body.Metadata.ResourceVersion {
+			return true, nil, apierrors.NewConflict(tektonv1.Resource("pipelineruns"), current.Name, fmt.Errorf("stale start"))
+		}
+	}
+	handled, result, err := k8stesting.ObjectReaction(f.cs.Tracker())(action)
+	if err != nil {
+		return handled, result, err
+	}
+	updated, ok := result.(*tektonv1.PipelineRun)
+	assert.Assert(t, ok)
+	rv, err := strconv.Atoi(current.ResourceVersion)
+	assert.NilError(t, err)
+	updated.ResourceVersion = strconv.Itoa(rv + 1)
+	assert.NilError(t, f.cs.Tracker().Update(resource, updated, "ns"))
+	return true, updated, nil
+}
+
+func (f *queueRecoveryFixture) call(mode string) error {
+	switch mode {
+	case "initial":
+		return f.r.queuePipelineRun(f.ctx, f.r.run.Clients.Log, f.owner)
+	case "finalization":
+		return f.r.FinalizeKind(f.ctx, f.owner)
+	case "abandonment":
+		return f.r.ReconcileKind(f.ctx, f.owner)
+	default:
+		provider := &testprovider.TestProviderImp{}
+		event := &info.Event{InstallationID: 1, Provider: &info.Provider{}}
+		_, err := f.r.reportFinalStatus(f.ctx, f.r.run.Clients.Log, f.r.run.Info.Pac, event, f.owner, provider)
+		return err
+	}
+}
+
+func TestQueueRecoveryPatchOutcomes(t *testing.T) {
+	tests := []struct {
+		name           string
+		apply          bool
+		readFails      bool
+		retryReadFails bool
+	}{
+		{name: "lost response after committed start", apply: true},
+		{name: "pending readback keeps an uncertain start owned"},
+		{name: "uncertain readback keeps an uncertain start owned", readFails: true},
+		{name: "a later transient read cannot requeue an uncertain start", retryReadFails: true},
+	}
+	for _, mode := range []string{"initial", "finalization", "abandonment", "normal completion"} {
+		for _, tt := range tests {
+			t.Run(mode+"/"+tt.name, func(t *testing.T) {
+				f := newQueueRecoveryFixture(t, 1, mode == "initial")
+				failed := false
+				f.cs.PrependReactor("patch", "pipelineruns", func(action k8stesting.Action) (bool, runtime.Object, error) {
+					patch, ok := action.(k8stesting.PatchAction)
+					if !ok || patch.GetName() != "first" || failed {
+						return false, nil, nil
+					}
+					failed = true
+					if tt.apply {
+						_, _, err := f.applyPatch(t, action)
+						assert.NilError(t, err)
+					}
+					return true, nil, io.ErrUnexpectedEOF
+				})
+				readFailed := false
+				f.cs.PrependReactor("get", "pipelineruns", func(action k8stesting.Action) (bool, runtime.Object, error) {
+					if get, ok := action.(k8stesting.GetAction); ok && tt.readFails && failed && !readFailed && get.GetName() == "first" {
+						readFailed = true
+						return true, nil, apierrors.NewServiceUnavailable("uncertain readback")
+					}
+					return false, nil, nil
+				})
+				err := f.call(mode)
+				switch {
+				case !tt.apply:
+					assert.Assert(t, stderrors.Is(err, ErrPipelineRunNotStarted), "got %v", err)
+				case mode == "initial":
+					assert.Assert(t, stderrors.Is(err, ErrProviderNotConfigured), "only post-start reporting may fail: %v", err)
+				default:
+					assert.NilError(t, err)
+				}
+				assert.DeepEqual(t, f.qm.RunningPipelineRuns(f.repo), []string{"ns/first"})
+				assert.Equal(t, f.get(t, "second").Spec.Status, tektonv1.PipelineRunSpecStatus(tektonv1.PipelineRunSpecStatusPending))
+				if !tt.apply {
+					assert.Equal(t, f.get(t, f.owner.Name).Annotations[keys.State], f.owner.Annotations[keys.State])
+					if tt.retryReadFails {
+						failRead := true
+						f.cs.PrependReactor("get", "pipelineruns", func(action k8stesting.Action) (bool, runtime.Object, error) {
+							if get, ok := action.(k8stesting.GetAction); ok && get.GetName() == "first" && failRead {
+								failRead = false
+								return true, nil, apierrors.NewServiceUnavailable("retry read")
+							}
+							return false, nil, nil
+						})
+						assert.ErrorContains(t, f.call(mode), "retry read")
+						assert.DeepEqual(t, f.qm.RunningPipelineRuns(f.repo), []string{"ns/first"})
+					}
+					err = f.call(mode)
+					if mode == "initial" {
+						assert.Assert(t, stderrors.Is(err, ErrProviderNotConfigured), "got %v", err)
+					} else {
+						assert.NilError(t, err)
+					}
+				}
+				assert.Equal(t, string(f.get(t, "first").Spec.Status), "")
+				assert.DeepEqual(t, f.qm.RunningPipelineRuns(f.repo), []string{"ns/first"})
+				// The actual reconciliation retry must terminate after reporting
+				// fails for an already-started candidate.
+				assert.NilError(t, f.r.ReconcileKind(f.ctx, f.get(t, f.owner.Name)))
+				assert.Equal(t, f.get(t, "second").Annotations[keys.State], kubeinteraction.StateQueued)
+			})
+		}
+	}
+}
+
+func TestQueueRecoveryTransientGet(t *testing.T) {
+	for _, mode := range []string{"initial", "finalization", "abandonment", "normal completion"} {
+		t.Run(mode, func(t *testing.T) {
+			f := newQueueRecoveryFixture(t, 1, mode == "initial")
+			gets := 0
+			failAt := 1
+			if mode == "initial" {
+				failAt = 2 // The first read builds the execution-order list.
+			}
+			f.cs.PrependReactor("get", "pipelineruns", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				if get, ok := action.(k8stesting.GetAction); ok && get.GetName() == "first" {
+					gets++
+					if gets == failAt {
+						return true, nil, apierrors.NewServiceUnavailable("transient successor read")
+					}
+				}
+				return false, nil, nil
+			})
+			assert.ErrorContains(t, f.call(mode), "transient successor read")
+			assert.Equal(t, len(f.qm.RunningPipelineRuns(f.repo)), 0)
+			assert.Equal(t, len(f.qm.QueuedPipelineRuns(f.repo)), 3)
+			assert.Equal(t, f.get(t, "first").Annotations[keys.State], kubeinteraction.StateQueued)
+			assert.Equal(t, f.get(t, f.owner.Name).Annotations[keys.State], f.owner.Annotations[keys.State])
+			err := f.call(mode)
+			if mode == "initial" {
+				assert.Assert(t, stderrors.Is(err, ErrProviderNotConfigured), "got %v", err)
+			} else {
+				assert.NilError(t, err)
+			}
+			assert.DeepEqual(t, f.qm.RunningPipelineRuns(f.repo), []string{"ns/first"})
+			assert.Equal(t, string(f.get(t, "first").Spec.Status), "")
+			assert.Equal(t, f.get(t, "second").Annotations[keys.State], kubeinteraction.StateQueued)
+		})
+	}
+}
+
+func TestQueueRecoveryTerminalPatchReplay(t *testing.T) {
+	tests := []struct {
+		name  string
+		apply bool
+		limit int
+	}{
+		{name: "before applying at limit one", limit: 1},
+		{name: "after applying at limit one", limit: 1, apply: true},
+		{name: "before applying with spare capacity", limit: 3},
+		{name: "after applying with spare capacity", limit: 3, apply: true},
+	}
+	for _, mode := range []string{"abandonment", "normal completion"} {
+		for _, tt := range tests {
+			t.Run(mode+"/"+tt.name, func(t *testing.T) {
+				f := newQueueRecoveryFixture(t, tt.limit, false)
+				failed := false
+				f.cs.PrependReactor("patch", "pipelineruns", func(action k8stesting.Action) (bool, runtime.Object, error) {
+					patch, ok := action.(k8stesting.PatchAction)
+					if !ok || patch.GetName() != "owner" || failed {
+						return false, nil, nil
+					}
+					failed = true
+					if tt.apply {
+						_, _, err := f.applyPatch(t, action)
+						assert.NilError(t, err)
+					}
+					return true, nil, io.ErrUnexpectedEOF
+				})
+				assert.ErrorContains(t, f.call(mode), "cannot update state")
+				assert.DeepEqual(t, f.qm.RunningPipelineRuns(f.repo), []string{"ns/first"})
+				if tt.apply {
+					assert.NilError(t, f.r.ReconcileKind(f.ctx, f.get(t, "owner")))
+				} else {
+					assert.NilError(t, f.call(mode))
+				}
+				// A repeated finalizer after the record has been cleaned up also
+				// cannot manufacture a second handoff for an absent reservation.
+				assert.NilError(t, f.r.FinalizeKind(f.ctx, f.owner))
+				assert.DeepEqual(t, f.qm.RunningPipelineRuns(f.repo), []string{"ns/first"})
+				assert.Equal(t, f.get(t, "second").Annotations[keys.State], kubeinteraction.StateQueued)
+			})
+		}
+	}
+}
+
+func TestQueueRecoveryDelayedPatch(t *testing.T) {
+	tests := []struct {
+		name          string
+		change        func(*tektonv1.PipelineRun)
+		settleOnRetry bool
+	}{
+		{name: "delayed request commits before the owner retries"},
+		{name: "successful retry fences the original request", settleOnRetry: true},
+		{name: "cancelled candidate", change: func(pr *tektonv1.PipelineRun) { pr.Spec.Status = tektonv1.PipelineRunSpecStatusCancelled }},
+		{name: "gracefully cancelled candidate", change: func(pr *tektonv1.PipelineRun) { pr.Spec.Status = tektonv1.PipelineRunSpecStatusCancelledRunFinally }},
+		{name: "gracefully stopped candidate", change: func(pr *tektonv1.PipelineRun) { pr.Spec.Status = tektonv1.PipelineRunSpecStatusStoppedRunFinally }},
+		{name: "completed candidate", change: func(pr *tektonv1.PipelineRun) { pr.Annotations[keys.State] = kubeinteraction.StateCompleted }},
+		{name: "deleted candidate", change: func(pr *tektonv1.PipelineRun) { now := metav1.Now(); pr.DeletionTimestamp = &now }},
+		{name: "replacement UID", change: func(pr *tektonv1.PipelineRun) { pr.UID = "replacement" }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newQueueRecoveryFixture(t, 1, false)
+			var delayed k8stesting.Action
+			f.cs.PrependReactor("patch", "pipelineruns", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				if patch, ok := action.(k8stesting.PatchAction); ok && patch.GetName() == "first" && delayed == nil {
+					delayed = action.DeepCopy()
+					return true, nil, io.ErrUnexpectedEOF
+				}
+				return false, nil, nil
+			})
+			assert.ErrorContains(t, f.call("finalization"), "start is not confirmed")
+			assert.DeepEqual(t, f.qm.RunningPipelineRuns(f.repo), []string{"ns/first"})
+			switch {
+			case tt.change != nil:
+				pr := f.get(t, "first")
+				tt.change(pr)
+				pr.ResourceVersion = "2"
+				assert.NilError(t, f.cs.Tracker().Update(tektonv1.SchemeGroupVersion.WithResource("pipelineruns"), pr, "ns"))
+				assert.NilError(t, f.call("finalization"))
+				assert.DeepEqual(t, f.qm.RunningPipelineRuns(f.repo), []string{"ns/second"})
+				_, _, err := f.applyPatch(t, delayed)
+				assert.Assert(t, apierrors.IsConflict(err), "a delayed start must be fenced: %v", err)
+				assert.Assert(t, f.get(t, "first").Spec.Status != "")
+			case tt.settleOnRetry:
+				assert.NilError(t, f.call("finalization"))
+				_, _, err := f.applyPatch(t, delayed)
+				assert.Assert(t, apierrors.IsConflict(err))
+				assert.DeepEqual(t, f.qm.RunningPipelineRuns(f.repo), []string{"ns/first"})
+				assert.Equal(t, f.get(t, "second").Annotations[keys.State], kubeinteraction.StateQueued)
+			default:
+				_, _, err := f.applyPatch(t, delayed)
+				assert.NilError(t, err)
+				assert.NilError(t, f.call("finalization"))
+				assert.DeepEqual(t, f.qm.RunningPipelineRuns(f.repo), []string{"ns/first"})
+				assert.Equal(t, f.get(t, "second").Annotations[keys.State], kubeinteraction.StateQueued)
+			}
+		})
+	}
+}
+
+func TestQueueRecoveryBatchAndCancellation(t *testing.T) {
+	tests := []struct {
+		name      string
+		cancel    bool
+		failFirst bool
+	}{
+		{name: "started owner resumes another candidate from its batch"},
+		{name: "first failure does not abandon the rest of the batch", failFirst: true},
+		{name: "cancelled context preserves owned work", cancel: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newQueueRecoveryFixture(t, 2, true)
+			failedName := "second"
+			if tt.failFirst {
+				failedName = "first"
+			}
+			failed := false
+			f.cs.PrependReactor("patch", "pipelineruns", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				if patch, ok := action.(k8stesting.PatchAction); ok && patch.GetName() == failedName && !failed {
+					failed = true
+					return true, nil, io.ErrUnexpectedEOF
+				}
+				return false, nil, nil
+			})
+			assert.ErrorContains(t, f.call("initial"), "start is not confirmed")
+			assert.Equal(t, len(f.qm.RunningPipelineRuns(f.repo)), 2)
+			startedName := "first"
+			if tt.failFirst {
+				startedName = "second"
+			}
+			assert.Equal(t, string(f.get(t, startedName).Spec.Status), "")
+			if tt.cancel {
+				ctx, cancel := context.WithCancel(f.ctx)
+				cancel()
+				assert.Assert(t, stderrors.Is(f.r.ReconcileKind(ctx, f.get(t, "first")), ctx.Err()))
+				assert.Equal(t, len(f.qm.RunningPipelineRuns(f.repo)), 2)
+			}
+
+			err := f.r.ReconcileKind(f.ctx, f.get(t, "first"))
+			assert.Assert(t, stderrors.Is(err, ErrProviderNotConfigured), "only reporting may fail after resuming: %v", err)
+			assert.Equal(t, string(f.get(t, "second").Spec.Status), "")
+			assert.Equal(t, f.get(t, "third").Annotations[keys.State], kubeinteraction.StateQueued)
+			assert.NilError(t, f.r.ReconcileKind(f.ctx, f.get(t, "first")))
+		})
+	}
+}
+
+func TestQueueRecoveryCancelledBeforeStart(t *testing.T) {
+	for _, mode := range []string{"initial", "finalization"} {
+		t.Run(mode, func(t *testing.T) {
+			f := newQueueRecoveryFixture(t, 1, mode == "initial")
+			ctx := f.ctx
+			cancelled, cancel := context.WithCancel(ctx)
+			cancel()
+			f.ctx = cancelled
+			assert.Assert(t, stderrors.Is(f.call(mode), cancelled.Err()))
+			assert.Equal(t, len(f.qm.RunningPipelineRuns(f.repo)), 0)
+			f.ctx = ctx
+			err := f.call(mode)
+			if mode == "initial" {
+				assert.Assert(t, stderrors.Is(err, ErrProviderNotConfigured), "got %v", err)
+			} else {
+				assert.NilError(t, err)
+			}
+			assert.DeepEqual(t, f.qm.RunningPipelineRuns(f.repo), []string{"ns/first"})
+		})
+	}
+}
+
+func TestQueueRecoveryGoneAdmissionOwner(t *testing.T) {
+	tests := []struct {
+		name string
+		gone bool
+	}{
+		{name: "deleted owner", gone: true},
+		{name: "cancelled owner"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newQueueRecoveryFixture(t, 1, true)
+			failed := false
+			f.cs.PrependReactor("patch", "pipelineruns", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				if patch, ok := action.(k8stesting.PatchAction); ok && patch.GetName() == "first" && !failed {
+					failed = true
+					return true, nil, io.ErrUnexpectedEOF
+				}
+				return false, nil, nil
+			})
+			assert.ErrorContains(t, f.call("initial"), "start is not confirmed")
+			pr := f.get(t, "first")
+			resource := tektonv1.SchemeGroupVersion.WithResource("pipelineruns")
+			if tt.gone {
+				assert.NilError(t, f.cs.Tracker().Delete(resource, "ns", "first"))
+			} else {
+				pr.Spec.Status = tektonv1.PipelineRunSpecStatusCancelled
+				pr.ResourceVersion = "2"
+				assert.NilError(t, f.cs.Tracker().Update(resource, pr, "ns"))
+			}
+			err := f.r.FinalizeKind(f.ctx, pr)
+			if tt.gone {
+				// The former owner can still finish its initial admission.
+				assert.Assert(t, stderrors.Is(err, ErrProviderNotConfigured), "got %v", err)
+				assert.NilError(t, f.r.FinalizeKind(f.ctx, pr))
+			} else {
+				assert.NilError(t, err)
+			}
+			assert.DeepEqual(t, f.qm.RunningPipelineRuns(f.repo), []string{"ns/second"})
+			assert.Equal(t, string(f.get(t, "second").Spec.Status), "")
+		})
+	}
+}
+
+func TestQueueRecoveryExecutionOrderRead(t *testing.T) {
+	f := newQueueRecoveryFixture(t, 1, true)
+	failed := false
+	f.cs.PrependReactor("get", "pipelineruns", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if get, ok := action.(k8stesting.GetAction); ok && get.GetName() == "first" && !failed {
+			failed = true
+			return true, nil, apierrors.NewServiceUnavailable("execution-order read")
+		}
+		return false, nil, nil
+	})
+	assert.ErrorContains(t, f.call("initial"), "execution-order read")
+	assert.Equal(t, len(f.qm.RunningPipelineRuns(f.repo)), 0)
+	assert.Assert(t, stderrors.Is(f.call("initial"), ErrProviderNotConfigured))
+	assert.DeepEqual(t, f.qm.RunningPipelineRuns(f.repo), []string{"ns/first"})
+}
+
+func TestQueueRecoveryReconcileLimitReduction(t *testing.T) {
+	tests := []struct {
+		name      string
+		inherited bool
+	}{
+		{name: "local concurrency limit"},
+		{name: "inherited global concurrency limit", inherited: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newQueueRecoveryFixture(t, 2, true)
+			configRepo := f.repo.DeepCopy()
+			if tt.inherited {
+				f.repo = f.repo.DeepCopy()
+				f.repo.Spec.ConcurrencyLimit = nil
+				f.repo.Spec.GitProvider = &v1alpha1.GitProvider{}
+				assert.NilError(t, f.repoIndexer.Update(f.repo))
+				configRepo.Name = "global"
+				configRepo.Namespace = "global"
+				configRepo.Spec.GitProvider = &v1alpha1.GitProvider{
+					Secret: &v1alpha1.Secret{Name: "global-secret"},
+				}
+				assert.NilError(t, f.repoIndexer.Add(configRepo))
+			}
+			gets := map[string]int{}
+			f.cs.PrependReactor("get", "pipelineruns", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				get, ok := action.(k8stesting.GetAction)
+				assert.Assert(t, ok)
+				name := get.GetName()
+				gets[name]++
+				// Fail only candidate reads, after the fresh owner read and
+				// execution-order filtering have completed.
+				if (name == "first" && gets[name] == 3) || (name == "second" && gets[name] == 2) {
+					return true, nil, apierrors.NewServiceUnavailable("transient candidate read")
+				}
+				return false, nil, nil
+			})
+			assert.ErrorContains(t, f.r.ReconcileKind(f.ctx, f.owner), "transient candidate read")
+			assert.Equal(t, gets["first"], 3)
+			assert.Equal(t, gets["second"], 2)
+			assert.Equal(t, len(f.qm.RunningPipelineRuns(f.repo)), 0)
+			assert.Equal(t, len(f.qm.QueuedPipelineRuns(f.repo)), 3)
+
+			configRepo = configRepo.DeepCopy()
+			limit := 1
+			configRepo.Spec.ConcurrencyLimit = &limit
+			assert.NilError(t, f.repoIndexer.Update(configRepo))
+			err := f.r.ReconcileKind(f.ctx, f.get(t, "first"))
+			assert.ErrorContains(t, err, "unfinished queue admission")
+			assert.Assert(t, stderrors.Is(err, ErrProviderNotConfigured), "only reporting may fail for the started candidate: %v", err)
+			assert.DeepEqual(t, f.qm.RunningPipelineRuns(f.repo), []string{"ns/first"})
+			assert.Equal(t, string(f.get(t, "first").Spec.Status), "")
+			for _, name := range []string{"second", "third"} {
+				pr := f.get(t, name)
+				assert.Equal(t, pr.Spec.Status, tektonv1.PipelineRunSpecStatus(tektonv1.PipelineRunSpecStatusPending))
+				assert.Equal(t, pr.Annotations[keys.State], kubeinteraction.StateQueued)
+			}
+			assert.ErrorContains(t, f.r.ReconcileKind(f.ctx, f.get(t, "first")), "waiting to resume")
+			if tt.inherited {
+				cached, err := f.r.repoLister.Repositories(f.repo.Namespace).Get(f.repo.Name)
+				assert.NilError(t, err)
+				assert.Assert(t, cached.Spec.ConcurrencyLimit == nil)
+				assert.Assert(t, cached.Spec.GitProvider.Secret == nil, "queue configuration must not change secret inheritance")
+			}
+		})
+	}
+}
+
+func TestQueueRecoveryStartConflict(t *testing.T) {
+	for _, mode := range []string{"initial", "finalization"} {
+		t.Run(mode, func(t *testing.T) {
+			f := newQueueRecoveryFixture(t, 1, mode == "initial")
+			patches := 0
+			patchesAtReadback := 0
+			f.cs.PrependReactor("patch", "pipelineruns", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				patch, ok := action.(k8stesting.PatchAction)
+				if !ok || patch.GetName() != "first" {
+					return false, nil, nil
+				}
+				patches++
+				if patches == 1 {
+					resource := tektonv1.SchemeGroupVersion.WithResource("pipelineruns")
+					obj, err := f.cs.Tracker().Get(resource, "ns", "first")
+					assert.NilError(t, err)
+					pr, ok := obj.(*tektonv1.PipelineRun)
+					assert.Assert(t, ok)
+					pr.ResourceVersion = "2"
+					assert.NilError(t, f.cs.Tracker().Update(resource, pr, "ns"))
+				}
+				return f.applyPatch(t, action)
+			})
+			f.cs.PrependReactor("get", "pipelineruns", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				if get, ok := action.(k8stesting.GetAction); ok && get.GetName() == "first" && patches > 0 && patchesAtReadback == 0 {
+					patchesAtReadback = patches
+				}
+				return false, nil, nil
+			})
+			err := f.call(mode)
+			assert.Assert(t, stderrors.Is(err, ErrPipelineRunNotStarted), "got %v", err)
+			assert.ErrorContains(t, err, "stale start")
+			assert.Equal(t, patchesAtReadback, 1, "a conflict must go straight to readback")
+			assert.Equal(t, patches, 1)
+			assert.DeepEqual(t, f.qm.RunningPipelineRuns(f.repo), []string{"ns/first"})
+			assert.Equal(t, f.get(t, "first").Spec.Status, tektonv1.PipelineRunSpecStatus(tektonv1.PipelineRunSpecStatusPending))
+
+			if mode == "initial" {
+				err = f.r.ReconcileKind(f.ctx, f.get(t, "first"))
+				assert.Assert(t, stderrors.Is(err, ErrProviderNotConfigured), "only reporting may fail after a fresh retry: %v", err)
+			} else {
+				assert.NilError(t, f.call(mode))
+			}
+			assert.Equal(t, patches, 2)
+			started := f.get(t, "first")
+			assert.Equal(t, started.ResourceVersion, "3")
+			assert.Equal(t, string(started.Spec.Status), "")
+			assert.Equal(t, started.Annotations[keys.State], kubeinteraction.StateStarted)
+			assert.DeepEqual(t, f.qm.RunningPipelineRuns(f.repo), []string{"ns/first"})
+			assert.Equal(t, f.get(t, "second").Annotations[keys.State], kubeinteraction.StateQueued)
+		})
+	}
+}

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -13,6 +13,7 @@ import (
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"knative.dev/pkg/logging"
 	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/pkg/system"
@@ -54,12 +55,11 @@ var (
 	_ pipelinerunreconciler.Finalizer = (*Reconciler)(nil)
 )
 
-// ErrPipelineRunNotStarted reports that a PipelineRun could not be moved out of
-// its pending state, so it is definitely not running in the cluster. Callers
-// holding a concurrency slot on its behalf must release it, otherwise the slot
-// is never freed: only a completed PipelineRun releases one, and this one never
-// started.
-var ErrPipelineRunNotStarted = stderrors.New("pipelineRun has not been started")
+// ErrPipelineRunNotStarted means a start has not been confirmed. It is not proof
+// that the write failed: the reservation and its retry owner must be retained.
+var ErrPipelineRunNotStarted = stderrors.New("pipelineRun start is not confirmed")
+
+var errPipelineRunGone = stderrors.New("pipelineRun is no longer startable")
 
 func copyRepositoryForMerge(repo *v1alpha1.Repository) *v1alpha1.Repository {
 	if repo == nil {
@@ -149,6 +149,9 @@ func (r *Reconciler) reconcileKind(ctx context.Context, pr *tektonv1.PipelineRun
 	// make sure we have the latest pipelinerun to reconcile, since there is something updating at the same time
 	lpr, err := r.run.Clients.Tekton.TektonV1().PipelineRuns(pr.GetNamespace()).Get(ctx, pr.GetName(), metav1.GetOptions{})
 	if err != nil {
+		if errors.IsNotFound(err) {
+			return r.finalizeKind(ctx, pr)
+		}
 		return fmt.Errorf("cannot get pipelineRun: %w", err)
 	}
 
@@ -157,15 +160,12 @@ func (r *Reconciler) reconcileKind(ctx context.Context, pr *tektonv1.PipelineRun
 		return nil
 	}
 
-	// if pipelineRun is in completed or failed state then return
-	state, exist := pr.GetAnnotations()[keys.State]
-	if exist && (state == kubeinteraction.StateCompleted || state == kubeinteraction.StateFailed) {
-		return nil
-	}
-
 	repoName := pr.GetAnnotations()[keys.Repository]
 	repo, err := r.repoLister.Repositories(pr.Namespace).Get(repoName)
 	if err != nil {
+		if errors.IsNotFound(err) {
+			r.qm.RemoveRepository(&v1alpha1.Repository{ObjectMeta: metav1.ObjectMeta{Name: repoName, Namespace: pr.Namespace}})
+		}
 		return fmt.Errorf("failed to get repository CR: %w", err)
 	}
 
@@ -185,6 +185,18 @@ func (r *Reconciler) reconcileKind(ctx context.Context, pr *tektonv1.PipelineRun
 		return err
 	}
 	r.run.Info.Controller = controllerInfo
+
+	// An admission owner can already be running/done while another member of
+	// its batch still needs recovery. Resume it before state-based early returns,
+	// using this owner's controller configuration for provider reporting.
+	if err := r.processQueueAdmission(ctx, logger, repo, pr, nil, queuepkg.AdmissionResume); err != nil {
+		return err
+	}
+	state, exist := pr.GetAnnotations()[keys.State]
+	if exist && (state == kubeinteraction.StateCompleted || state == kubeinteraction.StateFailed) {
+		r.qm.ForgetAdmission(queuepkg.RepoKey(repo), pr)
+		return nil
+	}
 
 	if secretCreated, ok := pr.GetAnnotations()[keys.SecretCreated]; ok && secretCreated == "false" && pacInfo.SecretAutoCreation {
 		// if secret creation is true then return anyway from createSecretForPipelineRun function
@@ -214,7 +226,19 @@ func (r *Reconciler) reconcileKind(ctx context.Context, pr *tektonv1.PipelineRun
 
 	if reason == string(tektonv1.PipelineRunReasonRunning) && !startReported {
 		logger.Infof("pipelineRun %s/%s is running but not yet reported to provider, updating status", pr.GetNamespace(), pr.GetName())
-		return r.updatePipelineRunToInProgress(ctx, logger, repo, pr)
+		// A run that is cancelled or gracefully stopped still reports the
+		// Running reason until Tekton catches up, and a graceful stop keeps it
+		// there until the running tasks drain. It can never be started, so
+		// there is nothing to retry: the promotion path treats this as
+		// StartGone for the same reason. Returning the error instead would
+		// requeue over a condition no retry can change.
+		if err := r.updatePipelineRunToInProgress(ctx, logger, repo, pr); err != nil {
+			if stderrors.Is(err, errPipelineRunGone) {
+				return nil
+			}
+			return err
+		}
+		return nil
 	}
 	logger.Debugf("pipelineRun %s/%s condition not met: reason='%s', startReported=%v", pr.GetNamespace(), pr.GetName(), reason, startReported)
 
@@ -414,18 +438,19 @@ func (r *Reconciler) reportFinalStatus(ctx context.Context, logger *zap.SugaredL
 			fmt.Sprintf("AI/LLM analysis failed for repository %s/%s and pipeline run %s: %v", repo.Namespace, repo.Name, newPr.Name, err))
 	}
 
+	if err := r.startNextPipelineRunInQueue(ctx, logger, repo, pr); err != nil {
+		return repo, err
+	}
 	if _, err := r.updatePipelineRunState(ctx, logger, pr, finalState); err != nil {
 		return repo, fmt.Errorf("cannot update state: %w", err)
 	}
+	r.qm.ForgetAdmission(queuepkg.RepoKey(repo), pr)
 
 	if err := r.emitMetrics(ctx, pr); err != nil {
 		logger.Error("failed to emit metrics: ", err)
 	}
 
 	emitTimingSpans(logger, pr, &pacInfo.Settings, trStatus)
-
-	// remove pipelineRun from Queue and start the next one
-	r.startNextPipelineRunInQueue(ctx, logger, repo, pr)
 
 	if err := r.cleanupPipelineRuns(ctx, logger, pacInfo, repo, pr); err != nil {
 		return repo, fmt.Errorf("error cleaning pipelineruns: %w", err)
@@ -434,93 +459,33 @@ func (r *Reconciler) reportFinalStatus(ctx context.Context, logger *zap.SugaredL
 	return repo, nil
 }
 
-// startNextPipelineRunInQueue frees the slot held by a finished PipelineRun and
-// starts the next one waiting in the repository's queue. Each candidate that
-// turns out not to be startable is definitely not running — either it is gone
-// from the cluster or its state patch never landed — so its freshly-taken slot
-// is handed back and the next candidate is tried. A candidate whose start
-// failed *after* the state patch is already running and keeps its slot.
-//
-// Handing a slot back and asking for another candidate is what makes this a
-// loop, and it only terminates because every candidate is removed from the
-// queue as it is tried, so the queue drains. A queue implementation that keeps
-// returning a key it was asked to remove would spin here forever and take the
-// process down with it, so a key seen twice is treated as a broken queue and
-// ends the loop. The loop is deliberately not capped at some fixed number of
-// candidates: a repository may legitimately have any number of stale entries
-// ahead of a startable one, and stopping early would leave that one queued with
-// no running PipelineRun left to trigger another promotion.
-func (r *Reconciler) startNextPipelineRunInQueue(ctx context.Context, logger *zap.SugaredLogger, repo *v1alpha1.Repository, pr *tektonv1.PipelineRun) {
-	repoKey := queuepkg.RepoKey(repo)
-	seen := map[string]bool{}
-	for {
-		// This both releases the slot of the finished PipelineRun and takes one
-		// for the next candidate, so it has to run at least once, before any
-		// cancellation check, or the finished PipelineRun's slot is never freed.
-		next := r.qm.RemoveAndTakeItemFromQueue(repo, pr)
-		if next == "" {
-			return
-		}
-		if seen[next] {
-			logger.Errorf("queue for repository %s returned %s twice, it is out of sync with the cluster, giving up on starting the next pipelineRun", repo.GetName(), next)
-			_ = r.qm.RemoveFromQueue(repoKey, next)
-			return
-		}
-		seen[next] = true
-
-		// Starting a PipelineRun means talking to the cluster and to the git
-		// provider, which is pointless once the context is done. Hand the slot
-		// we just took back rather than strand it. The queue is rebuilt from
-		// the cluster by InitQueues on the next start, so nothing is lost.
-		if err := ctx.Err(); err != nil {
-			logger.Warnf("not starting the next pipelineRun %s for repository %s, releasing its queue slot: %v", next, repo.GetName(), err)
-			_ = r.qm.RemoveFromQueue(repoKey, next)
-			return
-		}
-
-		key := strings.Split(next, "/")
-		if len(key) != 2 {
-			logger.Errorf("invalid pipelineRun key %q queued for repository %s, releasing its queue slot", next, repo.GetName())
-			_ = r.qm.RemoveFromQueue(repoKey, next)
-			continue
-		}
-		nextPR, err := r.run.Clients.Tekton.TektonV1().PipelineRuns(key[0]).Get(ctx, key[1], metav1.GetOptions{})
-		if err != nil {
-			// The next PipelineRun already holds the slot we just freed, but
-			// nothing has been written to the cluster for it yet, so it is
-			// still pending. Hand the slot back before moving on: a slot kept
-			// for a run that never starts is never released, since only a
-			// completed run releases one.
-			logger.Errorf("cannot get pipeline for next in queue: %w", err)
-			_ = r.qm.RemoveFromQueue(repoKey, next)
-			continue
-		}
-
-		if err := r.updatePipelineRunToInProgress(ctx, logger, repo, nextPR); err != nil {
-			logger.Errorf("failed to update status: %w", err)
-			if stderrors.Is(err, ErrPipelineRunNotStarted) {
-				// The state patch never landed, so the PipelineRun is still
-				// pending. Release the slot and try the next one in the queue.
-				_ = r.qm.RemoveFromQueue(repoKey, queuepkg.PrKey(nextPR))
-				continue
-			}
-			// The state patch landed before this failed, so the PipelineRun is
-			// already running in the cluster and rightfully owns the slot.
-			// Releasing it here would admit another run past the limit.
-			return
-		}
-		return
+// A promotion owns its retries and records a successful handoff, so retrying a
+// terminal write cannot consume another waiting candidate.
+func (r *Reconciler) startNextPipelineRunInQueue(ctx context.Context, logger *zap.SugaredLogger, repo *v1alpha1.Repository, pr *tektonv1.PipelineRun) error {
+	if err := r.processQueueAdmission(ctx, logger, repo, pr, nil, queuepkg.AdmissionResume); err != nil {
+		return err
 	}
+	return r.processQueueAdmission(ctx, logger, repo, pr, nil, queuepkg.AdmissionPromotion)
 }
 
 func (r *Reconciler) updatePipelineRunToInProgress(ctx context.Context, logger *zap.SugaredLogger, repo *v1alpha1.Repository, pr *tektonv1.PipelineRun) error {
-	pr, err := r.updatePipelineRunState(ctx, logger, pr, kubeinteraction.StateStarted)
-	if err != nil {
-		// the patch is what clears spec.status, so until it lands the PipelineRun
-		// is still Pending and cannot be running. Callers holding a concurrency
-		// slot for it need to know that so they can hand the slot back.
-		return fmt.Errorf("%w: cannot update state: %w", ErrPipelineRunNotStarted, err)
+	if noLongerStartable(pr) {
+		return errPipelineRunGone
 	}
+	patched, patchErr := r.updatePipelineRunState(ctx, logger, pr, kubeinteraction.StateStarted)
+	if patchErr != nil {
+		// Neither the PATCH error nor its input says whether Kubernetes applied
+		// it. A pending read also cannot rule out an in-flight conditional write.
+		var err error
+		patched, err = r.run.Clients.Tekton.TektonV1().PipelineRuns(pr.Namespace).Get(ctx, pr.Name, metav1.GetOptions{})
+		if errors.IsNotFound(err) || (err == nil && (patched.UID != pr.UID || noLongerStartable(patched))) {
+			return errPipelineRunGone
+		}
+		if err != nil || patched.Spec.Status == tektonv1.PipelineRunSpecStatusPending {
+			return fmt.Errorf("%w: cannot update state: %w", ErrPipelineRunNotStarted, stderrors.Join(patchErr, err))
+		}
+	}
+	pr = patched
 
 	detectedProvider, event, err := r.initGitProviderClient(ctx, logger, repo, pr)
 	if err != nil {
@@ -560,6 +525,12 @@ func (r *Reconciler) updatePipelineRunToInProgress(ctx context.Context, logger *
 
 	logger.Info("updated in_progress status on provider platform for pipelineRun ", pr.GetName())
 	return nil
+}
+
+func noLongerStartable(current *tektonv1.PipelineRun) bool {
+	return queuepkg.Finishing(current) ||
+		current.Annotations[keys.State] == kubeinteraction.StateCompleted ||
+		current.Annotations[keys.State] == kubeinteraction.StateFailed
 }
 
 func (r *Reconciler) initGitProviderClient(ctx context.Context, logger *zap.SugaredLogger, repo *v1alpha1.Repository, pr *tektonv1.PipelineRun) (provider.Interface, *info.Event, error) {
@@ -621,14 +592,19 @@ func (r *Reconciler) updatePipelineRunState(ctx context.Context, logger *zap.Sug
 		annotations[keys.SCMReportingPLRStarted] = "true"
 	}
 
-	mergePatch := map[string]any{
-		"metadata": map[string]any{
-			"labels": map[string]string{
-				keys.State: state,
-			},
-			"annotations": annotations,
+	metadata := map[string]any{
+		"labels": map[string]string{
+			keys.State: state,
 		},
+		"annotations": annotations,
 	}
+	if state == kubeinteraction.StateStarted {
+		// Optimistic concurrency fences delayed starts against cancellation,
+		// completion and replacement by a new PipelineRun with the same name.
+		metadata["resourceVersion"] = pr.ResourceVersion
+		metadata["uid"] = pr.UID
+	}
+	mergePatch := map[string]any{"metadata": metadata}
 
 	// if state is started and the pipelineRun is still pending then clear the
 	// pending status so Tekton can pick it up. If it already isn't pending
@@ -642,7 +618,20 @@ func (r *Reconciler) updatePipelineRunState(ctx context.Context, logger *zap.Sug
 		}
 	}
 	actionLog := state + " state"
-	patchedPR, err := action.PatchPipelineRun(ctx, logger, actionLog, r.run.Clients.Tekton, pr, mergePatch)
+	var (
+		patchedPR *tektonv1.PipelineRun
+		err       error
+	)
+	if state == kubeinteraction.StateStarted {
+		patch, marshalErr := json.Marshal(mergePatch)
+		if marshalErr != nil {
+			return pr, fmt.Errorf("error marshaling the pipelinerun patch: %w", marshalErr)
+		}
+		// A conflict needs fresh readback, not retries with the same resourceVersion.
+		patchedPR, err = r.run.Clients.Tekton.TektonV1().PipelineRuns(pr.Namespace).Patch(ctx, pr.Name, types.MergePatchType, patch, metav1.PatchOptions{})
+	} else {
+		patchedPR, err = action.PatchPipelineRun(ctx, logger, actionLog, r.run.Clients.Tekton, pr, mergePatch)
+	}
 	if err != nil {
 		return pr, fmt.Errorf("error patching the pipelinerun: %w", err)
 	}

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -161,10 +161,18 @@ func (r *Reconciler) reconcileKind(ctx context.Context, pr *tektonv1.PipelineRun
 	}
 
 	repoName := pr.GetAnnotations()[keys.Repository]
+	state, exist := pr.GetAnnotations()[keys.State]
+	done := exist && (state == kubeinteraction.StateCompleted || state == kubeinteraction.StateFailed)
 	repo, err := r.repoLister.Repositories(pr.Namespace).Get(repoName)
 	if err != nil {
 		if errors.IsNotFound(err) {
+			// Dropping the repository clears every admission it held, this one
+			// included, so a done PipelineRun has nothing left to recover and
+			// retrying can never make a deleted Repository reappear.
 			r.qm.RemoveRepository(&v1alpha1.Repository{ObjectMeta: metav1.ObjectMeta{Name: repoName, Namespace: pr.Namespace}})
+			if done {
+				return nil
+			}
 		}
 		return fmt.Errorf("failed to get repository CR: %w", err)
 	}
@@ -192,8 +200,7 @@ func (r *Reconciler) reconcileKind(ctx context.Context, pr *tektonv1.PipelineRun
 	if err := r.processQueueAdmission(ctx, logger, repo, pr, nil, queuepkg.AdmissionResume); err != nil {
 		return err
 	}
-	state, exist := pr.GetAnnotations()[keys.State]
-	if exist && (state == kubeinteraction.StateCompleted || state == kubeinteraction.StateFailed) {
+	if done {
 		r.qm.ForgetAdmission(queuepkg.RepoKey(repo), pr)
 		return nil
 	}
@@ -292,7 +299,21 @@ func (r *Reconciler) reconcileKind(ctx context.Context, pr *tektonv1.PipelineRun
 	if err != nil {
 		msg := fmt.Sprintf("detectProvider: %v", err)
 		r.eventEmitter.EmitMessage(nil, zap.ErrorLevel, "RepositoryDetectProvider", msg)
-		return nil
+
+		if stderrors.Is(err, ErrProviderNotConfigured) {
+			// Permanent: the git-provider annotation is missing or names a
+			// provider PAC does not know, so retrying detectProvider can
+			// never succeed. Returning the error here would rate-limited
+			// retry forever while still holding the concurrency slot; release
+			// it and mark the run failed instead.
+			return r.abandonDoneWithoutProvider(ctx, logger, repo, pr, err)
+		}
+		// Transient (e.g. a GitHub App client failed to initialize talking to
+		// the API): return the wrapped error so the reconcile is retried
+		// instead of swallowing it. Swallowing it here would forget the key,
+		// so reportFinalStatus never runs and the finished PipelineRun's
+		// concurrency slot is never released.
+		return fmt.Errorf("detect provider: %w", err)
 	}
 	detectedProvider.SetPacInfo(&pacInfo)
 
@@ -301,6 +322,28 @@ func (r *Reconciler) reconcileKind(ctx context.Context, pr *tektonv1.PipelineRun
 		r.eventEmitter.EmitMessage(repo, zap.ErrorLevel, "RepositoryReportFinalStatus", msg)
 		return err
 	}
+	return nil
+}
+
+// abandonDoneWithoutProvider marks a done PipelineRun failed and releases its
+// concurrency slot when its git-provider can never be resolved (missing or
+// unknown annotation, see ErrProviderNotConfigured). There is no provider or
+// event here to post a final status through, unlike reportFinalStatus, so
+// this only performs the two things needed to stop the run wedging its
+// repository's queue: releasing/promoting the queue and writing the terminal
+// PAC state, in that order.
+//
+// The manager remembers a successful handoff until the terminal write succeeds.
+// An unfinished promotion must return an error before the terminal state makes
+// reconcileKind short-circuit.
+func (r *Reconciler) abandonDoneWithoutProvider(ctx context.Context, logger *zap.SugaredLogger, repo *v1alpha1.Repository, pr *tektonv1.PipelineRun, cause error) error {
+	if err := r.startNextPipelineRunInQueue(ctx, logger, repo, pr); err != nil {
+		return err
+	}
+	if _, err := r.updatePipelineRunState(ctx, logger, pr, kubeinteraction.StateFailed); err != nil {
+		return fmt.Errorf("abandon pipelinerun without provider %s/%s (cause: %w): cannot update state: %w", pr.Namespace, pr.Name, cause, err)
+	}
+	r.qm.ForgetAdmission(queuepkg.RepoKey(repo), pr)
 	return nil
 }
 
@@ -481,7 +524,7 @@ func (r *Reconciler) updatePipelineRunToInProgress(ctx context.Context, logger *
 		if errors.IsNotFound(err) || (err == nil && (patched.UID != pr.UID || noLongerStartable(patched))) {
 			return errPipelineRunGone
 		}
-		if err != nil || patched.Spec.Status == tektonv1.PipelineRunSpecStatusPending {
+		if err != nil || !startConfirmed(patched) {
 			return fmt.Errorf("%w: cannot update state: %w", ErrPipelineRunNotStarted, stderrors.Join(patchErr, err))
 		}
 	}
@@ -531,6 +574,16 @@ func noLongerStartable(current *tektonv1.PipelineRun) bool {
 	return queuepkg.Finishing(current) ||
 		current.Annotations[keys.State] == kubeinteraction.StateCompleted ||
 		current.Annotations[keys.State] == kubeinteraction.StateFailed
+}
+
+// startConfirmed reports whether the start write is visible in the cluster. A
+// non-pending PipelineRun is not enough on its own: the patch is metadata-only
+// for a run Tekton already started, so a run that is merely running proves
+// nothing about the state and reporting annotations this patch carries.
+func startConfirmed(current *tektonv1.PipelineRun) bool {
+	return current.Spec.Status != tektonv1.PipelineRunSpecStatusPending &&
+		current.Annotations[keys.State] == kubeinteraction.StateStarted &&
+		current.Annotations[keys.SCMReportingPLRStarted] == "true"
 }
 
 func (r *Reconciler) initGitProviderClient(ctx context.Context, logger *zap.SugaredLogger, repo *v1alpha1.Repository, pr *tektonv1.PipelineRun) (provider.Interface, *info.Event, error) {

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -602,6 +602,7 @@ func TestReconcileKindControllerInfoHandling(t *testing.T) {
 						Controller: controller,
 					},
 				},
+				qm: queuepkg.NewManager(logger),
 			}
 
 			err := r.ReconcileKind(ctx, pr)
@@ -614,6 +615,75 @@ func TestReconcileKindControllerInfoHandling(t *testing.T) {
 				assert.DeepEqual(t, r.run.Info.Controller, tt.wantControl)
 				assert.Assert(t, r.run.Info.Controller == controller, "reconcile must keep the shared controller pointer")
 			}
+		})
+	}
+}
+
+func TestReconcileKindDropsUnstartableRunningPipelineRun(t *testing.T) {
+	tests := []struct {
+		name   string
+		status tektonv1.PipelineRunSpecStatus
+	}{
+		{name: "cancelled", status: tektonv1.PipelineRunSpecStatusCancelled},
+		{name: "cancelled run finally", status: tektonv1.PipelineRunSpecStatusCancelledRunFinally},
+		{name: "stopped run finally", status: tektonv1.PipelineRunSpecStatusStoppedRunFinally},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			observer, _ := zapobserver.New(zap.InfoLevel)
+			logger := zap.New(observer).Sugar()
+
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pr", Namespace: "test-ns",
+					Annotations: map[string]string{
+						keys.State:         kubeinteraction.StateStarted,
+						keys.Repository:    "test-repo",
+						keys.SecretCreated: "true",
+						keys.GitProvider:   "github",
+					},
+				},
+				Spec: tektonv1.PipelineRunSpec{Status: tt.status},
+				Status: tektonv1.PipelineRunStatus{
+					Status: knativeduckv1.Status{
+						Conditions: knativeduckv1.Conditions{{
+							Type:   knativeapi.ConditionSucceeded,
+							Status: corev1.ConditionUnknown,
+							Reason: string(tektonv1.PipelineRunReasonRunning),
+						}},
+					},
+				},
+			}
+			limit := 1
+			repo := &v1alpha1.Repository{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-repo", Namespace: "test-ns"},
+				Spec:       v1alpha1.RepositorySpec{ConcurrencyLimit: &limit},
+			}
+			stdata, informers := testclient.SeedTestData(t, ctx, testclient.Data{
+				PipelineRuns: []*tektonv1.PipelineRun{pr},
+				Repositories: []*v1alpha1.Repository{repo},
+			})
+			qm := queuepkg.NewManager(logger)
+			_, err := qm.AddListToRunningQueue(repo, []string{queuepkg.PrKey(pr)})
+			assert.NilError(t, err)
+
+			r := &Reconciler{
+				repoLister: informers.Repository.Lister(),
+				qm:         qm,
+				run: &params.Run{
+					Clients: clients.Clients{Tekton: stdata.Pipeline, Kube: stdata.Kube, Log: logger},
+					Info: info.Info{
+						Pac:        &info.PacOpts{Settings: settings.Settings{}},
+						Kube:       &info.KubeOpts{Namespace: "global"},
+						Controller: &info.ControllerInfo{Name: "default", GlobalRepository: "default-global"},
+					},
+				},
+				eventEmitter: events.NewEventEmitter(stdata.Kube, logger),
+			}
+
+			assert.NilError(t, r.ReconcileKind(ctx, pr),
+				"an unstartable run must not be retried forever")
 		})
 	}
 }
@@ -802,6 +872,7 @@ func TestReconcileKindSCMReportingLogic(t *testing.T) {
 				repoLister: informers.Repository.Lister(),
 				run:        cs,
 				kinteract:  kinterfaceTest,
+				qm:         queuepkg.NewManager(logger),
 			}
 
 			err := r.ReconcileKind(ctx, tt.pipelineRun)
@@ -1106,6 +1177,7 @@ func TestReconcileKindSecretCreationDoesNotLogOnSuccess(t *testing.T) {
 				"pac-provider-secret": "test-token",
 			},
 		},
+		qm: queuepkg.NewManager(logger),
 	}
 
 	err := r.ReconcileKind(ctx, pr)

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -2,6 +2,7 @@ package reconciler
 
 import (
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"maps"
@@ -619,6 +620,483 @@ func TestReconcileKindControllerInfoHandling(t *testing.T) {
 	}
 }
 
+// TestReconcileKindReturnsErrorWhenDetectProviderFailsTransiently asserts that
+// a done PipelineRun whose git-provider annotation names a real provider, but
+// whose provider client fails to initialize for what could be a transient
+// reason (here: the GitHub App private key secret is missing), makes
+// ReconcileKind return an error instead of nil. Swallowing the error here
+// used to forget the workqueue key: reportFinalStatus never ran, the
+// finished PipelineRun's concurrency slot was never released, and nothing
+// ever retried.
+func TestReconcileKindReturnsErrorWhenDetectProviderFailsTransiently(t *testing.T) {
+	ctx, _ := rtesting.SetupFakeContext(t)
+	observer, _ := zapobserver.New(zap.InfoLevel)
+	logger := zap.New(observer).Sugar()
+
+	pr := &tektonv1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pr",
+			Namespace: "test-ns",
+			Annotations: map[string]string{
+				keys.State:         kubeinteraction.StateStarted,
+				keys.Repository:    "test-repo",
+				keys.SecretCreated: "true",
+				keys.GitProvider:   "github",
+				// A non-zero InstallationID routes detectProvider through
+				// InitAppClient, which fails here because no GitHub App
+				// private key secret was seeded -- a stand-in for any
+				// transient client-initialization failure. CheckRunID must
+				// also be set, or reconcileKind returns early before ever
+				// reaching detectProvider.
+				keys.InstallationID: "123",
+				keys.CheckRunID:     "456",
+			},
+		},
+		Status: tektonv1.PipelineRunStatus{
+			Status: knativeduckv1.Status{
+				Conditions: knativeduckv1.Conditions{
+					{
+						Type:   knativeapi.ConditionSucceeded,
+						Status: corev1.ConditionTrue,
+						Reason: string(tektonv1.PipelineRunReasonSuccessful),
+					},
+				},
+			},
+		},
+	}
+	repo := &v1alpha1.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-repo",
+			Namespace: "test-ns",
+		},
+	}
+	stdata, informers := testclient.SeedTestData(t, ctx, testclient.Data{
+		PipelineRuns: []*tektonv1.PipelineRun{pr},
+		Repositories: []*v1alpha1.Repository{repo},
+	})
+	metrics, err := prmetrics.NewRecorder()
+	assert.NilError(t, err)
+	r := &Reconciler{
+		repoLister: informers.Repository.Lister(),
+		qm:         queuepkg.NewManager(logger),
+		run: &params.Run{
+			Clients: clients.Clients{
+				Tekton: stdata.Pipeline,
+				Kube:   stdata.Kube,
+				Log:    logger,
+			},
+			Info: info.Info{
+				Pac: &info.PacOpts{
+					Settings: settings.Settings{},
+				},
+				Kube: &info.KubeOpts{Namespace: "global"},
+				Controller: &info.ControllerInfo{
+					Name:             "default",
+					Secret:           "default-secret",
+					GlobalRepository: "default-global",
+				},
+			},
+		},
+		metrics:      metrics,
+		eventEmitter: events.NewEventEmitter(stdata.Kube, logger),
+	}
+
+	err = r.ReconcileKind(ctx, pr)
+	assert.ErrorContains(t, err, "detect provider")
+	assert.Assert(t, !stderrors.Is(err, ErrProviderNotConfigured),
+		"a transient client-init failure must not be classified as permanent")
+}
+
+// TestReconcileKindAbandonsDoneRunWhenProviderNotConfigured asserts that a
+// done PipelineRun whose git-provider annotation can never be resolved (a
+// permanent condition: retrying detectProvider can never succeed, whether
+// the annotation is missing or names an unsupported provider) is marked
+// failed and has its concurrency slot released and handed to the next
+// queued candidate, and that ReconcileKind returns nil rather than an error
+// that would otherwise be retried forever while still holding the slot.
+func TestReconcileKindAbandonsDoneRunWhenProviderNotConfigured(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+	}{
+		{
+			name: "missing git-provider annotation",
+			annotations: map[string]string{
+				keys.State:         kubeinteraction.StateStarted,
+				keys.Repository:    "test-repo",
+				keys.SecretCreated: "true",
+			},
+		},
+		{
+			name: "unknown git-provider annotation",
+			annotations: map[string]string{
+				keys.State:         kubeinteraction.StateStarted,
+				keys.Repository:    "test-repo",
+				keys.SecretCreated: "true",
+				keys.GitProvider:   "batman",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			observer, _ := zapobserver.New(zap.InfoLevel)
+			logger := zap.New(observer).Sugar()
+
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-pr",
+					Namespace:   "test-ns",
+					Annotations: tt.annotations,
+				},
+				Status: tektonv1.PipelineRunStatus{
+					Status: knativeduckv1.Status{
+						Conditions: knativeduckv1.Conditions{
+							{
+								Type:   knativeapi.ConditionSucceeded,
+								Status: corev1.ConditionTrue,
+								Reason: string(tektonv1.PipelineRunReasonSuccessful),
+							},
+						},
+					},
+				},
+			}
+			nextPR := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "next-pr",
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						keys.State: kubeinteraction.StateQueued,
+					},
+				},
+				Spec: tektonv1.PipelineRunSpec{
+					Status: tektonv1.PipelineRunSpecStatusPending,
+				},
+			}
+			limit := 1
+			repo := &v1alpha1.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-repo",
+					Namespace: "test-ns",
+				},
+				Spec: v1alpha1.RepositorySpec{
+					ConcurrencyLimit: &limit,
+				},
+			}
+			stdata, informers := testclient.SeedTestData(t, ctx, testclient.Data{
+				PipelineRuns: []*tektonv1.PipelineRun{pr, nextPR},
+				Repositories: []*v1alpha1.Repository{repo},
+			})
+			metrics, err := prmetrics.NewRecorder()
+			assert.NilError(t, err)
+
+			qm := queuepkg.NewManager(logger)
+			_, err = qm.AddListToRunningQueue(repo, []string{queuepkg.PrKey(pr)})
+			assert.NilError(t, err)
+			assert.DeepEqual(t, qm.RunningPipelineRuns(repo), []string{queuepkg.PrKey(pr)})
+			assert.NilError(t, qm.AddToPendingQueue(repo, []string{queuepkg.PrKey(nextPR)}))
+
+			r := &Reconciler{
+				repoLister: informers.Repository.Lister(),
+				qm:         qm,
+				run: &params.Run{
+					Clients: clients.Clients{
+						Tekton: stdata.Pipeline,
+						Kube:   stdata.Kube,
+						Log:    logger,
+					},
+					Info: info.Info{
+						Pac: &info.PacOpts{
+							Settings: settings.Settings{},
+						},
+						Kube: &info.KubeOpts{Namespace: "global"},
+						Controller: &info.ControllerInfo{
+							Name:             "default",
+							Secret:           "default-secret",
+							GlobalRepository: "default-global",
+						},
+					},
+				},
+				metrics:      metrics,
+				eventEmitter: events.NewEventEmitter(stdata.Kube, logger),
+			}
+
+			err = r.ReconcileKind(ctx, pr)
+			assert.NilError(t, err, "a permanent detectProvider failure must not be retried forever")
+			assert.DeepEqual(t, qm.RunningPipelineRuns(repo), []string{queuepkg.PrKey(nextPR)})
+			assert.Assert(t, len(qm.QueuedPipelineRuns(repo)) == 0, "the promoted candidate must no longer be pending")
+
+			updated, err := stdata.Pipeline.TektonV1().PipelineRuns(pr.Namespace).Get(ctx, pr.Name, metav1.GetOptions{})
+			assert.NilError(t, err)
+			assert.Equal(t, updated.GetAnnotations()[keys.State], kubeinteraction.StateFailed)
+		})
+	}
+}
+
+// TestReconcileKindAbandonsDoneRunReleasesQueueEvenWhenStatePatchFails proves
+// the ordering in abandonDoneWithoutProvider: the concurrency slot must be
+// released before the terminal state is written, not after. If the state
+// patch fails (here: the PipelineRun was deleted from the fake client
+// between detectProvider failing and the patch), ReconcileKind must still
+// return an error (so this reconcile is retried), but the queue release must
+// already have happened. The manager remembers the handoff while the state
+// write is retried, rather than acquiring another successor.
+func TestReconcileKindAbandonsDoneRunReleasesQueueEvenWhenStatePatchFails(t *testing.T) {
+	ctx, _ := rtesting.SetupFakeContext(t)
+	observer, _ := zapobserver.New(zap.InfoLevel)
+	logger := zap.New(observer).Sugar()
+
+	pr := &tektonv1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pr",
+			Namespace: "test-ns",
+			Annotations: map[string]string{
+				keys.State:         kubeinteraction.StateStarted,
+				keys.Repository:    "test-repo",
+				keys.SecretCreated: "true",
+				// keys.GitProvider deliberately absent: detectProvider fails
+				// permanently.
+			},
+		},
+		Status: tektonv1.PipelineRunStatus{
+			Status: knativeduckv1.Status{
+				Conditions: knativeduckv1.Conditions{
+					{
+						Type:   knativeapi.ConditionSucceeded,
+						Status: corev1.ConditionTrue,
+						Reason: string(tektonv1.PipelineRunReasonSuccessful),
+					},
+				},
+			},
+		},
+	}
+	limit := 1
+	repo := &v1alpha1.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-repo",
+			Namespace: "test-ns",
+		},
+		Spec: v1alpha1.RepositorySpec{
+			ConcurrencyLimit: &limit,
+		},
+	}
+	stdata, informers := testclient.SeedTestData(t, ctx, testclient.Data{
+		PipelineRuns: []*tektonv1.PipelineRun{pr},
+		Repositories: []*v1alpha1.Repository{repo},
+	})
+	metrics, err := prmetrics.NewRecorder()
+	assert.NilError(t, err)
+
+	qm := queuepkg.NewManager(logger)
+	_, err = qm.AddListToRunningQueue(repo, []string{queuepkg.PrKey(pr)})
+	assert.NilError(t, err)
+
+	// Make the terminal-state patch fail while leaving reads (including the
+	// "fetch latest" Get at the top of reconcileKind) unaffected, so the
+	// failure is isolated to abandonDoneWithoutProvider's state write.
+	stdata.Pipeline.PrependReactor("patch", "pipelineruns", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("injected patch failure")
+	})
+
+	r := &Reconciler{
+		repoLister: informers.Repository.Lister(),
+		qm:         qm,
+		run: &params.Run{
+			Clients: clients.Clients{
+				Tekton: stdata.Pipeline,
+				Kube:   stdata.Kube,
+				Log:    logger,
+			},
+			Info: info.Info{
+				Pac: &info.PacOpts{
+					Settings: settings.Settings{},
+				},
+				Kube: &info.KubeOpts{Namespace: "global"},
+				Controller: &info.ControllerInfo{
+					Name:             "default",
+					Secret:           "default-secret",
+					GlobalRepository: "default-global",
+				},
+			},
+		},
+		metrics:      metrics,
+		eventEmitter: events.NewEventEmitter(stdata.Kube, logger),
+	}
+
+	err = r.ReconcileKind(ctx, pr)
+	assert.ErrorContains(t, err, "cannot update state")
+	assert.Assert(t, len(qm.RunningPipelineRuns(repo)) == 0, "the concurrency slot must already be released even though the state patch failed")
+
+	// A second attempt (simulating a retry after the failed patch) must not
+	// find another reservation to release or promote: the queue step is
+	// already done and must not run twice.
+	assert.NilError(t, r.startNextPipelineRunInQueue(ctx, logger, repo, pr))
+	assert.Assert(t, len(qm.RunningPipelineRuns(repo)) == 0, "retrying the queue release must stay a no-op")
+}
+
+// TestReconcileKindDeletedRepositoryWithDoneRun asserts that a PipelineRun
+// whose Repository CR has been deleted stops being reconciled once it reached
+// a terminal PAC state. Dropping the repository clears every queue entry it
+// held, so there is nothing left to recover, and retrying could never make the
+// deleted Repository reappear. A run that is not done keeps returning the
+// error so the reconcile is retried.
+func TestReconcileKindDeletedRepositoryWithDoneRun(t *testing.T) {
+	tests := []struct {
+		name    string
+		state   string
+		wantErr bool
+	}{
+		{name: "completed run", state: kubeinteraction.StateCompleted},
+		{name: "failed run", state: kubeinteraction.StateFailed},
+		{name: "started run", state: kubeinteraction.StateStarted, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			observer, _ := zapobserver.New(zap.InfoLevel)
+			logger := zap.New(observer).Sugar()
+
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pr",
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						keys.State:         tt.state,
+						keys.Repository:    "deleted-repo",
+						keys.SecretCreated: "true",
+					},
+				},
+			}
+			// Never seeded in the lister: the Repository CR is gone, but the
+			// queue manager still holds the entries it had for it.
+			repo := &v1alpha1.Repository{
+				ObjectMeta: metav1.ObjectMeta{Name: "deleted-repo", Namespace: "test-ns"},
+			}
+			stdata, informers := testclient.SeedTestData(t, ctx, testclient.Data{
+				PipelineRuns: []*tektonv1.PipelineRun{pr},
+			})
+			qm := queuepkg.NewManager(logger)
+			_, err := qm.AddListToRunningQueue(repo, []string{queuepkg.PrKey(pr)})
+			assert.NilError(t, err)
+
+			r := &Reconciler{
+				repoLister: informers.Repository.Lister(),
+				qm:         qm,
+				run: &params.Run{
+					Clients: clients.Clients{
+						Tekton: stdata.Pipeline,
+						Kube:   stdata.Kube,
+						Log:    logger,
+					},
+					Info: info.Info{
+						Pac:        &info.PacOpts{Settings: settings.Settings{}},
+						Kube:       &info.KubeOpts{Namespace: "global"},
+						Controller: &info.ControllerInfo{Name: "default", GlobalRepository: "default-global"},
+					},
+				},
+				eventEmitter: events.NewEventEmitter(stdata.Kube, logger),
+			}
+
+			err = r.ReconcileKind(ctx, pr)
+			if tt.wantErr {
+				assert.ErrorContains(t, err, "failed to get repository CR")
+			} else {
+				assert.NilError(t, err, "a done pipelineRun must not be retried forever for a deleted repository")
+			}
+			assert.Equal(t, len(qm.RunningPipelineRuns(repo)), 0, "the queue of a deleted repository must be dropped")
+		})
+	}
+}
+
+// TestReconcileKindRetriesUnconfirmedStartOfRunningPipelineRun asserts that a
+// failed state patch on an already running PipelineRun is retried. The patch
+// only carries metadata for such a run, so a readback showing it is not
+// pending proves nothing: without the state and reporting annotations the
+// write did not land and the reconcile has to be retried.
+func TestReconcileKindRetriesUnconfirmedStartOfRunningPipelineRun(t *testing.T) {
+	ctx, _ := rtesting.SetupFakeContext(t)
+	observer, _ := zapobserver.New(zap.InfoLevel)
+	logger := zap.New(observer).Sugar()
+
+	pr := &tektonv1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pr",
+			Namespace: "test-ns",
+			Annotations: map[string]string{
+				keys.State:         kubeinteraction.StateQueued,
+				keys.Repository:    "test-repo",
+				keys.SecretCreated: "true",
+				keys.GitProvider:   "github",
+			},
+		},
+		// Tekton already started it, so it is no longer pending before the
+		// patch and the patch carries no spec change.
+		Status: tektonv1.PipelineRunStatus{
+			Status: knativeduckv1.Status{
+				Conditions: knativeduckv1.Conditions{
+					{
+						Type:   knativeapi.ConditionSucceeded,
+						Status: corev1.ConditionUnknown,
+						Reason: string(tektonv1.PipelineRunReasonRunning),
+					},
+				},
+			},
+		},
+	}
+	limit := 1
+	repo := &v1alpha1.Repository{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-repo", Namespace: "test-ns"},
+		Spec:       v1alpha1.RepositorySpec{ConcurrencyLimit: &limit},
+	}
+	stdata, informers := testclient.SeedTestData(t, ctx, testclient.Data{
+		PipelineRuns: []*tektonv1.PipelineRun{pr},
+		Repositories: []*v1alpha1.Repository{repo},
+	})
+	qm := queuepkg.NewManager(logger)
+	_, err := qm.AddListToRunningQueue(repo, []string{queuepkg.PrKey(pr)})
+	assert.NilError(t, err)
+
+	stdata.Pipeline.PrependReactor("patch", "pipelineruns", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.NewConflict(tektonv1.Resource("pipelineruns"), "test-pr", fmt.Errorf("stale start"))
+	})
+
+	r := &Reconciler{
+		repoLister: informers.Repository.Lister(),
+		qm:         qm,
+		run: &params.Run{
+			Clients: clients.Clients{
+				Tekton: stdata.Pipeline,
+				Kube:   stdata.Kube,
+				Log:    logger,
+			},
+			Info: info.Info{
+				Pac:        &info.PacOpts{Settings: settings.Settings{}},
+				Kube:       &info.KubeOpts{Namespace: "global"},
+				Controller: &info.ControllerInfo{Name: "default", GlobalRepository: "default-global"},
+			},
+		},
+		eventEmitter: events.NewEventEmitter(stdata.Kube, logger),
+	}
+
+	err = r.ReconcileKind(ctx, pr)
+	assert.Assert(t, stderrors.Is(err, ErrPipelineRunNotStarted), "got %v", err)
+	updated, getErr := stdata.Pipeline.TektonV1().PipelineRuns(pr.Namespace).Get(ctx, pr.Name, metav1.GetOptions{})
+	assert.NilError(t, getErr)
+	assert.Equal(t, updated.GetAnnotations()[keys.State], kubeinteraction.StateQueued)
+	_, reported := updated.GetAnnotations()[keys.SCMReportingPLRStarted]
+	assert.Assert(t, !reported, "the reporting marker was never written")
+	assert.DeepEqual(t, qm.RunningPipelineRuns(repo), []string{queuepkg.PrKey(pr)})
+}
+
+// TestReconcileKindDropsUnstartableRunningPipelineRun covers a PipelineRun that
+// Tekton still reports as Running while its spec has already been cancelled or
+// gracefully stopped, and whose start was never reported to the provider.
+//
+// Such a run can never be started, so the promotion path deliberately treats
+// errPipelineRunGone as "nothing to do" and returns nil. Returning it here
+// instead would requeue forever over a condition no retry can change. Graceful
+// stop makes that window wide: Tekton lets running tasks drain, so the Running
+// condition legitimately survives for as long as those tasks take.
 func TestReconcileKindDropsUnstartableRunningPipelineRun(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/pkg/test/concurrency/concurrency.go
+++ b/pkg/test/concurrency/concurrency.go
@@ -5,6 +5,7 @@ import (
 
 	pacv1alpha1 "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 	pacVersionedClient "github.com/openshift-pipelines/pipelines-as-code/pkg/generated/clientset/versioned"
+	"github.com/openshift-pipelines/pipelines-as-code/pkg/queue"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	tektonVersionedClient "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 )
@@ -31,8 +32,43 @@ type TestQMI struct {
 	// RepeatNext makes RemoveAndTakeItemFromQueue hand out the same key
 	// forever, modelling a queue that never releases a slot, so a test can
 	// check the caller gives up instead of looping.
-	RepeatNext string
+	RepeatNext       string
+	AdmissionRepoKey string
 }
+
+func (t TestQMI) AcquireAdmission(repo *pacv1alpha1.Repository, owner *tektonv1.PipelineRun, list []string, mode queue.AdmissionMode) (*queue.Admission, error) {
+	if mode == queue.AdmissionResume {
+		return nil, nil
+	}
+	var acquired []string
+	if mode == queue.AdmissionPromotion {
+		if next := t.RemoveAndTakeItemFromQueue(repo, owner); next != "" {
+			acquired = []string{next}
+		}
+	} else {
+		var err error
+		acquired, err = t.AddListToRunningQueue(repo, list)
+		if err != nil {
+			return nil, err
+		}
+	}
+	work := &queue.Admission{}
+	for _, key := range acquired {
+		work.Candidates = append(work.Candidates, queue.StartCandidate{Key: key})
+	}
+	return work, nil
+}
+
+func (t TestQMI) FinishAdmission(work *queue.Admission) error {
+	for _, candidate := range work.Candidates {
+		if candidate.Outcome == queue.StartGone {
+			t.RemoveFromQueue(t.AdmissionRepoKey, candidate.Key)
+		}
+	}
+	return nil
+}
+
+func (TestQMI) ForgetAdmission(string, *tektonv1.PipelineRun) {}
 
 func (TestQMI) InitQueues(_ context.Context, _ tektonVersionedClient.Interface, _ pacVersionedClient.Interface) error {
 	// TODO implement me

--- a/test/gitea_concurrency_test.go
+++ b/test/gitea_concurrency_test.go
@@ -570,7 +570,9 @@ func TestGiteaConcurrencyTransientAPIFailureDoesNotWedgeQueue(t *testing.T) {
 	runcnx, opts, giteacnx, err := tgitea.Setup(ctx)
 	assert.NilError(t, err)
 
-	// Restarts the watcher, so it has to happen before there is anything queued.
+	// Restarts the watcher, so it has to happen before there is anything
+	// queued: see EnsureQueueDebugEnabled.
+	tkubestuff.EnsureQueueDebugEnabled(ctx, t, runcnx)
 
 	yamlFiles := map[string]string{}
 	for i := 0; i < numPipelines; i++ {

--- a/test/pkg/kubestuff/watcher.go
+++ b/test/pkg/kubestuff/watcher.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -23,7 +25,10 @@ const (
 	watcherDeployment = "pipelines-as-code-watcher"
 	watcherContainer  = "pac-watcher"
 	watcherProbesPort = "probes"
+	queueDebugEnvVar  = "PAC_ENABLE_QUEUE_DEBUG"
 )
+
+var enableQueueDebugOnce sync.Once
 
 // WatcherHealth is a snapshot of how many times the watcher has restarted.
 type WatcherHealth struct {
@@ -97,6 +102,9 @@ func BounceWatcher(ctx context.Context, t *testing.T, runcnx *params.Run) {
 // The endpoint answers 503 while the reconciler holds the queue lock, since it
 // gives up rather than block the thing it is reporting on. That is expected
 // under load, so retry for a bit before calling it a failure.
+//
+// The endpoint is off by default, so callers must have called
+// EnsureQueueDebugEnabled before the scenario they intend to inspect.
 func QueueSnapshot(ctx context.Context, t *testing.T, runcnx *params.Run) map[string]queue.RepoQueue {
 	t.Helper()
 	pods := watcherPods(ctx, t, runcnx)
@@ -164,6 +172,75 @@ func keysOf(snapshot map[string]queue.RepoQueue) []string {
 		out = append(out, key)
 	}
 	return out
+}
+
+// EnsureQueueDebugEnabled turns on the watcher's /debug/queue endpoint if it
+// is not already on. The endpoint is disabled by default (it is
+// unauthenticated cluster-wide metadata), so E2E has to opt in explicitly the
+// same way an operator would, rather than relying on a special install.
+//
+// This restarts the watcher, so callers must invoke it before a scenario
+// queues or runs anything they intend to inspect afterward with
+// QueueSnapshot or AssertQueueDrained. Enabling it lazily, after the fact,
+// would reset the very in-memory state the scenario is trying to prove
+// leaked or did not leak.
+func EnsureQueueDebugEnabled(ctx context.Context, t *testing.T, runcnx *params.Run) {
+	t.Helper()
+	enableQueueDebugOnce.Do(func() {
+		dep, err := runcnx.Clients.Kube.AppsV1().Deployments(watcherNamespace).Get(ctx, watcherDeployment, metav1.GetOptions{})
+		assert.NilError(t, err)
+
+		containers := dep.Spec.Template.Spec.Containers
+		idx := slices.IndexFunc(containers, func(c corev1.Container) bool { return c.Name == watcherContainer })
+		assert.Assert(t, idx >= 0, "container %q not found in deployment %s/%s", watcherContainer, watcherNamespace, watcherDeployment)
+
+		env := &containers[idx].Env
+		if j := slices.IndexFunc(*env, func(e corev1.EnvVar) bool { return e.Name == queueDebugEnvVar }); j >= 0 {
+			if v, parseErr := strconv.ParseBool((*env)[j].Value); parseErr == nil && v {
+				return // already enabled, nothing to do
+			}
+			(*env)[j].Value = "true"
+		} else {
+			*env = append(*env, corev1.EnvVar{Name: queueDebugEnvVar, Value: "true"})
+		}
+
+		updatedDep, err := runcnx.Clients.Kube.AppsV1().Deployments(watcherNamespace).Update(ctx, dep, metav1.UpdateOptions{})
+		assert.NilError(t, err)
+		runcnx.Clients.Log.Infof("enabled %s on the watcher deployment for this test run", queueDebugEnvVar)
+		// Use the generation the server assigned to this update, not the one
+		// on the pre-update object: that one is already <= the deployment
+		// controller's current ObservedGeneration, so waiting on it would
+		// return immediately instead of waiting for the new pods to roll out.
+		waitForWatcherRollout(ctx, t, runcnx, updatedDep.Generation)
+	})
+}
+
+// waitForWatcherRollout waits until the deployment controller has observed the
+// update and every desired replica is updated, available and ready, with none
+// of the old pod template's replicas left. Checking UpdatedReplicas and
+// ReadyReplicas alone is not enough on a single-replica rollout: the new pod
+// counts as updated before it is ready while the old, pre-change watcher is
+// still counted as ready and still serving traffic.
+func waitForWatcherRollout(ctx context.Context, t *testing.T, runcnx *params.Run, targetGeneration int64) {
+	t.Helper()
+	for range 60 {
+		dep, err := runcnx.Clients.Kube.AppsV1().Deployments(watcherNamespace).Get(ctx, watcherDeployment, metav1.GetOptions{})
+		assert.NilError(t, err)
+		want := int32(1)
+		if dep.Spec.Replicas != nil {
+			want = *dep.Spec.Replicas
+		}
+		if dep.Status.ObservedGeneration >= targetGeneration &&
+			dep.Status.UpdatedReplicas == want &&
+			dep.Status.Replicas == want &&
+			dep.Status.AvailableReplicas == want &&
+			dep.Status.ReadyReplicas == want {
+			runcnx.Clients.Log.Infof("watcher rollout settled with %s enabled", queueDebugEnvVar)
+			return
+		}
+		time.Sleep(2 * time.Second)
+	}
+	t.Fatalf("watcher did not roll out the %s change within 2 minutes", queueDebugEnvVar)
 }
 
 func waitForWatcherReplicas(ctx context.Context, t *testing.T, runcnx *params.Run, want int32) {


### PR DESCRIPTION
## 📝 Description of the Change

Fixes concurrency queue recovery and malformed execution-order handling
following #2890, and makes the queue debug endpoint opt-in.

### Malformed execution-order entries (#2945)

Execution-order entries now use a shared parser that rejects empty or
malformed `namespace/name` pairs. Bad entries no longer panic the watcher
during startup or queue promotion. Finalization uses the same guarded
promotion path.

### Queue recovery after API failures

A failed start response does not prove that Kubernetes left a run pending.
The watcher reads the run's current state and keeps its concurrency
reservation while the outcome is uncertain. Retries resume that reservation
instead of admitting another run or waiting for a watcher restart.

Temporary read failures keep candidates in their original waiting order.
Retries respect the current concurrency limit, including inherited settings.
Conditional start requests prevent delayed writes from overwriting a newer
run state or affecting a replacement run with the same name.

Completion and finalization return queue-promotion errors for retry.
Completion records its terminal state only after promotion succeeds, since
terminal states stop further reconciliation. Successful handoffs are
remembered while the final state is being saved.

### Provider detection failures (#2946)

Temporary provider detection failures now return an error so the workqueue
retries. Previously, a finished run could keep its concurrency slot because
the failure was silently treated as success.

Missing or unknown providers take a separate path: release the finished run's
slot, promote the queue, then mark the run failed. If promotion fails, the
run stays retryable until its queue work finishes.

### Queue debug endpoint (#2947)

`/debug/queue` was registered unconditionally on the probe port and exposed
Repository and PipelineRun names across namespaces without authentication.
It is now gated behind `PAC_ENABLE_QUEUE_DEBUG`, disabled by default, and
stays disabled for an invalid value.

The E2E helper opts in by updating the watcher Deployment and waiting for
rollout. The concurrency documentation describes the toggle.

## 🔗 Linked GitHub Issue

Fixes #2945
Fixes #2946
Fixes #2947

Jira epic: [SRVKP-14316](https://redhat.atlassian.net/browse/SRVKP-14316) — Concurrency queue robustness:
no lost or leaked slots under failure

| Ticket | Covered by |
|--------|------------|
| [SRVKP-14113](https://redhat.atlassian.net/browse/SRVKP-14113) — watcher crash-loops on a malformed execution-order annotation | `fix: Keep queue recovery within concurrency limits` |
| [SRVKP-7608](https://redhat.atlassian.net/browse/SRVKP-7608) — PaC concurrency getting stuck with no running PipelineRuns | queue recovery + provider lookup commits |
| [SRVKP-11296](https://redhat.atlassian.net/browse/SRVKP-11296) — PipelineRuns stuck in Pending state (limit > 1) | queue recovery + provider lookup commits |
| [SRVKP-14317](https://redhat.atlassian.net/browse/SRVKP-14317) — `/debug/queue` unauthenticated and enabled by default | `fix(watcher): gate /debug/queue behind an env var` |

## 🧪 Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [x] End-to-end tests
- [ ] Manual testing
- [ ] Not Applicable

Unit coverage includes lost start responses, transient read failures,
retry ownership, concurrency-limit changes, final-state write failures,
malformed queue keys, provider detection, and the debug toggle.
The existing Gitea concurrency E2E case covers debug-endpoint opt-in;
live E2E execution is outside this update's scope.

## 🤖 AI Assistance

- [ ] I have not used any AI assistance for this PR.
- [x] I have used AI assistance for this PR.

## ✅ Submitter Checklist

- [x] 📝 My commit messages are clear, informative, and follow the project's [How to write a git commit message guide](https://developers.google.com/blockly/guides/contribute/get-started/commits). **The [Gitlint](https://jorisroovers.github.io/gitlint/latest) linter ensures in CI it's properly validated**
- [x] ✨ I have ensured my commit message prefix (e.g., `fix:`, `feat:`) matches the "Type of Change" I selected above.
- [x] ♽ I have run `make test` and `make lint` locally to check for and fix any
      issues. For an efficient workflow, I have considered installing
      [pre-commit](https://pre-commit.com/) and running `pre-commit install` to
      automate these checks.
- [x] 📖 I have added or updated documentation for any user-facing changes.
- [x] 🧪 I have added sufficient unit tests for my code changes.
- [x] 🎁 I have added end-to-end tests where feasible. See [README](https://github.com/tektoncd/pipelines-as-code/blob/main/test/README.md) for more details.
- [x] 🔎 I have addressed any CI test flakiness or provided a clear reason to bypass it.
- [ ] If adding a provider feature, I have filled in the following and updated the provider documentation:
  - [ ] GitHub App
  - [ ] GitHub Webhook
  - [ ] Gitea/Forgejo
  - [ ] GitLab
  - [ ] Bitbucket Cloud
  - [ ] Bitbucket Data Center

